### PR TITLE
feat: agent event support

### DIFF
--- a/.changeset/agent-loop-execution.md
+++ b/.changeset/agent-loop-execution.md
@@ -1,5 +1,8 @@
 ---
 "@runtypelabs/persona": minor
+"@runtypelabs/persona-proxy": minor
 ---
 
 Add agent loop execution support. The widget can now operate in agent mode by setting `config.agent` with a model, system prompt, and loop configuration instead of using `flowId`. Handles all agent-specific SSE events including `agent_turn_delta` (text and thinking content), `agent_tool_*`, `agent_reflection`, and `agent_iteration_*`. Added configurable `iterationDisplay` option (`'separate'` or `'merged'`) to control how multiple agent iterations appear in the chat UI. New exported types: `AgentConfig`, `AgentLoopConfig`, `AgentRequestOptions`, `AgentExecutionState`, `AgentMessageMetadata`, `AgentWidgetAgentRequestPayload`.
+
+The proxy now detects agent payloads (requests containing an `agent` field) and forwards them as-is to the upstream API instead of converting them into flow dispatch payloads.

--- a/.changeset/agent-loop-execution.md
+++ b/.changeset/agent-loop-execution.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add agent loop execution support. The widget can now operate in agent mode by setting `config.agent` with a model, system prompt, and loop configuration instead of using `flowId`. Handles all agent-specific SSE events including `agent_turn_delta` (text and thinking content), `agent_tool_*`, `agent_reflection`, and `agent_iteration_*`. Added configurable `iterationDisplay` option (`'separate'` or `'merged'`) to control how multiple agent iterations appear in the chat UI. New exported types: `AgentConfig`, `AgentLoopConfig`, `AgentRequestOptions`, `AgentExecutionState`, `AgentMessageMetadata`, `AgentWidgetAgentRequestPayload`.

