### PR TITLE
Reduce lint debt across widget tests and console directives

### DIFF
--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -91,7 +91,7 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
     );
 
     // Verify the empty message was filtered out
-    expect(capturedPayload).toBeDefined();
+    expect(global.fetch).toHaveBeenCalled();
     expect(capturedPayload.messages).toHaveLength(2);
     expect(capturedPayload.messages[0].content).toBe('What can you help me with?');
     expect(capturedPayload.messages[1].content).toBe('test');
@@ -261,7 +261,7 @@ describe('AgentWidgetClient - llmContent Priority', () => {
 
     await client.dispatch({ messages }, () => {});
 
-    expect(capturedPayload).toBeDefined();
+    expect(global.fetch).toHaveBeenCalled();
     expect(capturedPayload.messages).toHaveLength(1);
     // Should use llmContent, not content
     expect(capturedPayload.messages[0].content).toBe('LLM-specific content with more context');
@@ -291,7 +291,7 @@ describe('AgentWidgetClient - llmContent Priority', () => {
 
     await client.dispatch({ messages }, () => {});
 
-    expect(capturedPayload).toBeDefined();
+    expect(global.fetch).toHaveBeenCalled();
     expect(capturedPayload.messages).toHaveLength(1);
     expect(capturedPayload.messages[0].content).toBe('Regular content without llmContent');
   });
@@ -322,7 +322,7 @@ describe('AgentWidgetClient - llmContent Priority', () => {
 
     await client.dispatch({ messages }, () => {});
 
-    expect(capturedPayload).toBeDefined();
+    expect(global.fetch).toHaveBeenCalled();
     expect(capturedPayload.messages).toHaveLength(1);
     // Should use contentParts, not llmContent
     expect(capturedPayload.messages[0].content).toEqual([{ type: 'text', text: 'Multi-modal text' }]);
@@ -397,7 +397,7 @@ describe('AgentWidgetClient - llmContent Priority', () => {
 
     await client.dispatch({ messages }, () => {});
 
-    expect(capturedPayload).toBeDefined();
+    expect(global.fetch).toHaveBeenCalled();
     expect(capturedPayload.messages).toHaveLength(3);
 
     // First message: regular user message
@@ -706,7 +706,7 @@ describe('AgentWidgetClient - Agent Payload Building', () => {
 
     await client.dispatch({ messages }, () => {});
 
-    expect(capturedPayload).toBeDefined();
+    expect(global.fetch).toHaveBeenCalled();
     expect(capturedPayload.agent).toBeDefined();
     const payloadAgent = capturedPayload.agent as NonNullable<CapturedPayload['agent']>;
     expect(payloadAgent.name).toBe('Test Agent');

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -3,14 +3,46 @@ import { AgentWidgetClient } from './client';
 import { AgentWidgetEvent, AgentWidgetMessage } from './types';
 import { createJsonStreamParser } from './utils/formatting';
 
+type MockFetchOptions = {
+  body?: string;
+};
+
+type CapturedPayload = {
+  messages: Array<Record<string, unknown>>;
+  agent?: {
+    name?: string;
+    model?: string;
+    systemPrompt?: string;
+    loopConfig?: {
+      maxIterations?: number;
+    };
+  };
+  options?: {
+    streamResponse?: boolean;
+    recordMode?: string;
+  };
+};
+
+function parsePayload(options: MockFetchOptions): CapturedPayload {
+  const parsed = JSON.parse(options.body ?? '{}') as Partial<CapturedPayload>;
+  return {
+    messages: [],
+    ...parsed,
+  };
+}
+
+function emptyPayload(): CapturedPayload {
+  return { messages: [] };
+}
+
 describe('AgentWidgetClient - Empty Message Filtering', () => {
   let client: AgentWidgetClient;
   let events: AgentWidgetEvent[] = [];
-  let capturedPayload: any = null;
+  let capturedPayload: CapturedPayload = emptyPayload();
 
   beforeEach(() => {
     events = [];
-    capturedPayload = null;
+    capturedPayload = emptyPayload();
     client = new AgentWidgetClient({
       apiUrl: 'http://localhost:8000',
     });
@@ -18,8 +50,8 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
 
   it('should filter out messages with empty content before sending', async () => {
     // Create a mock fetch that captures the request payload
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       // Return a minimal successful response
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
@@ -66,14 +98,14 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
 
     // Verify no message has empty content
     const hasEmptyContent = capturedPayload.messages.some(
-      (m: any) => !m.content || (typeof m.content === 'string' && m.content.trim() === '')
+      (m: Record<string, unknown>) => !m.content || (typeof m.content === 'string' && m.content.trim() === '')
     );
     expect(hasEmptyContent).toBe(false);
   });
 
   it('should filter out messages with whitespace-only content', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -122,8 +154,8 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
   });
 
   it('should preserve messages with valid contentParts even if content is empty', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -139,7 +171,7 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
         id: 'usr_1',
         role: 'user',
         content: '', // Empty content but has contentParts - SHOULD BE PRESERVED
-        contentParts: [{ type: 'image', data: 'base64data' }] as any,
+        contentParts: [{ type: 'image', data: 'base64data' }] as unknown as AgentWidgetMessage['contentParts'],
         createdAt: '2025-01-01T00:00:00.000Z',
       },
       {
@@ -161,8 +193,8 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
   });
 
   it('should preserve messages with valid rawContent even if content is empty', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -195,18 +227,18 @@ describe('AgentWidgetClient - Empty Message Filtering', () => {
 
 describe('AgentWidgetClient - llmContent Priority', () => {
   let client: AgentWidgetClient;
-  let capturedPayload: any = null;
+  let capturedPayload: CapturedPayload = emptyPayload();
 
   beforeEach(() => {
-    capturedPayload = null;
+    capturedPayload = emptyPayload();
     client = new AgentWidgetClient({
       apiUrl: 'http://localhost:8000',
     });
   });
 
   it('should use llmContent instead of content when provided', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -236,8 +268,8 @@ describe('AgentWidgetClient - llmContent Priority', () => {
   });
 
   it('should fall back to content when llmContent is not provided', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -265,8 +297,8 @@ describe('AgentWidgetClient - llmContent Priority', () => {
   });
 
   it('should prioritize contentParts over llmContent', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -283,7 +315,7 @@ describe('AgentWidgetClient - llmContent Priority', () => {
         role: 'user',
         content: 'Display content',
         llmContent: 'LLM content (should be ignored)',
-        contentParts: [{ type: 'text', text: 'Multi-modal text' }] as any,
+        contentParts: [{ type: 'text', text: 'Multi-modal text' }] as unknown as AgentWidgetMessage['contentParts'],
         createdAt: '2025-01-01T00:00:00.000Z',
       },
     ];
@@ -297,8 +329,8 @@ describe('AgentWidgetClient - llmContent Priority', () => {
   });
 
   it('should preserve messages with valid llmContent even if content is empty', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -326,8 +358,8 @@ describe('AgentWidgetClient - llmContent Priority', () => {
   });
 
   it('should support dual-content pattern for redaction', async () => {
-    global.fetch = vi.fn().mockImplementation(async (url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -482,7 +514,7 @@ describe('AgentWidgetClient - JSON Streaming', () => {
     global.fetch = async () => ({
       ok: true,
       body: stream
-    }) as any;
+    }) as unknown as Response;
 
     // Dispatch and collect events
     await client.dispatch(
@@ -586,7 +618,7 @@ function sseEvent(eventType: string, data: Record<string, unknown>): string {
  * Helper to create a mock fetch that returns an SSE stream
  */
 function createAgentStreamFetch(events: string[]) {
-  return vi.fn().mockImplementation(async (_url: string, _options: any) => {
+  return vi.fn().mockImplementation(async (_url: string, _options: MockFetchOptions) => {
     const encoder = new TextEncoder();
     const stream = new ReadableStream({
       start(controller) {
@@ -624,9 +656,9 @@ describe('AgentWidgetClient - Agent Mode Detection', () => {
 
 describe('AgentWidgetClient - Agent Payload Building', () => {
   it('should build agent payload with agent config', async () => {
-    let capturedPayload: any = null;
-    global.fetch = vi.fn().mockImplementation(async (_url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    let capturedPayload: CapturedPayload = emptyPayload();
+    global.fetch = vi.fn().mockImplementation(async (_url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -676,20 +708,22 @@ describe('AgentWidgetClient - Agent Payload Building', () => {
 
     expect(capturedPayload).toBeDefined();
     expect(capturedPayload.agent).toBeDefined();
-    expect(capturedPayload.agent.name).toBe('Test Agent');
-    expect(capturedPayload.agent.model).toBe('openai:gpt-4o-mini');
-    expect(capturedPayload.agent.systemPrompt).toBe('You are a test assistant.');
-    expect(capturedPayload.agent.loopConfig.maxIterations).toBe(3);
+    const payloadAgent = capturedPayload.agent as NonNullable<CapturedPayload['agent']>;
+    expect(payloadAgent.name).toBe('Test Agent');
+    expect(payloadAgent.model).toBe('openai:gpt-4o-mini');
+    expect(payloadAgent.systemPrompt).toBe('You are a test assistant.');
+    expect(payloadAgent.loopConfig?.maxIterations).toBe(3);
     expect(capturedPayload.messages).toHaveLength(1);
     expect(capturedPayload.messages[0].content).toBe('Hello agent');
-    expect(capturedPayload.options.streamResponse).toBe(true);
-    expect(capturedPayload.options.recordMode).toBe('virtual');
+    const payloadOptions = capturedPayload.options as NonNullable<CapturedPayload['options']>;
+    expect(payloadOptions.streamResponse).toBe(true);
+    expect(payloadOptions.recordMode).toBe('virtual');
   });
 
   it('should filter out variant messages from agent payload', async () => {
-    let capturedPayload: any = null;
-    global.fetch = vi.fn().mockImplementation(async (_url: string, options: any) => {
-      capturedPayload = JSON.parse(options.body);
+    let capturedPayload: CapturedPayload = emptyPayload();
+    global.fetch = vi.fn().mockImplementation(async (_url: string, options: MockFetchOptions) => {
+      capturedPayload = parsePayload(options);
       const encoder = new TextEncoder();
       const stream = new ReadableStream({
         start(controller) {
@@ -1215,4 +1249,3 @@ describe('AgentWidgetClient - Agent Event Streaming', () => {
     expect(assistantMessages[0].content).toBe('Hi');
   });
 });
-

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -316,7 +316,6 @@ export class AgentWidgetClient {
     }
 
     if (this.debug) {
-      // eslint-disable-next-line no-console
       console.debug("[AgentWidgetClient] sending feedback", feedback);
     }
 
@@ -472,7 +471,6 @@ export class AgentWidgetClient {
       };
 
       if (this.debug) {
-        // eslint-disable-next-line no-console
         console.debug("[AgentWidgetClient] client token dispatch", chatRequest);
       }
 
@@ -546,7 +544,6 @@ export class AgentWidgetClient {
     const payload = await this.buildPayload(options.messages);
 
     if (this.debug) {
-      // eslint-disable-next-line no-console
       console.debug("[AgentWidgetClient] dispatch payload", payload);
     }
 
@@ -558,7 +555,6 @@ export class AgentWidgetClient {
         headers = { ...headers, ...dynamicHeaders };
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] getHeaders error:", error);
         }
       }
@@ -622,7 +618,6 @@ export class AgentWidgetClient {
     const payload = await this.buildAgentPayload(options.messages);
 
     if (this.debug) {
-      // eslint-disable-next-line no-console
       console.debug("[AgentWidgetClient] agent dispatch payload", payload);
     }
 
@@ -634,7 +629,6 @@ export class AgentWidgetClient {
         headers = { ...headers, ...dynamicHeaders };
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] getHeaders error:", error);
         }
       }
@@ -733,7 +727,6 @@ export class AgentWidgetClient {
             }
           } catch (error) {
             if (typeof console !== "undefined") {
-              // eslint-disable-next-line no-console
               console.warn("[AgentWidget] Context provider failed:", error);
             }
           }
@@ -786,7 +779,6 @@ export class AgentWidgetClient {
             }
           } catch (error) {
             if (typeof console !== "undefined") {
-              // eslint-disable-next-line no-console
               console.warn("[AgentWidget] Context provider failed:", error);
             }
           }
@@ -809,7 +801,6 @@ export class AgentWidgetClient {
         }
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] Request middleware error:", error);
         }
       }
@@ -875,7 +866,6 @@ export class AgentWidgetClient {
       return true; // Event was handled
     } catch (error) {
       if (typeof console !== "undefined") {
-        // eslint-disable-next-line no-console
         console.error("[AgentWidget] parseSSEEvent error:", error);
       }
       return false;
@@ -1948,7 +1938,6 @@ export class AgentWidgetClient {
             : payload.error?.message ?? 'Agent execution error';
           if (payload.recoverable) {
             if (typeof console !== "undefined") {
-              // eslint-disable-next-line no-console
               console.warn("[AgentWidget] Recoverable agent error:", errorMessage);
             }
           } else {

--- a/packages/widget/src/components/event-stream-view.test.ts
+++ b/packages/widget/src/components/event-stream-view.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { SSEEventRecord } from "../types";
+import type { EventStreamBuffer } from "../utils/event-stream-buffer";
 
 // ---------- DOM helpers for Node environment ----------
 
@@ -165,6 +166,12 @@ function createMockBuffer(events: SSEEventRecord[] = []) {
   };
 }
 
+function asEventStreamBuffer(
+  buffer: ReturnType<typeof createMockBuffer>
+): EventStreamBuffer {
+  return buffer as unknown as EventStreamBuffer;
+}
+
 beforeEach(() => {
   rafCallbacks = [];
   if (!globalThis.document) {
@@ -214,7 +221,9 @@ vi.mock("../utils/icons", () => ({
 async function loadModule() {
   const mod = await import("./event-stream-view");
   const origCreate = mod.createEventStreamView;
-  const wrappedCreate = (options: Parameters<typeof origCreate>[0]): { element: any; update: () => void; destroy: () => void } => {
+  const wrappedCreate = (
+    options: Parameters<typeof origCreate>[0]
+  ): ReturnType<typeof origCreate> => {
     return origCreate(options);
   };
   return { ...mod, createEventStreamView: wrappedCreate };
@@ -264,11 +273,23 @@ function getNoResultsMsg(element: any) {
   return getEventsWrapper(element).children[1]; // noResultsMsg
 }
 
+function fireMockEvent(
+  element: HTMLElement,
+  eventName: string,
+  detail?: unknown
+) {
+  (
+    element as unknown as {
+      __fireEvent: (event: string, payload?: unknown) => void;
+    }
+  ).__fireEvent(eventName, detail);
+}
+
 describe("createEventStreamView", () => {
   it("should create a container element with expected children", async () => {
     const { createEventStreamView } = await loadModule();
     const buffer = createMockBuffer();
-    const { element } = createEventStreamView({ buffer: buffer as any });
+    const { element } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
     // Container should have tabindex for keyboard events
     expect(element.getAttribute("tabindex")).toBe("0");
@@ -280,7 +301,7 @@ describe("createEventStreamView", () => {
   it("should return update and destroy functions", async () => {
     const { createEventStreamView } = await loadModule();
     const buffer = createMockBuffer();
-    const view = createEventStreamView({ buffer: buffer as any });
+    const view = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
     expect(typeof view.update).toBe("function");
     expect(typeof view.destroy).toBe("function");
@@ -291,7 +312,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -304,7 +325,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
       expect(getCountBadge(element).textContent).toBe("1");
@@ -327,7 +348,7 @@ describe("createEventStreamView", () => {
         makeEvent("flow_complete", 3),
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -345,7 +366,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -370,7 +391,7 @@ describe("createEventStreamView", () => {
         makeEvent("step_chunk", 3),
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -388,7 +409,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1, '{"message":"hello world"}')];
       const buffer = createMockBuffer(events);
-      const { element } = createEventStreamView({ buffer: buffer as any });
+      const { element } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const searchInput = getSearchInput(element);
 
@@ -408,7 +429,7 @@ describe("createEventStreamView", () => {
     it("should show clear button when search has text", async () => {
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer();
-      const { element } = createEventStreamView({ buffer: buffer as any });
+      const { element } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const searchInput = getSearchInput(element);
       const clearBtn = getSearchClearBtn(element);
@@ -428,7 +449,7 @@ describe("createEventStreamView", () => {
       vi.useFakeTimers();
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer([makeEvent("a", 1)]);
-      const { element } = createEventStreamView({ buffer: buffer as any });
+      const { element } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const searchInput = getSearchInput(element);
       const clearBtn = getSearchClearBtn(element);
@@ -453,7 +474,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1, '{"data":"hello"}')];
       const buffer = createMockBuffer(events);
-      const { element } = createEventStreamView({ buffer: buffer as any });
+      const { element } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const searchInput = getSearchInput(element);
 
@@ -479,7 +500,7 @@ describe("createEventStreamView", () => {
         makeEvent("flow_complete", 2),
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const copyAllBtn = getCopyAllBtn(element);
 
@@ -507,7 +528,7 @@ describe("createEventStreamView", () => {
       const buffer = createMockBuffer(events);
       const getFullHistory = vi.fn().mockResolvedValue(events);
       const { element } = createEventStreamView({
-        buffer: buffer as any,
+        buffer: asEventStreamBuffer(buffer),
         getFullHistory,
       });
 
@@ -525,7 +546,9 @@ describe("createEventStreamView", () => {
       expect(getFullHistory).not.toHaveBeenCalled();
 
       // Should copy only filtered events
-      const writeCall = (globalThis.navigator.clipboard.writeText as any).mock.calls[0][0];
+      const writeTextMock = globalThis.navigator.clipboard
+        .writeText as unknown as { mock: { calls: unknown[][] } };
+      const writeCall = writeTextMock.mock.calls[0][0] as string;
       const parsed = JSON.parse(writeCall);
       expect(parsed).toHaveLength(1);
       expect(parsed[0].index).toBe(1);
@@ -541,7 +564,7 @@ describe("createEventStreamView", () => {
       const fullHistory = [...events, makeEvent("old_event", 0)];
       const getFullHistory = vi.fn().mockResolvedValue(fullHistory);
       const { element, update } = createEventStreamView({
-        buffer: buffer as any,
+        buffer: asEventStreamBuffer(buffer),
         getFullHistory,
       });
 
@@ -561,7 +584,7 @@ describe("createEventStreamView", () => {
     it("should focus search on Ctrl+F", async () => {
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer();
-      const { element } = createEventStreamView({ buffer: buffer as any });
+      const { element } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const searchInput = getSearchInput(element);
 
@@ -572,7 +595,7 @@ describe("createEventStreamView", () => {
         metaKey: false,
         preventDefault: vi.fn(),
       };
-      element.__fireEvent("keydown", event);
+      fireMockEvent(element, "keydown", event);
 
       expect(event.preventDefault).toHaveBeenCalled();
       expect(searchInput.focus).toHaveBeenCalled();
@@ -583,7 +606,7 @@ describe("createEventStreamView", () => {
       vi.useFakeTimers();
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer([makeEvent("a", 1)]);
-      const { element } = createEventStreamView({ buffer: buffer as any });
+      const { element } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const searchInput = getSearchInput(element);
 
@@ -596,7 +619,7 @@ describe("createEventStreamView", () => {
       (globalThis.document as any).activeElement = searchInput;
 
       // Press Escape
-      element.__fireEvent("keydown", {
+      fireMockEvent(element, "keydown", {
         key: "Escape",
         ctrlKey: false,
         metaKey: false,
@@ -613,7 +636,7 @@ describe("createEventStreamView", () => {
       const buffer = createMockBuffer();
       const onClose = vi.fn();
       const { element } = createEventStreamView({
-        buffer: buffer as any,
+        buffer: asEventStreamBuffer(buffer),
         onClose,
       });
 
@@ -621,7 +644,7 @@ describe("createEventStreamView", () => {
       (globalThis.document as any).activeElement = element;
 
       // Press Escape
-      element.__fireEvent("keydown", {
+      fireMockEvent(element, "keydown", {
         key: "Escape",
         ctrlKey: false,
         metaKey: false,
@@ -640,7 +663,7 @@ describe("createEventStreamView", () => {
         { id: "evt-2", type: "step_start", timestamp: 1361, payload: '{"stepName":"Chatbot 1"}' },
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -655,10 +678,10 @@ describe("createEventStreamView", () => {
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
       const { update } = createEventStreamView({
-        buffer: buffer as any,
+        buffer: asEventStreamBuffer(buffer),
         config: {
           features: { eventStream: { timestampFormat: "absolute" } },
-        } as any,
+        },
       });
 
       update();
@@ -673,7 +696,7 @@ describe("createEventStreamView", () => {
         { id: "evt-1", type: "flow_start", timestamp: 1000, payload: '{"flowName":"My Flow"}' },
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -687,10 +710,10 @@ describe("createEventStreamView", () => {
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
       const { update } = createEventStreamView({
-        buffer: buffer as any,
+        buffer: asEventStreamBuffer(buffer),
         config: {
           features: { eventStream: { showSequenceNumbers: false } },
-        } as any,
+        },
       });
 
       update();
@@ -702,7 +725,7 @@ describe("createEventStreamView", () => {
       const events = [makeEvent("custom_type", 1)];
       const buffer = createMockBuffer(events);
       const { update } = createEventStreamView({
-        buffer: buffer as any,
+        buffer: asEventStreamBuffer(buffer),
         config: {
           features: {
             eventStream: {
@@ -712,7 +735,7 @@ describe("createEventStreamView", () => {
               },
             },
           },
-        } as any,
+        },
       });
 
       update();
@@ -725,7 +748,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1, '{"message":"hello"}')];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -784,7 +807,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1), makeEvent("step_chunk", 2)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // Initial render (Path A — first render)
       update();
@@ -819,7 +842,7 @@ describe("createEventStreamView", () => {
         makeEvent("step_chunk", 3, '{"msg":"third"}'),
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // Initial render
       update();
@@ -855,7 +878,7 @@ describe("createEventStreamView", () => {
         makeEvent("step_chunk", 3),
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // Initial render
       update();
@@ -883,7 +906,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1, '{"message":"hello"}')];
       const buffer = createMockBuffer(events);
-      const { update } = createEventStreamView({ buffer: buffer as any });
+      const { update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -900,7 +923,7 @@ describe("createEventStreamView", () => {
         makeEvent("flow_complete", 2),
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -924,7 +947,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -951,7 +974,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -964,7 +987,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // First update renders immediately
       update();
@@ -995,7 +1018,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // First update
       update();
@@ -1017,7 +1040,7 @@ describe("createEventStreamView", () => {
       vi.useFakeTimers();
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer([makeEvent("step_chunk", 1)]);
-      const { update } = createEventStreamView({ buffer: buffer as any });
+      const { update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // First call: immediate render
       update();
@@ -1047,7 +1070,7 @@ describe("createEventStreamView", () => {
         makeEvent("flow_complete", 2),
       ];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // Initial render
       update();
@@ -1067,7 +1090,7 @@ describe("createEventStreamView", () => {
       vi.useFakeTimers();
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer([makeEvent("step_chunk", 1)]);
-      const { update, destroy } = createEventStreamView({ buffer: buffer as any });
+      const { update, destroy } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // First update — immediate
       update();
@@ -1090,7 +1113,7 @@ describe("createEventStreamView", () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
-      const { element, update } = createEventStreamView({ buffer: buffer as any });
+      const { element, update } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       update();
 
@@ -1107,7 +1130,7 @@ describe("createEventStreamView", () => {
     it("should clean up event listeners on destroy", async () => {
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer();
-      const { destroy } = createEventStreamView({ buffer: buffer as any });
+      const { destroy } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       // Should not throw
       expect(() => destroy()).not.toThrow();
@@ -1117,7 +1140,7 @@ describe("createEventStreamView", () => {
       vi.useFakeTimers();
       const { createEventStreamView } = await loadModule();
       const buffer = createMockBuffer([makeEvent("a", 1)]);
-      const { element, destroy } = createEventStreamView({ buffer: buffer as any });
+      const { element, destroy } = createEventStreamView({ buffer: asEventStreamBuffer(buffer) });
 
       const searchInput = getSearchInput(element);
 
@@ -1148,8 +1171,8 @@ describe("createEventStreamView", () => {
       };
 
       const { update } = createEventStreamView({
-        buffer: buffer as any,
-        config: {} as any,
+        buffer: asEventStreamBuffer(buffer),
+        config: {},
         plugins: [plugin],
       });
 
@@ -1176,8 +1199,8 @@ describe("createEventStreamView", () => {
       };
 
       const { element } = createEventStreamView({
-        buffer: buffer as any,
-        config: {} as any,
+        buffer: asEventStreamBuffer(buffer),
+        config: {},
         plugins: [plugin],
       });
 
@@ -1198,8 +1221,8 @@ describe("createEventStreamView", () => {
       };
 
       const { element } = createEventStreamView({
-        buffer: buffer as any,
-        config: {} as any,
+        buffer: asEventStreamBuffer(buffer),
+        config: {},
         plugins: [plugin],
       });
 
@@ -1218,8 +1241,8 @@ describe("createEventStreamView", () => {
       };
 
       const { element, update } = createEventStreamView({
-        buffer: buffer as any,
-        config: {} as any,
+        buffer: asEventStreamBuffer(buffer),
+        config: {},
         plugins: [plugin],
       });
 

--- a/packages/widget/src/components/feedback.ts
+++ b/packages/widget/src/components/feedback.ts
@@ -189,7 +189,6 @@ export function createCSATFeedback(options: CSATFeedbackOptions): HTMLElement {
     } catch (error) {
       submitButton.disabled = false;
       submitButton.textContent = submitText;
-      // eslint-disable-next-line no-console
       console.error('[CSAT Feedback] Failed to submit:', error);
     }
   });
@@ -361,7 +360,6 @@ export function createNPSFeedback(options: NPSFeedbackOptions): HTMLElement {
     } catch (error) {
       submitButton.disabled = false;
       submitButton.textContent = submitText;
-      // eslint-disable-next-line no-console
       console.error('[NPS Feedback] Failed to submit:', error);
     }
   });

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -307,7 +307,6 @@ export const createAgentExperience = (
         return config.onStateLoaded(state);
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] onStateLoaded hook failed:", error);
         }
       }
@@ -339,7 +338,6 @@ export const createAgentExperience = (
       }
     } catch (error) {
       if (typeof console !== "undefined") {
-        // eslint-disable-next-line no-console
         console.error("[AgentWidget] Failed to load stored state:", error);
       }
     }
@@ -352,7 +350,6 @@ export const createAgentExperience = (
       }
     } catch (error) {
       if (typeof console !== "undefined") {
-        // eslint-disable-next-line no-console
         console.error("[AgentWidget] onStateLoaded hook failed:", error);
       }
     }
@@ -410,7 +407,6 @@ export const createAgentExperience = (
     pendingResubmitTimeout = setTimeout(() => {
       if (pendingResubmit) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.warn("[AgentWidget] Resubmit requested but no injection occurred within 10s");
         }
         pendingResubmit = false;
@@ -447,7 +443,6 @@ export const createAgentExperience = (
       if (session?.isClientTokenMode()) {
         session.submitMessageFeedback(message.id, 'copy').catch((error) => {
           if (config.debug) {
-            // eslint-disable-next-line no-console
             console.error("[AgentWidget] Failed to submit copy feedback:", error);
           }
         });
@@ -461,7 +456,6 @@ export const createAgentExperience = (
       if (session?.isClientTokenMode()) {
         session.submitMessageFeedback(feedback.messageId, feedback.type).catch((error) => {
           if (config.debug) {
-            // eslint-disable-next-line no-console
             console.error("[AgentWidget] Failed to submit feedback:", error);
           }
         });
@@ -758,7 +752,6 @@ export const createAgentExperience = (
           }
         } catch (error) {
           if (typeof console !== "undefined") {
-            // eslint-disable-next-line no-console
             console.error(`[AgentWidget] Error rendering slot "${slotName}":`, error);
           }
         }
@@ -867,7 +860,6 @@ export const createAgentExperience = (
           }, 2000);
         }).catch((err) => {
           if (typeof console !== "undefined") {
-            // eslint-disable-next-line no-console
             console.error("[AgentWidget] Failed to copy message:", err);
           }
         });
@@ -1222,14 +1214,12 @@ export const createAgentExperience = (
       if (result instanceof Promise) {
         result.catch((error) => {
           if (typeof console !== "undefined") {
-            // eslint-disable-next-line no-console
             console.error("[AgentWidget] Failed to persist state:", error);
           }
         });
       }
     } catch (error) {
       if (typeof console !== "undefined") {
-        // eslint-disable-next-line no-console
         console.error("[AgentWidget] Failed to persist state:", error);
       }
     }
@@ -1902,7 +1892,6 @@ export const createAgentExperience = (
   if (config.clientToken) {
     session.initClientSession().catch((err) => {
       if (config.debug) {
-        // eslint-disable-next-line no-console
         console.warn("[AgentWidget] Pre-init client session failed:", err);
       }
     });
@@ -1934,7 +1923,6 @@ export const createAgentExperience = (
       })
       .catch((error) => {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] Failed to hydrate stored state:", error);
         }
       });
@@ -2490,14 +2478,12 @@ export const createAgentExperience = (
           if (result instanceof Promise) {
             result.catch((error) => {
               if (typeof console !== "undefined") {
-                // eslint-disable-next-line no-console
                 console.error("[AgentWidget] Failed to clear storage adapter:", error);
               }
             });
           }
         } catch (error) {
           if (typeof console !== "undefined") {
-            // eslint-disable-next-line no-console
             console.error("[AgentWidget] Failed to clear storage adapter:", error);
           }
         }
@@ -3750,14 +3736,12 @@ export const createAgentExperience = (
           if (result instanceof Promise) {
             result.catch((error) => {
               if (typeof console !== "undefined") {
-                // eslint-disable-next-line no-console
                 console.error("[AgentWidget] Failed to clear storage adapter:", error);
               }
             });
           }
         } catch (error) {
           if (typeof console !== "undefined") {
-            // eslint-disable-next-line no-console
             console.error("[AgentWidget] Failed to clear storage adapter:", error);
           }
         }

--- a/packages/widget/src/utils/actions.ts
+++ b/packages/widget/src/utils/actions.ts
@@ -103,7 +103,6 @@ export const defaultActionHandlers: Record<
           element.click();
         }, 400);
       } else if (typeof console !== "undefined") {
-        // eslint-disable-next-line no-console
         console.warn("[AgentWidget] Element not found for selector:", selector);
       }
     }
@@ -163,7 +162,6 @@ export const createActionManager = (options: ActionManagerOptions) => {
       context.text.trim().startsWith("{") &&
       typeof console !== "undefined"
     ) {
-      // eslint-disable-next-line no-console
       console.warn(
         "[AgentWidget] Structured response detected but no raw payload was provided. Ensure your stream parser returns { text, raw }."
       );
@@ -219,7 +217,6 @@ export const createActionManager = (options: ActionManagerOptions) => {
         }
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] Action handler error:", error);
         }
       }

--- a/packages/widget/src/utils/events.ts
+++ b/packages/widget/src/utils/events.ts
@@ -29,7 +29,6 @@ export const createEventBus = <EventMap extends Record<string, any>>() => {
         handler(payload);
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] Event handler error:", error);
         }
       }

--- a/packages/widget/src/utils/storage.ts
+++ b/packages/widget/src/utils/storage.ts
@@ -10,7 +10,6 @@ const safeJsonParse = (value: string | null) => {
     return JSON.parse(value);
   } catch (error) {
     if (typeof console !== "undefined") {
-      // eslint-disable-next-line no-console
       console.error("[AgentWidget] Failed to parse stored state:", error);
     }
     return null;
@@ -50,7 +49,6 @@ export const createLocalStorageAdapter = (
         storage.setItem(key, JSON.stringify(payload));
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] Failed to persist state:", error);
         }
       }
@@ -62,7 +60,6 @@ export const createLocalStorageAdapter = (
         storage.removeItem(key);
       } catch (error) {
         if (typeof console !== "undefined") {
-          // eslint-disable-next-line no-console
           console.error("[AgentWidget] Failed to clear stored state:", error);
         }
       }


### PR DESCRIPTION
## Summary
- Removes 36 unused `eslint-disable-next-line no-console` directives in widget runtime code.
- Reduces explicit `any` usage in key widget tests using typed helper wrappers and safer casts.
- Keeps runtime behavior unchanged; this PR is focused on lint/type hygiene.

## Files Updated
- `packages/widget/src/client.ts`
- `packages/widget/src/ui.ts`
- `packages/widget/src/components/feedback.ts`
- `packages/widget/src/utils/actions.ts`
- `packages/widget/src/utils/events.ts`
- `packages/widget/src/utils/storage.ts`
- `packages/widget/src/components/event-stream-view.test.ts`
- `packages/widget/src/client.test.ts`

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --filter @runtypelabs/persona test:run -- src/components/event-stream-view.test.ts src/client.test.ts`

## Lint Debt Progress
- Unused disable directives fixed: **36**
- Explicit `any` tokens reduced in targeted tests: **71**
- Total meaningful lint-debt reduction in this PR: **~107**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily lint/type hygiene and test refactors; production logic changes are limited to comment-level lint suppression removals around logging.
> 
> **Overview**
> Cleans up widget runtime code by removing unused `eslint-disable-next-line no-console` directives while keeping existing `console.*` debug/error logging behavior intact.
> 
> Hardens widget tests by replacing broad `any` casts with typed helpers/casts (e.g., `MockFetchOptions`, `CapturedPayload`, `EventStreamBuffer` wrappers) and tightening assertions around mocked fetch/clipboard interactions, improving type-safety and lint compliance without altering functional coverage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 175ed954063730dca3a6302e2d00bd627604351f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->