### PR TITLE
feat(widget): add WebMCP integration with safe fallback

### DIFF
--- a/examples/embedded-app/README.md
+++ b/examples/embedded-app/README.md
@@ -121,11 +121,12 @@ The action middleware example demonstrates:
 ### WebMCP Browser Harness
 - **Harness page**: `http://localhost:5173/webmcp-harness.html`
   - Verifies WebMCP capability detection and fallback behavior in-browser
-  - Runs four scenarios:
+  - Runs five scenarios:
     - `Unsupported`: no `navigator.modelContext`, confirms fallback request path
     - `Mock Ready`: mocked `modelContext` confirms context + tool registration path
     - `Mock Error`: mocked failure confirms safe fallback with successful request
     - `Cleanup`: confirms `unregisterTool` and `clearContext` on widget destroy
+    - `Real Browser`: (if detected) runs against the native `navigator.modelContext` implementation
   - Uses `customFetch` to capture outgoing payload and return synthetic SSE responses (no backend required)
 
 ### Custom Components Demo

--- a/examples/embedded-app/README.md
+++ b/examples/embedded-app/README.md
@@ -118,6 +118,16 @@ The action middleware example demonstrates:
 - Page navigation with persistent chat state
 - localStorage-based chat history persistence
 
+### WebMCP Browser Harness
+- **Harness page**: `http://localhost:5173/webmcp-harness.html`
+  - Verifies WebMCP capability detection and fallback behavior in-browser
+  - Runs four scenarios:
+    - `Unsupported`: no `navigator.modelContext`, confirms fallback request path
+    - `Mock Ready`: mocked `modelContext` confirms context + tool registration path
+    - `Mock Error`: mocked failure confirms safe fallback with successful request
+    - `Cleanup`: confirms `unregisterTool` and `clearContext` on widget destroy
+  - Uses `customFetch` to capture outgoing payload and return synthetic SSE responses (no backend required)
+
 ### Custom Components Demo
 - **Components page**: `http://localhost:5173/custom-components.html`
   - Demonstrates custom component rendering from JSON directives

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -39,6 +39,7 @@
         <li><a href="/artifact-demo.html">Artifact sidebar demo</a></li>
         <li><a href="/fullscreen-assistant-demo.html">Fullscreen assistant (split chat + artifact)</a></li>
         <li><a href="/voice-integration-demo.html">🎤 Voice Integration Demo (ElevenLabs)</a></li>
+        <li><a href="/webmcp-harness.html">WebMCP Browser Harness</a></li>
       </ul>
       <h3>Standalone (CDN / Copy-Paste)</h3>
       <p><small>These load the widget via IIFE build (local on localhost, CDN in production). Run <code>pnpm build:widget</code> first.</small></p>