--- a/examples/embedded-app/agent-demo.html
+++ b/examples/embedded-app/agent-demo.html
@@ -1,0 +1,251 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Agent Loop Execution Demo</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+      background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+      color: #fff;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr 420px;
+      gap: 1.5rem;
+      padding: 1.5rem;
+      max-width: 1400px;
+      margin: 0 auto;
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+      min-height: 100vh;
+    }
+    @media (max-width: 900px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+    .panel {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+      overflow: hidden;
+    }
+    .info-panel {
+      background: rgba(255,255,255,0.05);
+      border-radius: 8px;
+      padding: 1.5rem;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .info-panel h1 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.5rem;
+    }
+    .info-panel p {
+      margin: 0 0 1.5rem 0;
+      color: #94a3b8;
+      line-height: 1.6;
+    }
+    .info-section {
+      background: rgba(0,0,0,0.2);
+      border-radius: 6px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .info-section h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.9rem;
+      color: #38bdf8;
+    }
+    .info-section p {
+      margin: 0;
+      font-size: 0.85rem;
+      color: #94a3b8;
+    }
+    .code-block {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 1rem;
+      overflow-x: auto;
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      font-size: 0.75rem;
+      color: #c9d1d9;
+      margin-bottom: 1rem;
+    }
+    .code-block .comment { color: #8b949e; }
+    .code-block .keyword { color: #ff7b72; }
+    .code-block .string { color: #a5d6ff; }
+    .code-block .prop { color: #79c0ff; }
+    .widget-container {
+      height: 600px;
+    }
+    #agent-widget {
+      height: 100%;
+    }
+    .back-link {
+      display: inline-block;
+      background: rgba(255,255,255,0.1);
+      padding: 0.5rem 1rem;
+      margin: 1rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      color: #fff;
+      font-size: 0.9rem;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .back-link:hover {
+      background: rgba(255,255,255,0.15);
+    }
+    .toggle-section {
+      background: rgba(0,0,0,0.3);
+      border-radius: 6px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+    .toggle-section label {
+      font-size: 0.9rem;
+      color: #fff;
+    }
+    .toggle-switch {
+      position: relative;
+      width: 48px;
+      height: 24px;
+    }
+    .toggle-switch input {
+      opacity: 0;
+      width: 0;
+      height: 0;
+    }
+    .toggle-slider {
+      position: absolute;
+      cursor: pointer;
+      top: 0;
+      left: 0;
+      right: 0;
+      bottom: 0;
+      background-color: #4b5563;
+      transition: 0.3s;
+      border-radius: 24px;
+    }
+    .toggle-slider:before {
+      position: absolute;
+      content: "";
+      height: 18px;
+      width: 18px;
+      left: 3px;
+      bottom: 3px;
+      background-color: white;
+      transition: 0.3s;
+      border-radius: 50%;
+    }
+    .toggle-switch input:checked + .toggle-slider {
+      background-color: #38bdf8;
+    }
+    .toggle-switch input:checked + .toggle-slider:before {
+      transform: translateX(24px);
+    }
+    .toggle-status {
+      font-size: 0.75rem;
+      color: #94a3b8;
+      margin-top: 0.5rem;
+    }
+    .badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    .badge-new {
+      background: #38bdf8;
+      color: #0f172a;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="back-link">&larr; Back to examples</a>
+
+  <div class="layout">
+    <!-- Left: Info Panel -->
+    <div class="info-panel">
+      <h1>Agent Loop Execution <span class="badge badge-new">New</span></h1>
+      <p>This demo shows the new agent execution mode with multi-iteration loops. Instead of dispatching to a pre-configured flow, the widget sends an agent configuration directly and handles streaming agent events.</p>
+
+      <div class="info-section">
+        <h3>How it works</h3>
+        <p>Set <code>config.agent</code> with a model, system prompt, and loop config. The widget sends this to the dispatch API and handles agent-specific SSE events: <code>agent_start</code>, <code>agent_turn_delta</code>, <code>agent_tool_*</code>, <code>agent_iteration_*</code>, and <code>agent_complete</code>.</p>
+      </div>
+
+      <div class="code-block">
+<span class="comment">// Agent execution configuration</span>
+{
+  <span class="prop">agent</span>: {
+    <span class="prop">name</span>: <span class="string">'Assistant'</span>,
+    <span class="prop">model</span>: <span class="string">'openai:gpt-4o-mini'</span>,
+    <span class="prop">systemPrompt</span>: <span class="string">'You are a helpful assistant.'</span>,
+    <span class="prop">temperature</span>: 0.7,
+    <span class="prop">loopConfig</span>: {
+      <span class="prop">maxIterations</span>: 3,
+      <span class="prop">stopCondition</span>: <span class="string">'auto'</span>
+    }
+  },
+  <span class="prop">agentOptions</span>: {
+    <span class="prop">streamResponse</span>: <span class="keyword">true</span>,
+    <span class="prop">recordMode</span>: <span class="string">'virtual'</span>
+  }
+}
+      </div>
+
+      <div class="info-section">
+        <h3>Iteration Display</h3>
+        <p>Control how multiple iterations appear in the chat with <code>iterationDisplay</code>:<br>
+        <strong>separate:</strong> Each iteration creates its own message bubble.<br>
+        <strong>merged:</strong> All iterations stream into a single message.</p>
+      </div>
+
+      <div class="toggle-section">
+        <label for="iteration-toggle">Separate Messages Per Iteration</label>
+        <label class="toggle-switch">
+          <input type="checkbox" id="iteration-toggle" checked>
+          <span class="toggle-slider"></span>
+        </label>
+      </div>
+      <div class="toggle-status" id="iteration-status">iterationDisplay: 'separate'</div>
+
+      <div class="info-section">
+        <h3>Agent Events</h3>
+        <p>The widget handles these agent-specific SSE events:</p>
+        <p style="margin-top: 0.5rem; font-family: monospace; font-size: 0.75rem; line-height: 1.8;">
+          agent_start &rarr; agent_iteration_start &rarr; agent_turn_start &rarr; agent_turn_delta (text/thinking) &rarr; agent_turn_complete &rarr; agent_tool_start/delta/complete &rarr; agent_iteration_complete &rarr; agent_complete
+        </p>
+      </div>
+
+      <div class="info-section">
+        <h3>Thinking Content</h3>
+        <p>When <code>contentType: 'thinking'</code> is received in <code>agent_turn_delta</code>, it appears as a reasoning bubble (same as extended thinking in flow mode).</p>
+      </div>
+
+      <div class="info-section">
+        <h3>Backward Compatible</h3>
+        <p>Agent mode is opt-in. Without <code>config.agent</code>, the widget uses flow dispatch as before. Both modes share the same SSE streaming infrastructure.</p>
+      </div>
+    </div>
+
+    <!-- Right: Widget -->
+    <div class="panel widget-container">
+      <div id="agent-widget"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/agent-demo.ts"></script>
+</body>
+</html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -31,6 +31,7 @@
         <li><a href="/client-token-demo.html">Client Token Demo (Direct API)</a></li>
         <li><a href="/client-token-feedback-demo.html">Client Token Feedback Demo (Automatic Feedback)</a></li>
         <li><a href="/custom-loading-indicator.html">Custom Loading Indicator</a></li>
+        <li><a href="/agent-demo.html">Agent Loop Execution Demo</a></li>
       </ul>
       <div class="cta-row">
         <button id="open-chat" type="button">Open Launcher</button>

--- a/examples/embedded-app/src/agent-demo.ts
+++ b/examples/embedded-app/src/agent-demo.ts
@@ -1,0 +1,97 @@
+import "@runtypelabs/persona/widget.css";
+
+import {
+  createAgentExperience,
+  markdownPostprocessor,
+  DEFAULT_WIDGET_CONFIG
+} from "@runtypelabs/persona";
+
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const apiUrl =
+  import.meta.env.VITE_PROXY_URL
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
+    : `http://localhost:${proxyPort}/api/chat/dispatch`;
+
+// ── State ──────────────────────────────────────────────────────
+let iterationDisplay: 'separate' | 'merged' = 'separate';
+
+// ── Mount ──────────────────────────────────────────────────────
+const mount = document.getElementById("agent-widget");
+if (!mount) throw new Error("Agent widget mount node missing");
+
+function createWidget() {
+  mount!.innerHTML = "";
+
+  createAgentExperience(mount!, {
+    ...DEFAULT_WIDGET_CONFIG,
+    apiUrl,
+
+    // Agent execution config (replaces flowId)
+    agent: {
+      name: "Assistant",
+      model: "openai:gpt-4o-mini",
+      systemPrompt:
+        "You are a helpful, friendly AI assistant. Be concise and clear in your responses. Use markdown formatting when helpful.",
+      temperature: 0.7,
+      loopConfig: {
+        maxIterations: 3,
+        stopCondition: "auto",
+      },
+    },
+    agentOptions: {
+      streamResponse: true,
+      recordMode: "virtual",
+      storeResults: false,
+    },
+
+    // Iteration display mode (toggled by UI)
+    iterationDisplay,
+
+    // Widget chrome
+    launcher: {
+      ...DEFAULT_WIDGET_CONFIG.launcher,
+      width: "100%",
+      enabled: false,
+    },
+    theme: {
+      ...DEFAULT_WIDGET_CONFIG.theme,
+      primary: "#0f172a",
+      accent: "#38bdf8",
+      surface: "#f8fafc",
+      muted: "#64748b",
+    },
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Agent Loop Demo",
+      welcomeSubtitle:
+        "This widget uses agent execution mode with multi-iteration loops instead of a pre-configured flow.",
+      inputPlaceholder: "Ask the agent anything...",
+    },
+    suggestionChips: [
+      "Write me a haiku about coding",
+      "What is the meaning of life?",
+      "Explain recursion simply",
+    ],
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+  });
+}
+
+// Initial render
+createWidget();
+
+// ── Toggle: Iteration Display ──────────────────────────────────
+const iterationToggle = document.getElementById("iteration-toggle") as HTMLInputElement | null;
+const iterationStatus = document.getElementById("iteration-status");
+
+if (iterationToggle) {
+  iterationToggle.checked = iterationDisplay === "separate";
+
+  iterationToggle.addEventListener("change", () => {
+    iterationDisplay = iterationToggle.checked ? "separate" : "merged";
+    if (iterationStatus) {
+      iterationStatus.textContent = `iterationDisplay: '${iterationDisplay}'`;
+    }
+    // Recreate widget with new config
+    createWidget();
+  });
+}

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -33,6 +33,8 @@ export default defineConfig({
         'navigation-persist-demo': path.resolve(__dirname, 'navigation-persist-demo.html'),
         'navigation-persist-page2': path.resolve(__dirname, 'navigation-persist-page2.html'),
         'preview-mode-demo': path.resolve(__dirname, 'preview-mode-demo.html'),
+        // Agent demo
+        'agent-demo': path.resolve(__dirname, 'agent-demo.html'),
         // Bakery demo pages
         'bakery': path.resolve(__dirname, 'bakery.html'),
         'bakery-story': path.resolve(__dirname, 'bakery-story.html'),

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -218,11 +218,7 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
       );
     }
 
-    let clientPayload: {
-      messages?: Array<{ role: string; content: string; createdAt?: string }>;
-      flowId?: string;
-      metadata?: Record<string, unknown>;
-    };
+    let clientPayload: Record<string, unknown>;
     try {
       clientPayload = await c.req.json();
     } catch (error) {
@@ -232,52 +228,56 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
       );
     }
 
-    // Build the Runtype payload
-    const messages = clientPayload.messages ?? [];
-    // Sort messages by timestamp to ensure correct order
-    const sortedMessages = [...messages].sort((a, b) => {
-      const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-      const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-      return timeA - timeB;
-    });
-    const formattedMessages = sortedMessages.map((message) => ({
-      role: message.role,
-      content: message.content
-    }));
-
-    // Determine which flow to use
-    const flowId = clientPayload.flowId ?? options.flowId;
-    const flowConfig = options.flowConfig ?? DEFAULT_FLOW;
-
-    const runtypePayload: Record<string, unknown> = {
-      record: {
-        name: "Streaming Chat Widget",
-        type: "standalone",
-        metadata: clientPayload.metadata || {}
-      },
-      messages: formattedMessages,
-      options: {
-        streamResponse: true,
-        recordMode: "virtual",
-        flowMode: flowId ? "existing" : "virtual",
-        autoAppendMetadata: false
-      }
-    };
-
-    // Use flow ID if provided, otherwise use flow config
-    if (flowId) {
-      runtypePayload.flow = {
-        id: flowId
-      }
-    } else {
-      runtypePayload.flow = flowConfig;
-    }
-
-    // Development logging
     const isDevelopment = process.env.NODE_ENV === "development" || !process.env.NODE_ENV;
 
+    // Detect agent mode: if the payload contains an `agent` field, forward it directly
+    const isAgentMode = !!clientPayload.agent;
+
+    let runtypePayload: Record<string, unknown>;
+
+    if (isAgentMode) {
+      // Agent dispatch - forward the payload as-is to the upstream API
+      runtypePayload = clientPayload;
+    } else {
+      // Flow dispatch - build the Runtype flow payload
+      const messages = (clientPayload.messages ?? []) as Array<{ role: string; content: string; createdAt?: string }>;
+      const sortedMessages = [...messages].sort((a, b) => {
+        const timeA = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        const timeB = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+        return timeA - timeB;
+      });
+      const formattedMessages = sortedMessages.map((message) => ({
+        role: message.role,
+        content: message.content
+      }));
+
+      const flowId = (clientPayload.flowId as string | undefined) ?? options.flowId;
+      const flowConfig = options.flowConfig ?? DEFAULT_FLOW;
+
+      runtypePayload = {
+        record: {
+          name: "Streaming Chat Widget",
+          type: "standalone",
+          metadata: (clientPayload.metadata as Record<string, unknown>) || {}
+        },
+        messages: formattedMessages,
+        options: {
+          streamResponse: true,
+          recordMode: "virtual",
+          flowMode: flowId ? "existing" : "virtual",
+          autoAppendMetadata: false
+        }
+      };
+
+      if (flowId) {
+        runtypePayload.flow = { id: flowId };
+      } else {
+        runtypePayload.flow = flowConfig;
+      }
+    }
+
     if (isDevelopment) {
-      console.log("\n=== Runtype Proxy Request ===");
+      console.log(`\n=== Runtype Proxy Request (${isAgentMode ? "agent" : "flow"}) ===`);
       console.log("URL:", upstream);
       console.log("API Key Used:", apiKey ? "Yes" : "No");
       console.log("API Key (first 12 chars):", apiKey ? apiKey.substring(0, 12) : "N/A");

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -571,3 +571,648 @@ describe('AgentWidgetClient - JSON Streaming', () => {
   });
 });
 
+// ============================================================================
+// Agent Loop Execution Tests
+// ============================================================================
+
+/**
+ * Helper to create an SSE event string
+ */
+function sseEvent(eventType: string, data: Record<string, unknown>): string {
+  return `event: ${eventType}\ndata: ${JSON.stringify({ type: eventType, ...data })}\n\n`;
+}
+
+/**
+ * Helper to create a mock fetch that returns an SSE stream
+ */
+function createAgentStreamFetch(events: string[]) {
+  return vi.fn().mockImplementation(async (_url: string, _options: any) => {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(controller) {
+        for (const event of events) {
+          controller.enqueue(encoder.encode(event));
+        }
+        controller.close();
+      }
+    });
+    return { ok: true, body: stream };
+  });
+}
+
+describe('AgentWidgetClient - Agent Mode Detection', () => {
+  it('should detect agent mode when agent config is provided', () => {
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: {
+        name: 'Test Agent',
+        model: 'openai:gpt-4o-mini',
+        systemPrompt: 'You are a test assistant.',
+      },
+    });
+    expect(client.isAgentMode()).toBe(true);
+    expect(client.isClientTokenMode()).toBe(false);
+  });
+
+  it('should not detect agent mode when no agent config', () => {
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+    });
+    expect(client.isAgentMode()).toBe(false);
+  });
+});
+
+describe('AgentWidgetClient - Agent Payload Building', () => {
+  it('should build agent payload with agent config', async () => {
+    let capturedPayload: any = null;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseEvent('agent_complete', {
+            executionId: 'exec_1',
+            agentId: 'virtual',
+            success: true,
+            iterations: 1,
+            stopReason: 'max_iterations',
+            completedAt: new Date().toISOString(),
+            seq: 1,
+          })));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: {
+        name: 'Test Agent',
+        model: 'openai:gpt-4o-mini',
+        systemPrompt: 'You are a test assistant.',
+        temperature: 0.7,
+        loopConfig: {
+          maxIterations: 3,
+          stopCondition: 'auto',
+        },
+      },
+      agentOptions: {
+        recordMode: 'virtual',
+        debugMode: false,
+      },
+    });
+
+    const messages: AgentWidgetMessage[] = [
+      {
+        id: 'usr_1',
+        role: 'user',
+        content: 'Hello agent',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      },
+    ];
+
+    await client.dispatch({ messages }, () => {});
+
+    expect(capturedPayload).toBeDefined();
+    expect(capturedPayload.agent).toBeDefined();
+    expect(capturedPayload.agent.name).toBe('Test Agent');
+    expect(capturedPayload.agent.model).toBe('openai:gpt-4o-mini');
+    expect(capturedPayload.agent.systemPrompt).toBe('You are a test assistant.');
+    expect(capturedPayload.agent.loopConfig.maxIterations).toBe(3);
+    expect(capturedPayload.messages).toHaveLength(1);
+    expect(capturedPayload.messages[0].content).toBe('Hello agent');
+    expect(capturedPayload.options.streamResponse).toBe(true);
+    expect(capturedPayload.options.recordMode).toBe('virtual');
+  });
+
+  it('should filter out variant messages from agent payload', async () => {
+    let capturedPayload: any = null;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode(sseEvent('agent_complete', {
+            executionId: 'exec_1', agentId: 'virtual', success: true,
+            iterations: 1, stopReason: 'max_iterations',
+            completedAt: new Date().toISOString(), seq: 1,
+          })));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    const messages: AgentWidgetMessage[] = [
+      { id: 'usr_1', role: 'user', content: 'Hello', createdAt: '2025-01-01T00:00:00.000Z' },
+      { id: 'ast_1', role: 'assistant', content: 'Hi there!', createdAt: '2025-01-01T00:00:01.000Z' },
+      { id: 'tool_1', role: 'assistant', content: '', variant: 'tool', createdAt: '2025-01-01T00:00:02.000Z' },
+      { id: 'reason_1', role: 'assistant', content: '', variant: 'reasoning', createdAt: '2025-01-01T00:00:03.000Z' },
+      { id: 'usr_2', role: 'user', content: 'Thanks', createdAt: '2025-01-01T00:00:04.000Z' },
+    ];
+
+    await client.dispatch({ messages }, () => {});
+
+    // Tool and reasoning variant messages should be filtered out
+    expect(capturedPayload.messages).toHaveLength(3);
+    expect(capturedPayload.messages[0].content).toBe('Hello');
+    expect(capturedPayload.messages[1].content).toBe('Hi there!');
+    expect(capturedPayload.messages[2].content).toBe('Thanks');
+  });
+});
+
+describe('AgentWidgetClient - Agent Event Streaming', () => {
+  it('should handle basic agent text streaming (single iteration)', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_1';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxIterations: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_start', {
+        executionId: execId, iteration: 1, turnIndex: 0,
+        role: 'assistant', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'Hello',
+        contentType: 'text', turnId: 'turn_1', seq: 4,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: ' World',
+        contentType: 'text', turnId: 'turn_1', seq: 5,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 1, role: 'assistant',
+        turnId: 'turn_1', completedAt: new Date().toISOString(), seq: 6,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 1, toolCallsMade: 0,
+        stopConditionMet: false, completedAt: new Date().toISOString(), seq: 7,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 8,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    // Find message events
+    const messageEvents = events.filter(e => e.type === 'message');
+    expect(messageEvents.length).toBeGreaterThan(0);
+
+    // Find the final assistant message
+    const lastMessage = messageEvents[messageEvents.length - 1];
+    expect(lastMessage.type).toBe('message');
+    if (lastMessage.type === 'message') {
+      expect(lastMessage.message.content).toBe('Hello World');
+      expect(lastMessage.message.streaming).toBe(false);
+      expect(lastMessage.message.role).toBe('assistant');
+      expect(lastMessage.message.agentMetadata).toBeDefined();
+      expect(lastMessage.message.agentMetadata?.executionId).toBe(execId);
+    }
+  });
+
+  it('should create separate messages per iteration in separate mode', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_2';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 2, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      // Iteration 1
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxIterations: 2,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_start', {
+        executionId: execId, iteration: 1, turnIndex: 0,
+        role: 'assistant', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'First iteration',
+        contentType: 'text', turnId: 'turn_1', seq: 4,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 1, role: 'assistant',
+        turnId: 'turn_1', completedAt: new Date().toISOString(), seq: 5,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 1, toolCallsMade: 0,
+        stopConditionMet: false, completedAt: new Date().toISOString(), seq: 6,
+      }),
+      // Iteration 2
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 2, maxIterations: 2,
+        startedAt: new Date().toISOString(), seq: 7,
+      }),
+      sseEvent('agent_turn_start', {
+        executionId: execId, iteration: 2, turnIndex: 0,
+        role: 'assistant', turnId: 'turn_2', seq: 8,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 2, delta: 'Second iteration',
+        contentType: 'text', turnId: 'turn_2', seq: 9,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 2, role: 'assistant',
+        turnId: 'turn_2', completedAt: new Date().toISOString(), seq: 10,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 2, toolCallsMade: 0,
+        stopConditionMet: false, completedAt: new Date().toISOString(), seq: 11,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 2, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 12,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+      iterationDisplay: 'separate',
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+
+    // Collect unique message IDs and their final content
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') {
+        messagesById.set(event.message.id, event.message);
+      }
+    }
+
+    // Should have created two distinct assistant messages
+    const assistantMessages = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant);
+
+    expect(assistantMessages.length).toBe(2);
+    expect(assistantMessages[0].content).toBe('First iteration');
+    expect(assistantMessages[0].streaming).toBe(false);
+    expect(assistantMessages[1].content).toBe('Second iteration');
+    expect(assistantMessages[1].streaming).toBe(false);
+  });
+
+  it('should merge iterations in merged mode', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_3';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 2, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxIterations: 2,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'First',
+        contentType: 'text', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 1, toolCallsMade: 0,
+        stopConditionMet: false, completedAt: new Date().toISOString(), seq: 4,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 2, maxIterations: 2,
+        startedAt: new Date().toISOString(), seq: 5,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 2, delta: ' Second',
+        contentType: 'text', turnId: 'turn_2', seq: 6,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 2, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 7,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+      iterationDisplay: 'merged',
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') {
+        messagesById.set(event.message.id, event.message);
+      }
+    }
+
+    // In merged mode, should have only one assistant message with combined content
+    const assistantMessages = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant);
+
+    expect(assistantMessages.length).toBe(1);
+    expect(assistantMessages[0].content).toBe('First Second');
+  });
+
+  it('should handle agent tool events', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_4';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxIterations: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_tool_start', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_1',
+        toolName: 'search', toolType: 'function',
+        parameters: { query: 'weather' }, seq: 3,
+      }),
+      sseEvent('agent_tool_delta', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_1',
+        delta: 'Searching...', seq: 4,
+      }),
+      sseEvent('agent_tool_complete', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_1',
+        toolName: 'search', success: true,
+        result: { temperature: 72 }, executionTime: 150, seq: 5,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'The weather is 72F.',
+        contentType: 'text', turnId: 'turn_1', seq: 6,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 7,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Weather?', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') {
+        messagesById.set(event.message.id, event.message);
+      }
+    }
+
+    // Should have a tool message
+    const toolMessages = Array.from(messagesById.values())
+      .filter(m => m.variant === 'tool');
+    expect(toolMessages.length).toBe(1);
+    expect(toolMessages[0].toolCall?.name).toBe('search');
+    expect(toolMessages[0].toolCall?.status).toBe('complete');
+    expect(toolMessages[0].toolCall?.result).toEqual({ temperature: 72 });
+    expect(toolMessages[0].toolCall?.durationMs).toBe(150);
+
+    // Should have an assistant message
+    const assistantMessages = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant);
+    expect(assistantMessages.length).toBe(1);
+    expect(assistantMessages[0].content).toBe('The weather is 72F.');
+  });
+
+  it('should handle agent thinking content', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_5';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxIterations: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'Let me think...',
+        contentType: 'thinking', turnId: 'think_1', seq: 3,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 1, role: 'assistant',
+        turnId: 'think_1', completedAt: new Date().toISOString(), seq: 4,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'The answer is 42.',
+        contentType: 'text', turnId: 'turn_1', seq: 5,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 6,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'What is the answer?', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') {
+        messagesById.set(event.message.id, event.message);
+      }
+    }
+
+    // Should have a reasoning message
+    const reasoningMessages = Array.from(messagesById.values())
+      .filter(m => m.variant === 'reasoning');
+    expect(reasoningMessages.length).toBe(1);
+    expect(reasoningMessages[0].reasoning?.chunks).toContain('Let me think...');
+    expect(reasoningMessages[0].reasoning?.status).toBe('complete');
+
+    // Should have an assistant message
+    const assistantMessages = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant);
+    expect(assistantMessages.length).toBe(1);
+    expect(assistantMessages[0].content).toBe('The answer is 42.');
+  });
+
+  it('should handle agent errors (recoverable and fatal)', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_6';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_error', {
+        executionId: execId, iteration: 1,
+        error: 'Rate limit hit, retrying...',
+        recoverable: true, seq: 2,
+      }),
+      sseEvent('agent_error', {
+        executionId: execId, iteration: 1,
+        error: 'Fatal: model unavailable',
+        recoverable: false, seq: 3,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    // Should have an error event for the non-recoverable error
+    const errorEvents = events.filter(e => e.type === 'error');
+    expect(errorEvents.length).toBe(1);
+    if (errorEvents[0].type === 'error') {
+      expect(errorEvents[0].error.message).toBe('Fatal: model unavailable');
+    }
+  });
+
+  it('should handle agent reflection events', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_7';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 2, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_reflection', {
+        executionId: execId, iteration: 1,
+        reflection: 'I should try a different approach.', seq: 2,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 2, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 3,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') {
+        messagesById.set(event.message.id, event.message);
+      }
+    }
+
+    // Should have a reflection message
+    const reflectionMessages = Array.from(messagesById.values())
+      .filter(m => m.variant === 'reasoning' && m.id.includes('reflection'));
+    expect(reflectionMessages.length).toBe(1);
+    expect(reflectionMessages[0].content).toBe('I should try a different approach.');
+    expect(reflectionMessages[0].reasoning?.chunks).toContain('I should try a different approach.');
+  });
+
+  it('should handle agent_ping events gracefully', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_test_8';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_ping', {
+        executionId: execId, timestamp: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'Hi',
+        contentType: 'text', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 4,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    // Ping should not generate any message events
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') {
+        messagesById.set(event.message.id, event.message);
+      }
+    }
+    const assistantMessages = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant);
+    expect(assistantMessages.length).toBe(1);
+    expect(assistantMessages[0].content).toBe('Hi');
+  });
+});
+

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -6,10 +6,12 @@ import {
   AgentWidgetContextProvider,
   AgentWidgetRequestMiddleware,
   AgentWidgetRequestPayload,
+  AgentWidgetAgentRequestPayload,
   AgentWidgetCustomFetch,
   AgentWidgetSSEEventParser,
   AgentWidgetHeadersFunction,
   AgentWidgetSSEEventResult as _AgentWidgetSSEEventResult,
+  AgentExecutionState,
   ClientSession,
   ClientInitResponse,
   ClientChatRequest,
@@ -115,6 +117,13 @@ export class AgentWidgetClient {
    */
   public isClientTokenMode(): boolean {
     return !!this.config.clientToken;
+  }
+
+  /**
+   * Check if operating in agent execution mode
+   */
+  public isAgentMode(): boolean {
+    return !!this.config.agent;
   }
 
   /**
@@ -384,6 +393,9 @@ export class AgentWidgetClient {
    * Send a message - handles both proxy and client token modes
    */
   public async dispatch(options: DispatchOptions, onEvent: SSEHandler) {
+    if (this.isAgentMode()) {
+      return this.dispatchAgent(options, onEvent);
+    }
     if (this.isClientTokenMode()) {
       return this.dispatchClientToken(options, onEvent);
     }
@@ -577,6 +589,146 @@ export class AgentWidgetClient {
     } finally {
       onEvent({ type: "status", status: "idle" });
     }
+  }
+
+  /**
+   * Agent mode dispatch
+   */
+  private async dispatchAgent(options: DispatchOptions, onEvent: SSEHandler) {
+    const controller = new AbortController();
+    if (options.signal) {
+      options.signal.addEventListener("abort", () => controller.abort());
+    }
+
+    onEvent({ type: "status", status: "connecting" });
+
+    const payload = await this.buildAgentPayload(options.messages);
+
+    if (this.debug) {
+      // eslint-disable-next-line no-console
+      console.debug("[AgentWidgetClient] agent dispatch payload", payload);
+    }
+
+    // Build headers - merge static headers with dynamic headers if provided
+    let headers = { ...this.headers };
+    if (this.getHeaders) {
+      try {
+        const dynamicHeaders = await this.getHeaders();
+        headers = { ...headers, ...dynamicHeaders };
+      } catch (error) {
+        if (typeof console !== "undefined") {
+          // eslint-disable-next-line no-console
+          console.error("[AgentWidget] getHeaders error:", error);
+        }
+      }
+    }
+
+    // Use customFetch if provided, otherwise use default fetch
+    let response: Response;
+    if (this.customFetch) {
+      try {
+        response = await this.customFetch(
+          this.apiUrl,
+          {
+            method: "POST",
+            headers,
+            body: JSON.stringify(payload),
+            signal: controller.signal
+          },
+          payload as unknown as AgentWidgetRequestPayload
+        );
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        onEvent({ type: "error", error: err });
+        throw err;
+      }
+    } else {
+      response = await fetch(this.apiUrl, {
+        method: "POST",
+        headers,
+        body: JSON.stringify(payload),
+        signal: controller.signal
+      });
+    }
+
+    if (!response.ok || !response.body) {
+      const error = new Error(
+        `Agent execution request failed: ${response.status} ${response.statusText}`
+      );
+      onEvent({ type: "error", error });
+      throw error;
+    }
+
+    onEvent({ type: "status", status: "connected" });
+    try {
+      await this.streamResponse(response.body, onEvent, options.assistantMessageId);
+    } finally {
+      onEvent({ type: "status", status: "idle" });
+    }
+  }
+
+  private async buildAgentPayload(
+    messages: AgentWidgetMessage[]
+  ): Promise<AgentWidgetAgentRequestPayload> {
+    if (!this.config.agent) {
+      throw new Error('Agent configuration required for agent mode');
+    }
+
+    // Filter out messages with empty content and normalize
+    const normalizedMessages = messages
+      .slice()
+      .filter(hasValidContent)
+      .filter(m => m.role === "user" || m.role === "assistant" || m.role === "system")
+      .filter(m => !m.variant || m.variant === "assistant")
+      .sort((a, b) => {
+        const timeA = new Date(a.createdAt).getTime();
+        const timeB = new Date(b.createdAt).getTime();
+        return timeA - timeB;
+      })
+      .map((message) => ({
+        role: message.role,
+        content: message.contentParts ?? message.llmContent ?? message.rawContent ?? message.content,
+        createdAt: message.createdAt
+      }));
+
+    const payload: AgentWidgetAgentRequestPayload = {
+      agent: this.config.agent,
+      messages: normalizedMessages,
+      options: {
+        streamResponse: true,
+        recordMode: 'virtual',
+        ...this.config.agentOptions
+      }
+    };
+
+    // Add context from providers
+    if (this.contextProviders.length) {
+      const contextAggregate: Record<string, unknown> = {};
+      await Promise.all(
+        this.contextProviders.map(async (provider) => {
+          try {
+            const result = await provider({
+              messages,
+              config: this.config
+            });
+            if (result && typeof result === "object") {
+              Object.assign(contextAggregate, result);
+            }
+          } catch (error) {
+            if (typeof console !== "undefined") {
+              // eslint-disable-next-line no-console
+              console.warn("[AgentWidget] Context provider failed:", error);
+            }
+          }
+        })
+      );
+
+      if (Object.keys(contextAggregate).length) {
+        payload.context = contextAggregate;
+      }
+    }
+
+    return payload;
   }
 
   private async buildPayload(
@@ -980,6 +1132,12 @@ export class AgentWidgetClient {
     const streamParsers = new Map<string, AgentWidgetStreamParser>();
     // Track accumulated raw content for structured formats (JSON, XML, etc.)
     const rawContentBuffers = new Map<string, string>();
+
+    // Agent execution state tracking
+    let agentExecution: AgentExecutionState | null = null;
+    // Track assistant messages per agent iteration for 'separate' mode
+    const agentIterationMessages = new Map<number, AgentWidgetMessage>();
+    const iterationDisplay = this.config.iterationDisplay ?? 'separate';
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -1579,6 +1737,208 @@ export class AgentWidgetClient {
             }
           }
           onEvent({ type: "status", status: "idle" });
+        // ================================================================
+        // Agent Loop Execution Events
+        // ================================================================
+        } else if (payloadType === "agent_start") {
+          agentExecution = {
+            executionId: payload.executionId,
+            agentId: payload.agentId ?? 'virtual',
+            agentName: payload.agentName ?? '',
+            status: 'running',
+            currentIteration: 0,
+            maxIterations: payload.maxIterations ?? 1,
+            startedAt: resolveTimestamp(payload.startedAt)
+          };
+        } else if (payloadType === "agent_iteration_start") {
+          if (agentExecution) {
+            agentExecution.currentIteration = payload.iteration;
+          }
+
+          // In 'separate' mode, finalize previous iteration's message and create a new one
+          if (iterationDisplay === 'separate' && payload.iteration > 1) {
+            const prevMsg = assistantMessage as AgentWidgetMessage | null;
+            if (prevMsg) {
+              prevMsg.streaming = false;
+              emitMessage(prevMsg);
+              // Store the completed message for this iteration
+              agentIterationMessages.set(payload.iteration - 1, prevMsg);
+              // Reset assistant message so ensureAssistantMessage creates a new one
+              assistantMessage = null;
+            }
+          }
+        } else if (payloadType === "agent_turn_start") {
+          // Nothing to do - turn tracking is handled by deltas
+        } else if (payloadType === "agent_turn_delta") {
+          if (payload.contentType === 'text') {
+            // Stream text to assistant message
+            const assistant = ensureAssistantMessage();
+            assistant.content += payload.delta ?? '';
+            assistant.agentMetadata = {
+              executionId: payload.executionId,
+              iteration: payload.iteration,
+              turnId: payload.turnId,
+              agentName: agentExecution?.agentName
+            };
+            emitMessage(assistant);
+          } else if (payload.contentType === 'thinking') {
+            // Stream thinking content to a reasoning message
+            const reasoningId = payload.turnId ?? `agent-think-${payload.iteration}`;
+            const reasoningMessage = ensureReasoningMessage(reasoningId);
+            reasoningMessage.reasoning = reasoningMessage.reasoning ?? {
+              id: reasoningId,
+              status: "streaming",
+              chunks: []
+            };
+            reasoningMessage.reasoning.chunks.push(payload.delta ?? '');
+            reasoningMessage.agentMetadata = {
+              executionId: payload.executionId,
+              iteration: payload.iteration,
+              turnId: payload.turnId
+            };
+            emitMessage(reasoningMessage);
+          } else if (payload.contentType === 'tool_input') {
+            // Stream tool input to current tool message
+            const toolId = payload.toolCallId ?? toolContext.lastId;
+            if (toolId) {
+              const toolMessage = toolMessages.get(toolId);
+              if (toolMessage?.toolCall) {
+                toolMessage.toolCall.chunks = toolMessage.toolCall.chunks ?? [];
+                toolMessage.toolCall.chunks.push(payload.delta ?? '');
+                emitMessage(toolMessage);
+              }
+            }
+          }
+        } else if (payloadType === "agent_turn_complete") {
+          // Mark any active reasoning for this turn as complete
+          const reasoningId = payload.turnId;
+          if (reasoningId) {
+            const reasoningMessage = reasoningMessages.get(reasoningId);
+            if (reasoningMessage?.reasoning) {
+              reasoningMessage.reasoning.status = "complete";
+              reasoningMessage.reasoning.completedAt = resolveTimestamp(payload.completedAt);
+              const start = reasoningMessage.reasoning.startedAt ?? Date.now();
+              reasoningMessage.reasoning.durationMs = Math.max(
+                0,
+                (reasoningMessage.reasoning.completedAt ?? Date.now()) - start
+              );
+              reasoningMessage.streaming = false;
+              emitMessage(reasoningMessage);
+            }
+          }
+        } else if (payloadType === "agent_tool_start") {
+          const toolId = payload.toolCallId ?? `agent-tool-${nextSequence()}`;
+          trackToolId(getToolCallKey(payload), toolId);
+          const toolMessage = ensureToolMessage(toolId);
+          const tool = toolMessage.toolCall ?? {
+            id: toolId, status: "pending" as const,
+            name: undefined, args: undefined, chunks: undefined,
+            result: undefined, duration: undefined, startedAt: undefined,
+            completedAt: undefined, durationMs: undefined
+          };
+          tool.name = payload.toolName ?? tool.name;
+          tool.status = "running";
+          if (payload.parameters !== undefined) {
+            tool.args = payload.parameters;
+          }
+          tool.startedAt = resolveTimestamp(payload.startedAt ?? payload.timestamp);
+          toolMessage.toolCall = tool;
+          toolMessage.streaming = true;
+          toolMessage.agentMetadata = {
+            executionId: payload.executionId,
+            iteration: payload.iteration
+          };
+          emitMessage(toolMessage);
+        } else if (payloadType === "agent_tool_delta") {
+          const toolId = payload.toolCallId ?? toolContext.lastId;
+          if (toolId) {
+            const toolMessage = toolMessages.get(toolId) ?? ensureToolMessage(toolId);
+            if (toolMessage.toolCall) {
+              toolMessage.toolCall.chunks = toolMessage.toolCall.chunks ?? [];
+              toolMessage.toolCall.chunks.push(payload.delta ?? '');
+              toolMessage.toolCall.status = "running";
+              toolMessage.streaming = true;
+              emitMessage(toolMessage);
+            }
+          }
+        } else if (payloadType === "agent_tool_complete") {
+          const toolId = payload.toolCallId ?? toolContext.lastId;
+          if (toolId) {
+            const toolMessage = toolMessages.get(toolId) ?? ensureToolMessage(toolId);
+            if (toolMessage.toolCall) {
+              toolMessage.toolCall.status = "complete";
+              if (payload.result !== undefined) {
+                toolMessage.toolCall.result = payload.result;
+              }
+              if (typeof payload.executionTime === "number") {
+                toolMessage.toolCall.durationMs = payload.executionTime;
+              }
+              toolMessage.toolCall.completedAt = resolveTimestamp(payload.completedAt ?? payload.timestamp);
+              toolMessage.streaming = false;
+              emitMessage(toolMessage);
+              const callKey = getToolCallKey(payload);
+              if (callKey) {
+                toolContext.byCall.delete(callKey);
+              }
+            }
+          }
+        } else if (payloadType === "agent_iteration_complete") {
+          // Iteration complete - no special handling needed
+          // In 'separate' mode, message finalization happens at next iteration_start
+        } else if (payloadType === "agent_reflection") {
+          // Create a reasoning message for reflection content
+          const reflectionId = `agent-reflection-${payload.executionId}-${payload.iteration}`;
+          const reflectionMessage: AgentWidgetMessage = {
+            id: reflectionId,
+            role: "assistant",
+            content: payload.reflection ?? '',
+            createdAt: new Date().toISOString(),
+            streaming: false,
+            variant: "reasoning",
+            sequence: nextSequence(),
+            reasoning: {
+              id: reflectionId,
+              status: "complete",
+              chunks: [payload.reflection ?? '']
+            },
+            agentMetadata: {
+              executionId: payload.executionId,
+              iteration: payload.iteration
+            }
+          };
+          emitMessage(reflectionMessage);
+        } else if (payloadType === "agent_complete") {
+          if (agentExecution) {
+            agentExecution.status = payload.success ? 'complete' : 'error';
+            agentExecution.completedAt = resolveTimestamp(payload.completedAt);
+            agentExecution.stopReason = payload.stopReason;
+          }
+
+          // Finalize the current assistant message
+          const finalMsg = assistantMessage as AgentWidgetMessage | null;
+          if (finalMsg) {
+            finalMsg.streaming = false;
+            emitMessage(finalMsg);
+          }
+
+          onEvent({ type: "status", status: "idle" });
+        } else if (payloadType === "agent_error") {
+          const errorMessage = typeof payload.error === 'string'
+            ? payload.error
+            : payload.error?.message ?? 'Agent execution error';
+          if (payload.recoverable) {
+            if (typeof console !== "undefined") {
+              // eslint-disable-next-line no-console
+              console.warn("[AgentWidget] Recoverable agent error:", errorMessage);
+            }
+          } else {
+            onEvent({
+              type: "error",
+              error: new Error(errorMessage)
+            });
+          }
+        } else if (payloadType === "agent_ping") {
+          // Keep-alive heartbeat - no action needed
         } else if (payloadType === "error" && payload.error) {
           onEvent({
             type: "error",

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -58,7 +58,14 @@ export type {
   LoadingIndicatorRenderContext,
   AgentWidgetLoadingIndicatorConfig,
   // Idle indicator types
-  IdleIndicatorRenderContext
+  IdleIndicatorRenderContext,
+  // Agent execution types
+  AgentConfig,
+  AgentLoopConfig,
+  AgentRequestOptions,
+  AgentExecutionState,
+  AgentMessageMetadata,
+  AgentWidgetAgentRequestPayload
 } from "./types";
 
 export { initAgentWidgetFn as initAgentWidget };

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -3,6 +3,7 @@ import {
   AgentWidgetConfig,
   AgentWidgetEvent,
   AgentWidgetMessage,
+  AgentExecutionState,
   ClientSession,
   ContentPart,
   InjectMessageOptions,
@@ -39,6 +40,9 @@ export class AgentWidgetSession {
   // Client token session management
   private clientSession: ClientSession | null = null;
 
+  // Agent execution state
+  private agentExecution: AgentExecutionState | null = null;
+
   constructor(
     private config: AgentWidgetConfig = {},
     private callbacks: SessionCallbacks
@@ -61,6 +65,27 @@ export class AgentWidgetSession {
    */
   public isClientTokenMode(): boolean {
     return this.client.isClientTokenMode();
+  }
+
+  /**
+   * Check if running in agent execution mode
+   */
+  public isAgentMode(): boolean {
+    return this.client.isAgentMode();
+  }
+
+  /**
+   * Get current agent execution state (if in agent mode)
+   */
+  public getAgentExecution(): AgentExecutionState | null {
+    return this.agentExecution;
+  }
+
+  /**
+   * Check if an agent execution is currently running
+   */
+  public isAgentExecuting(): boolean {
+    return this.agentExecution?.status === 'running';
   }
 
   /**
@@ -467,6 +492,7 @@ export class AgentWidgetSession {
     this.abortController?.abort();
     this.abortController = null;
     this.messages = [];
+    this.agentExecution = null;
     this.setStreaming(false);
     this.setStatus("idle");
     this.callbacks.onMessagesChanged([...this.messages]);
@@ -490,6 +516,22 @@ export class AgentWidgetSession {
   private handleEvent = (event: AgentWidgetEvent) => {
     if (event.type === "message") {
       this.upsertMessage(event.message);
+
+      // Track agent execution state from message metadata
+      if (event.message.agentMetadata?.executionId) {
+        if (!this.agentExecution) {
+          this.agentExecution = {
+            executionId: event.message.agentMetadata.executionId,
+            agentId: '',
+            agentName: event.message.agentMetadata.agentName ?? '',
+            status: 'running',
+            currentIteration: event.message.agentMetadata.iteration ?? 0,
+            maxIterations: 0
+          };
+        } else if (event.message.agentMetadata.iteration !== undefined) {
+          this.agentExecution.currentIteration = event.message.agentMetadata.iteration;
+        }
+      }
     } else if (event.type === "status") {
       this.setStatus(event.status);
       if (event.status === "connecting") {
@@ -497,11 +539,18 @@ export class AgentWidgetSession {
       } else if (event.status === "idle" || event.status === "error") {
         this.setStreaming(false);
         this.abortController = null;
+        // Mark agent execution as complete when streaming ends
+        if (this.agentExecution?.status === 'running') {
+          this.agentExecution.status = event.status === "error" ? 'error' : 'complete';
+        }
       }
     } else if (event.type === "error") {
       this.setStatus("error");
       this.setStreaming(false);
       this.abortController = null;
+      if (this.agentExecution?.status === 'running') {
+        this.agentExecution.status = 'error';
+      }
       this.callbacks.onError?.(event.error);
     }
   };

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -73,6 +73,91 @@ export type AgentWidgetRequestPayload = {
   metadata?: Record<string, unknown>;
 };
 
+// ============================================================================
+// Agent Execution Types
+// ============================================================================
+
+/**
+ * Configuration for agent loop behavior.
+ */
+export type AgentLoopConfig = {
+  /** Maximum number of reasoning iterations */
+  maxIterations: number;
+  /** Stop condition: 'auto' for automatic detection, or a custom JS expression */
+  stopCondition?: 'auto' | string;
+  /** Enable periodic reflection during execution */
+  enableReflection?: boolean;
+  /** Number of iterations between reflections */
+  reflectionInterval?: number;
+};
+
+/**
+ * Agent configuration for agent execution mode.
+ * When provided in the widget config, enables agent loop execution instead of flow dispatch.
+ */
+export type AgentConfig = {
+  /** Agent display name */
+  name: string;
+  /** Model identifier (e.g., 'openai:gpt-4o-mini') */
+  model: string;
+  /** System prompt for the agent */
+  systemPrompt: string;
+  /** Temperature for model responses */
+  temperature?: number;
+  /** Loop configuration for multi-iteration execution */
+  loopConfig?: AgentLoopConfig;
+};
+
+/**
+ * Options for agent execution requests.
+ */
+export type AgentRequestOptions = {
+  /** Whether to stream the response (should be true for widget usage) */
+  streamResponse?: boolean;
+  /** Record mode: 'virtual' for no persistence, 'existing'/'create' for database records */
+  recordMode?: 'virtual' | 'existing' | 'create';
+  /** Whether to store results server-side */
+  storeResults?: boolean;
+  /** Enable debug mode for additional event data */
+  debugMode?: boolean;
+};
+
+/**
+ * Request payload for agent execution mode.
+ */
+export type AgentWidgetAgentRequestPayload = {
+  agent: AgentConfig;
+  messages: AgentWidgetRequestPayloadMessage[];
+  options: AgentRequestOptions;
+  context?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+};
+
+/**
+ * Agent execution state tracking.
+ */
+export type AgentExecutionState = {
+  executionId: string;
+  agentId: string;
+  agentName: string;
+  status: 'running' | 'complete' | 'error';
+  currentIteration: number;
+  maxIterations: number;
+  startedAt?: number;
+  completedAt?: number;
+  stopReason?: 'max_iterations' | 'complete' | 'error' | 'manual';
+};
+
+/**
+ * Metadata attached to messages created during agent execution.
+ */
+export type AgentMessageMetadata = {
+  executionId?: string;
+  iteration?: number;
+  turnId?: string;
+  agentName?: string;
+};
+
 export type AgentWidgetRequestMiddlewareContext = {
   payload: AgentWidgetRequestPayload;
   config: AgentWidgetConfig;
@@ -1400,6 +1485,41 @@ export type AgentWidgetConfig = {
   apiUrl?: string;
   flowId?: string;
   /**
+   * Agent configuration for agent execution mode.
+   * When provided, the widget uses agent loop execution instead of flow dispatch.
+   * Mutually exclusive with `flowId`.
+   *
+   * @example
+   * ```typescript
+   * config: {
+   *   agent: {
+   *     name: 'Assistant',
+   *     model: 'openai:gpt-4o-mini',
+   *     systemPrompt: 'You are a helpful assistant.',
+   *     loopConfig: { maxIterations: 3, stopCondition: 'auto' }
+   *   }
+   * }
+   * ```
+   */
+  agent?: AgentConfig;
+  /**
+   * Options for agent execution requests.
+   * Only used when `agent` is configured.
+   *
+   * @default { streamResponse: true, recordMode: 'virtual' }
+   */
+  agentOptions?: AgentRequestOptions;
+  /**
+   * Controls how multiple agent iterations are displayed in the chat UI.
+   * Only used when `agent` is configured.
+   *
+   * - `'separate'`: Each iteration creates a new assistant message bubble
+   * - `'merged'`: All iterations stream into a single assistant message
+   *
+   * @default 'separate'
+   */
+  iterationDisplay?: 'separate' | 'merged';
+  /**
    * Client token for direct browser-to-API communication.
    * When set, the widget uses /v1/client/* endpoints instead of /v1/dispatch.
    * Mutually exclusive with apiKey/headers authentication.
@@ -1944,6 +2064,11 @@ export type AgentWidgetMessage = {
    * }
    */
   llmContent?: string;
+  /**
+   * Metadata for messages created during agent loop execution.
+   * Contains execution context like iteration number and turn ID.
+   */
+  agentMetadata?: AgentMessageMetadata;
 };
 
 // ============================================================================


### PR DESCRIPTION
Add agent loop execution support. The widget can now operate in agent mode by setting `config.agent` with a model, system prompt, and loop configuration instead of using `flowId`. Handles all agent-specific SSE events including `agent_turn_delta` (text and thinking content), `agent_tool_*`, `agent_reflection`, and `agent_iteration_*`. Added configurable `iterationDisplay` option (`'separate'` or `'merged'`) to control how multiple agent iterations appear in the chat UI. New exported types: `AgentConfig`, `AgentLoopConfig`, `AgentRequestOptions`, `AgentExecutionState`, `AgentMessageMetadata`, `AgentWidgetAgentRequestPayload`.