### PR TITLE
Add clipboard image paste support for attachments

### DIFF
--- a/.changeset/tough-hats-doubt.md
+++ b/.changeset/tough-hats-doubt.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+When attachments are enabled, pasted clipboard images are now added to the composer as attachments in addition to files selected from the file picker.

--- a/.changeset/tough-hats-doubt.md
+++ b/.changeset/tough-hats-doubt.md
@@ -3,3 +3,5 @@
 ---
 
 When attachments are enabled, pasted clipboard images are now added to the composer as attachments in addition to files selected from the file picker.
+
+Messages that include attached images now attempt to render bounded image previews directly in the chat bubble. If preview rendering fails, the existing `[Image]` fallback text is shown.

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -6,7 +6,8 @@ import {
   AgentWidgetTimestampConfig,
   AgentWidgetMessageActionsConfig,
   AgentWidgetMessageFeedback,
-  LoadingIndicatorRenderContext
+  LoadingIndicatorRenderContext,
+  ImageContentPart
 } from "../types";
 import { renderLucideIcon } from "../utils/icons";
 
@@ -22,6 +23,97 @@ export type MessageTransform = (context: {
 export type MessageActionCallbacks = {
   onCopy?: (message: AgentWidgetMessage) => void;
   onFeedback?: (feedback: AgentWidgetMessageFeedback) => void;
+};
+
+const MESSAGE_IMAGE_PREVIEW_MAX_WIDTH_PX = 320;
+const MESSAGE_IMAGE_PREVIEW_MAX_HEIGHT_PX = 320;
+const IMAGE_ONLY_FALLBACK_TEXT = "[Image]";
+
+const getMessageImageParts = (message: AgentWidgetMessage): ImageContentPart[] => {
+  if (!message.contentParts || message.contentParts.length === 0) {
+    return [];
+  }
+
+  return message.contentParts.filter(
+    (part): part is ImageContentPart =>
+      part.type === "image" &&
+      typeof part.image === "string" &&
+      part.image.trim().length > 0
+  );
+};
+
+const createMessageImagePreviews = (
+  imageParts: ImageContentPart[],
+  hasVisibleText: boolean,
+  onPreviewFailed?: () => void
+): HTMLElement | null => {
+  if (imageParts.length === 0) return null;
+
+  try {
+    const container = createElement(
+      "div",
+      "tvw-flex tvw-flex-col tvw-gap-2"
+    );
+    container.setAttribute("data-message-attachments", "images");
+    if (hasVisibleText) {
+      container.style.marginBottom = "8px";
+    }
+
+    let visiblePreviewCount = 0;
+    let failureHandled = false;
+
+    const handleTotalPreviewFailure = () => {
+      if (failureHandled) return;
+      failureHandled = true;
+      container.remove();
+      onPreviewFailed?.();
+    };
+
+    imageParts.forEach((imagePart, index) => {
+      const imageElement = createElement("img") as HTMLImageElement;
+      imageElement.alt = imagePart.alt?.trim() || `Attached image ${index + 1}`;
+      imageElement.loading = "lazy";
+      imageElement.decoding = "async";
+      imageElement.referrerPolicy = "no-referrer";
+      imageElement.style.display = "block";
+      imageElement.style.width = "100%";
+      imageElement.style.maxWidth = `${MESSAGE_IMAGE_PREVIEW_MAX_WIDTH_PX}px`;
+      imageElement.style.maxHeight = `${MESSAGE_IMAGE_PREVIEW_MAX_HEIGHT_PX}px`;
+      imageElement.style.height = "auto";
+      imageElement.style.objectFit = "contain";
+      imageElement.style.borderRadius = "10px";
+      imageElement.style.backgroundColor = "var(--cw-container, #f3f4f6)";
+      imageElement.style.border = "1px solid var(--cw-border, #e5e7eb)";
+
+      let settled = false;
+      visiblePreviewCount += 1;
+      imageElement.addEventListener("error", () => {
+        if (settled) return;
+        settled = true;
+        visiblePreviewCount = Math.max(0, visiblePreviewCount - 1);
+        imageElement.remove();
+        if (visiblePreviewCount === 0) {
+          handleTotalPreviewFailure();
+        }
+      });
+      imageElement.addEventListener("load", () => {
+        settled = true;
+      });
+
+      imageElement.src = imagePart.image;
+      container.appendChild(imageElement);
+    });
+
+    if (visiblePreviewCount === 0) {
+      handleTotalPreviewFailure();
+      return null;
+    }
+
+    return container;
+  } catch {
+    onPreviewFailed?.();
+    return null;
+  }
 };
 
 // Create typing indicator element
@@ -361,20 +453,49 @@ export const createStandardBubble = (
   bubble.id = `bubble-${message.id}`;
   bubble.setAttribute("data-message-id", message.id);
 
+  const imageParts = getMessageImageParts(message);
+  const messageContentText = message.content?.trim() ?? "";
+  const isImageOnlyFallbackMessage =
+    imageParts.length > 0 && messageContentText === IMAGE_ONLY_FALLBACK_TEXT;
+  const shouldHideTextUntilPreviewFails = isImageOnlyFallbackMessage;
+
   // Add message content
   const contentDiv = document.createElement("div");
-  contentDiv.innerHTML = transform({
+  const textContentDiv = document.createElement("div");
+  textContentDiv.innerHTML = transform({
     text: message.content,
     message,
     streaming: Boolean(message.streaming),
     raw: message.rawContent
   });
+  contentDiv.appendChild(textContentDiv);
+  if (shouldHideTextUntilPreviewFails) {
+    textContentDiv.style.display = "none";
+  }
 
   // Add inline timestamp if configured
   if (showTimestamp && timestampPosition === "inline" && message.createdAt) {
     const timestamp = createTimestamp(message, timestampConfig!);
     timestamp.classList.add("tvw-ml-2", "tvw-inline");
     contentDiv.appendChild(timestamp);
+  }
+
+  if (imageParts.length > 0) {
+    const imagePreviews = createMessageImagePreviews(
+      imageParts,
+      !shouldHideTextUntilPreviewFails && Boolean(messageContentText),
+      () => {
+        if (shouldHideTextUntilPreviewFails) {
+          textContentDiv.style.display = "";
+        }
+      }
+    );
+
+    if (imagePreviews) {
+      bubble.appendChild(imagePreviews);
+    } else if (shouldHideTextUntilPreviewFails) {
+      textContentDiv.style.display = "";
+    }
   }
 
   bubble.appendChild(contentDiv);

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -10,6 +10,7 @@ import {
   ImageContentPart
 } from "../types";
 import { renderLucideIcon } from "../utils/icons";
+import { IMAGE_ONLY_MESSAGE_FALLBACK_TEXT } from "../utils/content";
 
 export type LoadingIndicatorRenderer = (context: LoadingIndicatorRenderContext) => HTMLElement | null;
 
@@ -27,7 +28,6 @@ export type MessageActionCallbacks = {
 
 const MESSAGE_IMAGE_PREVIEW_MAX_WIDTH_PX = 320;
 const MESSAGE_IMAGE_PREVIEW_MAX_HEIGHT_PX = 320;
-const IMAGE_ONLY_FALLBACK_TEXT = "[Image]";
 
 const getMessageImageParts = (message: AgentWidgetMessage): ImageContentPart[] => {
   if (!message.contentParts || message.contentParts.length === 0) {
@@ -456,7 +456,7 @@ export const createStandardBubble = (
   const imageParts = getMessageImageParts(message);
   const messageContentText = message.content?.trim() ?? "";
   const isImageOnlyFallbackMessage =
-    imageParts.length > 0 && messageContentText === IMAGE_ONLY_FALLBACK_TEXT;
+    imageParts.length > 0 && messageContentText === IMAGE_ONLY_MESSAGE_FALLBACK_TEXT;
   const shouldHideTextUntilPreviewFails = isImageOnlyFallbackMessage;
 
   // Add message content

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -15,6 +15,7 @@ import {
   generateUserMessageId,
   generateAssistantMessageId
 } from "./utils/message-id";
+import { IMAGE_ONLY_MESSAGE_FALLBACK_TEXT } from "./utils/content";
 
 export type AgentWidgetSessionStatus =
   | "idle"
@@ -418,7 +419,7 @@ export class AgentWidgetSession {
     const userMessage: AgentWidgetMessage = {
       id: userMessageId,
       role: "user",
-      content: input || "[Image]", // Display text (fallback if only images)
+      content: input || IMAGE_ONLY_MESSAGE_FALLBACK_TEXT, // Display text (fallback if only images)
       createdAt: new Date().toISOString(),
       sequence: this.nextSequence(),
       viaVoice: options?.viaVoice || false,

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2038,6 +2038,8 @@ export const createAgentExperience = (
     const clipboardImageFiles = getClipboardImageFiles(event.clipboardData);
     if (clipboardImageFiles.length === 0) return;
 
+    // Prevent browser text/html paste when handling clipboard images as attachments.
+    event.preventDefault();
     await attachmentManager.handleFiles(clipboardImageFiles);
   };
 

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -68,6 +68,59 @@ import {
 const DEFAULT_CHAT_HISTORY_STORAGE_KEY = "persona-chat-history";
 const VOICE_STATE_RESTORE_WINDOW = 30 * 1000;
 
+const IMAGE_FILE_EXTENSION_BY_MIME_TYPE: Record<string, string> = {
+  "image/png": "png",
+  "image/jpeg": "jpg",
+  "image/jpg": "jpg",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "image/svg+xml": "svg",
+  "image/bmp": "bmp",
+  "image/tiff": "tiff"
+};
+
+function getClipboardImageFiles(clipboardData: DataTransfer | null): File[] {
+  if (!clipboardData) return [];
+
+  const imageFiles: File[] = [];
+  const clipboardItems = Array.from(clipboardData.items ?? []);
+
+  for (const item of clipboardItems) {
+    if (item.kind !== "file" || !item.type.startsWith("image/")) continue;
+    const file = item.getAsFile();
+    if (!file) continue;
+
+    if (file.name) {
+      imageFiles.push(file);
+      continue;
+    }
+
+    const extension = IMAGE_FILE_EXTENSION_BY_MIME_TYPE[file.type] ?? "png";
+    imageFiles.push(
+      new File(
+        [file],
+        `clipboard-image-${Date.now()}.${extension}`,
+        {
+          type: file.type,
+          lastModified: Date.now()
+        }
+      )
+    );
+  }
+
+  if (imageFiles.length > 0) {
+    return imageFiles;
+  }
+
+  for (const file of Array.from(clipboardData.files ?? [])) {
+    if (file.type.startsWith("image/")) {
+      imageFiles.push(file);
+    }
+  }
+
+  return imageFiles;
+}
+
 // ============================================================================
 // PERSIST STATE HELPERS
 // ============================================================================
@@ -1979,6 +2032,15 @@ export const createAgentExperience = (
     }
   };
 
+  const handleInputPaste = async (event: ClipboardEvent) => {
+    if (config.attachments?.enabled !== true || !attachmentManager) return;
+
+    const clipboardImageFiles = getClipboardImageFiles(event.clipboardData);
+    if (clipboardImageFiles.length === 0) return;
+
+    await attachmentManager.handleFiles(clipboardImageFiles);
+  };
+
   // Voice recognition state and logic
   let speechRecognition: any = null;
   let isRecording = false;
@@ -2515,10 +2577,12 @@ export const createAgentExperience = (
 
   composerForm.addEventListener("submit", handleSubmit);
   textarea.addEventListener("keydown", handleInputEnter);
+  textarea.addEventListener("paste", handleInputPaste);
 
   destroyCallbacks.push(() => {
     composerForm.removeEventListener("submit", handleSubmit);
     textarea.removeEventListener("keydown", handleInputEnter);
+    textarea.removeEventListener("paste", handleInputPaste);
   });
 
   destroyCallbacks.push(() => {

--- a/packages/widget/src/utils/attachment-manager.ts
+++ b/packages/widget/src/utils/attachment-manager.ts
@@ -152,10 +152,16 @@ export class AttachmentManager {
    */
   async handleFileSelect(files: FileList | null): Promise<void> {
     if (!files || files.length === 0) return;
+    await this.handleFiles(Array.from(files));
+  }
 
-    const filesToProcess = Array.from(files);
+  /**
+   * Handle an array of files (e.g., clipboard image paste)
+   */
+  async handleFiles(files: readonly File[]): Promise<void> {
+    if (!files.length) return;
 
-    for (const file of filesToProcess) {
+    for (const file of files) {
       // Check if we've hit the max files limit
       if (this.attachments.length >= this.config.maxFiles) {
         this.config.onFileRejected?.(file, "count");

--- a/packages/widget/src/utils/content.ts
+++ b/packages/widget/src/utils/content.ts
@@ -7,6 +7,11 @@
 import type { MessageContent, ContentPart, TextContentPart, ImageContentPart, FileContentPart } from '../types';
 
 /**
+ * Fallback display text for messages that only contain image attachments.
+ */
+export const IMAGE_ONLY_MESSAGE_FALLBACK_TEXT = "[Image]";
+
+/**
  * Normalize content to ContentPart[] format.
  * Converts string content to a single text content part.
  */


### PR DESCRIPTION
## Summary
- allow users to attach images by pasting clipboard image data when `attachments.enabled` is true
- keep existing file-picker attachment flow unchanged by reusing the same attachment manager path for both methods
- render attached image previews in chat bubbles when image `contentParts` are present
- bound preview sizing to guard against extreme image dimensions (`max-width: 320px`, `max-height: 320px`)
- preserve the existing `[Image]` fallback text for image-only messages when preview rendering fails for any reason
- include a changeset for `@runtypelabs/persona`

## Testing
- `pnpm --filter @runtypelabs/persona typecheck`
- `pnpm --filter @runtypelabs/persona lint`
- `pnpm --filter @runtypelabs/persona test:run` *(fails in this environment: missing package `fake-indexeddb/auto` in `event-stream-store` test setup)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core composer input handling and message rendering; risk is mainly UI/UX regressions (paste behavior, preview failures, layout/scroll) rather than data or auth concerns.
> 
> **Overview**
> Adds clipboard image paste support to the composer when `attachments.enabled` is true by extracting image `File`s from `ClipboardEvent` data and sending them through the same attachment handling path as the file picker.
> 
> Updates message rendering to show bounded (max 320×320) inline previews for image `contentParts` inside the chat bubble; for image-only messages, the `[Image]` fallback text is hidden when previews render and revealed if previews fail. Also centralizes the `[Image]` placeholder into `IMAGE_ONLY_MESSAGE_FALLBACK_TEXT` and includes a patch changeset for `@runtypelabs/persona`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7efd504ddc8eaf87dbc01b3cee1318fc93f92ebb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->