### PR TITLE
Reasoning event name move from chunk to delta

### DIFF
--- a/.changeset/refactor-event-handling-clarity.md
+++ b/.changeset/refactor-event-handling-clarity.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Refactor event handling in AgentWidgetClient to clarify alias usage. Updated the conditional check to maintain the order of event types for clarity, with `reason_delta` as the canonical event and `reason_chunk` as a legacy alias.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1404,7 +1404,7 @@ describe('AgentWidgetClient - Unified Event Names', () => {
     expect(reflectionMessages[0].reasoning?.chunks).toContain('Let me reconsider.');
   });
 
-  it('should handle reason_delta as alias for reason_chunk', async () => {
+  it('should handle reason_delta as canonical event (with reason_chunk as legacy alias)', async () => {
     const events: AgentWidgetEvent[] = [];
 
     const encoder = new TextEncoder();

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1234,7 +1234,7 @@ export class AgentWidgetClient {
           reasoningMessage.streaming = true;
           reasoningMessage.reasoning.status = "streaming";
           emitMessage(reasoningMessage);
-        } else if (payloadType === "reason_chunk" || payloadType === "reason_delta") {
+        } else if (payloadType === "reason_delta" || payloadType === "reason_chunk") {
           const reasoningId =
             resolveReasoningId(payload, false) ??
             resolveReasoningId(payload, true) ??


### PR DESCRIPTION
The rest of the stream events were `_delta` so this normalizes reasoning to match.