--- a/examples/embedded-app/src/webmcp-harness.ts
+++ b/examples/embedded-app/src/webmcp-harness.ts
@@ -1,0 +1,351 @@
+import "@runtypelabs/persona/widget.css";
+
+import {
+  createAgentExperience,
+  DEFAULT_WIDGET_CONFIG,
+  markdownPostprocessor,
+  type AgentWidgetController,
+  type AgentWidgetRequestPayload,
+  type AgentWidgetWebMcpConfig,
+  type AgentWidgetWebMcpEvent
+} from "@runtypelabs/persona";
+
+type MockCalls = {
+  provideContext: number;
+  registerTool: number;
+  unregisterTool: number;
+  clearContext: number;
+};
+
+type HarnessScenarioResult = {
+  pass: boolean;
+  name: string;
+  details: string;
+};
+
+type MockModelContext = {
+  provideContext: (...args: unknown[]) => Promise<void>;
+  registerTool: (...args: unknown[]) => Promise<void>;
+  unregisterTool: (...args: unknown[]) => Promise<void>;
+  clearContext: (...args: unknown[]) => Promise<void>;
+};
+
+const mount = document.getElementById("webmcp-widget");
+const resultsEl = document.getElementById("results");
+const logEl = document.getElementById("event-log");
+
+if (!mount || !resultsEl || !logEl) {
+  throw new Error("Harness DOM nodes missing");
+}
+
+let controller: AgentWidgetController | null = null;
+let lastPayload: AgentWidgetRequestPayload | null = null;
+let customFetchCount = 0;
+
+const originalModelContext = (navigator as any).modelContext;
+
+const writeLog = (line: string) => {
+  const ts = new Date().toLocaleTimeString();
+  logEl.textContent += `[${ts}] ${line}\n`;
+  logEl.scrollTop = logEl.scrollHeight;
+};
+
+const addResult = ({ pass, name, details }: HarnessScenarioResult) => {
+  const item = document.createElement("li");
+  item.className = `result-item ${pass ? "pass" : "fail"}`;
+  item.textContent = `${pass ? "PASS" : "FAIL"} ${name}\n${details}`;
+  resultsEl.appendChild(item);
+};
+
+const createSseResponse = (assistantText: string): Response => {
+  const encoder = new TextEncoder();
+  const chunks = [
+    `data: ${JSON.stringify({ type: "step_chunk", stepType: "prompt", text: assistantText })}\n\n`,
+    `data: ${JSON.stringify({ type: "flow_complete", success: true, result: { response: assistantText } })}\n\n`
+  ];
+  const body = new ReadableStream<Uint8Array>({
+    start(streamController) {
+      for (const chunk of chunks) {
+        streamController.enqueue(encoder.encode(chunk));
+      }
+      streamController.close();
+    }
+  });
+  return new Response(body, {
+    status: 200,
+    headers: { "Content-Type": "text/event-stream" }
+  });
+};
+
+const waitFor = async (
+  condition: () => boolean,
+  timeoutMs: number,
+  intervalMs: number = 25
+) => {
+  const start = Date.now();
+  while (!condition()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`Timed out after ${timeoutMs}ms`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+};
+
+const resetHarnessState = () => {
+  lastPayload = null;
+  customFetchCount = 0;
+};
+
+const destroyWidget = () => {
+  controller?.destroy();
+  controller = null;
+  mount.innerHTML = "";
+};
+
+const installModelContext = (mock: MockModelContext | undefined) => {
+  (navigator as any).modelContext = mock;
+};
+
+const createMockModelContext = (mode: "ready" | "error") => {
+  const calls: MockCalls = {
+    provideContext: 0,
+    registerTool: 0,
+    unregisterTool: 0,
+    clearContext: 0
+  };
+
+  const modelContext: MockModelContext = {
+    provideContext: async () => {
+      calls.provideContext += 1;
+      if (mode === "error") {
+        throw new Error("mock provideContext failure");
+      }
+    },
+    registerTool: async () => {
+      calls.registerTool += 1;
+    },
+    unregisterTool: async () => {
+      calls.unregisterTool += 1;
+    },
+    clearContext: async () => {
+      calls.clearContext += 1;
+    }
+  };
+
+  return { calls, modelContext };
+};
+
+const buildWebMcpConfig = (label: string): AgentWidgetWebMcpConfig => ({
+  enabled: true,
+  tools: [
+    {
+      name: "local_echo",
+      description: "Echoes input in the browser harness",
+      inputSchema: {
+        type: "object",
+        properties: {
+          text: { type: "string" }
+        },
+        required: ["text"]
+      },
+      handler: async (input) => ({ ok: true, input })
+    }
+  ],
+  onEvent: (event: AgentWidgetWebMcpEvent) => {
+    writeLog(`${label} ${event.phase} ${event.status.state} ${event.status.reason ?? ""}`.trim());
+  }
+});
+
+const createHarnessWidget = (label: string, webmcp: AgentWidgetWebMcpConfig) => {
+  destroyWidget();
+  resetHarnessState();
+
+  controller = createAgentExperience(mount, {
+    ...DEFAULT_WIDGET_CONFIG,
+    apiUrl: "https://harness.invalid/api/chat/dispatch",
+    launcher: {
+      ...DEFAULT_WIDGET_CONFIG.launcher,
+      enabled: false,
+      width: "100%"
+    },
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "WebMCP Harness",
+      welcomeSubtitle: `Scenario: ${label}`
+    },
+    suggestionChips: ["Run harness scenario"],
+    webmcp,
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+    customFetch: async (_url: string, _init: RequestInit, payload: AgentWidgetRequestPayload) => {
+      customFetchCount += 1;
+      lastPayload = payload;
+      writeLog(`${label} request sent (state=${(payload.context as any)?.webmcp?.state ?? "none"})`);
+      return createSseResponse(`Harness response for ${label}`);
+    }
+  });
+};
+
+const submitAndWait = async (text: string) => {
+  if (!controller) throw new Error("Controller not initialized");
+  const ok = controller.submitMessage(text);
+  if (!ok) throw new Error("submitMessage returned false");
+  await waitFor(() => controller?.getStatus() === "idle", 3000);
+};
+
+const assertScenario = (name: string, checks: Array<{ ok: boolean; message: string }>) => {
+  const failing = checks.filter((check) => !check.ok);
+  if (failing.length === 0) {
+    addResult({
+      pass: true,
+      name,
+      details: checks.map((check) => `- ${check.message}`).join("\n")
+    });
+    return;
+  }
+  addResult({
+    pass: false,
+    name,
+    details: failing.map((check) => `- ${check.message}`).join("\n")
+  });
+};
+
+const runUnsupported = async () => {
+  const scenario = "unsupported";
+  writeLog(`running ${scenario}`);
+  installModelContext(undefined);
+  createHarnessWidget(scenario, buildWebMcpConfig(scenario));
+  await submitAndWait("run unsupported case");
+
+  assertScenario("Unsupported fallback", [
+    {
+      ok: (lastPayload as any)?.context?.webmcp?.state === "unsupported",
+      message: "payload.context.webmcp.state is unsupported"
+    },
+    {
+      ok: customFetchCount === 1,
+      message: "normal request path executed exactly once"
+    },
+    {
+      ok: (controller?.getMessages() ?? []).some((m) => m.role === "assistant" && m.content.includes("Harness response")),
+      message: "assistant response rendered"
+    }
+  ]);
+};
+
+const runReady = async () => {
+  const scenario = "ready";
+  writeLog(`running ${scenario}`);
+  const { calls, modelContext } = createMockModelContext("ready");
+  installModelContext(modelContext);
+  createHarnessWidget(scenario, buildWebMcpConfig(scenario));
+  await submitAndWait("run ready case");
+
+  assertScenario("Mock ready path", [
+    {
+      ok: (lastPayload as any)?.context?.webmcp?.state === "ready",
+      message: "payload.context.webmcp.state is ready"
+    },
+    {
+      ok: calls.provideContext > 0,
+      message: "provideContext was called"
+    },
+    {
+      ok: calls.registerTool > 0,
+      message: "registerTool was called"
+    }
+  ]);
+};
+
+const runError = async () => {
+  const scenario = "error";
+  writeLog(`running ${scenario}`);
+  const { modelContext } = createMockModelContext("error");
+  installModelContext(modelContext);
+  createHarnessWidget(scenario, buildWebMcpConfig(scenario));
+  await submitAndWait("run error case");
+
+  assertScenario("Error fallback", [
+    {
+      ok: (lastPayload as any)?.context?.webmcp?.state === "error",
+      message: "payload.context.webmcp.state is error"
+    },
+    {
+      ok: customFetchCount === 1,
+      message: "request still completed through fallback path"
+    },
+    {
+      ok: (controller?.getMessages() ?? []).some((m) => m.role === "assistant"),
+      message: "assistant response still rendered"
+    }
+  ]);
+};
+
+const runCleanup = async () => {
+  const scenario = "cleanup";
+  writeLog(`running ${scenario}`);
+  const { calls, modelContext } = createMockModelContext("ready");
+  installModelContext(modelContext);
+  createHarnessWidget(scenario, buildWebMcpConfig(scenario));
+  await submitAndWait("run cleanup case");
+  destroyWidget();
+
+  assertScenario("Cleanup on destroy", [
+    {
+      ok: calls.unregisterTool > 0,
+      message: "unregisterTool was called on destroy"
+    },
+    {
+      ok: calls.clearContext > 0,
+      message: "clearContext was called on destroy"
+    }
+  ]);
+};
+
+const clearResults = () => {
+  resultsEl.innerHTML = "";
+  logEl.textContent = "";
+};
+
+document.getElementById("run-unsupported")?.addEventListener("click", () => {
+  void runUnsupported().catch((error) => {
+    addResult({ pass: false, name: "Unsupported fallback", details: String(error) });
+  });
+});
+
+document.getElementById("run-ready")?.addEventListener("click", () => {
+  void runReady().catch((error) => {
+    addResult({ pass: false, name: "Mock ready path", details: String(error) });
+  });
+});
+
+document.getElementById("run-error")?.addEventListener("click", () => {
+  void runError().catch((error) => {
+    addResult({ pass: false, name: "Error fallback", details: String(error) });
+  });
+});
+
+document.getElementById("run-cleanup")?.addEventListener("click", () => {
+  void runCleanup().catch((error) => {
+    addResult({ pass: false, name: "Cleanup on destroy", details: String(error) });
+  });
+});
+
+document.getElementById("run-all")?.addEventListener("click", () => {
+  void (async () => {
+    await runUnsupported();
+    await runReady();
+    await runError();
+    await runCleanup();
+  })().catch((error) => {
+    addResult({ pass: false, name: "Run all", details: String(error) });
+  });
+});
+
+document.getElementById("clear-results")?.addEventListener("click", clearResults);
+
+window.addEventListener("beforeunload", () => {
+  destroyWidget();
+  installModelContext(originalModelContext);
+});
+
+writeLog("Harness ready");

