### PR TITLE
feat(persona): Add first-class message injection API with dual-content support

### DIFF
--- a/.changeset/message-injection-dual-content.md
+++ b/.changeset/message-injection-dual-content.md
@@ -1,0 +1,29 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add first-class message injection API with dual-content support
+
+- Add `llmContent` field to `AgentWidgetMessage` for separating user-facing and LLM-facing content
+- Add `injectMessage()`, `injectAssistantMessage()`, `injectUserMessage()`, and `injectSystemMessage()` methods
+- Update content priority chain: `contentParts > llmContent > rawContent > content`
+- Deprecate `injectTestMessage()` in favor of new injection methods
+- Add comprehensive documentation at `docs/MESSAGE-INJECTION.md`
+
+**New Feature: Dual-Content Messages**
+
+Inject messages where the displayed content differs from what the LLM receives:
+
+```javascript
+// User sees rich markdown
+// LLM receives concise summary
+widgetHandle.injectAssistantMessage({
+  content: '**Found 3 products:**\n- iPhone 15 Pro - $1,199...',
+  llmContent: '[Search results: 3 iPhones, $799-$1199]'
+});
+```
+
+This enables:
+- Token efficiency (send summaries to LLM instead of full content)
+- Sensitive data redaction (show PII to user, hide from LLM)
+- Context injection (rich LLM context with minimal UI footprint)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,113 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Persona is a pnpm monorepo containing a themeable, pluggable streaming chat widget for websites. It consists of two publishable packages and three example applications.
+
+**Packages:**
+- `packages/widget` (`@runtypelabs/persona`) - The main chat widget library
+- `packages/proxy` (`@runtypelabs/persona-proxy`) - Optional Hono-based proxy server
+
+**Examples:**
+- `examples/embedded-app` - Vite demo with vanilla JS
+- `examples/vercel-edge` - Node.js proxy for Vercel/Railway/Fly.io
+- `examples/cloudflare-workers` - Edge proxy for Cloudflare Workers
+
+## Common Commands
+
+```bash
+# Development
+pnpm dev                # Start proxy (port 43111) + widget demo (port 5173) concurrently
+pnpm dev:widget         # Start widget demo only
+pnpm dev:vercel         # Start vercel-edge proxy only
+
+# Build
+pnpm build              # Build both widget and proxy packages
+pnpm build:widget       # Build widget only
+pnpm build:proxy        # Build proxy only
+
+# Quality
+pnpm lint               # Lint both packages
+pnpm typecheck          # Type check both packages
+
+# Testing (in packages/widget)
+cd packages/widget
+pnpm test               # Run tests in watch mode
+pnpm test:run           # Run tests once
+pnpm test:ui            # Run tests with UI
+
+# Releases
+pnpm changeset          # Create a changeset for version tracking
+pnpm changeset version  # Apply changesets to bump versions
+pnpm release            # Publish to npm
+```
+
+## Changesets Requirement
+
+All changes that affect published packages must include a changeset. Create one with `pnpm changeset` before committing. Changesets go in `.changeset/` and describe what changed for the changelog.
+
+## Architecture
+
+### Widget Package (`packages/widget/src/`)
+
+The widget uses a layered architecture:
+
+1. **Entry Points**
+   - `index.ts` - Public API exports
+   - `install.ts` - Script tag installer for CDN usage
+   - `runtime/init.ts` - Widget initialization
+
+2. **Core Layer**
+   - `client.ts` - HTTP client handling SSE streaming, message dispatch, and API communication
+   - `session.ts` - Message state management, injection methods, client session handling
+   - `types.ts` - All TypeScript type definitions (~1700 lines)
+
+3. **UI Layer** (`ui.ts` + `components/`)
+   - `ui.ts` - Main UI controller, DOM rendering, event handling
+   - `components/` - Modular UI components (launcher, panel, header, messages, feedback)
+   - `styles/widget.css` - Tailwind CSS with `tvw-` prefix for style scoping
+
+4. **Utilities** (`utils/`)
+   - `formatting.ts` - Stream parsers (JSON, XML, plain text)
+   - `content.ts` - Multi-modal content handling (text, images, files)
+   - `attachment-manager.ts` - File attachment handling
+   - `actions.ts` - AI action parsing and handling
+   - `component-parser.ts` / `component-middleware.ts` - Dynamic component system
+
+5. **Extensibility**
+   - `plugins/` - Plugin system for custom functionality
+   - `postprocessors.ts` - Markdown and directive postprocessors
+   - `defaults.ts` - Default configuration with theme presets
+
+### Key Patterns
+
+**Streaming:** SSE-based with pluggable parsers. Uses `partial-json` for incomplete JSON chunks during streaming.
+
+**Content Priority Chain:** When building API payloads, content resolves as: `contentParts > llmContent > rawContent > content`
+
+**Message Injection:** Use `injectMessage()`, `injectAssistantMessage()`, `injectUserMessage()`, `injectSystemMessage()` for programmatic message insertion. Supports dual-content where displayed content differs from LLM content.
+
+**DOM Updates:** Uses `idiomorph` for efficient DOM morphing/diffing.
+
+### Proxy Package (`packages/proxy/src/`)
+
+Hono-based server that proxies requests to the Runtype API:
+- `index.ts` - Main app factory and route handlers
+- `flows/` - Pre-configured flow definitions (conversational, shopping, scheduling)
+
+## Testing
+
+Tests use Vitest. Main test files:
+- `packages/widget/src/client.test.ts` - Client and streaming tests
+- `packages/widget/src/session.test.ts` - Session and injection tests
+- `packages/widget/src/utils/*.test.ts` - Utility tests
+
+## Build Outputs
+
+The widget builds to multiple formats via tsup:
+- ESM (`dist/index.js`)
+- CJS (`dist/index.cjs`)
+- IIFE (`dist/index.global.js`) - For script tag usage
+- TypeScript declarations (`dist/index.d.ts`)

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -137,6 +137,97 @@ const chat = initAgentWidget({
 chat.clearChat()
 ```
 
+#### Message Injection
+
+Inject messages programmatically from external sources like tool call responses, system events, or third-party integrations. This is useful when local tools need to push results back into the conversation.
+
+```ts
+const chat = initAgentWidget({
+  target: '#launcher-root',
+  config: { /* ... */ }
+})
+
+// Simple message injection
+chat.injectAssistantMessage({
+  content: 'Here are your search results...'
+});
+
+// User message injection
+chat.injectUserMessage({
+  content: 'Add to cart'
+});
+
+// System context injection
+chat.injectSystemMessage({
+  content: '[Context updated]',
+  llmContent: 'User is viewing product page for iPhone 15 Pro'
+});
+```
+
+**Dual-Content Messages (llmContent)**
+
+Use `llmContent` to show different content to the user versus what gets sent to the LLM. This is useful for:
+- **Token efficiency**: Show rich content to users while sending concise summaries to the LLM
+- **Sensitive data redaction**: Display PII to users while hiding it from the LLM
+- **Context injection**: Provide detailed LLM context with minimal UI footprint
+
+```ts
+// Example: Tool callback that injects search results
+async function handleProductSearch(query: string) {
+  const results = await searchProducts(query);
+
+  // User sees full product details with images and prices
+  // LLM receives a concise summary to save tokens
+  chat.injectAssistantMessage({
+    content: `**Found ${results.length} products:**
+${results.map(p => `- ${p.name} - $${p.price} (SKU: ${p.sku})`).join('\n')}`,
+
+    llmContent: `[Search results: ${results.length} products found, price range $${results.minPrice}-$${results.maxPrice}]`
+  });
+}
+
+// Example: Redacting sensitive information
+chat.injectAssistantMessage({
+  // User sees their order confirmation with details
+  content: `Your order #12345 has been placed!
+- Card ending in 4242
+- Shipping to: 123 Main St, Anytown, USA`,
+
+  // LLM only knows an order was placed (no PII)
+  llmContent: '[Order confirmation displayed to user]'
+});
+```
+
+**Content Priority**
+
+When messages are sent to the API, content is resolved in this priority order:
+1. `contentParts` - Multi-modal content (images, files)
+2. `llmContent` - Explicit LLM-specific content
+3. `content` - Display content as fallback
+
+**Streaming Updates**
+
+For long-running operations, use the same message ID to update content:
+
+```ts
+const messageId = 'search-123';
+
+// Show loading state
+chat.injectAssistantMessage({
+  id: messageId,
+  content: 'Searching...',
+  streaming: true
+});
+
+// Update with results
+chat.injectAssistantMessage({
+  id: messageId,
+  content: 'Found 5 results...',
+  llmContent: '[5 search results]',
+  streaming: false
+});
+```
+
 #### Accessing from window
 
 To access the controller globally (e.g., from browser console or external scripts), use the `windowKey` option:

--- a/packages/widget/docs/MESSAGE-INJECTION.md
+++ b/packages/widget/docs/MESSAGE-INJECTION.md
@@ -1,0 +1,181 @@
+# Message Injection API
+
+The Persona widget supports programmatic message injection, allowing you to add messages to the conversation from external sources such as tool call responses, system events, or third-party integrations.
+
+## Overview
+
+Message injection is useful for:
+- **Tool call responses**: Inject search results, product listings, or API responses
+- **System context**: Add context about user behavior (e.g., "User is viewing product X")
+- **External integrations**: Push messages from CRM systems, analytics, or other services
+- **Dual-content messages**: Show rich content to users while sending concise summaries to the LLM
+
+## API Reference
+
+### `injectMessage(options)`
+
+The primary method for injecting messages into the conversation.
+
+```typescript
+interface InjectMessageOptions {
+  role: 'user' | 'assistant' | 'system';
+  content: string;              // User-facing (UI display)
+  llmContent?: string;          // LLM-facing (defaults to content)
+  contentParts?: ContentPart[]; // Multi-modal (highest priority for LLM)
+  id?: string;                  // Custom message ID
+  createdAt?: string;           // ISO timestamp
+  sequence?: number;            // Sort order
+  streaming?: boolean;          // For streaming updates
+}
+```
+
+### Convenience Methods
+
+```typescript
+// Assistant messages (role: 'assistant')
+widgetHandle.injectAssistantMessage(options);
+
+// User messages (role: 'user')
+widgetHandle.injectUserMessage(options);
+
+// System messages (role: 'system')
+widgetHandle.injectSystemMessage(options);
+```
+
+## Content Priority
+
+When building the API payload, content is resolved in this priority order:
+
+1. `contentParts` - Multi-modal content (images, files)
+2. `llmContent` - Explicit LLM-specific content
+3. `rawContent` - Backward compatibility for structured parsers
+4. `content` - Display content as fallback
+
+## Examples
+
+### Basic Message Injection
+
+```javascript
+const widgetHandle = initAgentWidget({
+  apiUrl: 'https://api.example.com/chat'
+});
+
+// Simple assistant message
+widgetHandle.injectAssistantMessage({
+  content: 'Here are your search results...'
+});
+```
+
+### Dual-Content (User vs LLM)
+
+Show rich content to users while sending a concise summary to the LLM:
+
+```javascript
+// User sees full product details
+// LLM receives concise summary to save tokens
+widgetHandle.injectAssistantMessage({
+  content: `**Found 3 products:**
+- iPhone 15 Pro - $1,199 (SKU: IP15P-256)
+- iPhone 15 - $999 (SKU: IP15-128)
+- iPhone 14 - $799 (SKU: IP14-128)`,
+
+  llmContent: '[Search results: 3 iPhones found, $799-$1199]'
+});
+```
+
+### System Context Injection
+
+Inject context that guides LLM behavior without cluttering the chat:
+
+```javascript
+// Minimal display, rich context for LLM
+widgetHandle.injectSystemMessage({
+  content: '[Context updated]',
+  llmContent: 'User is viewing iPhone 15 Pro product page. Cart contains 2 items totaling $45.99. User has Gold membership.'
+});
+```
+
+### Sensitive Data Redaction
+
+Show sensitive information to users while redacting it from LLM:
+
+```javascript
+// User sees their order details
+// LLM only sees that an order exists
+widgetHandle.injectAssistantMessage({
+  content: `Your order #12345:
+- Card ending in 4242
+- Shipping to: 123 Main St, Anytown, USA`,
+
+  llmContent: '[Order confirmation displayed to user]'
+});
+```
+
+### Streaming Updates
+
+For long-running operations, use streaming to show progress:
+
+```javascript
+const messageId = 'search-results-123';
+
+// Initial streaming message
+widgetHandle.injectAssistantMessage({
+  id: messageId,
+  content: 'Searching...',
+  streaming: true
+});
+
+// Update with partial results
+widgetHandle.injectAssistantMessage({
+  id: messageId,
+  content: 'Found 2 results so far...',
+  streaming: true
+});
+
+// Final update
+widgetHandle.injectAssistantMessage({
+  id: messageId,
+  content: 'Here are all 5 results...',
+  llmContent: '[5 search results]',
+  streaming: false
+});
+```
+
+## Migration from `injectTestMessage`
+
+The previous `injectTestMessage` method is deprecated. Migrate using:
+
+**Before:**
+```javascript
+widgetHandle.injectTestMessage({
+  type: 'message',
+  message: {
+    id: 'msg-123',
+    role: 'assistant',
+    content: 'Hello!',
+    createdAt: new Date().toISOString()
+  }
+});
+```
+
+**After:**
+```javascript
+widgetHandle.injectAssistantMessage({
+  content: 'Hello!'
+});
+```
+
+## Best Practices
+
+1. **Use llmContent for token efficiency**: When displaying rich content (tables, lists, detailed info), provide a concise summary in `llmContent`
+
+2. **Redact sensitive data**: Never send PII, payment details, or credentials to the LLM - use `llmContent` for redacted summaries
+
+3. **Use appropriate roles**:
+   - `assistant` for responses and information display
+   - `user` for simulating user actions (use sparingly)
+   - `system` for context injection that should influence LLM behavior
+
+4. **Leverage streaming**: For operations that take time, use streaming updates to keep users informed
+
+5. **Consistent message IDs**: When updating messages, always use the same ID to avoid duplicates

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -193,6 +193,192 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
   });
 });
 
+describe('AgentWidgetClient - llmContent Priority', () => {
+  let client: AgentWidgetClient;
+  let capturedPayload: any = null;
+
+  beforeEach(() => {
+    capturedPayload = null;
+    client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+    });
+  });
+
+  it('should use llmContent instead of content when provided', async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const messages: AgentWidgetMessage[] = [
+      {
+        id: 'usr_1',
+        role: 'user',
+        content: 'Display content for user',
+        llmContent: 'LLM-specific content with more context',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+
+    await client.dispatch({ messages }, () => {});
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.messages).toHaveLength(1);
+    // Should use llmContent, not content
+    expect(capturedPayload.messages[0].content).toBe('LLM-specific content with more context');
+  });
+
+  it('should fall back to content when llmContent is not provided', async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const messages: AgentWidgetMessage[] = [
+      {
+        id: 'usr_1',
+        role: 'user',
+        content: 'Regular content without llmContent',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+
+    await client.dispatch({ messages }, () => {});
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.messages).toHaveLength(1);
+    expect(capturedPayload.messages[0].content).toBe('Regular content without llmContent');
+  });
+
+  it('should prioritize contentParts over llmContent', async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const messages: AgentWidgetMessage[] = [
+      {
+        id: 'usr_1',
+        role: 'user',
+        content: 'Display content',
+        llmContent: 'LLM content (should be ignored)',
+        contentParts: [{ type: 'text', text: 'Multi-modal text' }] as any,
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+
+    await client.dispatch({ messages }, () => {});
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.messages).toHaveLength(1);
+    // Should use contentParts, not llmContent
+    expect(capturedPayload.messages[0].content).toEqual([{ type: 'text', text: 'Multi-modal text' }]);
+  });
+
+  it('should preserve messages with valid llmContent even if content is empty', async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const messages: AgentWidgetMessage[] = [
+      {
+        id: 'ast_1',
+        role: 'assistant',
+        content: '', // Empty display content
+        llmContent: '[Context: User viewing product details]', // But has llmContent
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+
+    await client.dispatch({ messages }, () => {});
+
+    expect(capturedPayload.messages).toHaveLength(1);
+    expect(capturedPayload.messages[0].content).toBe('[Context: User viewing product details]');
+  });
+
+  it('should support dual-content pattern for redaction', async () => {
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    // Simulate a conversation with dual-content messages
+    const messages: AgentWidgetMessage[] = [
+      {
+        id: 'usr_1',
+        role: 'user',
+        content: 'Search for iPhones',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+      {
+        id: 'ast_1',
+        role: 'assistant',
+        // User sees full product details
+        content: '**Found 3 products:**\n- iPhone 15 Pro - $1,199\n- iPhone 15 - $999\n- iPhone 14 - $799',
+        // LLM receives concise summary
+        llmContent: '[Search results: 3 iPhones found, $799-$1199]',
+        createdAt: '2025-01-01T00:00:01.000Z',
+      },
+      {
+        id: 'usr_2',
+        role: 'user',
+        content: 'Tell me more about the first one',
+        createdAt: '2025-01-01T00:00:02.000Z',
+      },
+    ];
+
+    await client.dispatch({ messages }, () => {});
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.messages).toHaveLength(3);
+
+    // First message: regular user message
+    expect(capturedPayload.messages[0].content).toBe('Search for iPhones');
+
+    // Second message: assistant with llmContent (should use redacted version)
+    expect(capturedPayload.messages[1].content).toBe('[Search results: 3 iPhones found, $799-$1199]');
+
+    // Third message: regular user message
+    expect(capturedPayload.messages[2].content).toBe('Tell me more about the first one');
+  });
+});
+
 describe('AgentWidgetClient - JSON Streaming', () => {
   let client: AgentWidgetClient;
   let events: AgentWidgetEvent[] = [];

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -47,11 +47,15 @@ const hasValidContent = (message: AgentWidgetMessage): boolean => {
   if (message.contentParts && message.contentParts.length > 0) {
     return true;
   }
-  // Check rawContent
+  // Check llmContent (explicit LLM content)
+  if (message.llmContent && message.llmContent.trim().length > 0) {
+    return true;
+  }
+  // Check rawContent (structured parser output)
   if (message.rawContent && message.rawContent.trim().length > 0) {
     return true;
   }
-  // Check content
+  // Check content (display content)
   if (message.content && message.content.trim().length > 0) {
     return true;
   }
@@ -589,8 +593,8 @@ export class AgentWidgetClient {
       })
       .map((message) => ({
         role: message.role,
-        // Use contentParts for multi-modal messages, otherwise fall back to string content
-        content: message.contentParts ?? message.rawContent ?? message.content,
+        // Priority: contentParts (multi-modal) > llmContent (explicit LLM content) > rawContent (structured parsers) > content (display)
+        content: message.contentParts ?? message.llmContent ?? message.rawContent ?? message.content,
         createdAt: message.createdAt
       }));
 

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -48,7 +48,12 @@ export type {
   ClientInitResponse,
   ClientChatRequest,
   ClientFeedbackRequest,
-  ClientFeedbackType
+  ClientFeedbackType,
+  // Message injection types
+  InjectMessageOptions,
+  InjectAssistantMessageOptions,
+  InjectUserMessageOptions,
+  InjectSystemMessageOptions
 } from "./types";
 
 export { initAgentWidgetFn as initAgentWidget };

--- a/packages/widget/src/session.test.ts
+++ b/packages/widget/src/session.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { AgentWidgetSession, AgentWidgetSessionStatus } from './session';
+import { AgentWidgetMessage } from './types';
+
+describe('AgentWidgetSession - Message Injection', () => {
+  let session: AgentWidgetSession;
+  let messages: AgentWidgetMessage[] = [];
+  let _status: AgentWidgetSessionStatus = 'idle';
+  let _streaming = false;
+  let _lastError: Error | undefined;
+
+  beforeEach(() => {
+    messages = [];
+    _status = 'idle';
+    _streaming = false;
+    _lastError = undefined;
+
+    session = new AgentWidgetSession(
+      { apiUrl: 'http://localhost:8000' },
+      {
+        onMessagesChanged: (msgs) => { messages = msgs; },
+        onStatusChanged: (s) => { _status = s; },
+        onStreamingChanged: (s) => { _streaming = s; },
+        onError: (e) => { _lastError = e; }
+      }
+    );
+  });
+
+  describe('injectMessage', () => {
+    it('should inject a message with the specified role', () => {
+      const result = session.injectMessage({
+        role: 'assistant',
+        content: 'Hello, how can I help you?'
+      });
+
+      expect(result.role).toBe('assistant');
+      expect(result.content).toBe('Hello, how can I help you?');
+      expect(result.id).toBeDefined();
+      expect(result.createdAt).toBeDefined();
+      expect(result.sequence).toBeDefined();
+      expect(messages).toHaveLength(1);
+      expect(messages[0]).toEqual(result);
+    });
+
+    it('should support llmContent for dual-content messages', () => {
+      const result = session.injectMessage({
+        role: 'assistant',
+        content: '**Full product details**\n- iPhone 15 Pro - $1,199',
+        llmContent: '[Product: iPhone 15 Pro, $1,199]'
+      });
+
+      expect(result.content).toBe('**Full product details**\n- iPhone 15 Pro - $1,199');
+      expect(result.llmContent).toBe('[Product: iPhone 15 Pro, $1,199]');
+    });
+
+    it('should support contentParts for multi-modal messages', () => {
+      const contentParts = [
+        { type: 'text' as const, text: 'Here is the image:' },
+        { type: 'image' as const, image: 'data:image/png;base64,abc123', mimeType: 'image/png' }
+      ];
+
+      const result = session.injectMessage({
+        role: 'user',
+        content: 'Here is the image:',
+        contentParts
+      });
+
+      expect(result.contentParts).toEqual(contentParts);
+    });
+
+    it('should allow custom id and createdAt', () => {
+      const customId = 'custom-message-id';
+      const customCreatedAt = '2025-01-01T00:00:00.000Z';
+
+      const result = session.injectMessage({
+        role: 'assistant',
+        content: 'Test message',
+        id: customId,
+        createdAt: customCreatedAt
+      });
+
+      expect(result.id).toBe(customId);
+      expect(result.createdAt).toBe(customCreatedAt);
+    });
+
+    it('should allow custom sequence number', () => {
+      const customSequence = 12345;
+
+      const result = session.injectMessage({
+        role: 'assistant',
+        content: 'Test message',
+        sequence: customSequence
+      });
+
+      expect(result.sequence).toBe(customSequence);
+    });
+
+    it('should support streaming flag', () => {
+      const result = session.injectMessage({
+        role: 'assistant',
+        content: 'Partial...',
+        streaming: true
+      });
+
+      expect(result.streaming).toBe(true);
+    });
+
+    it('should update existing message with same id (upsert)', () => {
+      const messageId = 'msg-to-update';
+
+      // First injection
+      session.injectMessage({
+        role: 'assistant',
+        content: 'Partial content...',
+        id: messageId,
+        streaming: true
+      });
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('Partial content...');
+
+      // Second injection (update)
+      session.injectMessage({
+        role: 'assistant',
+        content: 'Complete content!',
+        id: messageId,
+        streaming: false
+      });
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('Complete content!');
+      expect(messages[0].streaming).toBe(false);
+    });
+  });
+
+  describe('injectAssistantMessage', () => {
+    it('should inject a message with role "assistant"', () => {
+      const result = session.injectAssistantMessage({
+        content: 'I am an assistant message'
+      });
+
+      expect(result.role).toBe('assistant');
+      expect(result.content).toBe('I am an assistant message');
+      expect(result.id).toMatch(/^ast_/); // Assistant IDs start with ast_
+    });
+
+    it('should support dual-content', () => {
+      const result = session.injectAssistantMessage({
+        content: 'User sees this',
+        llmContent: 'LLM sees this'
+      });
+
+      expect(result.role).toBe('assistant');
+      expect(result.content).toBe('User sees this');
+      expect(result.llmContent).toBe('LLM sees this');
+    });
+  });
+
+  describe('injectUserMessage', () => {
+    it('should inject a message with role "user"', () => {
+      const result = session.injectUserMessage({
+        content: 'I am a user message'
+      });
+
+      expect(result.role).toBe('user');
+      expect(result.content).toBe('I am a user message');
+      expect(result.id).toMatch(/^usr_/); // User IDs start with usr_
+    });
+  });
+
+  describe('injectSystemMessage', () => {
+    it('should inject a message with role "system"', () => {
+      const result = session.injectSystemMessage({
+        content: '[Context updated]',
+        llmContent: 'User is viewing product page for iPhone 15 Pro'
+      });
+
+      expect(result.role).toBe('system');
+      expect(result.content).toBe('[Context updated]');
+      expect(result.llmContent).toBe('User is viewing product page for iPhone 15 Pro');
+      expect(result.id).toMatch(/^system-/); // System IDs start with system-
+    });
+  });
+
+  describe('message ordering', () => {
+    it('should maintain chronological order', () => {
+      session.injectMessage({
+        role: 'user',
+        content: 'First message',
+        createdAt: '2025-01-01T00:00:01.000Z'
+      });
+
+      session.injectMessage({
+        role: 'assistant',
+        content: 'Second message',
+        createdAt: '2025-01-01T00:00:02.000Z'
+      });
+
+      session.injectMessage({
+        role: 'user',
+        content: 'Third message',
+        createdAt: '2025-01-01T00:00:03.000Z'
+      });
+
+      expect(messages).toHaveLength(3);
+      expect(messages[0].content).toBe('First message');
+      expect(messages[1].content).toBe('Second message');
+      expect(messages[2].content).toBe('Third message');
+    });
+
+    it('should insert messages in correct position based on timestamp', () => {
+      // Insert out of order
+      session.injectMessage({
+        role: 'assistant',
+        content: 'Second message',
+        createdAt: '2025-01-01T00:00:02.000Z'
+      });
+
+      session.injectMessage({
+        role: 'user',
+        content: 'First message',
+        createdAt: '2025-01-01T00:00:01.000Z'
+      });
+
+      expect(messages).toHaveLength(2);
+      expect(messages[0].content).toBe('First message');
+      expect(messages[1].content).toBe('Second message');
+    });
+  });
+
+  describe('backward compatibility', () => {
+    it('should still support injectTestEvent (deprecated)', () => {
+      session.injectTestEvent({
+        type: 'message',
+        message: {
+          id: 'test-msg',
+          role: 'assistant',
+          content: 'Legacy message',
+          createdAt: new Date().toISOString()
+        }
+      });
+
+      expect(messages).toHaveLength(1);
+      expect(messages[0].content).toBe('Legacy message');
+    });
+  });
+});

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -4,7 +4,11 @@ import {
   AgentWidgetEvent,
   AgentWidgetMessage,
   ClientSession,
-  ContentPart
+  ContentPart,
+  InjectMessageOptions,
+  InjectAssistantMessageOptions,
+  InjectUserMessageOptions,
+  InjectSystemMessageOptions
 } from "./types";
 import {
   generateUserMessageId,
@@ -184,8 +188,130 @@ export class AgentWidgetSession {
     return this.streaming;
   }
 
+  /**
+   * @deprecated Use injectMessage() instead.
+   * Injects a raw event into the session event handler.
+   */
   public injectTestEvent(event: AgentWidgetEvent) {
     this.handleEvent(event);
+  }
+
+  /**
+   * Inject a message into the conversation.
+   * This is the primary API for adding messages programmatically.
+   *
+   * Supports dual-content where the displayed content differs from what the LLM receives.
+   *
+   * @param options - Message injection options including dual-content support
+   * @returns The created message object
+   *
+   * @example
+   * // Same content for user and LLM
+   * session.injectMessage({
+   *   role: 'assistant',
+   *   content: 'Here are the search results...'
+   * });
+   *
+   * @example
+   * // Different content for user and LLM (redaction)
+   * session.injectMessage({
+   *   role: 'assistant',
+   *   content: '**Found 3 products:**\n- iPhone 15 Pro ($1,199)\n- iPhone 15 ($999)',
+   *   llmContent: '[Search results: 3 iPhone products, $799-$1199]'
+   * });
+   */
+  public injectMessage(options: InjectMessageOptions): AgentWidgetMessage {
+    const {
+      role,
+      content,
+      llmContent,
+      contentParts,
+      id,
+      createdAt,
+      sequence,
+      streaming = false
+    } = options;
+
+    // Generate appropriate ID based on role
+    const messageId =
+      id ??
+      (role === "user"
+        ? generateUserMessageId()
+        : role === "assistant"
+          ? generateAssistantMessageId()
+          : `system-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+
+    const message: AgentWidgetMessage = {
+      id: messageId,
+      role,
+      content,
+      createdAt: createdAt ?? new Date().toISOString(),
+      sequence: sequence ?? this.nextSequence(),
+      streaming,
+      // Only include optional fields if provided
+      ...(llmContent !== undefined && { llmContent }),
+      ...(contentParts !== undefined && { contentParts })
+    };
+
+    // Use upsert to handle both new messages and updates (streaming)
+    this.upsertMessage(message);
+
+    return message;
+  }
+
+  /**
+   * Convenience method for injecting assistant messages.
+   * Role defaults to 'assistant'.
+   *
+   * @example
+   * // Simple assistant message
+   * session.injectAssistantMessage({
+   *   content: 'Here are your search results...'
+   * });
+   *
+   * @example
+   * // With redacted LLM content
+   * session.injectAssistantMessage({
+   *   content: 'Full product details for the user...',
+   *   llmContent: '[Product details summary]'
+   * });
+   */
+  public injectAssistantMessage(
+    options: InjectAssistantMessageOptions
+  ): AgentWidgetMessage {
+    return this.injectMessage({ ...options, role: "assistant" });
+  }
+
+  /**
+   * Convenience method for injecting user messages.
+   * Role defaults to 'user'.
+   *
+   * @example
+   * session.injectUserMessage({
+   *   content: 'Add iPhone 15 Pro to my cart'
+   * });
+   */
+  public injectUserMessage(
+    options: InjectUserMessageOptions
+  ): AgentWidgetMessage {
+    return this.injectMessage({ ...options, role: "user" });
+  }
+
+  /**
+   * Convenience method for injecting system messages.
+   * Role defaults to 'system'.
+   *
+   * @example
+   * // Inject context that guides LLM behavior
+   * session.injectSystemMessage({
+   *   content: '[Context updated]',  // Minimal display
+   *   llmContent: 'User is viewing iPhone 15 Pro. Cart has 2 items.'
+   * });
+   */
+  public injectSystemMessage(
+    options: InjectSystemMessageOptions
+  ): AgentWidgetMessage {
+    return this.injectMessage({ ...options, role: "system" });
   }
 
   public async sendMessage(

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1618,7 +1618,120 @@ export type AgentWidgetMessage = {
    * Populated automatically when structured parsers run.
    */
   rawContent?: string;
+  /**
+   * LLM-specific content for API requests.
+   * When present, this is sent to the LLM instead of `content`.
+   *
+   * Priority for API payload:
+   * 1. `contentParts` (if present, used as-is for multi-modal)
+   * 2. `llmContent` (if present, sent as string)
+   * 3. `rawContent` (backward compatibility with structured parsers)
+   * 4. `content` (fallback - display content)
+   *
+   * The `content` field is always used for UI display.
+   *
+   * @example
+   * // Show full details to user, send summary to LLM
+   * {
+   *   content: "**Product:** iPhone 15 Pro\n**Price:** $1,199\n**SKU:** IP15P-256",
+   *   llmContent: "[Product search: iPhone 15 Pro, $1199]"
+   * }
+   */
+  llmContent?: string;
 };
+
+// ============================================================================
+// Message Injection Types
+// ============================================================================
+
+/**
+ * Options for injecting a message into the conversation.
+ * Supports dual-content where UI display differs from LLM context.
+ *
+ * @example
+ * // Same content for user and LLM
+ * {
+ *   role: 'assistant',
+ *   content: 'Here are your search results...'
+ * }
+ *
+ * @example
+ * // Different content: user sees full details, LLM sees summary
+ * {
+ *   role: 'assistant',
+ *   content: '**Found 3 products:**\n- iPhone 15 Pro ($1,199)\n- iPhone 15 ($999)',
+ *   llmContent: '[Search results: 3 iPhones, $999-$1199]'
+ * }
+ */
+export type InjectMessageOptions = {
+  /**
+   * Message role: "assistant", "user", or "system"
+   */
+  role: AgentWidgetMessageRole;
+
+  /**
+   * Content displayed to the user in the chat UI.
+   * This is what appears in the message bubble.
+   */
+  content: string;
+
+  /**
+   * Content sent to the LLM in API requests.
+   * When omitted, `content` is used for both display and LLM.
+   *
+   * Use cases:
+   * - Redacted content: Show full product details to user, send summary to LLM
+   * - Structured data: Show formatted markdown to user, send JSON to LLM
+   * - Token optimization: Show verbose content to user, send concise version to LLM
+   */
+  llmContent?: string;
+
+  /**
+   * Multi-modal content parts for the LLM (images, files).
+   * Takes precedence over `llmContent` when present.
+   * The `content` field is still used for UI display.
+   */
+  contentParts?: ContentPart[];
+
+  /**
+   * Optional message ID. If omitted, auto-generated based on role.
+   */
+  id?: string;
+
+  /**
+   * Optional creation timestamp (ISO string). If omitted, uses current time.
+   */
+  createdAt?: string;
+
+  /**
+   * Optional sequence number for ordering.
+   */
+  sequence?: number;
+
+  /**
+   * Whether the message is still streaming (for incremental updates).
+   * @default false
+   */
+  streaming?: boolean;
+};
+
+/**
+ * Options for injecting assistant messages (most common case).
+ * Role defaults to 'assistant'.
+ */
+export type InjectAssistantMessageOptions = Omit<InjectMessageOptions, "role">;
+
+/**
+ * Options for injecting user messages.
+ * Role defaults to 'user'.
+ */
+export type InjectUserMessageOptions = Omit<InjectMessageOptions, "role">;
+
+/**
+ * Options for injecting system messages.
+ * Role defaults to 'system'.
+ */
+export type InjectSystemMessageOptions = Omit<InjectMessageOptions, "role">;
 
 export type AgentWidgetEvent =
   | { type: "message"; message: AgentWidgetMessage }

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -13,7 +13,11 @@ import {
   WidgetLayoutSlot,
   SlotRenderer,
   AgentWidgetMessageFeedback,
-  ContentPart
+  ContentPart,
+  InjectMessageOptions,
+  InjectAssistantMessageOptions,
+  InjectUserMessageOptions,
+  InjectSystemMessageOptions
 } from "./types";
 import { AttachmentManager } from "./utils/attachment-manager";
 import { createTextPart, ALL_SUPPORTED_MIME_TYPES } from "./utils/content";
@@ -83,6 +87,26 @@ type Controller = {
   submitMessage: (message?: string) => boolean;
   startVoiceRecognition: () => boolean;
   stopVoiceRecognition: () => boolean;
+  /**
+   * Inject a message into the conversation with dual-content support.
+   * Auto-opens the widget if closed and launcher is enabled.
+   */
+  injectMessage: (options: InjectMessageOptions) => AgentWidgetMessage;
+  /**
+   * Convenience method for injecting assistant messages.
+   */
+  injectAssistantMessage: (options: InjectAssistantMessageOptions) => AgentWidgetMessage;
+  /**
+   * Convenience method for injecting user messages.
+   */
+  injectUserMessage: (options: InjectUserMessageOptions) => AgentWidgetMessage;
+  /**
+   * Convenience method for injecting system messages.
+   */
+  injectSystemMessage: (options: InjectSystemMessageOptions) => AgentWidgetMessage;
+  /**
+   * @deprecated Use injectMessage() instead.
+   */
   injectTestMessage: (event: AgentWidgetEvent) => void;
   getMessages: () => AgentWidgetMessage[];
   getStatus: () => AgentWidgetSessionStatus;
@@ -3191,12 +3215,41 @@ export const createAgentExperience = (
     },
     stopVoiceRecognition(): boolean {
       if (!isRecording) return false;
-      
+
       voiceState.manuallyDeactivated = true;
       persistVoiceMetadata();
       stopVoiceRecognition("user");
       return true;
     },
+    injectMessage(options: InjectMessageOptions): AgentWidgetMessage {
+      // Auto-open widget if closed and launcher is enabled
+      if (!open && launcherEnabled) {
+        setOpenState(true, "system");
+      }
+      return session.injectMessage(options);
+    },
+    injectAssistantMessage(options: InjectAssistantMessageOptions): AgentWidgetMessage {
+      // Auto-open widget if closed and launcher is enabled
+      if (!open && launcherEnabled) {
+        setOpenState(true, "system");
+      }
+      return session.injectAssistantMessage(options);
+    },
+    injectUserMessage(options: InjectUserMessageOptions): AgentWidgetMessage {
+      // Auto-open widget if closed and launcher is enabled
+      if (!open && launcherEnabled) {
+        setOpenState(true, "system");
+      }
+      return session.injectUserMessage(options);
+    },
+    injectSystemMessage(options: InjectSystemMessageOptions): AgentWidgetMessage {
+      // Auto-open widget if closed and launcher is enabled
+      if (!open && launcherEnabled) {
+        setOpenState(true, "system");
+      }
+      return session.injectSystemMessage(options);
+    },
+    /** @deprecated Use injectMessage() instead */
     injectTestMessage(event: AgentWidgetEvent) {
       // Auto-open widget if closed and launcher is enabled
       if (!open && launcherEnabled) {


### PR DESCRIPTION
## Summary

- Adds `llmContent` field to `AgentWidgetMessage` for separating user-facing and LLM-facing content; useful when you want to redact information from an LLM when injecting new messages onto the stack via callbacks from local tools
- Adds `injectMessage()`, `injectAssistantMessage()`, `injectUserMessage()`, and `injectSystemMessage()` methods
- Updates content priority chain: `contentParts > llmContent > rawContent > content`
- Deprecates `injectTestMessage()` in favor of new injection methods
- Adds comprehensive tests and documentation

## New Feature: Dual-Content Messages

Inject messages where the displayed content differs from what the LLM receives:

```javascript
// User sees rich markdown
// LLM receives concise summary
widgetHandle.injectAssistantMessage({
  content: '**Found 3 products:**\n- iPhone 15 Pro - $1,199...',
  llmContent: '[Search results: 3 iPhones, $799-$1199]'
});
```

This enables:
- **Token efficiency**: Send summaries to LLM instead of full content
- **Sensitive data redaction**: Show PII to user, hide from LLM
- **Context injection**: Rich LLM context with minimal UI footprint

## Files Changed

| File | Changes |
|------|---------|
| `packages/widget/src/types.ts` | Add `llmContent` field, injection option types |
| `packages/widget/src/client.ts` | Update `buildPayload()` priority chain |
| `packages/widget/src/session.ts` | Add injection methods |
| `packages/widget/src/ui.ts` | Add controller wrapper methods |
| `packages/widget/src/index.ts` | Export new types |
| `packages/widget/src/client.test.ts` | Tests for llmContent priority |
| `packages/widget/src/session.test.ts` | Tests for injection methods |
| `packages/widget/docs/MESSAGE-INJECTION.md` | Documentation |

## Test plan

- [x] All existing tests pass
- [x] New llmContent priority tests pass (5 tests)
- [x] New session injection tests pass (14 tests)

Generated with [Claude Code](https://claude.ai/code)