### PR TITLE
feat: migrate to camelCase API convention

### DIFF
--- a/.changeset/camelcase-step-configs.md
+++ b/.changeset/camelcase-step-configs.md
@@ -1,0 +1,15 @@
+---
+"@runtypelabs/persona": patch
+"@runtypelabs/persona-proxy": patch
+---
+
+Complete camelCase migration for step config fields and add ESLint enforcement
+
+Proxy step config changes:
+- `response_format` → `responseFormat`
+- `output_variable` → `outputVariable`
+- `user_prompt` → `userPrompt`
+- `system_prompt` → `systemPrompt`
+- `previous_messages` → `previousMessages`
+
+ESLint rule added to prevent snake_case regression in API payloads.

--- a/packages/proxy/.eslintrc.cjs
+++ b/packages/proxy/.eslintrc.cjs
@@ -18,6 +18,27 @@ module.exports = {
   rules: {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }],
+    // Disallow snake_case in property names (catches API payload fields)
+    // Allows: camelCase, PascalCase, UPPER_CASE, kebab-case (CSS), colons (events), slashes (MIME)
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: "property",
+        format: null,
+        custom: {
+          // Fail if property contains underscore followed by lowercase (snake_case pattern)
+          // but allow leading underscore (_private) and ALL_CAPS constants
+          // Also excludes Stripe API fields via filter below
+          regex: "^(?!_).*_[a-z]",
+          match: false,
+        },
+        // Allow Stripe API snake_case fields (external API requirement)
+        filter: {
+          regex: "^(price_data|product_data|unit_amount|payment_method_types|success_url|cancel_url|line_items)",
+          match: false,
+        },
+      },
+    ],
   },
   ignorePatterns: ["dist/", "node_modules/"],
 };

--- a/packages/proxy/src/flows/conversational.ts
+++ b/packages/proxy/src/flows/conversational.ts
@@ -15,11 +15,11 @@ export const CONVERSATIONAL_FLOW: RuntypeFlowConfig = {
       enabled: true,
       config: {
         model: "meta/llama3.1-8b-instruct-free",
-        response_format: "markdown",
-        output_variable: "prompt_result",
-        user_prompt: "{{user_message}}",
-        system_prompt: "you are a helpful assistant, chatting with a user",
-        previous_messages: "{{messages}}"
+        responseFormat: "markdown",
+        outputVariable: "prompt_result",
+        userPrompt: "{{user_message}}",
+        systemPrompt: "you are a helpful assistant, chatting with a user",
+        previousMessages: "{{messages}}"
       }
     }
   ]

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -78,16 +78,16 @@ const DEFAULT_FLOW: RuntypeFlowConfig = {
       config: {
         model: "gemini-2.5-flash",
         // model: "gpt-4o",
-        response_format: "markdown",
-        output_variable: "prompt_result",
-        user_prompt: "{{user_message}}",
-        system_prompt: "you are a helpful assistant, chatting with a user",
+        responseFormat: "markdown",
+        outputVariable: "prompt_result",
+        userPrompt: "{{user_message}}",
+        systemPrompt: "you are a helpful assistant, chatting with a user",
         // tools: {
-        //   tool_ids: [
+        //   toolIds: [
         //     "builtin:dalle"
         //   ]
         // },
-        previous_messages: "{{messages}}"
+        previousMessages: "{{messages}}"
       }
     }
   ]

--- a/packages/widget/.eslintrc.cjs
+++ b/packages/widget/.eslintrc.cjs
@@ -22,6 +22,21 @@ module.exports = {
   rules: {
     "no-unused-vars": "off",
     "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_", varsIgnorePattern: "^_" }],
+    // Disallow snake_case in property names (catches API payload fields)
+    // Allows: camelCase, PascalCase, UPPER_CASE, kebab-case (CSS), colons (events), slashes (MIME)
+    "@typescript-eslint/naming-convention": [
+      "error",
+      {
+        selector: "property",
+        format: null,
+        custom: {
+          // Fail if property contains underscore followed by lowercase (snake_case pattern)
+          // but allow leading underscore (_private) and ALL_CAPS constants
+          regex: "^(?!_).*_[a-z]",
+          match: false,
+        },
+      },
+    ],
   },
   ignorePatterns: ["dist/", "node_modules/"],
 };

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1474,13 +1474,13 @@ export const createAgentExperience = (
     config = {
       ...config,
       getStoredSessionId: () => {
-        const storedId = persistentMetadata['session_id'];
+        const storedId = persistentMetadata['sessionId'];
         return typeof storedId === 'string' ? storedId : null;
       },
       setStoredSessionId: (sessionId: string) => {
         updateSessionMetadata((prev) => ({
           ...prev,
-          session_id: sessionId,
+          sessionId: sessionId,
         }));
       },
     };


### PR DESCRIPTION
## Summary

- Complete migration to camelCase for all Runtype API interactions
- Add ESLint rule to enforce camelCase naming convention and prevent regression
- Update step config fields in proxy flows to use camelCase

## Changes

### Proxy Package
- Options: `stream_response` → `streamResponse`, `record_mode` → `recordMode`, etc.
- Step configs: `response_format` → `responseFormat`, `user_prompt` → `userPrompt`, etc.

### Widget Package
- Client init/chat/feedback requests migrated to camelCase
- Session storage key: `session_id` → `sessionId`

### ESLint
- Added `@typescript-eslint/naming-convention` rule to catch snake_case properties
- Excludes legitimate non-camelCase patterns (HTTP headers, MIME types, CSS classes, event names)
- Proxy excludes Stripe API fields (external API requirement)

## Breaking Change

Requires Runtype API v2.x+ with camelCase support. The API maintains backward compatibility for snake_case, but new code should use camelCase.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes  
- [x] `pnpm build` passes
- [ ] Manual test with Runtype API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Completes camelCase migration and lints to prevent regression.
> 
> - **Proxy**: Step config fields in `flows/conversational.ts` and `src/index.ts` switched to `responseFormat`, `outputVariable`, `userPrompt`, `systemPrompt`, `previousMessages` (from snake_case).
> - **Widget**: Session persistence keys updated in client token mode (`session_id` → `sessionId`) via `getStoredSessionId`/`setStoredSessionId`.
> - **ESLint**: Adds `@typescript-eslint/naming-convention` to proxy and widget to disallow snake_case properties; proxy config whitelists Stripe fields.
> - **Changeset**: Notes patch releases for `@runtypelabs/persona` and `@runtypelabs/persona-proxy`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f398a27f5fbfd3be57be532234aa533e537a453e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->