### PR TITLE
Implement unified SSE event names and enhance tool event handling

### DIFF
--- a/.changeset/unify-sse-event-names.md
+++ b/.changeset/unify-sse-event-names.md
@@ -1,0 +1,12 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Support unified SSE event names ahead of platform-wide rename
+
+- Accept `step_delta`, `tool_delta`, and `reason_delta` as aliases for `step_chunk`, `tool_chunk`, and `reason_chunk` (aligns with industry-standard `delta` terminology used by Anthropic, Vercel AI SDK, and OpenAI)
+- Accept `agent_reflect` as alias for `agent_reflection` (consistent `entity_verb` grammar)
+- Enrich `tool_start`, `tool_delta`, and `tool_complete` handlers to carry `agentMetadata` when the payload includes `agentContext` or direct `executionId`/`iteration` fields, supporting the upcoming unification of `agent_tool_*` events into shared `tool_*` events
+- Accept `parameters` as alias for `args` and `executionTime` as alias for `duration` in tool event payloads for forward compatibility with the unified format
+
+All existing event names continue to work unchanged. No breaking changes.

--- a/examples/embedded-app/agent-demo.html
+++ b/examples/embedded-app/agent-demo.html
@@ -182,7 +182,7 @@
 
       <div class="info-section">
         <h3>How it works</h3>
-        <p>Set <code>config.agent</code> with a model, system prompt, and loop config. The widget sends this to the dispatch API and handles agent-specific SSE events: <code>agent_start</code>, <code>agent_turn_delta</code>, <code>agent_tool_*</code>, <code>agent_iteration_*</code>, and <code>agent_complete</code>.</p>
+        <p>Set <code>config.agent</code> with a model, system prompt, and loop config. The widget sends this to the dispatch API and handles agent-specific SSE events: <code>agent_start</code>, <code>agent_turn_delta</code>, <code>tool_*</code> (with optional <code>agentContext</code>), <code>agent_iteration_*</code>, and <code>agent_complete</code>.</p>
       </div>
 
       <div class="code-block">
@@ -225,7 +225,7 @@
         <h3>Agent Events</h3>
         <p>The widget handles these agent-specific SSE events:</p>
         <p style="margin-top: 0.5rem; font-family: monospace; font-size: 0.75rem; line-height: 1.8;">
