### PR TITLE
fix: typo in widget package description

### DIFF
--- a/.changeset/fix-widget-description-typo.md
+++ b/.changeset/fix-widget-description-typo.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix typo in package description ("plugable" → "pluggable")

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runtypelabs/persona",
   "version": "1.43.2",
-  "description": "Themeable, plugable streaming agent widget for websites, in plain JS with support for voice input and reasoning / tool output.",
+  "description": "Themeable, pluggable streaming agent widget for websites, in plain JS with support for voice input and reasoning / tool output.",
   "type": "module",
   "main": "dist/index.cjs",
   "module": "dist/index.js",


### PR DESCRIPTION
## Summary
- Fixes typo in widget `package.json` description: "plugable" → "pluggable"
- Includes a patch changeset to trigger a release for testing the R2 CDN pipeline

## Test plan
1. Merge this PR
2. Changesets creates a "chore: version packages" PR — merge that
3. Verify the `publish-to-r2` job runs automatically after npm publish in the Release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates package metadata text and adds a patch changeset; no runtime or build logic is affected.
> 
> **Overview**
> Fixes a typo in `@runtypelabs/persona` widget `package.json` description ("plugable" → "pluggable").
> 
> Adds a patch Changesets entry to trigger a release for this metadata-only change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b79b5aa8530d862c6ce5bb2e57c6e93d10f7998. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->