### PR TITLE
Fix inline timestamp regression in message bubbles

### DIFF
--- a/.changeset/fair-kids-dream.md
+++ b/.changeset/fair-kids-dream.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix inline timestamp positioning regression in message bubbles by avoiding an always-on wrapper div around transformed text content.

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -461,16 +461,21 @@ export const createStandardBubble = (
 
   // Add message content
   const contentDiv = document.createElement("div");
-  const textContentDiv = document.createElement("div");
-  textContentDiv.innerHTML = transform({
+  const transformedContent = transform({
     text: message.content,
     message,
     streaming: Boolean(message.streaming),
     raw: message.rawContent
   });
-  contentDiv.appendChild(textContentDiv);
+  let textContentDiv: HTMLElement | null = null;
+
   if (shouldHideTextUntilPreviewFails) {
+    textContentDiv = document.createElement("div");
+    textContentDiv.innerHTML = transformedContent;
     textContentDiv.style.display = "none";
+    contentDiv.appendChild(textContentDiv);
+  } else {
+    contentDiv.innerHTML = transformedContent;
   }
 
   // Add inline timestamp if configured
@@ -485,7 +490,7 @@ export const createStandardBubble = (
       imageParts,
       !shouldHideTextUntilPreviewFails && Boolean(messageContentText),
       () => {
-        if (shouldHideTextUntilPreviewFails) {
+        if (shouldHideTextUntilPreviewFails && textContentDiv) {
           textContentDiv.style.display = "";
         }
       }
@@ -493,7 +498,7 @@ export const createStandardBubble = (
 
     if (imagePreviews) {
       bubble.appendChild(imagePreviews);
-    } else if (shouldHideTextUntilPreviewFails) {
+    } else if (shouldHideTextUntilPreviewFails && textContentDiv) {
       textContentDiv.style.display = "";
     }
   }


### PR DESCRIPTION
## Summary
- fix the inline timestamp layout regression called out in https://github.com/runtypelabs/persona/pull/50#discussion_r2855865484
- restore the original rendering path (`contentDiv.innerHTML = transformedContent`) for normal messages
- keep the wrapper `div` only for image-only fallback messages where text hide/show behavior is required
- add a changeset for `@runtypelabs/persona` patch release

## Verification
- `pnpm --filter @runtypelabs/persona lint`
- `pnpm --filter @runtypelabs/persona typecheck`
- `pnpm --filter @runtypelabs/persona test:run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small DOM-structure tweak limited to message bubble rendering; primary risk is subtle layout/HTML injection behavior differences due to changing where `innerHTML` is applied.
> 
> **Overview**
> Fixes an inline timestamp positioning regression in `message-bubble` rendering by **avoiding an always-on wrapper `<div>`** around transformed message text.
> 
> Message content is now written directly to `contentDiv.innerHTML` for normal messages, while the wrapper element is only created for the image-only fallback case that needs hide/show behavior; related preview-failure callbacks now guard against `null` text nodes.
> 
> Adds a changeset for a **patch** release of `@runtypelabs/persona`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b7d2b6f1bd789a6dc0a82b7e68d9b05ae870b0e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->