--- a/examples/embedded-app/src/webmcp-harness.ts
+++ b/examples/embedded-app/src/webmcp-harness.ts
@@ -301,6 +301,31 @@ const runCleanup = async () => {
   ]);
 };
 
+const runReal = async () => {
+  const scenario = "real";
+  writeLog(`running ${scenario}`);
+  // Restore original context
+  installModelContext(originalModelContext);
+  
+  createHarnessWidget(scenario, buildWebMcpConfig(scenario));
+  await submitAndWait("run real case");
+
+  assertScenario("Real Browser WebMCP", [
+    {
+      ok: (lastPayload as any)?.context?.webmcp?.state === "ready",
+      message: "payload.context.webmcp.state is ready"
+    },
+    {
+      ok: Array.isArray((lastPayload as any)?.context?.webmcp?.registeredTools),
+      message: "registeredTools is an array"
+    },
+    {
+      ok: (lastPayload as any)?.context?.webmcp?.registeredTools?.includes("local_echo"),
+      message: "local_echo tool was registered"
+    }
+  ]);
+};
+
 const clearResults = () => {
   resultsEl.innerHTML = "";
   logEl.textContent = "";
@@ -349,3 +374,20 @@ window.addEventListener("beforeunload", () => {
 });
 
 writeLog("Harness ready");
+
+if (originalModelContext) {
+  const statusEl = document.getElementById("browser-status");
+  const runRealBtn = document.getElementById("run-real") as HTMLButtonElement;
+  if (statusEl && runRealBtn) {
+    statusEl.textContent = "WebMCP detected in this browser";
+    statusEl.style.color = "#166534";
+    runRealBtn.disabled = false;
+    runRealBtn.style.opacity = "1";
+    runRealBtn.style.cursor = "pointer";
+    runRealBtn.addEventListener("click", () => {
+      void runReal().catch((error) => {
+        addResult({ pass: false, name: "Real Browser WebMCP", details: String(error) });
+      });
+    });
+  }
+}

--- a/examples/embedded-app/webmcp-harness.html
+++ b/examples/embedded-app/webmcp-harness.html
@@ -105,8 +105,11 @@
       <h1>WebMCP Browser Harness</h1>
       <p class="small">
         Verifies unsupported fallback, mock WebMCP ready path, error fallback, and cleanup behavior in-browser.
+        <br>
+        <span id="browser-status" style="font-weight: 600; color: #dc2626;">WebMCP not detected in this browser</span>
       </p>
       <div class="controls">
+        <button id="run-real" disabled style="opacity: 0.5; cursor: not-allowed;">Run Real (Browser)</button>
         <button id="run-unsupported">Run Unsupported</button>
         <button id="run-ready">Run Mock Ready</button>
         <button id="run-error">Run Mock Error</button>

--- a/examples/embedded-app/webmcp-harness.html
+++ b/examples/embedded-app/webmcp-harness.html
@@ -1,0 +1,127 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>WebMCP Browser Harness</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f3f4f6;
+      color: #111827;
+    }
+    .layout {
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 1rem;
+      display: grid;
+      gap: 1rem;
+      grid-template-columns: 1fr 420px;
+    }
+    @media (max-width: 960px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+    .panel {
+      background: #ffffff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      padding: 1rem;
+    }
+    .controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin: 0.5rem 0 1rem;
+    }
+    button {
+      border: 1px solid #d1d5db;
+      background: #111827;
+      color: #ffffff;
+      border-radius: 8px;
+      padding: 0.5rem 0.75rem;
+      font-size: 0.9rem;
+      cursor: pointer;
+    }
+    button.secondary {
+      background: #ffffff;
+      color: #111827;
+    }
+    .result-list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: grid;
+      gap: 0.4rem;
+    }
+    .result-item {
+      font-family: ui-monospace, Menlo, Monaco, "Cascadia Mono", Consolas, monospace;
+      font-size: 0.82rem;
+      padding: 0.5rem 0.6rem;
+      border-radius: 8px;
+      border: 1px solid #e5e7eb;
+      background: #f9fafb;
+      white-space: pre-wrap;
+      word-break: break-word;
+    }
+    .pass { border-color: #86efac; background: #f0fdf4; color: #166534; }
+    .fail { border-color: #fca5a5; background: #fef2f2; color: #991b1b; }
+    .log {
+      margin-top: 0.75rem;
+      max-height: 260px;
+      overflow: auto;
+      background: #0f172a;
+      color: #e2e8f0;
+      border-radius: 10px;
+      padding: 0.75rem;
+      font-family: ui-monospace, Menlo, Monaco, Consolas, monospace;
+      font-size: 0.78rem;
+      line-height: 1.4;
+      white-space: pre-wrap;
+    }
+    #webmcp-widget {
+      min-height: 620px;
+      height: 70vh;
+    }
+    .small {
+      font-size: 0.84rem;
+      color: #4b5563;
+    }
+    .back-link {
+      display: inline-block;
+      margin: 1rem;
+      color: #1d4ed8;
+      text-decoration: none;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="back-link">&larr; Back to examples</a>
+  <main class="layout">
+    <section class="panel">
+      <h1>WebMCP Browser Harness</h1>
+      <p class="small">
+        Verifies unsupported fallback, mock WebMCP ready path, error fallback, and cleanup behavior in-browser.
+      </p>
+      <div class="controls">
+        <button id="run-unsupported">Run Unsupported</button>
+        <button id="run-ready">Run Mock Ready</button>
+        <button id="run-error">Run Mock Error</button>
+        <button id="run-cleanup">Run Cleanup</button>
+        <button id="run-all">Run All</button>
+        <button class="secondary" id="clear-results">Clear Results</button>
+      </div>
+      <ul id="results" class="result-list"></ul>
+      <div id="event-log" class="log"></div>
+    </section>
+    <section class="panel">
+      <h2>Harness Widget</h2>
+      <div id="webmcp-widget"></div>
+    </section>
+  </main>
+  <script type="module" src="/src/webmcp-harness.ts"></script>
+</body>
+</html>

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -1358,6 +1358,48 @@ const controller = initAgentWidget({
 
 This ensures all configuration values are set to sensible defaults while allowing you to customize only what you need.
 
+### Experimental: WebMCP
+
+You can enable experimental browser-side WebMCP integration when available, while automatically falling back to normal Persona behavior when it is not supported.
+
+```ts
+import { initAgentWidget } from '@runtypelabs/persona';
+
+initAgentWidget({
+  target: '#chat-root',
+  config: {
+    apiUrl: '/api/chat/dispatch',
+    webmcp: {
+      enabled: true,
+      tools: [
+        {
+          name: 'local_echo',
+          description: 'Returns the input payload',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              text: { type: 'string' }
+            },
+            required: ['text']
+          },
+          handler: async (input) => {
+            return { ok: true, echo: input };
+          }
+        }
+      ],
+      onEvent: (event) => {
+        console.debug('[webmcp]', event.phase, event.status);
+      }
+    }
+  }
+});
+```
+
+Notes:
+- WebMCP is optional. If `navigator.modelContext` is unavailable, requests continue using non-WebMCP flows.
+- If WebMCP sync or registration fails, the widget degrades safely and still sends normal chat requests.
+- By default, status is attached to outbound request context as `context.webmcp`. Set `webmcp.exposeStatusInContext = false` to disable this.
+
 ### Configuration reference
 
 All options are safe to mutate via `initAgentWidget(...).update(newConfig)`.
@@ -1375,6 +1417,7 @@ For detailed theme styling properties, see [THEME-CONFIG.md](./THEME-CONFIG.md).
 | `getHeaders` | `() => Record<string, string> \| Promise<...>` | Dynamic headers function called before each request. Use for auth tokens that may change. |
 | `customFetch` | `(url, init, payload) => Promise<Response>` | Replace the default `fetch` entirely. Receives URL, RequestInit, and the payload. |
 | `parseSSEEvent` | `(eventData) => { text?, done?, error? } \| null` | Transform non-standard SSE events into the expected format. Return `null` to ignore an event. |
+| `webmcp` | `AgentWidgetWebMcpConfig` | Experimental browser-side WebMCP integration. Enables capability detection, optional tool registration, and automatic fallback when unavailable. |
 
 #### Client Token Mode
 

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterAll, vi } from 'vitest';
 import { AgentWidgetClient } from './client';
 import { AgentWidgetEvent, AgentWidgetMessage } from './types';
 import { createJsonStreamParser } from './utils/formatting';
@@ -190,6 +190,110 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
 
     expect(capturedPayload.messages).toHaveLength(1);
     expect(capturedPayload.messages[0].content).toBe('{"action": "message", "text": "Hello"}');
+  });
+});
+
+describe('AgentWidgetClient - WebMCP Integration', () => {
+  const originalModelContext = (globalThis.navigator as any)?.modelContext;
+  let capturedPayload: any = null;
+
+  beforeEach(() => {
+    capturedPayload = null;
+    (globalThis.navigator as any).modelContext = undefined;
+  });
+
+  const mockFetch = () => {
+    global.fetch = vi.fn().mockImplementation(async (_url: string, options: any) => {
+      capturedPayload = JSON.parse(options.body);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+  };
+
+  it('falls back cleanly when navigator.modelContext is unavailable', async () => {
+    mockFetch();
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      webmcp: { enabled: true },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'hello', createdAt: new Date().toISOString() }] },
+      () => {}
+    );
+
+    expect(capturedPayload?.context?.webmcp?.state).toBe('unsupported');
+    expect(capturedPayload?.context?.webmcp?.reason).toBe('navigator.modelContext_unavailable');
+  });
+
+  it('registers tools and provides context when WebMCP is available', async () => {
+    mockFetch();
+    const provideContext = vi.fn().mockResolvedValue(undefined);
+    const registerTool = vi.fn().mockResolvedValue(undefined);
+    const unregisterTool = vi.fn().mockResolvedValue(undefined);
+    const clearContext = vi.fn().mockResolvedValue(undefined);
+    (globalThis.navigator as any).modelContext = {
+      provideContext,
+      registerTool,
+      unregisterTool,
+      clearContext
+    };
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      webmcp: {
+        enabled: true,
+        tools: [
+          {
+            name: 'local_echo',
+            description: 'Echo tool'
+          }
+        ]
+      },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_2', role: 'user', content: 'hello', createdAt: new Date().toISOString() }] },
+      () => {}
+    );
+
+    expect(provideContext).toHaveBeenCalled();
+    expect(registerTool).toHaveBeenCalled();
+    expect(capturedPayload?.context?.webmcp?.state).toBe('ready');
+    expect(capturedPayload?.context?.webmcp?.registeredTools).toContain('local_echo');
+
+    await client.destroy();
+    expect(unregisterTool).toHaveBeenCalled();
+    expect(clearContext).toHaveBeenCalled();
+  });
+
+  it('falls back to normal requests when WebMCP sync throws', async () => {
+    mockFetch();
+    const provideContext = vi.fn().mockRejectedValue(new Error('boom'));
+    (globalThis.navigator as any).modelContext = { provideContext };
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      webmcp: { enabled: true },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_3', role: 'user', content: 'hello', createdAt: new Date().toISOString() }] },
+      () => {}
+    );
+
+    expect(capturedPayload?.context?.webmcp?.state).toBe('error');
+    expect((global.fetch as any).mock.calls.length).toBe(1);
+  });
+
+  afterAll(() => {
+    (globalThis.navigator as any).modelContext = originalModelContext;
   });
 });
 
