### PR TITLE
fix(widget): include llmContent in client token mode dispatch

### DIFF
--- a/.changeset/llm-content-client-token-fix.md
+++ b/.changeset/llm-content-client-token-fix.md
@@ -1,0 +1,9 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix llmContent not being sent to server in client token mode
+
+- Add missing `llmContent` to content priority chain in client token dispatch
+- Content priority now matches proxy mode: `contentParts > llmContent > rawContent > content`
+- Fixes message injection API when using client tokens instead of proxy

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -432,8 +432,8 @@ export class AgentWidgetClient {
         messages: options.messages.filter(hasValidContent).map(m => ({
           id: m.id, // Include message ID for tracking
           role: m.role,
-          // Use contentParts for multi-modal messages, otherwise fall back to string content
-          content: m.contentParts ?? m.rawContent ?? m.content,
+          // Priority: contentParts (multi-modal) > llmContent (explicit LLM content) > rawContent (structured parsers) > content (display)
+          content: m.contentParts ?? m.llmContent ?? m.rawContent ?? m.content,
         })),
         // Include pre-generated assistant message ID if provided
         ...(options.assistantMessageId && { assistant_message_id: options.assistantMessageId }),


### PR DESCRIPTION
## Summary
- Fix bug where `llmContent` field was not being sent to the server in client token mode
- Add missing `llmContent` to content priority chain in client token dispatch (line 436)
- Content priority now matches proxy mode: `contentParts > llmContent > rawContent > content`

## Problem
When using the message injection API with client tokens, the `llmContent` field was ignored. This meant that dual-content messages (where displayed content differs from LLM content) would not work correctly in client token mode.

## Solution
Updated line 436 in `client.ts` from:
```javascript
content: m.contentParts ?? m.rawContent ?? m.content,
```
to:
```javascript
content: m.contentParts ?? m.llmContent ?? m.rawContent ?? m.content,
```

## Test plan
- [x] All existing tests pass
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)