### PR TITLE
fix: consolidate R2 CDN publish into release workflow

### DIFF
--- a/.changeset/consolidate-r2-release.md
+++ b/.changeset/consolidate-r2-release.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Consolidate R2 CDN publish into release workflow and add manual dispatch

--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -1,8 +1,12 @@
-name: Publish to R2 CDN
+name: Publish to R2 CDN (Manual)
 
 on:
-  release:
-    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Git tag to publish (e.g. @runtypelabs/persona@1.44.0)'
+        required: true
+        type: string
 
 concurrency:
   group: r2-release
@@ -11,8 +15,7 @@ concurrency:
 jobs:
   publish-to-r2:
     name: Publish to R2 CDN
-    # Only run for widget package releases (tag format: @runtypelabs/persona@x.y.z)
-    if: startsWith(github.event.release.tag_name, '@runtypelabs/persona@')
+    if: startsWith(inputs.tag, '@runtypelabs/persona@')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
@@ -22,7 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag }}
           fetch-depth: 0
 
       - name: Setup pnpm
@@ -53,16 +56,13 @@ jobs:
         id: check-latest
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
         run: |
           CURRENT="$RELEASE_VERSION"
-          IS_PRERELEASE="$RELEASE_PRERELEASE"
           CURRENT_NO_BUILD="${CURRENT%%+*}"
 
           # Pre-releases should never update latest.
-          # Detect from both GitHub metadata and semver version string.
-          if [[ "$IS_PRERELEASE" == "true" ]] || [[ "$CURRENT_NO_BUILD" == *-* ]]; then
-            echo "Skipping latest update: pre-release (metadata=$IS_PRERELEASE, version=$CURRENT)"
+          if [[ "$CURRENT_NO_BUILD" == *-* ]]; then
+            echo "Skipping latest update: pre-release version $CURRENT"
             echo "should_update=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -113,14 +113,12 @@ jobs:
       - name: Summary
         env:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
-          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
           SHOULD_UPDATE_LATEST: ${{ steps.check-latest.outputs.should_update }}
         run: |
           echo "## R2 CDN Upload Summary" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "**Version:** \`$RELEASE_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
           echo "**Bucket:** \`$R2_BUCKET\`" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Pre-release:** $RELEASE_PRERELEASE" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "### Uploaded Paths" >> "$GITHUB_STEP_SUMMARY"
           echo "- \`persona/$RELEASE_VERSION/\`" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ jobs:
       contents: write
       pull-requests: write
       id-token: write
+    outputs:
+      published: ${{ steps.changesets.outputs.published }}
+      publishedPackages: ${{ steps.changesets.outputs.publishedPackages }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -48,3 +51,120 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-to-r2:
+    name: Publish to R2 CDN
+    needs: release
+    if: >-
+      needs.release.outputs.published == 'true' &&
+      contains(needs.release.outputs.publishedPackages, '@runtypelabs/persona')
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    env:
+      R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+      R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+      R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+      R2_BUCKET: ${{ vars.R2_BUCKET || 'cdn-assets' }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build widget
+        run: pnpm build:widget
+
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(node -p "require('./packages/widget/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Extracted version: $VERSION"
+
+      - name: Check if should update latest
+        id: check-latest
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          CURRENT="$RELEASE_VERSION"
+          CURRENT_NO_BUILD="${CURRENT%%+*}"
+
+          # Pre-releases should never update latest.
+          if [[ "$CURRENT_NO_BUILD" == *-* ]]; then
+            echo "Skipping latest update: pre-release version $CURRENT"
+            echo "should_update=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Get the highest stable version from existing git tags
+          HIGHEST=$(git tag -l '@runtypelabs/persona@*' | \
+            sed 's/@runtypelabs\/persona@//' | \
+            grep -v '-' | \
+            sort -V | \
+            tail -1)
+
+          echo "Current version: $CURRENT"
+          echo "Highest stable version: $HIGHEST"
+
+          # Update latest only if current >= highest
+          if [[ -z "$HIGHEST" ]] || [[ "$(printf '%s\n' "$HIGHEST" "$CURRENT" | sort -V | tail -1)" == "$CURRENT" ]]; then
+            echo "Will update latest"
+            echo "should_update=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Skipping latest update: $CURRENT is older than $HIGHEST"
+            echo "should_update=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Upload versioned release to R2
+        id: upload-versioned
+        uses: ryand56/r2-upload-action@v1.4
+        with:
+          r2-account-id: ${{ env.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ env.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ env.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ env.R2_BUCKET }}
+          source-dir: packages/widget/dist
+          destination-dir: persona/${{ steps.version.outputs.version }}
+
+      - name: Upload latest to R2
+        id: upload-latest
+        if: steps.check-latest.outputs.should_update == 'true'
+        uses: ryand56/r2-upload-action@v1.4
+        with:
+          r2-account-id: ${{ env.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ env.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ env.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ env.R2_BUCKET }}
+          source-dir: packages/widget/dist
+          destination-dir: persona/latest
+          keep-file-fresh: true
+
+      - name: Summary
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          SHOULD_UPDATE_LATEST: ${{ steps.check-latest.outputs.should_update }}
+        run: |
+          echo "## R2 CDN Upload Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Version:** \`$RELEASE_VERSION\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Bucket:** \`$R2_BUCKET\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Uploaded Paths" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`persona/$RELEASE_VERSION/\`" >> "$GITHUB_STEP_SUMMARY"
+          if [[ "$SHOULD_UPDATE_LATEST" == "true" ]]; then
+            echo "- \`persona/latest/\` ✓" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "- \`persona/latest/\` _(skipped)_" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
## Summary
- Adds `publish-to-r2` job to `release.yml` that runs after changesets publishes the widget — fixes the `GITHUB_TOKEN` event propagation issue where the standalone R2 workflow was never triggered
- Simplifies `r2-release.yml` to `workflow_dispatch` only for manual re-runs against a specific tag
- Includes a patch changeset to test the full pipeline end-to-end

## Test plan
1. Merge this PR
2. Changesets creates a "chore: version packages" PR — merge that
3. Verify the `publish-to-r2` job runs automatically after npm publish in the Release workflow
4. Optionally test manual dispatch: Actions > "Publish to R2 CDN (Manual)" > Run with an existing tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CI/CD release automation and CDN upload conditions; mistakes could prevent uploads or incorrectly update `persona/latest`, though scoped to the release workflows.
> 
> **Overview**
> Consolidates R2 CDN publishing into `release.yml` by adding a `publish-to-r2` job that runs after Changesets publishing and only when `@runtypelabs/persona` was actually published.
> 
> Refactors `r2-release.yml` from a release-triggered workflow into a *manual* `workflow_dispatch` job that publishes a user-specified tag, and simplifies “latest” handling to rely on semver prerelease detection. Adds a patch Changeset to exercise the end-to-end pipeline.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b23630cb83e87e442548cfc16efc9c4b65fd372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->