### PR TITLE
feat(widget): add resubmit flag to action handler results

### DIFF
--- a/.changeset/action-handler-resubmit.md
+++ b/.changeset/action-handler-resubmit.md
@@ -1,0 +1,10 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add resubmit flag to action handler results for automatic model continuation
+
+- Add `resubmit?: boolean` to `AgentWidgetActionHandlerResult` type
+- Add `action:resubmit` event to `AgentWidgetControllerEventMap`
+- When a handler returns `resubmit: true`, automatically trigger another model call
+- Enables handlers that inject data (e.g., search results) to have the model analyze and respond to that data

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -101,6 +101,7 @@ export type AgentWidgetActionHandlerResult = {
   handled?: boolean;
   displayText?: string;
   persistMessage?: boolean; // If false, prevents message from being saved to history
+  resubmit?: boolean; // If true, automatically triggers another model call after handler completes
 };
 
 export type AgentWidgetActionContext = {
@@ -247,6 +248,7 @@ export type AgentWidgetControllerEventMap = {
   "assistant:complete": AgentWidgetMessage;
   "voice:state": AgentWidgetVoiceStateEvent;
   "action:detected": AgentWidgetActionEventPayload;
+  "action:resubmit": AgentWidgetActionEventPayload;
   "widget:opened": AgentWidgetStateEvent;
   "widget:closed": AgentWidgetStateEvent;
   "widget:state": AgentWidgetStateSnapshot;

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1785,6 +1785,19 @@ export const createAgentExperience = (
   });
   destroyCallbacks.push(autoResumeUnsub);
 
+  // Handle action:resubmit event - automatically trigger another model call
+  // when an action handler needs the model to continue processing (e.g., analyzing search results)
+  const resubmitUnsub = eventBus.on("action:resubmit", () => {
+    // Small delay to ensure UI has updated with injected message
+    setTimeout(() => {
+      if (session && !session.isStreaming()) {
+        // Send empty message to trigger model continuation with existing context
+        session.sendMessage("");
+      }
+    }, 150);
+  });
+  destroyCallbacks.push(resubmitUnsub);
+
   const toggleOpen = () => {
     setOpenState(!open, "user");
   };

--- a/packages/widget/src/utils/actions.ts
+++ b/packages/widget/src/utils/actions.ts
@@ -140,7 +140,7 @@ export const createActionManager = (options: ActionManagerOptions) => {
     }));
   };
 
-  const process = (context: ActionManagerProcessContext): { text: string; persist: boolean } | null => {
+  const process = (context: ActionManagerProcessContext): { text: string; persist: boolean; resubmit?: boolean } | null => {
     if (
       context.streaming ||
       context.message.role !== "assistant" ||
@@ -206,7 +206,11 @@ export const createActionManager = (options: ActionManagerOptions) => {
           // persistMessage defaults to true if not specified
           const persist = handlerResult.persistMessage !== false;
           const displayText = handlerResult.displayText !== undefined ? handlerResult.displayText : "";
-          return { text: displayText, persist };
+          // Emit resubmit event if handler requests automatic continuation
+          if (handlerResult.resubmit) {
+            options.emit("action:resubmit", eventPayload);
+          }
+          return { text: displayText, persist, resubmit: handlerResult.resubmit };
         }
       } catch (error) {
         if (typeof console !== "undefined") {


### PR DESCRIPTION
Adds the ability for action handlers to request automatic model continuation after injecting results. When a handler returns `resubmit: true`, the widget automatically triggers another model call with an empty message, allowing the model to analyze injected data (e.g., search results, order details).

Changes:
- Add resubmit?: boolean to AgentWidgetActionHandlerResult type
- Add action:resubmit event to AgentWidgetControllerEventMap
- Emit action:resubmit from action manager when handler returns resubmit
- Subscribe to action:resubmit in ui.ts and call session.sendMessage("")