### PR TITLE
fix: resolve race condition in action handler resubmit feature

### DIFF
--- a/.changeset/fix-resubmit-race-condition.md
+++ b/.changeset/fix-resubmit-race-condition.md
@@ -1,0 +1,11 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix race condition in action handler resubmit feature
+
+- Add `continueConversation()` method to session for triggering model continuation without adding a visible user message
+- Add `triggerResubmit()` function to action context, allowing handlers to trigger resubmit AFTER async work completes
+- Update resubmit handler to use `continueConversation()` instead of `sendMessage("[continue]")`
+- This fixes the race condition where resubmit would fire before async data was injected, causing the model to hallucinate results
+- The `[continue]` message is no longer visible to users

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -384,6 +384,64 @@ export class AgentWidgetSession {
     }
   }
 
+  /**
+   * Continue the conversation without adding a new user message.
+   * Triggers the model to respond based on the current conversation state.
+   *
+   * Use this for automatic continuation after action handlers inject data
+   * (e.g., search results) that the model should analyze.
+   *
+   * @example
+   * // After injecting search results, trigger model to analyze them
+   * session.injectAssistantMessage({ content: 'Found 5 products...' });
+   * session.continueConversation();
+   */
+  public async continueConversation() {
+    // Don't continue if already streaming
+    if (this.streaming) return;
+
+    this.abortController?.abort();
+
+    const assistantMessageId = generateAssistantMessageId();
+
+    this.setStreaming(true);
+
+    const controller = new AbortController();
+    this.abortController = controller;
+
+    const snapshot = [...this.messages];
+
+    try {
+      await this.client.dispatch(
+        {
+          messages: snapshot,
+          signal: controller.signal,
+          assistantMessageId
+        },
+        this.handleEvent
+      );
+    } catch (error) {
+      const fallback: AgentWidgetMessage = {
+        id: assistantMessageId,
+        role: "assistant",
+        createdAt: new Date().toISOString(),
+        content:
+          "It looks like the proxy isn't returning a real response yet. Here's a sample message so you can continue testing locally.",
+        sequence: this.nextSequence()
+      };
+
+      this.appendMessage(fallback);
+      this.setStatus("idle");
+      this.setStreaming(false);
+      this.abortController = null;
+      if (error instanceof Error) {
+        this.callbacks.onError?.(error);
+      } else {
+        this.callbacks.onError?.(new Error(String(error)));
+      }
+    }
+  }
+
   public cancel() {
     this.abortController?.abort();
     this.abortController = null;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -111,6 +111,21 @@ export type AgentWidgetActionContext = {
     updater: (prev: Record<string, unknown>) => Record<string, unknown>
   ) => void;
   document: Document | null;
+  /**
+   * Trigger automatic model continuation.
+   * Call this AFTER completing async operations (e.g., injecting search results)
+   * to have the model analyze the injected data.
+   *
+   * Use this instead of returning `resubmit: true` for handlers that do async work,
+   * as it ensures the continuation happens after the data is available in context.
+   *
+   * @example
+   * // In an action handler
+   * const results = await fetchProducts(query);
+   * session.injectAssistantMessage({ content: formatResults(results) });
+   * context.triggerResubmit();
+   */
+  triggerResubmit: () => void;
 };
 
 export type AgentWidgetActionHandler = (

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1788,14 +1788,14 @@ export const createAgentExperience = (
   // Handle action:resubmit event - automatically trigger another model call
   // when an action handler needs the model to continue processing (e.g., analyzing search results)
   const resubmitUnsub = eventBus.on("action:resubmit", () => {
-    // Delay to ensure async operations complete and UI has updated with injected message
+    // Short delay to allow UI to update with any injected messages
+    // Handlers should call context.triggerResubmit() AFTER their async work completes
     setTimeout(() => {
       if (session && !session.isStreaming()) {
-        // Send continuation message to trigger model to analyze injected results
-        // Using a special marker that signals the model should continue with its analysis
-        session.sendMessage("[continue]");
+        // Continue conversation without adding a visible user message
+        session.continueConversation();
       }
-    }, 500);
+    }, 100);
   });
   destroyCallbacks.push(resubmitUnsub);
 

--- a/packages/widget/src/utils/actions.ts
+++ b/packages/widget/src/utils/actions.ts
@@ -193,11 +193,18 @@ export const createActionManager = (options: ActionManagerOptions) => {
     for (const handler of options.handlers) {
       if (!handler) continue;
       try {
+        // Create triggerResubmit function that emits the resubmit event
+        // Handlers should call this AFTER async work completes (not return resubmit: true)
+        const triggerResubmit = () => {
+          options.emit("action:resubmit", eventPayload);
+        };
+
         const handlerResult = handler(action, {
           message: context.message,
           metadata: options.getSessionMetadata(),
           updateMetadata: options.updateSessionMetadata,
-          document: options.documentRef
+          document: options.documentRef,
+          triggerResubmit
         } as AgentWidgetActionContext) as AgentWidgetActionHandlerResult | void;
 
         if (!handlerResult) continue;


### PR DESCRIPTION
- Add continueConversation() method to session for silent model continuation
- Add triggerResubmit() to action context for handlers to call after async work
- Update UI to use continueConversation() instead of sendMessage("[continue]")
- Fixes issue where resubmit fired before injected data was available