@@ -1439,4 +1543,3 @@ describe('AgentWidgetClient - Unified Event Names', () => {
     expect(reasoningMessages[0].reasoning?.chunks).toContain('Thinking...');
   });
 });
-

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -12,6 +12,7 @@ import {
   AgentWidgetHeadersFunction,
   AgentWidgetSSEEventResult as _AgentWidgetSSEEventResult,
   AgentExecutionState,
+  AgentWidgetWebMcpStatus,
   ClientSession,
   ClientInitResponse,
   ClientChatRequest,
@@ -19,6 +20,7 @@ import {
   ClientFeedbackType,
   PersonaArtifactKind
 } from "./types";
+import { WebMcpRuntime } from "./webmcp";
 import { 
   extractTextFromJson, 
   createPlainTextParser,
@@ -96,6 +98,8 @@ export class AgentWidgetClient {
   private readonly parseSSEEvent?: AgentWidgetSSEEventParser;
   private readonly getHeaders?: AgentWidgetHeadersFunction;
   private onSSEEvent?: SSEEventCallback;
+  private readonly webMcpRuntime: WebMcpRuntime | null = null;
+  private webMcpStatus: AgentWidgetWebMcpStatus | null = null;
   
   // Client token mode properties
   private clientSession: ClientSession | null = null;
@@ -115,6 +119,10 @@ export class AgentWidgetClient {
     this.customFetch = config.customFetch;
     this.parseSSEEvent = config.parseSSEEvent;
     this.getHeaders = config.getHeaders;
+    if (config.webmcp?.enabled) {
+      this.webMcpRuntime = new WebMcpRuntime(config.webmcp, config);
+      this.webMcpStatus = this.webMcpRuntime.getStatus();
+    }
   }
 
   /**
@@ -129,6 +137,22 @@ export class AgentWidgetClient {
    */
   public getSSEEventCallback(): SSEEventCallback | undefined {
     return this.onSSEEvent;
+  }
+
+  /**
+   * Dispose client resources.
+   */
+  public async destroy(): Promise<void> {
+    if (this.webMcpRuntime) {
+      try {
+        await this.webMcpRuntime.dispose();
+      } catch (error) {
+        if (typeof console !== "undefined") {
+          // eslint-disable-next-line no-console
+          console.warn("[AgentWidget] WebMCP dispose failed:", error);
+        }
+      }
+    }
   }
 
   /**
@@ -433,6 +457,8 @@ export class AgentWidgetClient {
     onEvent({ type: "status", status: "connecting" });
 
     try {
+      await this.ensureWebMcp(options.messages, controller.signal);
+
       // Ensure session is initialized
       const session = await this.initSession();
 
@@ -546,6 +572,7 @@ export class AgentWidgetClient {
 
     onEvent({ type: "status", status: "connecting" });
 
+    await this.ensureWebMcp(options.messages, controller.signal);
     const payload = await this.buildPayload(options.messages);
 
     if (this.debug) {
@@ -622,6 +649,7 @@ export class AgentWidgetClient {
 
     onEvent({ type: "status", status: "connecting" });
 
+    await this.ensureWebMcp(options.messages, controller.signal);
     const payload = await this.buildAgentPayload(options.messages);
 
     if (this.debug) {
@@ -799,6 +827,14 @@ export class AgentWidgetClient {
       }
     }
 
+    const webMcpContext = this.getWebMcpContext();
+    if (webMcpContext) {
+      payload.context = {
+        ...(payload.context ?? {}),
+        webmcp: webMcpContext
+      };
+    }
+
     return payload;
   }
 
@@ -852,6 +888,14 @@ export class AgentWidgetClient {
       }
     }
 
+    const webMcpContext = this.getWebMcpContext();
+    if (webMcpContext) {
+      payload.context = {
+        ...(payload.context ?? {}),
+        webmcp: webMcpContext
+      };
+    }
+
     if (this.requestMiddleware) {
       try {
         const result = await this.requestMiddleware({
@@ -870,6 +914,38 @@ export class AgentWidgetClient {
     }
 
     return payload;
+  }
+
+  private async ensureWebMcp(
+    messages: AgentWidgetMessage[],
+    signal?: AbortSignal
+  ): Promise<void> {
+    if (!this.webMcpRuntime) return;
+    try {
+      this.webMcpStatus = await this.webMcpRuntime.sync(messages, signal);
+    } catch (error) {
+      this.webMcpStatus = {
+        state: "error",
+        reason: "webmcp_unhandled_sync_failure",
+        details: error instanceof Error ? error.message : String(error)
+      };
+      if (typeof console !== "undefined") {
+        // eslint-disable-next-line no-console
+        console.warn("[AgentWidget] WebMCP sync failed, using fallback path:", error);
+      }
+    }
+  }
+
+  private getWebMcpContext(): Record<string, unknown> | null {
+    if (this.config.webmcp?.enabled !== true) return null;
+    if (this.config.webmcp?.exposeStatusInContext === false) return null;
+    if (!this.webMcpStatus) return null;
+    return {
+      state: this.webMcpStatus.state,
+      reason: this.webMcpStatus.reason,
+      details: this.webMcpStatus.details,
+      registeredTools: this.webMcpStatus.registeredTools ?? []
+    };
   }
 
   /**

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -25,6 +25,11 @@ export type {
   AgentWidgetSSEEventParser,
   AgentWidgetSSEEventResult,
   AgentWidgetHeadersFunction,
+  AgentWidgetWebMcpConfig,
+  AgentWidgetWebMcpToolDefinition,
+  AgentWidgetWebMcpToolHandlerContext,
+  AgentWidgetWebMcpStatus,
+  AgentWidgetWebMcpEvent,
   // Multi-modal content types
   TextContentPart,
   ImageContentPart,

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -496,9 +496,9 @@ export class AgentWidgetSession {
     return this.client.submitNPSFeedback(rating, comment);
   }
 
-  public updateConfig(next: AgentWidgetConfig) {
-    void this.client.destroy();
+  public async updateConfig(next: AgentWidgetConfig) {
     const prevSSECallback = this.client.getSSEEventCallback();
+    await this.client.destroy();
     this.config = { ...this.config, ...next };
     this.client = new AgentWidgetClient(this.config);
     if (prevSSECallback) {

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -497,12 +497,19 @@ export class AgentWidgetSession {
   }
 
   public updateConfig(next: AgentWidgetConfig) {
+    void this.client.destroy();
     const prevSSECallback = this.client.getSSEEventCallback();
     this.config = { ...this.config, ...next };
     this.client = new AgentWidgetClient(this.config);
     if (prevSSECallback) {
       this.client.setSSEEventCallback(prevSSECallback);
     }
+  }
+
+  public destroy() {
+    this.abortController?.abort();
+    this.abortController = null;
+    void this.client.destroy();
   }
 
   public getMessages() {

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1304,6 +1304,92 @@ export type AgentWidgetCustomFetch = (
 export type AgentWidgetHeadersFunction = () => Record<string, string> | Promise<Record<string, string>>;
 
 // ============================================================================
+// WebMCP Types
+// ============================================================================
+
+/**
+ * Context passed to WebMCP tool handlers.
+ */
+export type AgentWidgetWebMcpToolHandlerContext = {
+  messages: AgentWidgetMessage[];
+  config: AgentWidgetConfig;
+  signal?: AbortSignal;
+};
+
+/**
+ * Definition for a WebMCP tool to register in compatible browsers.
+ */
+export type AgentWidgetWebMcpToolDefinition = {
+  name: string;
+  description?: string;
+  inputSchema?: Record<string, unknown>;
+  handler?: (
+    input: unknown,
+    context: AgentWidgetWebMcpToolHandlerContext
+  ) => unknown | Promise<unknown>;
+};
+
+/**
+ * Runtime status emitted by the WebMCP integration.
+ */
+export type AgentWidgetWebMcpStatus = {
+  state: "disabled" | "unsupported" | "ready" | "error";
+  reason?: string;
+  details?: string;
+  registeredTools?: string[];
+};
+
+/**
+ * Event emitted as WebMCP state changes.
+ */
+export type AgentWidgetWebMcpEvent = {
+  phase: "detect" | "init" | "context" | "tool-register" | "dispose";
+  status: AgentWidgetWebMcpStatus;
+  toolName?: string;
+  error?: Error;
+};
+
+/**
+ * Configuration for experimental WebMCP integration.
+ */
+export type AgentWidgetWebMcpConfig = {
+  /**
+   * Enables WebMCP integration.
+   * When false/undefined, widget behavior is unchanged.
+   */
+  enabled?: boolean;
+  /**
+   * Optional tool definitions to register when WebMCP is available.
+   */
+  tools?: AgentWidgetWebMcpToolDefinition[];
+  /**
+   * Optional provider for browser-local context.
+   * Defaults to lightweight recent-message context.
+   */
+  contextProvider?: (context: {
+    messages: AgentWidgetMessage[];
+    config: AgentWidgetConfig;
+  }) =>
+    | Record<string, unknown>
+    | void
+    | Promise<Record<string, unknown> | void>;
+  /**
+   * Number of recent messages included by default when `contextProvider` is not set.
+   * @default 20
+   */
+  maxContextMessages?: number;
+  /**
+   * Include current WebMCP status under `context.webmcp` in outbound payloads.
+   * @default true
+   */
+  exposeStatusInContext?: boolean;
+  /**
+   * Callback for observability and debugging.
+   */
+  onEvent?: (event: AgentWidgetWebMcpEvent) => void;
+};
+
+// ============================================================================
 // Client Token Types
 // ============================================================================
 
@@ -2245,6 +2331,11 @@ export type AgentWidgetConfig = {
    * ```
    */
   getHeaders?: AgentWidgetHeadersFunction;
+  /**
+   * Experimental WebMCP integration.
+   * Uses browser capabilities when available and automatically falls back.
+   */
+  webmcp?: AgentWidgetWebMcpConfig;
   copy?: {
     welcomeTitle?: string;
     welcomeSubtitle?: string;

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -5132,6 +5132,7 @@ export const createAgentExperience = (
       return session.submitNPSFeedback(rating, comment);
     },
     destroy() {
+      session.destroy();
       destroyCallbacks.forEach((cb) => cb());
       wrapper.remove();
       launcherButtonInstance?.destroy();

--- a/packages/widget/src/webmcp.ts
+++ b/packages/widget/src/webmcp.ts
@@ -1,0 +1,283 @@
+import type {
+  AgentWidgetConfig,
+  AgentWidgetMessage,
+  AgentWidgetWebMcpConfig,
+  AgentWidgetWebMcpEvent,
+  AgentWidgetWebMcpStatus,
+  AgentWidgetWebMcpToolDefinition
+} from "./types";
+
+type ModelContextLike = {
+  provideContext?: (...args: any[]) => unknown;
+  clearContext?: (...args: any[]) => unknown;
+  registerTool?: (...args: any[]) => unknown;
+  unregisterTool?: (...args: any[]) => unknown;
+};
+
+const DEFAULT_MAX_CONTEXT_MESSAGES = 20;
+
+const asError = (value: unknown) =>
+  value instanceof Error ? value : new Error(String(value));
+
+const safeAwait = async <T>(value: T | Promise<T>) => Promise.resolve(value);
+
+const getModelContext = (): ModelContextLike | null => {
+  if (typeof navigator === "undefined") return null;
+  const modelContext = (navigator as any).modelContext;
+  if (!modelContext || typeof modelContext !== "object") return null;
+  return modelContext as ModelContextLike;
+};
+
+const toToolSummary = (tools: AgentWidgetWebMcpToolDefinition[]) =>
+  tools.map((tool) => tool.name);
+
+export class WebMcpRuntime {
+  private status: AgentWidgetWebMcpStatus;
+  private readonly registeredTools = new Set<string>();
+  private initialized = false;
+  private disabledAfterError = false;
+
+  constructor(
+    private readonly config: AgentWidgetWebMcpConfig,
+    private readonly widgetConfig: AgentWidgetConfig
+  ) {
+    this.status = config.enabled
+      ? { state: "unsupported", reason: "not_checked" }
+      : { state: "disabled", reason: "webmcp_not_enabled" };
+  }
+
+  public getStatus(): AgentWidgetWebMcpStatus {
+    return { ...this.status, registeredTools: [...this.registeredTools] };
+  }
+
+  public async sync(
+    messages: AgentWidgetMessage[],
+    signal?: AbortSignal
+  ): Promise<AgentWidgetWebMcpStatus> {
+    if (!this.config.enabled) {
+      this.status = { state: "disabled", reason: "webmcp_not_enabled" };
+      return this.getStatus();
+    }
+    if (this.disabledAfterError) {
+      return this.getStatus();
+    }
+    if (signal?.aborted) {
+      return this.getStatus();
+    }
+
+    const modelContext = getModelContext();
+    if (!modelContext) {
+      this.status = {
+        state: "unsupported",
+        reason: "navigator.modelContext_unavailable"
+      };
+      this.emit("detect", this.getStatus());
+      return this.getStatus();
+    }
+
+    this.emit("detect", {
+      state: "ready",
+      reason: "navigator.modelContext_detected",
+      registeredTools: [...this.registeredTools]
+    });
+
+    try {
+      const isFirstSync = !this.initialized;
+      await this.syncContext(modelContext, messages);
+      await this.syncTools(modelContext, messages, signal);
+      this.initialized = true;
+      this.status = {
+        state: "ready",
+        reason: "webmcp_active",
+        registeredTools: [...this.registeredTools]
+      };
+      this.emit(isFirstSync ? "init" : "context", this.getStatus());
+      return this.getStatus();
+    } catch (error) {
+      const err = asError(error);
+      this.status = {
+        state: "error",
+        reason: "webmcp_sync_failed",
+        details: err.message,
+        registeredTools: [...this.registeredTools]
+      };
+      this.disabledAfterError = true;
+      this.emit("init", this.getStatus(), err);
+      return this.getStatus();
+    }
+  }
+
+  public async dispose(): Promise<void> {
+    if (!this.config.enabled) return;
+    const modelContext = getModelContext();
+    if (!modelContext) return;
+
+    const toolNames = [...this.registeredTools];
+    for (const name of toolNames) {
+      try {
+        await this.tryUnregisterTool(modelContext, name);
+      } catch (error) {
+        this.emit("dispose", this.getStatus(), asError(error), name);
+      }
+    }
+    this.registeredTools.clear();
+
+    try {
+      if (typeof modelContext.clearContext === "function") {
+        await safeAwait(modelContext.clearContext());
+      }
+    } catch (error) {
+      this.emit("dispose", this.getStatus(), asError(error));
+    }
+  }
+
+  private emit(
+    phase: AgentWidgetWebMcpEvent["phase"],
+    status: AgentWidgetWebMcpStatus,
+    error?: Error,
+    toolName?: string
+  ) {
+    this.config.onEvent?.({ phase, status, error, toolName });
+  }
+
+  private async syncContext(
+    modelContext: ModelContextLike,
+    messages: AgentWidgetMessage[]
+  ) {
+    if (typeof modelContext.provideContext !== "function") return;
+
+    const provided =
+      (await this.config.contextProvider?.({
+        messages,
+        config: this.widgetConfig
+      })) ?? this.buildDefaultContext(messages);
+
+    const provideContext = modelContext.provideContext.bind(modelContext);
+    const payload = provided && typeof provided === "object" ? provided : {};
+    await this.tryProvideContext(provideContext, payload);
+    this.emit("context", this.getStatus());
+  }
+
+  private async syncTools(
+    modelContext: ModelContextLike,
+    messages: AgentWidgetMessage[],
+    signal?: AbortSignal
+  ) {
+    if (typeof modelContext.registerTool !== "function") return;
+    const tools = this.config.tools ?? [];
+    for (const tool of tools) {
+      if (signal?.aborted) return;
+      if (this.registeredTools.has(tool.name)) continue;
+      await this.tryRegisterTool(modelContext, tool, messages, signal);
+      this.registeredTools.add(tool.name);
+      this.emit("tool-register", {
+        state: "ready",
+        reason: "tool_registered",
+        registeredTools: [...this.registeredTools]
+      }, undefined, tool.name);
+    }
+  }
+
+  private async tryProvideContext(
+    provideContext: (...args: any[]) => unknown,
+    payload: Record<string, unknown>
+  ) {
+    const attempts: Array<() => Promise<unknown>> = [
+      () => safeAwait(provideContext(payload)),
+      () => safeAwait(provideContext("persona", payload))
+    ];
+    let lastError: Error | null = null;
+    for (const attempt of attempts) {
+      try {
+        await attempt();
+        return;
+      } catch (error) {
+        lastError = asError(error);
+      }
+    }
+    if (lastError) {
+      throw lastError;
+    }
+  }
+
+  private async tryRegisterTool(
+    modelContext: ModelContextLike,
+    tool: AgentWidgetWebMcpToolDefinition,
+    messages: AgentWidgetMessage[],
+    signal?: AbortSignal
+  ) {
+    const registerTool = modelContext.registerTool!.bind(modelContext);
+    const definition = {
+      name: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      ...(tool.inputSchema ? { inputSchema: tool.inputSchema } : {})
+    };
+
+    const handler = async (input: unknown) => {
+      if (!tool.handler) {
+        return { ok: false, error: "No tool handler configured" };
+      }
+      return tool.handler(input, {
+        messages,
+        config: this.widgetConfig,
+        signal
+      });
+    };
+
+    const attempts: Array<() => Promise<unknown>> = [
+      () => safeAwait(registerTool(definition, handler)),
+      () => safeAwait(registerTool(tool.name, definition, handler)),
+      () => safeAwait(registerTool(tool.name, handler))
+    ];
+
+    let lastError: Error | null = null;
+    for (const attempt of attempts) {
+      try {
+        await attempt();
+        return;
+      } catch (error) {
+        lastError = asError(error);
+      }
+    }
+    if (lastError) {
+      throw lastError;
+    }
+  }
+
+  private async tryUnregisterTool(modelContext: ModelContextLike, name: string) {
+    if (typeof modelContext.unregisterTool !== "function") return;
+    const unregisterTool = modelContext.unregisterTool.bind(modelContext);
+    const attempts: Array<() => Promise<unknown>> = [
+      () => safeAwait(unregisterTool(name)),
+      () => safeAwait(unregisterTool({ name }))
+    ];
+
+    let lastError: Error | null = null;
+    for (const attempt of attempts) {
+      try {
+        await attempt();
+        return;
+      } catch (error) {
+        lastError = asError(error);
+      }
+    }
+    if (lastError) {
+      throw lastError;
+    }
+  }
+
+  private buildDefaultContext(messages: AgentWidgetMessage[]) {
+    const maxMessages = this.config.maxContextMessages ?? DEFAULT_MAX_CONTEXT_MESSAGES;
+    const recent = messages.slice(-maxMessages).map((message) => ({
+      id: message.id,
+      role: message.role,
+      createdAt: message.createdAt,
+      content: message.llmContent ?? message.rawContent ?? message.content
+    }));
+    return {
+      source: "persona-widget",
+      messages: recent,
+      registeredTools: toToolSummary(this.config.tools ?? [])
+    };
+  }
+}

--- a/packages/widget/src/webmcp.ts
+++ b/packages/widget/src/webmcp.ts
@@ -19,8 +19,6 @@ const DEFAULT_MAX_CONTEXT_MESSAGES = 20;
 const asError = (value: unknown) =>
   value instanceof Error ? value : new Error(String(value));
 
-const safeAwait = async <T>(value: T | Promise<T>) => Promise.resolve(value);
-
 const getModelContext = (): ModelContextLike | null => {
   if (typeof navigator === "undefined") return null;
   const modelContext = (navigator as any).modelContext;
@@ -36,6 +34,8 @@ export class WebMcpRuntime {
   private readonly registeredTools = new Set<string>();
   private initialized = false;
   private disabledAfterError = false;
+  private currentMessages: AgentWidgetMessage[] = [];
+  private currentSignal?: AbortSignal;
 
   constructor(
     private readonly config: AgentWidgetWebMcpConfig,
@@ -81,10 +81,13 @@ export class WebMcpRuntime {
       registeredTools: [...this.registeredTools]
     });
 
+    this.currentMessages = messages;
+    this.currentSignal = signal;
+
     try {
       const isFirstSync = !this.initialized;
       await this.syncContext(modelContext, messages);
-      await this.syncTools(modelContext, messages, signal);
+      await this.syncTools(modelContext, signal);
       this.initialized = true;
       this.status = {
         state: "ready",
@@ -124,7 +127,7 @@ export class WebMcpRuntime {
 
     try {
       if (typeof modelContext.clearContext === "function") {
-        await safeAwait(modelContext.clearContext());
+        await Promise.resolve(modelContext.clearContext());
       }
     } catch (error) {
       this.emit("dispose", this.getStatus(), asError(error));
@@ -160,7 +163,6 @@ export class WebMcpRuntime {
 
   private async syncTools(
     modelContext: ModelContextLike,
-    messages: AgentWidgetMessage[],
     signal?: AbortSignal
   ) {
     if (typeof modelContext.registerTool !== "function") return;
@@ -168,7 +170,7 @@ export class WebMcpRuntime {
     for (const tool of tools) {
       if (signal?.aborted) return;
       if (this.registeredTools.has(tool.name)) continue;
-      await this.tryRegisterTool(modelContext, tool, messages, signal);
+      await this.tryRegisterTool(modelContext, tool);
       this.registeredTools.add(tool.name);
       this.emit("tool-register", {
         state: "ready",
@@ -183,8 +185,8 @@ export class WebMcpRuntime {
     payload: Record<string, unknown>
   ) {
     const attempts: Array<() => Promise<unknown>> = [
-      () => safeAwait(provideContext(payload)),
-      () => safeAwait(provideContext("persona", payload))
+      () => Promise.resolve(provideContext(payload)),
+      () => Promise.resolve(provideContext("persona", payload))
     ];
     let lastError: Error | null = null;
     for (const attempt of attempts) {
@@ -202,9 +204,7 @@ export class WebMcpRuntime {
 
   private async tryRegisterTool(
     modelContext: ModelContextLike,
-    tool: AgentWidgetWebMcpToolDefinition,
-    messages: AgentWidgetMessage[],
-    signal?: AbortSignal
+    tool: AgentWidgetWebMcpToolDefinition
   ) {
     const registerTool = modelContext.registerTool!.bind(modelContext);
     const definition = {
@@ -218,16 +218,16 @@ export class WebMcpRuntime {
         return { ok: false, error: "No tool handler configured" };
       }
       return tool.handler(input, {
-        messages,
+        messages: this.currentMessages,
         config: this.widgetConfig,
-        signal
+        signal: this.currentSignal
       });
     };
 
     const attempts: Array<() => Promise<unknown>> = [
-      () => safeAwait(registerTool(definition, handler)),
-      () => safeAwait(registerTool(tool.name, definition, handler)),
-      () => safeAwait(registerTool(tool.name, handler))
+      () => Promise.resolve(registerTool(definition, handler)),
+      () => Promise.resolve(registerTool(tool.name, definition, handler)),
+      () => Promise.resolve(registerTool(tool.name, handler))
     ];
 
     let lastError: Error | null = null;
@@ -248,8 +248,8 @@ export class WebMcpRuntime {
     if (typeof modelContext.unregisterTool !== "function") return;
     const unregisterTool = modelContext.unregisterTool.bind(modelContext);
     const attempts: Array<() => Promise<unknown>> = [
-      () => safeAwait(unregisterTool(name)),
-      () => safeAwait(unregisterTool({ name }))
+      () => Promise.resolve(unregisterTool(name)),
+      () => Promise.resolve(unregisterTool({ name }))
     ];
 
     let lastError: Error | null = null;


### PR DESCRIPTION
## Summary
- add experimental WebMCP runtime support in the widget client
- register WebMCP tools/context when available and expose status via context.webmcp
- keep dispatch behavior resilient with automatic fallback when WebMCP is unavailable or errors
- add lifecycle cleanup (tool/context disposal) on session update/destroy
- add WebMCP docs and usage example in widget README
- add client tests covering unavailable, available, and failure fallback paths

## Validation
- pnpm --filter @runtypelabs/persona typecheck
- pnpm --filter @runtypelabs/persona lint
- pnpm --filter @runtypelabs/persona exec vitest run src/client.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request dispatch and session lifecycle: outbound payloads may now include `context.webmcp`, and new sync/cleanup logic runs before/after requests; failures should fall back but could impact chat reliability in edge browsers.
> 
> **Overview**
> Adds an **experimental WebMCP integration** to the widget client: when `webmcp.enabled` is set, the client detects `navigator.modelContext`, provides browser-local context, optionally registers tools, and safely degrades to normal requests when unsupported or when sync/registration fails.
> 
> Outbound requests can now include **WebMCP status metadata** under `context.webmcp` (configurable via `webmcp.exposeStatusInContext`), and widget lifecycle now performs **explicit cleanup** (unregister tools / clear context) on session `destroy()` and before `updateConfig()` recreates the client.
> 
> Includes new public WebMCP types/exports, adds unit tests for unsupported/ready/error paths, documents usage in the widget README, and adds an `examples/embedded-app` **browser harness page** to validate WebMCP behavior end-to-end without a backend.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da740205dee209af86aa0d1d530b0cd6e382b81e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->