-          agent_start &rarr; agent_iteration_start &rarr; agent_turn_start &rarr; agent_turn_delta (text/thinking) &rarr; agent_turn_complete &rarr; agent_tool_start/delta/complete &rarr; agent_iteration_complete &rarr; agent_complete
+          agent_start &rarr; agent_iteration_start &rarr; agent_turn_start &rarr; agent_turn_delta (text/thinking) &rarr; agent_turn_complete &rarr; tool_start/tool_delta/tool_complete (with agentContext) &rarr; agent_iteration_complete &rarr; agent_complete
         </p>
       </div>
 

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -188,8 +188,8 @@ if (loadMessagesButton) {
 
       if (isUser) {
         target.__pushEventStreamEvent({
-          type: 'step_chunk',
-          payload: { type: 'step_chunk', text: batch[msg].content, stepType: 'prompt' }
+          type: 'step_delta',
+          payload: { type: 'step_delta', text: batch[msg].content, stepType: 'prompt' }
         });
         target.__pushEventStreamEvent({
           type: 'step_complete',
@@ -200,8 +200,8 @@ if (loadMessagesButton) {
           const chunkStart = Math.floor((chunk / chunksPerMessage) * batch[msg].content.length);
           const chunkEnd = Math.floor(((chunk + 1) / chunksPerMessage) * batch[msg].content.length);
           target.__pushEventStreamEvent({
-            type: 'step_chunk',
-            payload: { type: 'step_chunk', text: batch[msg].content.slice(chunkStart, chunkEnd), stepType: 'prompt', messageId: `ast_${msg}` }
+            type: 'step_delta',
+            payload: { type: 'step_delta', text: batch[msg].content.slice(chunkStart, chunkEnd), stepType: 'prompt', messageId: `ast_${msg}` }
           });
         }
         target.__pushEventStreamEvent({
@@ -211,7 +211,7 @@ if (loadMessagesButton) {
       }
 
       if (msg % 20 === 0) {
-        for (const t of ['reason_start', 'reason_chunk', 'reason_complete', 'tool_start', 'tool_chunk', 'tool_complete']) {
+        for (const t of ['reason_start', 'reason_delta', 'reason_complete', 'tool_start', 'tool_delta', 'tool_complete']) {
           target.__pushEventStreamEvent({
             type: t,
             payload: { type: t, text: `Simulated ${t} for msg #${msgNum}`, toolName: t.startsWith('tool') ? 'web_search' : undefined }

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1216,3 +1216,228 @@ describe('AgentWidgetClient - Agent Event Streaming', () => {
   });
 });
 
+// ============================================================================
+// Unified Event Name Support (chunk → delta, agent_tool_* → tool_* with agentContext)
+// ============================================================================
+
+describe('AgentWidgetClient - Unified Event Names', () => {
+  it('should handle step_delta as alias for step_chunk', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_start","flowId":"f1","flowName":"Test","totalSteps":1}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"step_start","id":"s1","name":"Prompt","stepType":"prompt","index":1,"totalSteps":1}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"step_delta","id":"s1","name":"Prompt","executionType":"prompt","text":"Hello "}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"step_delta","id":"s1","name":"Prompt","executionType":"prompt","text":"world"}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"step_complete","id":"s1","name":"Prompt"}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const assistantMessages = messageEvents
+      .map(e => e.type === 'message' ? e.message : null)
+      .filter((m): m is AgentWidgetMessage => m !== null && m.role === 'assistant' && !m.variant);
+    expect(assistantMessages.length).toBeGreaterThan(0);
+    const final = assistantMessages[assistantMessages.length - 1];
+    expect(final.content).toContain('Hello ');
+    expect(final.content).toContain('world');
+  });
+
+  it('should handle tool_delta as alias for tool_chunk', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_start","flowId":"f1","flowName":"Test","totalSteps":1}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"tool_start","toolCallId":"tc_1","toolName":"search"}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"tool_delta","toolCallId":"tc_1","delta":"Searching..."}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"tool_complete","toolCallId":"tc_1","toolName":"search","result":{"found":true},"duration":100}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Search', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const toolMessages = Array.from(messagesById.values()).filter(m => m.variant === 'tool');
+    expect(toolMessages.length).toBe(1);
+    expect(toolMessages[0].toolCall?.name).toBe('search');
+    expect(toolMessages[0].toolCall?.chunks).toContain('Searching...');
+    expect(toolMessages[0].toolCall?.status).toBe('complete');
+  });
+
+  it('should handle tool_start with agentContext (unified agent tool events)', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_unified_1';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxIterations: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('tool_start', {
+        toolCallId: 'tc_1', toolName: 'search', parameters: { query: 'weather' },
+        agentContext: { executionId: execId, iteration: 1, seq: 3 },
+      }),
+      sseEvent('tool_delta', {
+        toolCallId: 'tc_1', delta: 'Searching...',
+        agentContext: { executionId: execId, iteration: 1, seq: 4 },
+      }),
+      sseEvent('tool_complete', {
+        toolCallId: 'tc_1', toolName: 'search', result: { temperature: 72 },
+        executionTime: 150,
+        agentContext: { executionId: execId, iteration: 1, seq: 5 },
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'The weather is 72F.',
+        contentType: 'text', turnId: 'turn_1', seq: 6,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 7,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Weather?', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const toolMessages = Array.from(messagesById.values()).filter(m => m.variant === 'tool');
+    expect(toolMessages.length).toBe(1);
+    expect(toolMessages[0].toolCall?.name).toBe('search');
+    expect(toolMessages[0].toolCall?.status).toBe('complete');
+    expect(toolMessages[0].toolCall?.result).toEqual({ temperature: 72 });
+    expect(toolMessages[0].toolCall?.durationMs).toBe(150);
+    expect(toolMessages[0].agentMetadata?.executionId).toBe(execId);
+    expect(toolMessages[0].agentMetadata?.iteration).toBe(1);
+
+    const assistantMessages = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant);
+    expect(assistantMessages.length).toBe(1);
+    expect(assistantMessages[0].content).toBe('The weather is 72F.');
+  });
+
+  it('should handle agent_reflect as alias for agent_reflection', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_reflect_1';
+
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxIterations: 2, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_reflect', {
+        executionId: execId, iteration: 1,
+        reflection: 'Let me reconsider.', seq: 2,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 2, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 3,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const reflectionMessages = Array.from(messagesById.values())
+      .filter(m => m.variant === 'reasoning' && m.id.includes('reflection'));
+    expect(reflectionMessages.length).toBe(1);
+    expect(reflectionMessages[0].content).toBe('Let me reconsider.');
+    expect(reflectionMessages[0].reasoning?.chunks).toContain('Let me reconsider.');
+  });
+
+  it('should handle reason_delta as alias for reason_chunk', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_start","flowId":"f1","flowName":"Test","totalSteps":1}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"reason_start","reasoningId":"r1"}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"reason_delta","reasoningId":"r1","reasoningText":"Thinking..."}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"reason_complete","reasoningId":"r1"}\n\n'));
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Think', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const reasoningMessages = Array.from(messagesById.values())
+      .filter(m => m.variant === 'reasoning');
+    expect(reasoningMessages.length).toBe(1);
+    expect(reasoningMessages[0].reasoning?.chunks).toContain('Thinking...');
+  });
+});
+

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1234,7 +1234,7 @@ export class AgentWidgetClient {
           reasoningMessage.streaming = true;
           reasoningMessage.reasoning.status = "streaming";
           emitMessage(reasoningMessage);
-        } else if (payloadType === "reason_chunk") {
+        } else if (payloadType === "reason_chunk" || payloadType === "reason_delta") {
           const reasoningId =
             resolveReasoningId(payload, false) ??
             resolveReasoningId(payload, true) ??
@@ -1304,6 +1304,8 @@ export class AgentWidgetClient {
           tool.status = "running";
           if (payload.args !== undefined) {
             tool.args = payload.args;
+          } else if (payload.parameters !== undefined) {
+            tool.args = payload.parameters;
           }
           tool.startedAt =
             tool.startedAt ??
@@ -1312,8 +1314,15 @@ export class AgentWidgetClient {
           tool.durationMs = undefined;
           toolMessage.toolCall = tool;
           toolMessage.streaming = true;
+          const agentCtx = payload.agentContext;
+          if (agentCtx || payload.executionId) {
+            toolMessage.agentMetadata = {
+              executionId: agentCtx?.executionId ?? payload.executionId,
+              iteration: agentCtx?.iteration ?? payload.iteration,
+            };
+          }
           emitMessage(toolMessage);
-        } else if (payloadType === "tool_chunk") {
+        } else if (payloadType === "tool_chunk" || payloadType === "tool_delta") {
           const toolId =
             resolveToolId(payload, false) ??
             resolveToolId(payload, true) ??
@@ -1335,6 +1344,13 @@ export class AgentWidgetClient {
           tool.status = "running";
           toolMessage.toolCall = tool;
           toolMessage.streaming = true;
+          const agentCtxChunk = payload.agentContext;
+          if (agentCtxChunk || payload.executionId) {
+            toolMessage.agentMetadata = toolMessage.agentMetadata ?? {
+              executionId: agentCtxChunk?.executionId ?? payload.executionId,
+              iteration: agentCtxChunk?.iteration ?? payload.iteration,
+            };
+          }
           emitMessage(toolMessage);
         } else if (payloadType === "tool_complete") {
           const toolId =
@@ -1356,8 +1372,9 @@ export class AgentWidgetClient {
           tool.completedAt = resolveTimestamp(
             payload.completedAt ?? payload.timestamp
           );
-          if (typeof payload.duration === "number") {
-            tool.durationMs = payload.duration;
+          const durationValue = payload.duration ?? payload.executionTime;
+          if (typeof durationValue === "number") {
+            tool.durationMs = durationValue;
           } else {
             const start = tool.startedAt ?? Date.now();
             tool.durationMs = Math.max(
@@ -1367,12 +1384,19 @@ export class AgentWidgetClient {
           }
           toolMessage.toolCall = tool;
           toolMessage.streaming = false;
+          const agentCtxComplete = payload.agentContext;
+          if (agentCtxComplete || payload.executionId) {
+            toolMessage.agentMetadata = toolMessage.agentMetadata ?? {
+              executionId: agentCtxComplete?.executionId ?? payload.executionId,
+              iteration: agentCtxComplete?.iteration ?? payload.iteration,
+            };
+          }
           emitMessage(toolMessage);
           const callKey = getToolCallKey(payload);
           if (callKey) {
             toolContext.byCall.delete(callKey);
           }
-        } else if (payloadType === "step_chunk") {
+        } else if (payloadType === "step_chunk" || payloadType === "step_delta") {
           // Only process chunks for prompt steps, not tool/context steps
           const stepType = (payload as any).stepType;
           const executionType = (payload as any).executionType;
@@ -1905,7 +1929,7 @@ export class AgentWidgetClient {
         } else if (payloadType === "agent_iteration_complete") {
           // Iteration complete - no special handling needed
           // In 'separate' mode, message finalization happens at next iteration_start
-        } else if (payloadType === "agent_reflection") {
+        } else if (payloadType === "agent_reflection" || payloadType === "agent_reflect") {
           // Create a reasoning message for reflection content
           const reflectionId = `agent-reflection-${payload.executionId}-${payload.iteration}`;
           const reflectionMessage: AgentWidgetMessage = {

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1952,8 +1952,8 @@ export type AgentWidgetConfig = {
    * // For Runtype API format
    * config: {
    *   parseSSEEvent: (data) => {
-   *     if (data.type === 'step_chunk' && data.chunk) {
-   *       return { text: data.chunk };
+   *     if ((data.type === 'step_delta' || data.type === 'step_chunk') && (data.delta || data.chunk)) {
+   *       return { text: data.delta ?? data.chunk };
    *     }
    *     if (data.type === 'flow_complete') {
    *       return { done: true };


### PR DESCRIPTION
- Introduced aliases for event names: `step_delta` for `step_chunk`, `tool_delta` for `tool_chunk`, and `agent_reflect` for `agent_reflection` to align with industry standards.
- Updated event handlers to include `agentMetadata` for `tool_start`, `tool_delta`, and `tool_complete` when relevant context is provided.
- Ensured backward compatibility by maintaining existing event names without breaking changes.
- Updated documentation and examples to reflect the new event naming conventions.