### PR TITLE
Add GitHub Actions workflow to publish widget to R2 CDN

### DIFF
--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -1,0 +1,60 @@
+name: Publish to R2 CDN
+
+on:
+  release:
+    types: [published]
+
+concurrency:
+  group: r2-release
+  cancel-in-progress: false
+
+jobs:
+  publish-to-r2:
+    name: Publish to R2 CDN
+    # Only run for widget package releases (tag format: @runtypelabs/persona@x.y.z)
+    if: startsWith(github.event.release.tag_name, '@runtypelabs/persona@')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build widget
+        run: pnpm build:widget
+
+      - name: Extract version
+        id: version
+        run: echo "version=$(node -p "require('./packages/widget/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Upload versioned release to R2
+        uses: ryand56/r2-upload-action@latest
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: cdn-assets
+          source-dir: packages/widget/dist
+          destination-dir: persona/${{ steps.version.outputs.version }}
+
+      - name: Upload latest to R2
+        uses: ryand56/r2-upload-action@latest
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: cdn-assets
+          source-dir: packages/widget/dist
+          destination-dir: persona/latest
+          keep-file-fresh: true

--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -14,6 +14,11 @@ jobs:
     # Only run for widget package releases (tag format: @runtypelabs/persona@x.y.z)
     if: startsWith(github.event.release.tag_name, '@runtypelabs/persona@')
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ vars.R2_BUCKET || 'cdn-assets' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -36,25 +41,41 @@ jobs:
 
       - name: Extract version
         id: version
-        run: echo "version=$(node -p "require('./packages/widget/package.json').version")" >> "$GITHUB_OUTPUT"
+        run: |
+          VERSION=$(node -p "require('./packages/widget/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION"
 
       - name: Upload versioned release to R2
-        uses: ryand56/r2-upload-action@latest
+        id: upload-versioned
+        uses: ryand56/r2-upload-action@v1.4
         with:
-          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          r2-bucket: cdn-assets
+          r2-account-id: ${{ env.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ env.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ env.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ env.R2_BUCKET }}
           source-dir: packages/widget/dist
           destination-dir: persona/${{ steps.version.outputs.version }}
 
       - name: Upload latest to R2
-        uses: ryand56/r2-upload-action@latest
+        id: upload-latest
+        uses: ryand56/r2-upload-action@v1.4
         with:
-          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
-          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
-          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          r2-bucket: cdn-assets
+          r2-account-id: ${{ env.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ env.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ env.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ env.R2_BUCKET }}
           source-dir: packages/widget/dist
           destination-dir: persona/latest
           keep-file-fresh: true
+
+      - name: Summary
+        run: |
+          echo "## R2 CDN Upload Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Bucket:** \`${{ env.R2_BUCKET }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Uploaded Paths" >> $GITHUB_STEP_SUMMARY
+          echo "- \`persona/${{ steps.version.outputs.version }}/\`" >> $GITHUB_STEP_SUMMARY
+          echo "- \`persona/latest/\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -21,6 +21,9 @@ jobs:
       R2_BUCKET: ${{ vars.R2_BUCKET || 'cdn-assets' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -46,6 +49,38 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Extracted version: $VERSION"
 
+      - name: Check if should update latest
+        id: check-latest
+        run: |
+          CURRENT="${{ steps.version.outputs.version }}"
+          IS_PRERELEASE="${{ github.event.release.prerelease }}"
+
+          # Pre-releases should never update latest
+          if [[ "$IS_PRERELEASE" == "true" ]]; then
+            echo "Skipping latest update: pre-release"
+            echo "should_update=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get the highest stable version from existing git tags
+          HIGHEST=$(git tag -l '@runtypelabs/persona@*' | \
+            sed 's/@runtypelabs\/persona@//' | \
+            grep -v '-' | \
+            sort -V | \
+            tail -1)
+
+          echo "Current version: $CURRENT"
+          echo "Highest stable version: $HIGHEST"
+
+          # Update latest only if current >= highest
+          if [[ -z "$HIGHEST" ]] || [[ "$(printf '%s\n' "$HIGHEST" "$CURRENT" | sort -V | tail -1)" == "$CURRENT" ]]; then
+            echo "Will update latest"
+            echo "should_update=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping latest update: $CURRENT is older than $HIGHEST"
+            echo "should_update=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Upload versioned release to R2
         id: upload-versioned
         uses: ryand56/r2-upload-action@v1.4
@@ -59,6 +94,7 @@ jobs:
 
       - name: Upload latest to R2
         id: upload-latest
+        if: steps.check-latest.outputs.should_update == 'true'
         uses: ryand56/r2-upload-action@v1.4
         with:
           r2-account-id: ${{ env.R2_ACCOUNT_ID }}
@@ -75,7 +111,12 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Bucket:** \`${{ env.R2_BUCKET }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Pre-release:** ${{ github.event.release.prerelease }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Uploaded Paths" >> $GITHUB_STEP_SUMMARY
           echo "- \`persona/${{ steps.version.outputs.version }}/\`" >> $GITHUB_STEP_SUMMARY
-          echo "- \`persona/latest/\`" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.check-latest.outputs.should_update }}" == "true" ]]; then
+            echo "- \`persona/latest/\` ✓" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- \`persona/latest/\` _(skipped)_" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -51,9 +51,12 @@ jobs:
 
       - name: Check if should update latest
         id: check-latest
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
-          CURRENT="${{ steps.version.outputs.version }}"
-          IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          CURRENT="$RELEASE_VERSION"
+          IS_PRERELEASE="$RELEASE_PRERELEASE"
           CURRENT_NO_BUILD="${CURRENT%%+*}"
 
           # Pre-releases should never update latest.
@@ -108,17 +111,21 @@ jobs:
           keep-file-fresh: true
 
       - name: Summary
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          SHOULD_UPDATE_LATEST: ${{ steps.check-latest.outputs.should_update }}
         run: |
-          echo "## R2 CDN Upload Summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Version:** \`${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Bucket:** \`${{ env.R2_BUCKET }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Pre-release:** ${{ github.event.release.prerelease }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Uploaded Paths" >> $GITHUB_STEP_SUMMARY
-          echo "- \`persona/${{ steps.version.outputs.version }}/\`" >> $GITHUB_STEP_SUMMARY
-          if [[ "${{ steps.check-latest.outputs.should_update }}" == "true" ]]; then
-            echo "- \`persona/latest/\` ✓" >> $GITHUB_STEP_SUMMARY
+          echo "## R2 CDN Upload Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** \`$RELEASE_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Bucket:** \`$R2_BUCKET\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Pre-release:** $RELEASE_PRERELEASE" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Uploaded Paths" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`persona/$RELEASE_VERSION/\`" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$SHOULD_UPDATE_LATEST" == "true" ]]; then
+            echo "- \`persona/latest/\` ✓" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- \`persona/latest/\` _(skipped)_" >> $GITHUB_STEP_SUMMARY
+            echo "- \`persona/latest/\` _(skipped)_" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -54,10 +54,12 @@ jobs:
         run: |
           CURRENT="${{ steps.version.outputs.version }}"
           IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          CURRENT_NO_BUILD="${CURRENT%%+*}"
 
-          # Pre-releases should never update latest
-          if [[ "$IS_PRERELEASE" == "true" ]]; then
-            echo "Skipping latest update: pre-release"
+          # Pre-releases should never update latest.
+          # Detect from both GitHub metadata and semver version string.
+          if [[ "$IS_PRERELEASE" == "true" ]] || [[ "$CURRENT_NO_BUILD" == *-* ]]; then
+            echo "Skipping latest update: pre-release (metadata=$IS_PRERELEASE, version=$CURRENT)"
             echo "should_update=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi


### PR DESCRIPTION
## Summary
This PR adds a new GitHub Actions workflow that automatically publishes the Persona widget package to Cloudflare R2 CDN whenever a release is published.

## Key Changes
- Added `.github/workflows/r2-release.yml` workflow that:
  - Triggers on GitHub release publication events
  - Filters to only run for `@runtypelabs/persona@` tagged releases
  - Builds the widget package using `pnpm build:widget`
  - Extracts the version from `packages/widget/package.json`
  - Uploads built artifacts to R2 CDN in two locations:
    - Versioned directory: `persona/{version}/`
    - Latest directory: `persona/latest/` (with file freshness tracking)

## Implementation Details
- Uses `pnpm` v10 and Node.js v24 for consistent builds
- Leverages `ryand56/r2-upload-action` for R2 uploads
- Implements concurrency control to prevent simultaneous uploads
- Requires R2 credentials stored as GitHub secrets: `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`
- Runs on `blacksmith-4vcpu-ubuntu-2404` runner for reliable builds

https://claude.ai/code/session_01FruCyZG9N4s5zvKvmcpjug

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new release-triggered workflow that builds and uploads artifacts to an external CDN; misconfiguration could publish incorrect versions or overwrite `persona/latest`, but code changes are isolated to CI.
> 
> **Overview**
> Automatically publishes the built widget to Cloudflare R2 when a GitHub Release is published for tags matching `@runtypelabs/persona@*`.
> 
> The new `.github/workflows/r2-release.yml` builds via `pnpm build:widget`, uploads `packages/widget/dist` to `persona/<version>/`, and conditionally updates `persona/latest/` only for stable versions that are not older than the highest existing stable tag (skipping pre-releases), with a step summary of uploaded paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 80eda8f3de1a0f6cafeaac27ba6d060f492d0d9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->