### PR TITLE
feat(widget): use package version in generated CDN URLs

### DIFF
--- a/.changeset/code-generator-version.md
+++ b/.changeset/code-generator-version.md
@@ -1,0 +1,10 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Use pinned package version in generated CDN URLs instead of @latest
+
+- Code generator now uses the installed package version in CDN URLs
+- Generated snippets use exact version (e.g., `@runtypelabs/persona@1.36.1`) instead of `@latest`
+- Ensures reproducible deployments where generated code matches the installed widget version
+- Export `VERSION` constant from package for programmatic access

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -111,6 +111,7 @@ export {
 } from "./utils/message-id";
 export { generateCodeSnippet } from "./utils/code-generators";
 export type { CodeFormat, CodeGeneratorHooks, CodeGeneratorOptions } from "./utils/code-generators";
+export { VERSION } from "./version";
 export type { AgentWidgetInitHandle };
 
 // Plugin system exports

--- a/packages/widget/src/utils/code-generators.test.ts
+++ b/packages/widget/src/utils/code-generators.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { generateCodeSnippet, type CodeFormat, type CodeGeneratorHooks, type CodeGeneratorOptions as _CodeGeneratorOptions } from "./code-generators";
+import { VERSION } from "../version";
 
 // =============================================================================
 // Test Fixtures
@@ -496,5 +497,38 @@ describe("Backward Compatibility", () => {
 
     expect(code).toContain("import");
     expect(code).toContain("from");
+  });
+});
+
+// =============================================================================
+// CDN Version Tests
+// =============================================================================
+
+describe("CDN Version", () => {
+  it("should use package version instead of @latest in script-installer format", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-installer");
+
+    expect(code).toContain(`@runtypelabs/persona@${VERSION}`);
+    expect(code).not.toContain("@latest");
+  });
+
+  it("should use package version instead of @latest in script-manual format", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-manual");
+
+    expect(code).toContain(`@runtypelabs/persona@${VERSION}/dist/widget.css`);
+    expect(code).toContain(`@runtypelabs/persona@${VERSION}/dist/index.global.js`);
+    expect(code).not.toContain("@latest");
+  });
+
+  it("should use package version instead of @latest in script-advanced format", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-advanced");
+
+    expect(code).toContain(`@runtypelabs/persona@${VERSION}/dist`);
+    expect(code).not.toContain("@latest");
+  });
+
+  it("should have a valid semver version format", () => {
+    // Verify VERSION looks like a semver (e.g., "1.36.1")
+    expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 });

--- a/packages/widget/src/utils/code-generators.ts
+++ b/packages/widget/src/utils/code-generators.ts
@@ -1,4 +1,5 @@
 import type { AgentWidgetConfig } from "../types";
+import { VERSION } from "../version";
 
 type ParserType = "plain" | "json" | "regex-json" | "xml";
 export type CodeFormat = "esm" | "script-installer" | "script-manual" | "script-advanced" | "react-component" | "react-advanced";
@@ -1351,7 +1352,7 @@ function generateScriptInstallerCode(config: any): string {
   // Escape single quotes in JSON for HTML attribute
   const configJson = JSON.stringify(serializableConfig, null, 0).replace(/'/g, "&#39;");
   
-  return `<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js" data-config='${configJson}'></script>`;
+  return `<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist/install.global.js" data-config='${configJson}'></script>`;
 }
 
 function generateScriptManualCode(config: any, options?: CodeGeneratorOptions): string {
@@ -1361,10 +1362,10 @@ function generateScriptManualCode(config: any, options?: CodeGeneratorOptions): 
 
   const lines: string[] = [
     "<!-- Load CSS -->",
-    "<link rel=\"stylesheet\" href=\"https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/widget.css\" />",
+    `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist/widget.css" />`,
     "",
     "<!-- Load JavaScript -->",
-    "<script src=\"https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/index.global.js\"></script>",
+    `<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist/index.global.js"></script>`,
     "",
     "<!-- Initialize widget -->",
     "<script>",
@@ -1523,7 +1524,7 @@ function generateScriptAdvancedCode(config: any, options?: CodeGeneratorOptions)
     `  var CONFIG = ${configJson.split('\n').map((line, i) => i === 0 ? line : '  ' + line).join('\n')};`,
     "",
     "  // Constants",
-    "  var CDN_BASE = 'https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist';",
+    `  var CDN_BASE = 'https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist';`,
     "  var STORAGE_KEY = 'chat-widget-state';",
     "  var PROCESSED_ACTIONS_KEY = 'chat-widget-processed-actions';",
     "",

--- a/packages/widget/src/version.ts
+++ b/packages/widget/src/version.ts
@@ -1,0 +1,7 @@
+import packageJson from "../package.json";
+
+/**
+ * The current version of the @runtypelabs/persona package.
+ * This is automatically derived from package.json.
+ */
+export const VERSION = packageJson.version;


### PR DESCRIPTION
## Summary
- Code generator now uses the installed package version in CDN URLs instead of `@latest`
- Generated snippets use exact version (e.g., `@runtypelabs/persona@1.37.0`) instead of `@latest`
- Ensures reproducible deployments where generated code matches the installed widget version
- Exports `VERSION` constant from package for programmatic access

## Changes
- Create `version.ts` that exports `VERSION` from `package.json`
- Update `code-generators.ts` to use `VERSION` in CDN URLs
- Export `VERSION` from main package entry point
- Add tests verifying version appears in generated code

## Test plan
- [x] All existing tests pass
- [x] New tests verify version number appears in generated code instead of @latest
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)