### PR TITLE
fix: defer resubmit until after injectAssistantMessage

### DIFF
--- a/.changeset/injection-triggered-resubmit.md
+++ b/.changeset/injection-triggered-resubmit.md
@@ -1,0 +1,11 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix race condition with resubmit flag for async action handlers
+
+When an action handler returns `resubmit: true`, the library now waits for `injectAssistantMessage()` to be called before triggering the automatic model continuation. This prevents race conditions where the resubmit would fire before async operations (like API calls) completed, causing the model to hallucinate instead of using the injected data.
+
+Previously, the `action:resubmit` event was emitted immediately when the handler returned, which fired too early for handlers with async operations. Now, the resubmit is deferred until after the handler injects its results via `injectAssistantMessage()`.
+
+Handlers that use `context.triggerResubmit()` are unaffected and continue to work as before.

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -135,11 +135,12 @@ type Controller = {
 
 const buildPostprocessor = (
   cfg: AgentWidgetConfig | undefined,
-  actionManager?: ReturnType<typeof createActionManager>
+  actionManager?: ReturnType<typeof createActionManager>,
+  onResubmitRequested?: () => void
 ): MessageTransform => {
   // Create markdown processor from config if markdown config is provided
   // This allows users to enable markdown rendering via config.markdown
-  const markdownProcessor = cfg?.markdown 
+  const markdownProcessor = cfg?.markdown
     ? createMarkdownProcessorFromConfig(cfg.markdown)
     : null;
 
@@ -159,6 +160,11 @@ const buildPostprocessor = (
         // Mark message as non-persistable if persist is false
         if (!actionResult.persist) {
           (context.message as any).__skipPersist = true;
+        }
+        // Request deferred resubmit if handler requested it (and message is complete)
+        // The actual resubmit will be triggered when injectAssistantMessage is called
+        if (actionResult.resubmit && !context.streaming && onResubmitRequested) {
+          onResubmitRequested();
         }
       }
     }
@@ -266,7 +272,32 @@ export const createAgentExperience = (
   let prevLauncherEnabled = launcherEnabled;
   let prevHeaderLayout = config.layout?.header?.layout;
   let open = launcherEnabled ? autoExpand : true;
-  let postprocess = buildPostprocessor(config, actionManager);
+
+  // Track pending resubmit state for injection-triggered resubmit
+  // When a handler returns resubmit: true, we wait for injectAssistantMessage()
+  // to be called before triggering the actual resubmit (to avoid race conditions)
+  let pendingResubmit = false;
+  let pendingResubmitTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  const handleResubmitRequested = () => {
+    pendingResubmit = true;
+    // Clear any existing timeout
+    if (pendingResubmitTimeout) {
+      clearTimeout(pendingResubmitTimeout);
+    }
+    // Safety timeout - clear flag after 10s if no injection occurs
+    pendingResubmitTimeout = setTimeout(() => {
+      if (pendingResubmit) {
+        if (typeof console !== "undefined") {
+          // eslint-disable-next-line no-console
+          console.warn("[AgentWidget] Resubmit requested but no injection occurred within 10s");
+        }
+        pendingResubmit = false;
+      }
+    }, 10000);
+  };
+
+  let postprocess = buildPostprocessor(config, actionManager, handleResubmitRequested);
   let showReasoning = config.features?.showReasoning ?? true;
   let showToolCalls = config.features?.showToolCalls ?? true;
   
@@ -2687,7 +2718,7 @@ export const createAgentExperience = (
         documentRef: typeof document !== "undefined" ? document : null
       });
 
-      postprocess = buildPostprocessor(config, actionManager);
+      postprocess = buildPostprocessor(config, actionManager, handleResubmitRequested);
       session.updateConfig(config);
       renderMessagesWithPlugins(
         messagesWrapper,
@@ -3247,7 +3278,26 @@ export const createAgentExperience = (
       if (!open && launcherEnabled) {
         setOpenState(true, "system");
       }
-      return session.injectAssistantMessage(options);
+      const result = session.injectAssistantMessage(options);
+
+      // Check if we should trigger resubmit after injection
+      // This handles the case where a handler returned resubmit: true and then
+      // injected a message - we wait until after injection to trigger resubmit
+      if (pendingResubmit) {
+        pendingResubmit = false;
+        if (pendingResubmitTimeout) {
+          clearTimeout(pendingResubmitTimeout);
+          pendingResubmitTimeout = null;
+        }
+        // Short delay to ensure message is in context
+        setTimeout(() => {
+          if (session && !session.isStreaming()) {
+            session.continueConversation();
+          }
+        }, 100);
+      }
+
+      return result;
     },
     injectUserMessage(options: InjectUserMessageOptions): AgentWidgetMessage {
       // Auto-open widget if closed and launcher is enabled

--- a/packages/widget/src/utils/actions.ts
+++ b/packages/widget/src/utils/actions.ts
@@ -213,10 +213,8 @@ export const createActionManager = (options: ActionManagerOptions) => {
           // persistMessage defaults to true if not specified
           const persist = handlerResult.persistMessage !== false;
           const displayText = handlerResult.displayText !== undefined ? handlerResult.displayText : "";
-          // Emit resubmit event if handler requests automatic continuation
-          if (handlerResult.resubmit) {
-            options.emit("action:resubmit", eventPayload);
-          }
+          // Return resubmit flag - the caller (ui.ts) will handle deferred resubmit
+          // after injectAssistantMessage is called (to avoid race conditions with async handlers)
           return { text: displayText, persist, resubmit: handlerResult.resubmit };
         }
       } catch (error) {


### PR DESCRIPTION
## Summary

- Fixes race condition with `resubmit: true` flag for async action handlers
- When a handler returns `resubmit: true`, the library now waits for `injectAssistantMessage()` to be called before triggering the automatic model continuation
- This prevents models from hallucinating when async operations haven't completed yet

## Problem

Previously:
1. Handler returns `{ handled: true, resubmit: true }` immediately
2. Library immediately emits `action:resubmit` event
3. Event triggers `session.continueConversation()` after 100ms
4. But async fetch (products, orders, etc.) hasn't completed yet
5. Model hallucinates results instead of using injected data

## Solution

1. Remove immediate `action:resubmit` event emission from `actions.ts`
2. Add `pendingResubmit` state tracking in `ui.ts`
3. When handler returns `resubmit: true`, set flag and wait
4. When `injectAssistantMessage()` is called, check flag and trigger resubmit
5. Safety timeout clears flag after 10s if no injection occurs

## Backward Compatibility

- Handlers using `context.triggerResubmit()` continue to work unchanged
- The existing event listener remains for backward compatibility

## Test plan

- [ ] Test "search for X and tell me the cheapest" → model should analyze real results
- [ ] Test content page fetching → model should use fetched content
- [ ] Test actions without resubmit flag → no auto-continuation

🤖 Generated with [Claude Code](https://claude.com/claude-code)