### PR TITLE
Custom loading indicator

### DIFF
--- a/.changeset/2ac4d69e2ff8256f.md
+++ b/.changeset/2ac4d69e2ff8256f.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add custom loading indicator and idle state support. Users can now customize loading indicators via `loadingIndicator.render` and `loadingIndicator.renderIdle` config options, or through plugin hooks `renderLoadingIndicator` and `renderIdleIndicator`. Added `showBubble` option to control bubble styling around standalone loading indicators.

--- a/examples/embedded-app/custom-loading-indicator.html
+++ b/examples/embedded-app/custom-loading-indicator.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Custom Loading Indicator Demo</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+      background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+      color: #fff;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr 420px;
+      gap: 1.5rem;
+      padding: 1.5rem;
+      max-width: 1400px;
+      margin: 0 auto;
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+      min-height: 100vh;
+    }
+    @media (max-width: 900px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+    .panel {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+      overflow: hidden;
+    }
+    .info-panel {
+      background: rgba(255,255,255,0.05);
+      border-radius: 8px;
+      padding: 1.5rem;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .info-panel h1 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.5rem;
+    }
+    .info-panel p {
+      margin: 0 0 1.5rem 0;
+      color: #94a3b8;
+      line-height: 1.6;
+    }
+    .info-section {
+      background: rgba(0,0,0,0.2);
+      border-radius: 6px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .info-section h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.9rem;
+      color: #00ff88;
+    }
+    .info-section p {
+      margin: 0;
+      font-size: 0.85rem;
+      color: #94a3b8;
+    }
+    .code-block {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 1rem;
+      overflow-x: auto;
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      font-size: 0.75rem;
+      color: #c9d1d9;
+      margin-bottom: 1rem;
+    }
+    .code-block .comment { color: #8b949e; }
+    .code-block .keyword { color: #ff7b72; }
+    .code-block .string { color: #a5d6ff; }
+    .code-block .function { color: #d2a8ff; }
+    .widget-container {
+      height: 600px;
+    }
+    #loading-widget {
+      height: 100%;
+    }
+    .back-link {
+      display: inline-block;
+      background: rgba(255,255,255,0.1);
+      padding: 0.5rem 1rem;
+      margin: 1rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      color: #fff;
+      font-size: 0.9rem;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .back-link:hover {
+      background: rgba(255,255,255,0.15);
+    }
+    .preview-box {
+      background: #fff;
+      border-radius: 8px;
+      padding: 1rem 1.5rem;
+      display: inline-flex;
+      align-items: center;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+    .preview-label {
+      font-size: 0.875rem;
+      color: #666;
+    }
+    .toggle-section {
+      background: rgba(0,0,0,0.3);
+      border-radius: 6px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .toggle-section label {
+      font-size: 0.9rem;
+      color: #fff;
+    }
+    .toggle-switch {
+      position: relative;
+      width: 48px;
+      height: 24px;
+    }
+    .toggle-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #4b5563;
+      transition: 0.3s;
+      border-radius: 24px;
+    }
+    .toggle-slider:before {
+      position: absolute;
+      content: "";
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background-color: white;
+      transition: 0.3s;
+      border-radius: 50%;
+    }
+    .toggle-switch input:checked + .toggle-slider {
+      background-color: #00ff88;
+    }
+    .toggle-switch input:checked + .toggle-slider:before {
+      transform: translateX(24px);
+    }
+    .toggle-status {
+      font-size: 0.75rem;
+      color: #94a3b8;
+      margin-top: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="back-link">&larr; Back to examples</a>
+
+  <div class="layout">
+    <!-- Left: Info Panel -->
+    <div class="info-panel">
+      <h1>Custom Loading Indicator</h1>
+      <p>This example demonstrates how to replace the default bouncing dots loading indicator with a custom animated SVG.</p>
+
+      <div class="info-section">
+        <h3>How it works</h3>
+        <p>The <code>loadingIndicator.render</code> config option lets you provide a custom function that returns an HTMLElement. The function receives a context with the <code>location</code> ('standalone' or 'inline') so you can use different indicators in different places.</p>
+      </div>
+
+      <div class="info-section">
+        <h3>Animation Preservation</h3>
+        <p>Add <code>data-preserve-animation="true"</code> to your custom element to prevent the DOM morpher from interrupting CSS animations during updates.</p>
+      </div>
+
+      <div class="code-block">
+<span class="comment">// Custom loading indicator configuration</span>
+loadingIndicator: {
+  <span class="comment">// Hide bubble background/border for cleaner custom indicators</span>
+  showBubble: <span class="keyword">false</span>,
+  render: ({ location, defaultRenderer }) => {
+    <span class="keyword">if</span> (location === <span class="string">'standalone'</span>) {
+      <span class="comment">// Custom animated SVG for standalone</span>
+      <span class="keyword">return</span> <span class="function">createRuntypeLoader</span>();
+    }
+    <span class="comment">// Default dots for inline</span>
+    <span class="keyword">return</span> <span class="function">defaultRenderer</span>();
+  }
+}
+      </div>
+
+      <div class="info-section">
+        <h3>Location Types</h3>
+        <p><strong>standalone:</strong> Shown in its own bubble while waiting for the stream to start.<br>
+        <strong>inline:</strong> Shown inside the assistant message bubble when content is empty.</p>
+      </div>
+
+      <div class="info-section">
+        <h3>Bubble Visibility</h3>
+        <p>Set <code>showBubble: false</code> to hide the background, border, and shadow from the standalone indicator wrapper. This lets custom animated icons render without the default bubble styling.</p>
+      </div>
+
+      <div class="toggle-section">
+        <label for="bubble-toggle">Show Bubble</label>
+        <label class="toggle-switch">
+          <input type="checkbox" id="bubble-toggle">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+      <div class="toggle-status" id="toggle-status">Bubble: hidden (showBubble: false)</div>
+
+      <div class="info-section">
+        <h3>Idle State Indicator</h3>
+        <p>Show a custom indicator when the assistant is waiting for the next user message. Use <code>loadingIndicator.renderIdle</code> to customize what appears after a response completes.</p>
+      </div>
+
+      <div class="toggle-section">
+        <label for="idle-toggle">Show Idle Indicator</label>
+        <label class="toggle-switch">
+          <input type="checkbox" id="idle-toggle">
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+      <div class="toggle-status" id="idle-toggle-status">Idle indicator: disabled</div>
+
+      <div class="info-section">
+        <h3>Other Options</h3>
+        <p>Return <code>null</code> to hide the indicator entirely. You can also use a plugin's <code>renderLoadingIndicator</code> or <code>renderIdleIndicator</code> hooks for the same functionality.</p>
+      </div>
+    </div>
+
+    <!-- Right: Widget -->
+    <div class="panel widget-container">
+      <div id="loading-widget"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/custom-loading-indicator.ts"></script>
+</body>
+</html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -30,6 +30,7 @@
         <li><a href="/feedback-integration-demo.html">Feedback Integration Demo</a></li>
         <li><a href="/client-token-demo.html">Client Token Demo (Direct API)</a></li>
         <li><a href="/client-token-feedback-demo.html">Client Token Feedback Demo (Automatic Feedback)</a></li>
+        <li><a href="/custom-loading-indicator.html">Custom Loading Indicator</a></li>
       </ul>
       <div class="cta-row">
         <button id="open-chat" type="button">Open Launcher</button>

--- a/examples/embedded-app/src/bakery-demo.ts
+++ b/examples/embedded-app/src/bakery-demo.ts
@@ -1,4 +1,4 @@
-import "vanilla-agent/widget.css";
+import "@runtypelabs/persona/widget.css";
 import "./index.css";
 
 import {
@@ -11,7 +11,7 @@ import {
   DEFAULT_WIDGET_CONFIG,
   createLocalStorageAdapter,
   defaultActionHandlers
-} from "vanilla-agent";
+} from "@runtypelabs/persona";
 import {
   collectPageContext,
   formatPageContext,
@@ -28,7 +28,7 @@ import {
   saveOrder,
   STORAGE_KEY
 } from "./middleware";
-import { createFlexibleJsonStreamParser } from "vanilla-agent";
+import { createFlexibleJsonStreamParser } from "@runtypelabs/persona";
 import type {
   AgentWidgetStorageAdapter,
   AgentWidgetStoredState,
@@ -1187,7 +1187,7 @@ widgetController.on('widget:closed', () => {
 });
 
 // Clear state when chat is cleared
-window.addEventListener("vanilla-agent:clear-chat", () => {
+window.addEventListener("persona:clear-chat", () => {
   console.log("[Bakery] Clear chat event received");
   processedActionIds.clear();
   clearOrder();

--- a/examples/embedded-app/src/custom-loading-indicator.ts
+++ b/examples/embedded-app/src/custom-loading-indicator.ts
@@ -1,0 +1,539 @@
+import "@runtypelabs/persona/widget.css";
+import {
+  createAgentExperience,
+  markdownPostprocessor,
+  DEFAULT_WIDGET_CONFIG,
+  createTypingIndicator
+} from "@runtypelabs/persona";
+import type { LoadingIndicatorRenderContext, IdleIndicatorRenderContext } from "@runtypelabs/persona";
+
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const proxyUrl =
+  import.meta.env.VITE_PROXY_URL
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
+    : `http://localhost:${proxyPort}/api/chat/dispatch`;
+
+// Function to create the animated SVG loading indicator
+function createRuntypeLoader(): HTMLElement {
+  const container = document.createElement("div");
+  container.style.cssText = "width: 40px; height: 35px; perspective: 500px;";
+  // Add data-preserve-animation to prevent morphing from interrupting the animation
+  container.setAttribute("data-preserve-animation", "true");
+
+  container.innerHTML = `
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 5.761835 5.0342874"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <style>
+          @keyframes rotateIn {
+            0% {
+              opacity: 0;
+              transform: rotateY(90deg) rotateX(45deg);
+            }
+            50% {
+              opacity: 1;
+            }
+            100% {
+              opacity: 1;
+              transform: rotateY(0deg) rotateX(0deg);
+            }
+          }
+          @keyframes rRotateIn {
+            0% {
+              opacity: 0;
+              transform: rotateY(-180deg) rotateZ(45deg);
+            }
+            100% {
+              opacity: 1;
+              transform: rotateY(0deg) rotateZ(0deg);
+            }
+          }
+          .bg-square {
+            fill: none;
+            stroke: #9ca3af;
+            stroke-width: 0.03;
+            opacity: 0;
+            transform-origin: center;
+            transform-box: fill-box;
+          }
+          .r-square-group {
+            opacity: 0;
+            transform-origin: center;
+            transform-box: fill-box;
+          }
+          .r-square-group rect {
+            fill: none;
+            stroke: #1f2937;
+            stroke-width: 0.03;
+          }
+          .r-square-group line {
+            stroke: #1f2937;
+            stroke-width: 0.03;
+          }
+          /* Staggered 3D rotation for each square */
+          .sq0 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0s; }
+          .sq1 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.04s; }
+          .sq2 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.08s; }
+          .sq3 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.12s; }
+          .sq4 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.16s; }
+          .sq5 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.2s; }
+          .sq6 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.24s; }
+          .sq7 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.28s; }
+          .sq8 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.06s; }
+          .sq9 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.1s; }
+          .sq10 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.14s; }
+          .sq11 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.18s; }
+          .sq12 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.22s; }
+          .sq13 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.26s; }
+          .sq14 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.3s; }
+          .sq15 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.34s; }
+          .sq16 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.12s; }
+          .sq17 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.16s; }
+          .sq18 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.2s; }
+          .sq19 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.24s; }
+          .sq20 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.28s; }
+          .sq21 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.32s; }
+          .sq22 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.36s; }
+          .sq23 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.4s; }
+          .sq24 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.18s; }
+          .sq25 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.22s; }
+          .sq26 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.26s; }
+          .sq27 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.3s; }
+          .sq28 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.34s; }
+          .sq29 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.38s; }
+          .sq30 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.42s; }
+          .sq31 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.46s; }
+          .sq32 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.24s; }
+          .sq33 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.28s; }
+          .sq34 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.32s; }
+          .sq35 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.36s; }
+          .sq36 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.4s; }
+          .sq37 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.44s; }
+          .sq38 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.48s; }
+          .sq39 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.52s; }
+          .sq40 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.3s; }
+          .sq41 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.34s; }
+          .sq42 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.38s; }
+          .sq43 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.42s; }
+          .sq44 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.46s; }
+          .sq45 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.5s; }
+          .sq46 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.54s; }
+          .sq47 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.58s; }
+          .sq48 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.36s; }
+          .sq49 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.4s; }
+          .sq50 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.44s; }
+          .sq51 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.48s; }
+          .sq52 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.52s; }
+          .sq53 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.56s; }
+          .sq54 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.6s; }
+          .sq55 { animation: rotateIn 0.6s ease-out forwards; animation-delay: 0.64s; }
+          /* R letter squares rotate in with staggered delays */
+          .r-sq0 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.2s; }
+          .r-sq1 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.3s; }
+          .r-sq2 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.4s; }
+          .r-sq3 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.5s; }
+          .r-sq4 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.6s; }
+          .r-sq5 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.7s; }
+          .r-sq6 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.8s; }
+          .r-sq7 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 1.9s; }
+          .r-sq8 { animation: rRotateIn 0.8s ease-out forwards; animation-delay: 2.0s; }
+        </style>
+      </defs>
+      <g transform="matrix(0.75837457,0,0,0.75837457,-597.36163,-129.28708)">
+        <!-- Background grid squares - 8 columns x 7 rows = 56 squares -->
+        <!-- Row 0 -->
+        <rect class="bg-square sq0" x="787.68679" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq1" x="788.65759" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq2" x="789.62839" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq3" x="790.59919" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq4" x="791.56999" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq5" x="792.54079" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq6" x="793.51159" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq7" x="794.48239" y="170.47919" width="0.79733" height="0.79733" />
+        <!-- Row 1 -->
+        <rect class="bg-square sq8" x="787.68679" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq9" x="788.65759" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq10" x="789.62839" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq11" x="790.59919" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq12" x="791.56999" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq13" x="792.54079" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq14" x="793.51159" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq15" x="794.48239" y="171.45086" width="0.79733" height="0.79733" />
+        <!-- Row 2 -->
+        <rect class="bg-square sq16" x="787.68679" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq17" x="788.65759" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq18" x="789.62839" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq19" x="790.59919" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq20" x="791.56999" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq21" x="792.54079" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq22" x="793.51159" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq23" x="794.48239" y="172.42253" width="0.79733" height="0.79733" />
+        <!-- Row 3 -->
+        <rect class="bg-square sq24" x="787.68679" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq25" x="788.65759" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq26" x="789.62839" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq27" x="790.59919" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq28" x="791.56999" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq29" x="792.54079" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq30" x="793.51159" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq31" x="794.48239" y="173.39419" width="0.79733" height="0.79733" />
+        <!-- Row 4 -->
+        <rect class="bg-square sq32" x="787.68679" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq33" x="788.65759" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq34" x="789.62839" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq35" x="790.59919" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq36" x="791.56999" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq37" x="792.54079" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq38" x="793.51159" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq39" x="794.48239" y="174.36586" width="0.79733" height="0.79733" />
+        <!-- Row 5 -->
+        <rect class="bg-square sq40" x="787.68679" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq41" x="788.65759" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq42" x="789.62839" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq43" x="790.59919" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq44" x="791.56999" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq45" x="792.54079" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq46" x="793.51159" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq47" x="794.48239" y="175.33752" width="0.79733" height="0.79733" />
+        <!-- Row 6 -->
+        <rect class="bg-square sq48" x="787.68679" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq49" x="788.65759" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq50" x="789.62839" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq51" x="790.59919" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq52" x="791.56999" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq53" x="792.54079" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq54" x="793.51159" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="bg-square sq55" x="794.48239" y="176.30919" width="0.79733" height="0.79733" />
+
+        <!-- "r" letter as outlined squares with diagonal lines (polygon style) -->
+        <!-- Row 2: columns 3, 5, 6 -->
+        <g class="r-square-group r-sq0">
+          <rect x="790.59919" y="172.42253" width="0.79733" height="0.79733" />
+          <line x1="790.59919" y1="172.42253" x2="791.39652" y2="173.21986" />
+        </g>
+        <g class="r-square-group r-sq1">
+          <rect x="792.54079" y="172.42253" width="0.79733" height="0.79733" />
+          <line x1="792.54079" y1="172.42253" x2="793.33812" y2="173.21986" />
+        </g>
+        <g class="r-square-group r-sq2">
+          <rect x="793.51159" y="172.42253" width="0.79733" height="0.79733" />
+          <line x1="793.51159" y1="172.42253" x2="794.30892" y2="173.21986" />
+        </g>
+        <!-- Row 3: columns 3, 4, 7 -->
+        <g class="r-square-group r-sq3">
+          <rect x="790.59919" y="173.39419" width="0.79733" height="0.79733" />
+          <line x1="790.59919" y1="173.39419" x2="791.39652" y2="174.19152" />
+        </g>
+        <g class="r-square-group r-sq4">
+          <rect x="791.56999" y="173.39419" width="0.79733" height="0.79733" />
+          <line x1="791.56999" y1="173.39419" x2="792.36732" y2="174.19152" />
+        </g>
+        <g class="r-square-group r-sq5">
+          <rect x="794.48239" y="173.39419" width="0.79733" height="0.79733" />
+          <line x1="794.48239" y1="173.39419" x2="795.27972" y2="174.19152" />
+        </g>
+        <!-- Row 4: column 3 -->
+        <g class="r-square-group r-sq6">
+          <rect x="790.59919" y="174.36586" width="0.79733" height="0.79733" />
+          <line x1="790.59919" y1="174.36586" x2="791.39652" y2="175.16319" />
+        </g>
+        <!-- Row 5: column 3 -->
+        <g class="r-square-group r-sq7">
+          <rect x="790.59919" y="175.33752" width="0.79733" height="0.79733" />
+          <line x1="790.59919" y1="175.33752" x2="791.39652" y2="176.13485" />
+        </g>
+        <!-- Row 6: column 3 -->
+        <g class="r-square-group r-sq8">
+          <rect x="790.59919" y="176.30919" width="0.79733" height="0.79733" />
+          <line x1="790.59919" y1="176.30919" x2="791.39652" y2="177.10652" />
+        </g>
+      </g>
+    </svg>
+  `;
+
+  return container;
+}
+
+// Function to create the randomized color assembly idle indicator using CSS animations
+function createIdleIndicator(): HTMLElement {
+  const container = document.createElement("div");
+  container.style.cssText = "display: flex; align-items: center; gap: 10px;";
+  // Add data-preserve-animation to prevent morphing from interrupting the animation
+  container.setAttribute("data-preserve-animation", "true");
+
+  // Create icon container
+  const iconContainer = document.createElement("div");
+  iconContainer.style.cssText = "width: 24px; height: 21px; flex-shrink: 0;";
+
+  // Generate CSS keyframes for each square with random color cycling
+  // Total animation: 8s cycle (4s color cycling, 2s settle to gray, 2s show R)
+  const colors = ['#FF6B6B', '#4ECDC4', '#45B7D1', '#96CEB4', '#FFEAA7', '#DDA0DD', '#98D8C8', '#F7DC6F', '#BB8FCE', '#85C1E9', '#F8B500', '#00CED1'];
+
+  // Generate unique random color sequences for each of the 56 squares
+  let squareKeyframes = '';
+  for (let i = 0; i < 56; i++) {
+    // Each square gets ~40 color changes over 4 seconds (every 100ms = 10% of 4s out of 8s = 5%)
+    // We'll use 8 keyframe stops for the color cycling phase (0-50% of animation)
+    const colorStops = [];
+    for (let j = 0; j <= 8; j++) {
+      const percent = (j * 50 / 8).toFixed(1);
+      const color = colors[Math.floor(Math.random() * colors.length)];
+      colorStops.push(`${percent}% { fill: ${color}; fill-opacity: 0.8; }`);
+    }
+    // Settle phase: transition to gray (50% to 75%)
+    const settleDelay = (i * 0.4).toFixed(1); // Staggered settle
+    colorStops.push(`${Math.min(50 + parseFloat(settleDelay), 74).toFixed(1)}% { fill: ${colors[Math.floor(Math.random() * colors.length)]}; fill-opacity: 0.8; }`);
+    colorStops.push(`${Math.min(52 + parseFloat(settleDelay), 75).toFixed(1)}% { fill: #333333; fill-opacity: 0.15; }`);
+    colorStops.push(`100% { fill: #333333; fill-opacity: 0.15; }`);
+
+    squareKeyframes += `
+      @keyframes idle-sq${i} {
+        ${colorStops.join('\n        ')}
+      }
+    `;
+  }
+
+  iconContainer.innerHTML = `
+    <svg
+      width="100%"
+      height="100%"
+      viewBox="0 0 5.761835 5.0342874"
+      version="1.1"
+      xmlns="http://www.w3.org/2000/svg">
+      <defs>
+        <style>
+          ${squareKeyframes}
+
+          @keyframes idle-r-fade {
+            0%, 70% { fill-opacity: 0; }
+            80%, 100% { fill-opacity: 1; }
+          }
+
+          .idle-bg-square {
+            fill: #333333;
+            fill-opacity: 0.15;
+          }
+          ${Array.from({length: 56}, (_, i) => `.idle-sq${i} { animation: idle-sq${i} 8s ease-in-out forwards; }`).join('\n          ')}
+
+          .idle-r-square {
+            fill: #333333;
+            fill-opacity: 0;
+            animation: idle-r-fade 8s ease-in-out forwards;
+          }
+        </style>
+      </defs>
+      <g transform="matrix(0.75837457,0,0,0.75837457,-597.36163,-129.28708)">
+        <!-- Background grid squares - 8 columns x 7 rows = 56 squares -->
+        <!-- Row 0 -->
+        <rect class="idle-bg-square idle-sq0" x="787.68679" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq1" x="788.65759" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq2" x="789.62839" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq3" x="790.59919" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq4" x="791.56999" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq5" x="792.54079" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq6" x="793.51159" y="170.47919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq7" x="794.48239" y="170.47919" width="0.79733" height="0.79733" />
+        <!-- Row 1 -->
+        <rect class="idle-bg-square idle-sq8" x="787.68679" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq9" x="788.65759" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq10" x="789.62839" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq11" x="790.59919" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq12" x="791.56999" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq13" x="792.54079" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq14" x="793.51159" y="171.45086" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq15" x="794.48239" y="171.45086" width="0.79733" height="0.79733" />
+        <!-- Row 2 -->
+        <rect class="idle-bg-square idle-sq16" x="787.68679" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq17" x="788.65759" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq18" x="789.62839" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq19" x="790.59919" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq20" x="791.56999" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq21" x="792.54079" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq22" x="793.51159" y="172.42253" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq23" x="794.48239" y="172.42253" width="0.79733" height="0.79733" />
+        <!-- Row 3 -->
+        <rect class="idle-bg-square idle-sq24" x="787.68679" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq25" x="788.65759" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq26" x="789.62839" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq27" x="790.59919" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq28" x="791.56999" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq29" x="792.54079" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq30" x="793.51159" y="173.39419" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq31" x="794.48239" y="173.39419" width="0.79733" height="0.79733" />
+        <!-- Row 4 -->
+        <rect class="idle-bg-square idle-sq32" x="787.68679" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq33" x="788.65759" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq34" x="789.62839" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq35" x="790.59919" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq36" x="791.56999" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq37" x="792.54079" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq38" x="793.51159" y="174.36586" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq39" x="794.48239" y="174.36586" width="0.79733" height="0.79733" />
+        <!-- Row 5 -->
+        <rect class="idle-bg-square idle-sq40" x="787.68679" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq41" x="788.65759" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq42" x="789.62839" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq43" x="790.59919" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq44" x="791.56999" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq45" x="792.54079" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq46" x="793.51159" y="175.33752" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq47" x="794.48239" y="175.33752" width="0.79733" height="0.79733" />
+        <!-- Row 6 -->
+        <rect class="idle-bg-square idle-sq48" x="787.68679" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq49" x="788.65759" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq50" x="789.62839" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq51" x="790.59919" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq52" x="791.56999" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq53" x="792.54079" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq54" x="793.51159" y="176.30919" width="0.79733" height="0.79733" />
+        <rect class="idle-bg-square idle-sq55" x="794.48239" y="176.30919" width="0.79733" height="0.79733" />
+
+        <!-- Solid "r" letter squares -->
+        <path
+           class="idle-r-square"
+           d="m 790.61041,172.43346 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z m 1.94333,0 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z m 0.97166,0 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z m -2.91499,0.97166 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z m 0.97167,0 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z m 2.91499,0 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z m -3.88666,0.97167 v 0 h -0.01 v 0.01 0.77734 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77734 -0.01 h -0.01 z m 0,0.97166 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z m 0,0.97167 v 0 h -0.01 v 0.01 0.77733 0.01 h 0.01 0.77733 0.01 v -0.01 -0.77733 -0.01 h -0.01 z"
+           aria-label="r" />
+      </g>
+    </svg>
+  `;
+
+  // Create text element
+  const textElement = document.createElement("span");
+  textElement.style.cssText = "font-size: 13px; font-weight: 300; color: #6b7280;";
+  textElement.textContent = "What would you like to do next?";
+
+  // Assemble the container
+  container.appendChild(iconContainer);
+  container.appendChild(textElement);
+
+  return container;
+}
+
+// Initialize widget
+const mount = document.getElementById("loading-widget");
+if (!mount) throw new Error("Widget mount not found");
+
+// Track current visibility states
+let showBubble = false;
+let showIdleIndicator = false;
+
+function createWidget(showBubbleOption: boolean, showIdleOption: boolean) {
+  // Clear existing content
+  mount.innerHTML = "";
+
+  return createAgentExperience(mount, {
+    ...DEFAULT_WIDGET_CONFIG,
+    apiUrl: proxyUrl,
+    launcher: {
+      ...DEFAULT_WIDGET_CONFIG.launcher,
+      enabled: false,
+      width: "100%"
+    },
+    theme: {
+      ...DEFAULT_WIDGET_CONFIG.theme,
+      primary: "#1a1a2e",
+      accent: "#00ff88",
+      surface: "#ffffff"
+    },
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Custom Loading Demo",
+      welcomeSubtitle: "Send a message to see the custom loading indicator!",
+      inputPlaceholder: "Type a message..."
+    },
+    suggestionChips: [
+      "Tell me a story",
+      "What's the weather like?",
+      "Help me plan a trip"
+    ],
+
+    // Custom loading indicator configuration
+    loadingIndicator: {
+      // Control bubble background/border visibility
+      showBubble: showBubbleOption,
+      render: (context: LoadingIndicatorRenderContext) => {
+        // Use custom Runtype loader for standalone indicator
+        // Use default bouncing dots for inline (inside message bubble)
+        if (context.location === "standalone") {
+          return createRuntypeLoader();
+        }
+        return createTypingIndicator();
+      },
+      // Idle state indicator - shows when assistant is waiting for next message
+      renderIdle: (context: IdleIndicatorRenderContext) => {
+        // Only show idle indicator if enabled and after assistant responses
+        if (!showIdleOption) return null;
+        if (context.lastMessage?.role !== "assistant") return null;
+        return createIdleIndicator();
+      }
+    },
+
+    postprocessMessage: ({ text }) => markdownPostprocessor(text)
+  });
+}
+
+// Create initial widget
+let controller = createWidget(showBubble, showIdleIndicator);
+
+// Set up toggle listeners
+const bubbleToggle = document.getElementById("bubble-toggle") as HTMLInputElement | null;
+const toggleStatus = document.getElementById("toggle-status");
+const idleToggle = document.getElementById("idle-toggle") as HTMLInputElement | null;
+const idleToggleStatus = document.getElementById("idle-toggle-status");
+
+function updateToggleStatus(checked: boolean) {
+  if (toggleStatus) {
+    toggleStatus.textContent = checked
+      ? "Bubble: visible (showBubble: true)"
+      : "Bubble: hidden (showBubble: false)";
+  }
+}
+
+function updateIdleToggleStatus(checked: boolean) {
+  if (idleToggleStatus) {
+    idleToggleStatus.textContent = checked
+      ? "Idle indicator: enabled (renderIdle returns element)"
+      : "Idle indicator: disabled (renderIdle returns null)";
+  }
+}
+
+function recreateWidget() {
+  controller = createWidget(showBubble, showIdleIndicator);
+  // Update window reference
+  (window as unknown as { loadingController: typeof controller }).loadingController = controller;
+}
+
+if (bubbleToggle) {
+  // Set initial state
+  bubbleToggle.checked = showBubble;
+  updateToggleStatus(showBubble);
+
+  bubbleToggle.addEventListener("change", () => {
+    showBubble = bubbleToggle.checked;
+    updateToggleStatus(showBubble);
+    recreateWidget();
+    console.log(`Bubble visibility changed to: ${showBubble}`);
+  });
+}
+
+if (idleToggle) {
+  // Set initial state
+  idleToggle.checked = showIdleIndicator;
+  updateIdleToggleStatus(showIdleIndicator);
+
+  idleToggle.addEventListener("change", () => {
+    showIdleIndicator = idleToggle.checked;
+    updateIdleToggleStatus(showIdleIndicator);
+    recreateWidget();
+    console.log(`Idle indicator changed to: ${showIdleIndicator}`);
+  });
+}
+
+// Make controller available for debugging
+(window as unknown as { loadingController: typeof controller }).loadingController = controller;
+
+console.log("Custom loading indicator demo initialized");

--- a/examples/embedded-app/src/middleware.ts
+++ b/examples/embedded-app/src/middleware.ts
@@ -32,10 +32,10 @@ export type PageElement = {
   tagName: string;
 };
 
-export const STORAGE_KEY = "vanilla-agent-action-middleware";
-const NAV_FLAG_KEY = "vanilla-agent-nav-flag";
-const EXECUTED_ACTIONS_KEY = "vanilla-agent-executed-actions"; // Track which message IDs have had actions executed
-export const ORDER_STORAGE_KEY = "vanilla-agent-order";
+export const STORAGE_KEY = "runtype-persona-action-middleware";
+const NAV_FLAG_KEY = "runtype-persona-nav-flag";
+const EXECUTED_ACTIONS_KEY = "runtype-persona-executed-actions"; // Track which message IDs have had actions executed
+export const ORDER_STORAGE_KEY = "runtype-persona-order";
 
 // Expiry times for order cleanup
 const ORDER_EXPIRY_MS = 24 * 60 * 60 * 1000; // 24 hours for completed orders

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -568,6 +568,157 @@ type AgentWidgetMessageActionsConfig = {
 - **Copy button**: Shows a checkmark briefly after successful copy
 - **Vote buttons**: Toggle active state and are mutually exclusive (upvoting clears downvote and vice versa)
 
+### Loading & Idle Indicators
+
+The widget displays visual indicators during different states of the conversation:
+
+- **Loading indicator**: Shown while waiting for a response (standalone) or when an assistant message is streaming but has no content yet (inline)
+- **Idle indicator**: Shown when the widget is idle (not streaming) and has at least one message - useful for showing the assistant is "waiting" for user input
+
+#### Configuration
+
+```ts
+const controller = initAgentWidget({
+  target: '#app',
+  config: {
+    apiUrl: '/api/chat/dispatch',
+
+    loadingIndicator: {
+      // Show/hide bubble styling around standalone indicator (default: true)
+      showBubble: false,
+
+      // Custom loading indicator renderer
+      render: ({ location, config, defaultRenderer }) => {
+        // location: 'standalone' (separate bubble) or 'inline' (inside message)
+        if (location === 'standalone') {
+          const el = document.createElement('div');
+          el.innerHTML = '<svg class="spinner">...</svg>';
+          el.setAttribute('data-preserve-animation', 'true');
+          return el;
+        }
+        // Use default 3-dot bouncing indicator for inline
+        return defaultRenderer();
+      },
+
+      // Custom idle state indicator (shown after response completes)
+      renderIdle: ({ lastMessage, messageCount, config }) => {
+        // Only show after assistant messages
+        if (lastMessage?.role !== 'assistant') return null;
+
+        const el = document.createElement('div');
+        el.textContent = 'What would you like to do next?';
+        el.setAttribute('data-preserve-animation', 'true');
+        return el;
+      }
+    }
+  }
+});
+```
+
+#### Indicator Locations
+
+| Location | When Shown | Description |
+|----------|------------|-------------|
+| `standalone` | Waiting for stream to start | Separate bubble shown after user sends a message |
+| `inline` | Streaming with empty content | Inside the assistant message bubble |
+| `idle` | Not streaming, has messages | After assistant finishes responding |
+
+#### Animation Preservation
+
+When using custom animated indicators, add the `data-preserve-animation="true"` attribute to prevent the DOM morpher from interrupting CSS animations during updates:
+
+```ts
+render: () => {
+  const el = document.createElement('div');
+  el.setAttribute('data-preserve-animation', 'true');
+  el.innerHTML = `
+    <style>
+      @keyframes spin { to { transform: rotate(360deg); } }
+      .spinner { animation: spin 1s linear infinite; }
+    </style>
+    <div class="spinner">⟳</div>
+  `;
+  return el;
+}
+```
+
+#### Hiding Indicators
+
+Return `null` from any render function to hide that indicator:
+
+```ts
+loadingIndicator: {
+  // Hide loading indicator entirely
+  render: () => null,
+
+  // Hide idle indicator (default behavior)
+  renderIdle: () => null
+}
+```
+
+#### Using Plugins
+
+You can also customize indicators via plugins, which take priority over config:
+
+```ts
+const customIndicatorPlugin = {
+  id: 'custom-indicators',
+
+  renderLoadingIndicator: ({ location, defaultRenderer }) => {
+    if (location === 'standalone') {
+      return createCustomSpinner();
+    }
+    return defaultRenderer();
+  },
+
+  renderIdleIndicator: ({ lastMessage, messageCount }) => {
+    if (messageCount === 0) return null;
+    if (lastMessage?.role !== 'assistant') return null;
+    return createIdleAnimation();
+  }
+};
+
+initAgentWidget({
+  target: '#app',
+  config: {
+    plugins: [customIndicatorPlugin]
+  }
+});
+```
+
+#### Type Definitions
+
+```typescript
+// Loading indicator context
+type LoadingIndicatorRenderContext = {
+  config: AgentWidgetConfig;
+  streaming: boolean;
+  location: 'inline' | 'standalone';
+  defaultRenderer: () => HTMLElement;
+};
+
+// Idle indicator context
+type IdleIndicatorRenderContext = {
+  config: AgentWidgetConfig;
+  lastMessage: AgentWidgetMessage | undefined;
+  messageCount: number;
+};
+
+// Configuration
+type AgentWidgetLoadingIndicatorConfig = {
+  showBubble?: boolean;
+  render?: (context: LoadingIndicatorRenderContext) => HTMLElement | null;
+  renderIdle?: (context: IdleIndicatorRenderContext) => HTMLElement | null;
+};
+```
+
+#### Priority Chain
+
+Indicators are resolved in this order:
+1. **Plugin hook** (`renderLoadingIndicator` / `renderIdleIndicator`)
+2. **Config function** (`loadingIndicator.render` / `loadingIndicator.renderIdle`)
+3. **Default** (3-dot bouncing animation for loading, `null` for idle)
+
 ### Runtype adapter
 
 This package ships with a Runtype adapter by default. The proxy handles all flow configuration, keeping the client lightweight and flexible.

--- a/packages/widget/src/components/composer-builder.ts
+++ b/packages/widget/src/components/composer-builder.ts
@@ -85,7 +85,7 @@ export const buildComposer = (context: ComposerBuildContext): ComposerElements =
   const textarea = createElement("textarea") as HTMLTextAreaElement;
   textarea.placeholder = config?.copy?.inputPlaceholder ?? "Type your message…";
   textarea.className =
-    "tvw-w-full tvw-min-h-[24px] tvw-resize-none tvw-border-none tvw-bg-transparent tvw-text-sm tvw-text-cw-primary focus:tvw-outline-none focus:tvw-border-none";
+    "tvw-w-full tvw-min-h-[24px] tvw-resize-none tvw-border-none tvw-bg-transparent tvw-text-sm tvw-text-cw-primary focus:tvw-outline-none focus:tvw-border-none tvw-composer-textarea";
   textarea.rows = 1;
 
   // Apply font family and weight from config

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -1,13 +1,16 @@
 import { createElement } from "../utils/dom";
-import { 
-  AgentWidgetMessage, 
+import {
+  AgentWidgetMessage,
   AgentWidgetMessageLayoutConfig,
   AgentWidgetAvatarConfig,
   AgentWidgetTimestampConfig,
   AgentWidgetMessageActionsConfig,
-  AgentWidgetMessageFeedback
+  AgentWidgetMessageFeedback,
+  LoadingIndicatorRenderContext
 } from "../types";
 import { renderLucideIcon } from "../utils/icons";
+
+export type LoadingIndicatorRenderer = (context: LoadingIndicatorRenderContext) => HTMLElement | null;
 
 export type MessageTransform = (context: {
   text: string;
@@ -48,6 +51,35 @@ export const createTypingIndicator = (): HTMLElement => {
   container.appendChild(srOnly);
 
   return container;
+};
+
+/**
+ * Render loading indicator with fallback chain:
+ * 1. Custom renderer (if provided and returns non-null)
+ * 2. Default typing indicator
+ */
+export const renderLoadingIndicatorWithFallback = (
+  location: 'inline' | 'standalone',
+  customRenderer?: LoadingIndicatorRenderer,
+  widgetConfig?: import("../types").AgentWidgetConfig
+): HTMLElement | null => {
+  const context: LoadingIndicatorRenderContext = {
+    config: widgetConfig ?? ({} as import("../types").AgentWidgetConfig),
+    streaming: true,
+    location,
+    defaultRenderer: createTypingIndicator
+  };
+
+  // Try custom renderer first
+  if (customRenderer) {
+    const result = customRenderer(context);
+    if (result !== null) {
+      return result;
+    }
+  }
+
+  // Fall back to default
+  return createTypingIndicator();
 };
 
 /**
@@ -395,6 +427,20 @@ export const createMessageActions = (
 };
 
 /**
+ * Options for creating a standard message bubble
+ */
+export type CreateStandardBubbleOptions = {
+  /**
+   * Custom loading indicator renderer for inline location
+   */
+  loadingIndicatorRenderer?: LoadingIndicatorRenderer;
+  /**
+   * Full widget config (needed for loading indicator context)
+   */
+  widgetConfig?: import("../types").AgentWidgetConfig;
+};
+
+/**
  * Create standard message bubble
  * Supports layout configuration for avatars, timestamps, and visual presets
  */
@@ -403,7 +449,8 @@ export const createStandardBubble = (
   transform: MessageTransform,
   layoutConfig?: AgentWidgetMessageLayoutConfig,
   actionsConfig?: AgentWidgetMessageActionsConfig,
-  actionCallbacks?: MessageActionCallbacks
+  actionCallbacks?: MessageActionCallbacks,
+  options?: CreateStandardBubbleOptions
 ): HTMLElement => {
   const config = layoutConfig ?? {};
   const layout = config.layout ?? "bubble";
@@ -449,8 +496,15 @@ export const createStandardBubble = (
   // Add typing indicator if this is a streaming assistant message
   if (message.streaming && message.role === "assistant") {
     if (!message.content || !message.content.trim()) {
-      const typingIndicator = createTypingIndicator();
-      bubble.appendChild(typingIndicator);
+      // Use custom renderer if provided, otherwise default
+      const indicator = renderLoadingIndicatorWithFallback(
+        'inline',
+        options?.loadingIndicatorRenderer,
+        options?.widgetConfig
+      );
+      if (indicator) {
+        bubble.appendChild(indicator);
+      }
     }
   }
 
@@ -502,7 +556,8 @@ export const createBubbleWithLayout = (
   transform: MessageTransform,
   layoutConfig?: AgentWidgetMessageLayoutConfig,
   actionsConfig?: AgentWidgetMessageActionsConfig,
-  actionCallbacks?: MessageActionCallbacks
+  actionCallbacks?: MessageActionCallbacks,
+  options?: CreateStandardBubbleOptions
 ): HTMLElement => {
   const config = layoutConfig ?? {};
 
@@ -524,5 +579,5 @@ export const createBubbleWithLayout = (
   }
 
   // Fall back to standard bubble
-  return createStandardBubble(message, transform, layoutConfig, actionsConfig, actionCallbacks);
+  return createStandardBubble(message, transform, layoutConfig, actionsConfig, actionCallbacks, options);
 };

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -53,7 +53,12 @@ export type {
   InjectMessageOptions,
   InjectAssistantMessageOptions,
   InjectUserMessageOptions,
-  InjectSystemMessageOptions
+  InjectSystemMessageOptions,
+  // Loading indicator types
+  LoadingIndicatorRenderContext,
+  AgentWidgetLoadingIndicatorConfig,
+  // Idle indicator types
+  IdleIndicatorRenderContext
 } from "./types";
 
 export { initAgentWidgetFn as initAgentWidget };
@@ -169,9 +174,15 @@ export {
   createStandardBubble,
   createBubbleWithLayout,
   createTypingIndicator,
-  createMessageActions
+  createMessageActions,
+  renderLoadingIndicatorWithFallback
 } from "./components/message-bubble";
-export type { MessageTransform, MessageActionCallbacks } from "./components/message-bubble";
+export type {
+  MessageTransform,
+  MessageActionCallbacks,
+  LoadingIndicatorRenderer,
+  CreateStandardBubbleOptions
+} from "./components/message-bubble";
 export {
   createCSATFeedback,
   createNPSFeedback

--- a/packages/widget/src/plugins/types.ts
+++ b/packages/widget/src/plugins/types.ts
@@ -1,4 +1,4 @@
-import { AgentWidgetMessage, AgentWidgetConfig } from "../types";
+import { AgentWidgetMessage, AgentWidgetConfig, LoadingIndicatorRenderContext, IdleIndicatorRenderContext } from "../types";
 
 /**
  * Plugin interface for customizing widget components
@@ -74,6 +74,43 @@ export interface AgentWidgetPlugin {
     defaultRenderer: () => HTMLElement;
     config: AgentWidgetConfig;
   }) => HTMLElement | null;
+
+  /**
+   * Custom renderer for loading indicator
+   * Return null to use default renderer (or config-based renderer)
+   *
+   * @example
+   * ```typescript
+   * renderLoadingIndicator: ({ location, defaultRenderer }) => {
+   *   if (location === 'standalone') {
+   *     const el = document.createElement('div');
+   *     el.textContent = 'Thinking...';
+   *     return el;
+   *   }
+   *   return defaultRenderer();
+   * }
+   * ```
+   */
+  renderLoadingIndicator?: (context: LoadingIndicatorRenderContext) => HTMLElement | null;
+
+  /**
+   * Custom renderer for idle state indicator.
+   * Called when the widget is idle (not streaming) and has at least one message.
+   * Return an HTMLElement to display, or null to hide (default).
+   *
+   * @example
+   * ```typescript
+   * renderIdleIndicator: ({ lastMessage, messageCount }) => {
+   *   if (messageCount === 0) return null;
+   *   if (lastMessage?.role !== 'assistant') return null;
+   *   const el = document.createElement('div');
+   *   el.className = 'idle-pulse';
+   *   el.setAttribute('data-preserve-animation', 'true');
+   *   return el;
+   * }
+   * ```
+   */
+  renderIdleIndicator?: (context: IdleIndicatorRenderContext) => HTMLElement | null;
 
   /**
    * Called when plugin is registered

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -687,6 +687,13 @@
   box-shadow: none !important;
 }
 
+/* Prevent iOS Safari from zooming on input focus (requires 16px minimum) */
+@media (hover: none) and (pointer: coarse) {
+  .tvw-composer-textarea {
+    font-size: 1rem !important;
+  }
+}
+
 /* Prevent form container from showing focus styles */
 .tvw-widget-composer:focus-within {
   outline: none !important;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1256,6 +1256,146 @@ export type AgentWidgetPersistStateConfig = {
   clearOnChatClear?: boolean;
 };
 
+// ============================================================================
+// Loading Indicator Types
+// ============================================================================
+
+/**
+ * Context provided to loading indicator render functions.
+ * Used for customizing the loading indicator appearance.
+ */
+export type LoadingIndicatorRenderContext = {
+  /**
+   * Full widget configuration for accessing theme, etc.
+   */
+  config: AgentWidgetConfig;
+  /**
+   * Current streaming state (always true when indicator is shown)
+   */
+  streaming: boolean;
+  /**
+   * Location where the indicator is rendered:
+   * - 'inline': Inside a streaming assistant message bubble (when content is empty)
+   * - 'standalone': Separate bubble while waiting for stream to start
+   */
+  location: 'inline' | 'standalone';
+  /**
+   * Function to render the default 3-dot bouncing indicator.
+   * Call this if you want to use the default for certain cases.
+   */
+  defaultRenderer: () => HTMLElement;
+};
+
+/**
+ * Context provided to idle indicator render functions.
+ * Used for customizing the idle state indicator appearance.
+ */
+export type IdleIndicatorRenderContext = {
+  /**
+   * Full widget configuration for accessing theme, etc.
+   */
+  config: AgentWidgetConfig;
+  /**
+   * The last message in the conversation (if any).
+   * Useful for conditional rendering based on who spoke last.
+   */
+  lastMessage: AgentWidgetMessage | undefined;
+  /**
+   * Total number of messages in the conversation.
+   */
+  messageCount: number;
+};
+
+/**
+ * Configuration for customizing the loading indicator.
+ * The loading indicator is shown while waiting for a response or
+ * when an assistant message is streaming but has no content yet.
+ *
+ * @example
+ * ```typescript
+ * // Custom animated spinner
+ * config: {
+ *   loadingIndicator: {
+ *     render: ({ location }) => {
+ *       const el = document.createElement('div');
+ *       el.innerHTML = '<svg class="spinner">...</svg>';
+ *       el.setAttribute('data-preserve-animation', 'true');
+ *       return el;
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Different indicators by location
+ * config: {
+ *   loadingIndicator: {
+ *     render: ({ location, defaultRenderer }) => {
+ *       if (location === 'inline') {
+ *         return defaultRenderer(); // Use default for inline
+ *       }
+ *       // Custom for standalone
+ *       const el = document.createElement('div');
+ *       el.textContent = 'Thinking...';
+ *       return el;
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * @example
+ * ```typescript
+ * // Hide loading indicator entirely
+ * config: {
+ *   loadingIndicator: {
+ *     render: () => null
+ *   }
+ * }
+ * ```
+ */
+export type AgentWidgetLoadingIndicatorConfig = {
+  /**
+   * Whether to show the bubble background and border around the standalone loading indicator.
+   * Set to false to render the loading indicator without any bubble styling.
+   * @default true
+   */
+  showBubble?: boolean;
+
+  /**
+   * Custom render function for the loading indicator.
+   * Return an HTMLElement to display, or null to hide the indicator.
+   *
+   * For custom animations, add `data-preserve-animation="true"` attribute
+   * to prevent the DOM morpher from interrupting the animation.
+   */
+  render?: (context: LoadingIndicatorRenderContext) => HTMLElement | null;
+
+  /**
+   * Render function for the idle state indicator.
+   * Called when the widget is idle (not streaming) and has at least one message.
+   * Return an HTMLElement to display, or null to hide (default).
+   *
+   * For animations, add `data-preserve-animation="true"` attribute
+   * to prevent the DOM morpher from interrupting the animation.
+   *
+   * @example
+   * ```typescript
+   * loadingIndicator: {
+   *   renderIdle: ({ lastMessage }) => {
+   *     // Only show idle indicator after assistant messages
+   *     if (lastMessage?.role !== 'assistant') return null;
+   *     const el = document.createElement('div');
+   *     el.className = 'pulse-dot';
+   *     el.setAttribute('data-preserve-animation', 'true');
+   *     return el;
+   *   }
+   * }
+   * ```
+   */
+  renderIdle?: (context: IdleIndicatorRenderContext) => HTMLElement | null;
+};
+
 export type AgentWidgetConfig = {
   apiUrl?: string;
   flowId?: string;
@@ -1693,6 +1833,29 @@ export type AgentWidgetConfig = {
    * ```
    */
   persistState?: boolean | AgentWidgetPersistStateConfig;
+
+  /**
+   * Configuration for customizing the loading indicator.
+   * The loading indicator is shown while waiting for a response or
+   * when an assistant message is streaming but has no content yet.
+   *
+   * @example
+   * ```typescript
+   * config: {
+   *   loadingIndicator: {
+   *     render: ({ location, defaultRenderer }) => {
+   *       if (location === 'standalone') {
+   *         const el = document.createElement('div');
+   *         el.textContent = 'Thinking...';
+   *         return el;
+   *       }
+   *       return defaultRenderer();
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  loadingIndicator?: AgentWidgetLoadingIndicatorConfig;
 };
 
 export type AgentWidgetMessageRole = "user" | "assistant" | "system";

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -17,7 +17,9 @@ import {
   InjectMessageOptions,
   InjectAssistantMessageOptions,
   InjectUserMessageOptions,
-  InjectSystemMessageOptions
+  InjectSystemMessageOptions,
+  LoadingIndicatorRenderContext,
+  IdleIndicatorRenderContext
 } from "./types";
 import { AttachmentManager } from "./utils/attachment-manager";
 import { createTextPart, ALL_SUPPORTED_MIME_TYPES } from "./utils/content";
@@ -31,7 +33,7 @@ import { createWrapper, buildPanel, buildHeader, buildComposer, attachHeaderToCo
 import { buildHeaderWithLayout } from "./components/header-layouts";
 import { positionMap } from "./utils/positioning";
 import type { HeaderElements as _HeaderElements, ComposerElements as _ComposerElements } from "./components/panel";
-import { MessageTransform, MessageActionCallbacks } from "./components/message-bubble";
+import { MessageTransform, MessageActionCallbacks, LoadingIndicatorRenderer } from "./components/message-bubble";
 import { createStandardBubble, createTypingIndicator } from "./components/message-bubble";
 import { createReasoningBubble, reasoningExpansionState, updateReasoningBubbleUI } from "./components/reasoning-bubble";
 import { createToolBubble, toolExpansionState, updateToolBubbleUI } from "./components/tool-bubble";
@@ -1150,6 +1152,25 @@ export const createAgentExperience = (
     // Build new content in a temporary container for morphing
     const tempContainer = document.createElement("div");
 
+    // Create inline loading indicator renderer using priority chain: plugin -> config -> default
+    const getInlineLoadingIndicatorRenderer = (): LoadingIndicatorRenderer | undefined => {
+      // Check if any plugin has renderLoadingIndicator
+      const loadingPlugin = plugins.find(p => p.renderLoadingIndicator);
+      if (loadingPlugin?.renderLoadingIndicator) {
+        return loadingPlugin.renderLoadingIndicator;
+      }
+
+      // Check if config has loadingIndicator.render
+      if (config.loadingIndicator?.render) {
+        return config.loadingIndicator.render;
+      }
+
+      // Return undefined to use default in createStandardBubble
+      return undefined;
+    };
+
+    const inlineLoadingRenderer = getInlineLoadingIndicatorRenderer();
+
     messages.forEach((message) => {
       let bubble: HTMLElement | null = null;
 
@@ -1190,11 +1211,15 @@ export const createAgentExperience = (
             message,
             defaultRenderer: () => {
               const b = createStandardBubble(
-                message, 
-                transform, 
-                messageLayoutConfig, 
-                config.messageActions, 
-                messageActionCallbacks
+                message,
+                transform,
+                messageLayoutConfig,
+                config.messageActions,
+                messageActionCallbacks,
+                {
+                  loadingIndicatorRenderer: inlineLoadingRenderer,
+                  widgetConfig: config
+                }
               );
               if (message.role !== "user") {
                 enhanceWithForms(b, message, config, session);
@@ -1278,11 +1303,15 @@ export const createAgentExperience = (
             });
           } else {
             bubble = createStandardBubble(
-              message, 
-              transform, 
-              messageLayoutConfig, 
-              config.messageActions, 
-              messageActionCallbacks
+              message,
+              transform,
+              messageLayoutConfig,
+              config.messageActions,
+              messageActionCallbacks,
+              {
+                loadingIndicatorRenderer: inlineLoadingRenderer,
+                widgetConfig: config
+              }
             );
           }
           if (message.role !== "user" && bubble) {
@@ -1316,34 +1345,133 @@ export const createAgentExperience = (
     const hasRecentAssistantResponse = lastMessage?.role === "assistant" && !lastMessage.streaming;
 
     if (isStreaming && messages.some((msg) => msg.role === "user") && !hasStreamingAssistantMessage && !hasRecentAssistantResponse) {
-      const typingIndicator = createTypingIndicator();
+      // Get loading indicator using priority chain: plugin -> config -> default
+      const loadingIndicatorContext: LoadingIndicatorRenderContext = {
+        config,
+        streaming: true,
+        location: 'standalone',
+        defaultRenderer: createTypingIndicator
+      };
 
-      // Create a bubble wrapper for the typing indicator (similar to assistant messages)
-      const typingBubble = document.createElement("div");
-      typingBubble.className = [
-        "tvw-max-w-[85%]",
-        "tvw-rounded-2xl",
-        "tvw-text-sm",
-        "tvw-leading-relaxed",
-        "tvw-shadow-sm",
-        "tvw-bg-cw-surface",
-        "tvw-border",
-        "tvw-border-cw-message-border",
-        "tvw-text-cw-primary",
-        "tvw-px-5",
-        "tvw-py-3"
-      ].join(" ");
-      typingBubble.setAttribute("data-typing-indicator", "true");
+      // Try plugin renderLoadingIndicator first
+      const loadingPlugin = plugins.find(p => p.renderLoadingIndicator);
+      let typingIndicator: HTMLElement | null = null;
 
-      typingBubble.appendChild(typingIndicator);
+      if (loadingPlugin?.renderLoadingIndicator) {
+        typingIndicator = loadingPlugin.renderLoadingIndicator(loadingIndicatorContext);
+      }
 
-      const typingWrapper = document.createElement("div");
-      typingWrapper.className = "tvw-flex";
-      // Set id for idiomorph matching
-      typingWrapper.id = "wrapper-typing-indicator";
-      typingWrapper.setAttribute("data-wrapper-id", "typing-indicator");
-      typingWrapper.appendChild(typingBubble);
-      tempContainer.appendChild(typingWrapper);
+      // Try config loadingIndicator.render if no plugin handled it
+      if (typingIndicator === null && config.loadingIndicator?.render) {
+        typingIndicator = config.loadingIndicator.render(loadingIndicatorContext);
+      }
+
+      // Fall back to default
+      if (typingIndicator === null) {
+        typingIndicator = createTypingIndicator();
+      }
+
+      // Only render if we have an indicator (allows hiding via returning null)
+      if (typingIndicator) {
+        // Create a bubble wrapper for the typing indicator (similar to assistant messages)
+        const typingBubble = document.createElement("div");
+        const showBubble = config.loadingIndicator?.showBubble !== false; // default true
+        typingBubble.className = showBubble
+          ? [
+              "tvw-max-w-[85%]",
+              "tvw-rounded-2xl",
+              "tvw-text-sm",
+              "tvw-leading-relaxed",
+              "tvw-shadow-sm",
+              "tvw-bg-cw-surface",
+              "tvw-border",
+              "tvw-border-cw-message-border",
+              "tvw-text-cw-primary",
+              "tvw-px-5",
+              "tvw-py-3"
+            ].join(" ")
+          : [
+              "tvw-max-w-[85%]",
+              "tvw-text-sm",
+              "tvw-leading-relaxed",
+              "tvw-text-cw-primary"
+            ].join(" ");
+        typingBubble.setAttribute("data-typing-indicator", "true");
+
+        typingBubble.appendChild(typingIndicator);
+
+        const typingWrapper = document.createElement("div");
+        typingWrapper.className = "tvw-flex";
+        // Set id for idiomorph matching
+        typingWrapper.id = "wrapper-typing-indicator";
+        typingWrapper.setAttribute("data-wrapper-id", "typing-indicator");
+        typingWrapper.appendChild(typingBubble);
+        tempContainer.appendChild(typingWrapper);
+      }
+    }
+
+    // Render idle state indicator when not streaming and has messages
+    if (!isStreaming && messages.length > 0) {
+      const lastMessage = messages[messages.length - 1];
+
+      // Create context for idle indicator render functions
+      const idleIndicatorContext: IdleIndicatorRenderContext = {
+        config,
+        lastMessage,
+        messageCount: messages.length
+      };
+
+      // Get idle indicator using priority chain: plugin -> config -> null (default)
+      // Try plugin renderIdleIndicator first
+      const idlePlugin = plugins.find(p => p.renderIdleIndicator);
+      let idleIndicator: HTMLElement | null = null;
+
+      if (idlePlugin?.renderIdleIndicator) {
+        idleIndicator = idlePlugin.renderIdleIndicator(idleIndicatorContext);
+      }
+
+      // Try config loadingIndicator.renderIdle if no plugin handled it
+      if (idleIndicator === null && config.loadingIndicator?.renderIdle) {
+        idleIndicator = config.loadingIndicator.renderIdle(idleIndicatorContext);
+      }
+
+      // Only render if we have an indicator (default is null - no idle indicator)
+      if (idleIndicator) {
+        // Create a wrapper for the idle indicator (similar to typing indicator)
+        const idleBubble = document.createElement("div");
+        const showBubble = config.loadingIndicator?.showBubble !== false; // default true
+        idleBubble.className = showBubble
+          ? [
+              "tvw-max-w-[85%]",
+              "tvw-rounded-2xl",
+              "tvw-text-sm",
+              "tvw-leading-relaxed",
+              "tvw-shadow-sm",
+              "tvw-bg-cw-surface",
+              "tvw-border",
+              "tvw-border-cw-message-border",
+              "tvw-text-cw-primary",
+              "tvw-px-5",
+              "tvw-py-3"
+            ].join(" ")
+          : [
+              "tvw-max-w-[85%]",
+              "tvw-text-sm",
+              "tvw-leading-relaxed",
+              "tvw-text-cw-primary"
+            ].join(" ");
+        idleBubble.setAttribute("data-idle-indicator", "true");
+
+        idleBubble.appendChild(idleIndicator);
+
+        const idleWrapper = document.createElement("div");
+        idleWrapper.className = "tvw-flex";
+        // Set id for idiomorph matching
+        idleWrapper.id = "wrapper-idle-indicator";
+        idleWrapper.setAttribute("data-wrapper-id", "idle-indicator");
+        idleWrapper.appendChild(idleBubble);
+        tempContainer.appendChild(idleWrapper);
+      }
     }
 
     // Use idiomorph to morph the container contents

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -3763,11 +3763,11 @@ export const createAgentExperience = (
 
         // Listen for clear chat event
         const handleClearChat = () => clearPersistState();
-        window.addEventListener('vanilla-agent:clear-chat', handleClearChat);
+        window.addEventListener('persona:clear-chat', handleClearChat);
 
         // Clean up listener on destroy
         destroyCallbacks.push(() => {
-          window.removeEventListener('vanilla-agent:clear-chat', handleClearChat);
+          window.removeEventListener('persona:clear-chat', handleClearChat);
         });
       }
     }

--- a/packages/widget/src/utils/morph.ts
+++ b/packages/widget/src/utils/morph.ts
@@ -25,8 +25,10 @@ export const morphMessages = (
         if (!(oldNode instanceof HTMLElement)) return;
 
         // Preserve typing indicator dots to maintain animation continuity
+        // Also preserve elements with data-preserve-animation attribute for custom loading indicators
         if (preserveTypingAnimation) {
-          if (oldNode.classList.contains("tvw-animate-typing")) {
+          if (oldNode.classList.contains("tvw-animate-typing") ||
+              oldNode.hasAttribute("data-preserve-animation")) {
             return false;
           }
         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,8 @@ importers:
         specifier: ^5.4.1
         version: 5.4.20(@types/node@20.19.22)
 
+  examples/standalone-widget: {}
+
   examples/vercel-edge:
     dependencies:
       '@hono/node-server':


### PR DESCRIPTION
Add custom loading indicator and idle state support. Users can now customize loading indicators via `loadingIndicator.render` and `loadingIndicator.renderIdle` config options, or through plugin hooks `renderLoadingIndicator` and `renderIdleIndicator`.

Added `showBubble` option to control bubble styling around standalone loading indicators.