### PR TITLE
fix: llmContent client token mode + resubmit feature

### DIFF
--- a/.changeset/resubmit-continue-message.md
+++ b/.changeset/resubmit-continue-message.md
@@ -1,0 +1,12 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix resubmit to use [continue] message instead of empty string
+
+Empty string messages were being filtered out by the session, preventing
+automatic continuation. Now sends "[continue]" as a special marker that
+signals the model should analyze previously injected results.
+
+Also increased resubmit delay from 150ms to 500ms to ensure async
+operations complete before triggering continuation.

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1788,13 +1788,14 @@ export const createAgentExperience = (
   // Handle action:resubmit event - automatically trigger another model call
   // when an action handler needs the model to continue processing (e.g., analyzing search results)
   const resubmitUnsub = eventBus.on("action:resubmit", () => {
-    // Small delay to ensure UI has updated with injected message
+    // Delay to ensure async operations complete and UI has updated with injected message
     setTimeout(() => {
       if (session && !session.isStreaming()) {
-        // Send empty message to trigger model continuation with existing context
-        session.sendMessage("");
+        // Send continuation message to trigger model to analyze injected results
+        // Using a special marker that signals the model should continue with its analysis
+        session.sendMessage("[continue]");
       }
-    }, 150);
+    }, 500);
   });
   destroyCallbacks.push(resubmitUnsub);
 


### PR DESCRIPTION
## Summary
- Fix llmContent not being sent to server in client token mode
- Add resubmit feature for action handlers to trigger automatic model continuation
- Fix resubmit to use `[continue]` message instead of empty string

## Changes

### llmContent fix
- Add missing `llmContent` to content priority chain in client token dispatch
- Content priority now matches proxy mode: `contentParts > llmContent > rawContent > content`

### Resubmit feature
- Add `resubmit?: boolean` to `AgentWidgetActionHandlerResult` type
- Add `action:resubmit` event to `AgentWidgetControllerEventMap`
- When a handler returns `resubmit: true`, automatically trigger another model call
- Use `[continue]` marker message (empty strings were filtered)
- 500ms delay to allow async operations to complete

## Test plan
- [ ] Test llmContent is sent correctly in client token mode
- [ ] Test resubmit triggers model continuation after action handlers inject data
- [ ] Verify `[continue]` message triggers model to analyze injected results

🤖 Generated with [Claude Code](https://claude.com/claude-code)