### PR TITLE
fix: preserve SSE event stream callback on config update

### DIFF
--- a/.changeset/fix-sse-callback-on-config-update.md
+++ b/.changeset/fix-sse-callback-on-config-update.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix SSE event stream callback lost on config update. `session.updateConfig()` was creating a new `AgentWidgetClient` without preserving the `onSSEEvent` callback, causing the Event Stream Inspector to show 0 events after any `controller.update()` call (e.g. theme changes).

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -123,6 +123,13 @@ export class AgentWidgetClient {
   }
 
   /**
+   * Get the current SSE event callback (used to preserve across client recreation)
+   */
+  public getSSEEventCallback(): SSEEventCallback | undefined {
+    return this.onSSEEvent;
+  }
+
+  /**
    * Check if running in client token mode
    */
   public isClientTokenMode(): boolean {

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -204,8 +204,12 @@ export class AgentWidgetSession {
   }
 
   public updateConfig(next: AgentWidgetConfig) {
+    const prevSSECallback = this.client.getSSEEventCallback();
     this.config = { ...this.config, ...next };
     this.client = new AgentWidgetClient(this.config);
+    if (prevSSECallback) {
+      this.client.setSSEEventCallback(prevSSECallback);
+    }
   }
 
   public getMessages() {


### PR DESCRIPTION
Ensure that the SSE event stream callback is retained when updating the AgentWidgetClient configuration. The `updateConfig` method now saves the previous callback and reassigns it after recreating the client, preventing loss of event handling during configuration changes.