### PR TITLE
Human in the loop UX / hooks

### DIFF
--- a/.changeset/connect-stream-feature.md
+++ b/.changeset/connect-stream-feature.md
@@ -1,0 +1,7 @@
+---
+"@runtypelabs/persona": minor
+---
+
+feat: add connectStream() to pipe external SSE streams through SDK event pipeline
+
+Enables streaming approval responses (and other external SSE sources) through the SDK's native message/tool/reasoning handling instead of static injection.

--- a/.changeset/theme-aware-bubbles.md
+++ b/.changeset/theme-aware-bubbles.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Use theme-aware styling for approval, tool, and reasoning bubbles instead of hardcoded colors and ghost CSS classes. All three bubble types now adapt to dark mode and custom themes. Config overrides still take priority.

--- a/examples/embedded-app/approval-demo.html
+++ b/examples/embedded-app/approval-demo.html
@@ -1,0 +1,224 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Tool Approval Demo</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+      background: linear-gradient(135deg, #451a03 0%, #78350f 50%, #92400e 100%);
+      color: #fff;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr 420px;
+      gap: 1.5rem;
+      padding: 1.5rem;
+      max-width: 1400px;
+      margin: 0 auto;
+      margin-top: 2rem;
+      margin-bottom: 2rem;
+      min-height: 100vh;
+    }
+    @media (max-width: 900px) {
+      .layout {
+        grid-template-columns: 1fr;
+      }
+    }
+    .panel {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+      overflow: hidden;
+    }
+    .info-panel {
+      background: rgba(255,255,255,0.05);
+      border-radius: 8px;
+      padding: 1.5rem;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .info-panel h1 {
+      margin: 0 0 0.5rem 0;
+      font-size: 1.5rem;
+    }
+    .info-panel p {
+      margin: 0 0 1.5rem 0;
+      color: #fed7aa;
+      line-height: 1.6;
+    }
+    .info-section {
+      background: rgba(0,0,0,0.2);
+      border-radius: 6px;
+      padding: 1rem;
+      margin-bottom: 1rem;
+    }
+    .info-section h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.9rem;
+      color: #fbbf24;
+    }
+    .info-section p {
+      margin: 0;
+      font-size: 0.85rem;
+      color: #fed7aa;
+    }
+    .code-block {
+      background: #0d1117;
+      border: 1px solid #30363d;
+      border-radius: 6px;
+      padding: 1rem;
+      overflow-x: auto;
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      font-size: 0.75rem;
+      color: #c9d1d9;
+      margin-bottom: 1rem;
+    }
+    .code-block .comment { color: #8b949e; }
+    .code-block .keyword { color: #ff7b72; }
+    .code-block .string { color: #a5d6ff; }
+    .code-block .prop { color: #79c0ff; }
+    .widget-container {
+      height: 600px;
+    }
+    #approval-widget {
+      height: 100%;
+    }
+    .back-link {
+      display: inline-block;
+      background: rgba(255,255,255,0.1);
+      padding: 0.5rem 1rem;
+      margin: 1rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      color: #fff;
+      font-size: 0.9rem;
+      border: 1px solid rgba(255,255,255,0.1);
+    }
+    .back-link:hover {
+      background: rgba(255,255,255,0.15);
+    }
+    .badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+    }
+    .badge-new {
+      background: #fbbf24;
+      color: #451a03;
+    }
+    .btn-group {
+      display: flex;
+      gap: 0.5rem;
+      margin-bottom: 1rem;
+    }
+    .btn {
+      padding: 0.5rem 1rem;
+      border-radius: 6px;
+      border: 1px solid rgba(255,255,255,0.2);
+      background: rgba(255,255,255,0.1);
+      color: #fff;
+      font-size: 0.85rem;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+    .btn:hover {
+      background: rgba(255,255,255,0.2);
+    }
+    .btn-approve {
+      background: rgba(22, 163, 74, 0.3);
+      border-color: rgba(22, 163, 74, 0.5);
+    }
+    .btn-approve:hover {
+      background: rgba(22, 163, 74, 0.5);
+    }
+    .btn-deny {
+      background: rgba(220, 38, 38, 0.3);
+      border-color: rgba(220, 38, 38, 0.5);
+    }
+    .btn-deny:hover {
+      background: rgba(220, 38, 38, 0.5);
+    }
+    .event-log {
+      background: rgba(0,0,0,0.3);
+      border-radius: 6px;
+      padding: 0.75rem;
+      max-height: 200px;
+      overflow-y: auto;
+      font-family: 'SF Mono', Monaco, 'Cascadia Code', monospace;
+      font-size: 0.75rem;
+      color: #fed7aa;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="back-link">&larr; Back to examples</a>
+
+  <div class="layout">
+    <!-- Left: Info Panel -->
+    <div class="info-panel">
+      <h1>Tool Approval <span class="badge badge-new">New</span></h1>
+      <p>This demo shows the native tool approval system. When an agent needs to execute a tool that requires human approval, an inline approval bubble appears in the chat with Approve/Deny buttons.</p>
+
+      <div class="info-section">
+        <h3>How it works</h3>
+        <p>The SDK natively handles <code>agent_approval_start</code> and <code>step_await</code> (with <code>approval_required</code>) SSE events. It creates an approval bubble inline in the chat. When the user clicks Approve or Deny, the SDK calls the approval API and pipes the response stream back through the chat.</p>
+      </div>
+
+      <div class="code-block">
+<span class="comment">// Approval config</span>
+{
+  <span class="prop">approval</span>: {
+    <span class="prop">title</span>: <span class="string">"Approval Required"</span>,
+    <span class="prop">approveLabel</span>: <span class="string">"Approve"</span>,
+    <span class="prop">denyLabel</span>: <span class="string">"Deny"</span>,
+    <span class="prop">approveButtonColor</span>: <span class="string">"#16a34a"</span>,
+    <span class="comment">// Custom handler (optional)</span>
+    <span class="prop">onDecision</span>: <span class="keyword">async</span> (data, decision) =&gt; {
+      <span class="comment">// Return Response or ReadableStream</span>
+    }
+  }
+}
+      </div>
+
+      <div class="info-section">
+        <h3>Programmatic Control</h3>
+        <p>Use <code>controller.resolveApproval(approvalId, decision)</code> to resolve approvals programmatically from your application code.</p>
+      </div>
+
+      <div class="btn-group">
+        <button class="btn btn-approve" id="btn-approve">Approve (API)</button>
+        <button class="btn btn-deny" id="btn-deny">Deny (API)</button>
+      </div>
+
+      <div class="info-section">
+        <h3>Controller Events</h3>
+        <p>Listen for <code>approval:requested</code> and <code>approval:resolved</code> events on the controller to react to the approval lifecycle in your app.</p>
+      </div>
+
+      <div class="info-section">
+        <h3>Customization</h3>
+        <p>Style the approval bubble via <code>config.approval</code> (colors, labels), override rendering with the <code>renderApproval</code> plugin hook, or disable entirely with <code>approval: false</code>.</p>
+      </div>
+
+      <div class="info-section">
+        <h3>Event Log</h3>
+        <div class="event-log" id="event-log"></div>
+      </div>
+    </div>
+
+    <!-- Right: Widget -->
+    <div class="panel widget-container">
+      <div id="approval-widget"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/approval-demo.ts"></script>
+</body>
+</html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -32,6 +32,7 @@
         <li><a href="/client-token-feedback-demo.html">Client Token Feedback Demo (Automatic Feedback)</a></li>
         <li><a href="/custom-loading-indicator.html">Custom Loading Indicator</a></li>
         <li><a href="/agent-demo.html">Agent Loop Execution Demo</a></li>
+        <li><a href="/approval-demo.html">Tool Approval Demo</a></li>
       </ul>
       <div class="cta-row">
         <button id="open-chat" type="button">Open Launcher</button>

--- a/examples/embedded-app/src/approval-demo.ts
+++ b/examples/embedded-app/src/approval-demo.ts
@@ -1,0 +1,195 @@
+import "@runtypelabs/persona/widget.css";
+
+import {
+  createAgentExperience,
+  markdownPostprocessor,
+  DEFAULT_WIDGET_CONFIG,
+  type AgentWidgetController,
+} from "@runtypelabs/persona";
+
+// ── Simulated SSE stream helper ──────────────────────────────
+function createSSEStream(events: Array<{ type: string; [key: string]: unknown }>, delayMs = 300): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let index = 0;
+
+  return new ReadableStream({
+    async pull(controller) {
+      if (index >= events.length) {
+        controller.close();
+        return;
+      }
+
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+
+      const event = events[index++];
+      const data = JSON.stringify(event);
+      controller.enqueue(encoder.encode(`data: ${data}\n\n`));
+    }
+  });
+}
+
+// ── Mount ──────────────────────────────────────────────────────
+const mount = document.getElementById("approval-widget");
+if (!mount) throw new Error("Approval widget mount node missing");
+
+let controller: AgentWidgetController | null = null;
+
+// Track approval decisions for the simulated flow
+let lastApprovalDecision: 'approved' | 'denied' | null = null;
+
+function createWidget() {
+  mount!.innerHTML = "";
+
+  const handle = createAgentExperience(mount!, {
+    ...DEFAULT_WIDGET_CONFIG,
+
+    // Use customFetch to simulate the entire flow
+    customFetch: async (_url, init, _payload) => {
+      // Simulate: assistant starts typing, then pauses for approval
+      const events = [
+        { type: "agent_start", executionId: "exec-demo-1", agentId: "demo-agent", agentName: "Demo Agent", maxIterations: 3, startedAt: Date.now() },
+        { type: "agent_iteration_start", executionId: "exec-demo-1", iteration: 1 },
+        { type: "agent_turn_start", executionId: "exec-demo-1", turnId: "turn-1" },
+        { type: "agent_turn_delta", executionId: "exec-demo-1", turnId: "turn-1", delta: "Let me search for that information using Exa..." },
+        { type: "agent_turn_complete", executionId: "exec-demo-1", turnId: "turn-1" },
+        // Tool approval event
+        {
+          type: "agent_approval_start",
+          executionId: "exec-demo-1",
+          approvalId: `approval-${Date.now()}`,
+          toolName: "exa_search",
+          toolType: "mcp",
+          description: "Search the web using Exa for relevant information",
+          parameters: { query: "latest AI news 2025", numResults: 5 },
+        },
+      ];
+
+      const stream = createSSEStream(events, 200);
+
+      return new Response(stream, {
+        status: 200,
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    },
+
+    // Custom approval handler that simulates the approve/deny response
+    approval: {
+      onDecision: async (data, decision) => {
+        lastApprovalDecision = decision;
+        updateLog(`Decision: ${decision} for tool "${data.toolName}" (approval: ${data.approvalId})`);
+
+        if (decision === 'denied') {
+          // Simulate a denial response
+          const events = [
+            { type: "agent_turn_start", executionId: data.executionId, turnId: "turn-denied" },
+            { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-denied", delta: "The tool execution was denied. I'll try to help without using that tool." },
+            { type: "agent_turn_complete", executionId: data.executionId, turnId: "turn-denied" },
+            { type: "agent_complete", executionId: data.executionId, success: true, stopReason: "complete" },
+          ];
+          return createSSEStream(events, 150);
+        }
+
+        // Simulate an approval response with tool execution
+        const events = [
+          { type: "agent_approval_complete", executionId: data.executionId, approvalId: data.approvalId, decision: "approved", toolName: data.toolName },
+          { type: "agent_tool_start", executionId: data.executionId, toolCallId: "tool-1", toolName: data.toolName, parameters: { query: "latest AI news 2025", numResults: 5 } },
+          { type: "agent_tool_delta", executionId: data.executionId, toolCallId: "tool-1", delta: "Searching..." },
+          { type: "agent_tool_complete", executionId: data.executionId, toolCallId: "tool-1", result: { results: ["Result 1: AI breakthrough", "Result 2: New model released"] }, executionTime: 1200 },
+          { type: "agent_turn_start", executionId: data.executionId, turnId: "turn-2" },
+          { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-2", delta: "Based on the search results, here are the latest AI developments:\n\n" },
+          { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-2", delta: "1. **AI Breakthrough** - Major advances in reasoning capabilities\n" },
+          { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-2", delta: "2. **New Model Released** - Next-gen models with improved performance\n" },
+          { type: "agent_turn_complete", executionId: data.executionId, turnId: "turn-2" },
+          { type: "agent_complete", executionId: data.executionId, success: true, stopReason: "complete" },
+        ];
+        return createSSEStream(events, 150);
+      },
+    },
+
+    // Widget chrome
+    launcher: {
+      ...DEFAULT_WIDGET_CONFIG.launcher,
+      width: "100%",
+      enabled: false,
+    },
+    theme: {
+      ...DEFAULT_WIDGET_CONFIG.theme,
+      primary: "#0f172a",
+      accent: "#d97706",
+      surface: "#f8fafc",
+      muted: "#64748b",
+    },
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Approval Demo",
+      welcomeSubtitle:
+        "This demo simulates tool approval requests. Send any message to trigger an approval flow.",
+      inputPlaceholder: "Send a message to trigger approval...",
+    },
+    features: {
+      showToolCalls: true,
+      showReasoning: true,
+    },
+    suggestionChips: [
+      "Search for AI news",
+      "Find recent papers",
+      "Look up documentation",
+    ],
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+  });
+
+  controller = handle;
+
+  // Listen for approval events
+  controller.on("approval:requested", (event) => {
+    updateLog(`Approval requested: "${event.approval.toolName}" - ${event.approval.description}`);
+  });
+
+  controller.on("approval:resolved", (event) => {
+    updateLog(`Approval resolved: ${event.decision}`);
+  });
+}
+
+// ── Event Log ──────────────────────────────────────────────────
+const logContainer = document.getElementById("event-log");
+
+function updateLog(message: string) {
+  if (!logContainer) return;
+  const entry = document.createElement("div");
+  entry.style.cssText = "padding: 0.25rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.8rem;";
+  const time = new Date().toLocaleTimeString();
+  entry.innerHTML = `<span style="color: #64748b;">[${time}]</span> ${message}`;
+  logContainer.prepend(entry);
+}
+
+// ── Programmatic Buttons ──────────────────────────────────────
+const approveBtn = document.getElementById("btn-approve");
+const denyBtn = document.getElementById("btn-deny");
+
+approveBtn?.addEventListener("click", () => {
+  if (!controller) return;
+  const messages = controller.getMessages();
+  const pending = messages.find(m => m.variant === "approval" && m.approval?.status === "pending");
+  if (pending?.approval) {
+    controller.resolveApproval(pending.approval.id, "approved");
+    updateLog("Programmatic approve triggered");
+  } else {
+    updateLog("No pending approval found");
+  }
+});
+
+denyBtn?.addEventListener("click", () => {
+  if (!controller) return;
+  const messages = controller.getMessages();
+  const pending = messages.find(m => m.variant === "approval" && m.approval?.status === "pending");
+  if (pending?.approval) {
+    controller.resolveApproval(pending.approval.id, "denied");
+    updateLog("Programmatic deny triggered");
+  } else {
+    updateLog("No pending approval found");
+  }
+});
+
+// Initial render
+createWidget();
+updateLog("Widget initialized - send a message to trigger approval flow");

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -41,6 +41,8 @@ export default defineConfig({
         'bakery-locations': path.resolve(__dirname, 'bakery-locations.html'),
         'bakery-goods': path.resolve(__dirname, 'bakery-goods.html'),
         'bakery-services': path.resolve(__dirname, 'bakery-services.html'),
+        // Approval demo
+        'approval-demo': path.resolve(__dirname, 'approval-demo.html'),
       }
     }
   },

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -702,6 +702,39 @@ export class AgentWidgetClient {
     }
   }
 
+  /**
+   * Send an approval decision to the API and return the response
+   * for streaming continuation.
+   */
+  public async resolveApproval(
+    approval: { agentId: string; executionId: string; approvalId: string },
+    decision: 'approved' | 'denied'
+  ): Promise<Response> {
+    const baseUrl = this.config.apiUrl
+      ?.replace(/\/+$/, '')
+      .replace(/\/v1\/dispatch$/, '') || DEFAULT_CLIENT_API_BASE;
+    const url = `${baseUrl}/v1/agents/${approval.agentId}/approve`;
+
+    let headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.headers
+    };
+    if (this.getHeaders) {
+      Object.assign(headers, await this.getHeaders());
+    }
+
+    return fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        executionId: approval.executionId,
+        approvalId: approval.approvalId,
+        decision,
+        streamResponse: true,
+      }),
+    });
+  }
+
   private async buildAgentPayload(
     messages: AgentWidgetMessage[]
   ): Promise<AgentWidgetAgentRequestPayload> {
@@ -2001,6 +2034,78 @@ export class AgentWidgetClient {
           }
         } else if (payloadType === "agent_ping") {
           // Keep-alive heartbeat - no action needed
+        // ================================================================
+        // Tool Approval Events
+        // ================================================================
+        } else if (payloadType === "agent_approval_start") {
+          const approvalId = payload.approvalId ?? `approval-${nextSequence()}`;
+          const approvalMessage: AgentWidgetMessage = {
+            id: `approval-${approvalId}`,
+            role: "assistant",
+            content: "",
+            createdAt: new Date().toISOString(),
+            streaming: false,
+            variant: "approval",
+            sequence: nextSequence(),
+            approval: {
+              id: approvalId,
+              status: "pending",
+              agentId: agentExecution?.agentId ?? 'virtual',
+              executionId: payload.executionId ?? agentExecution?.executionId ?? '',
+              toolName: payload.toolName ?? '',
+              toolType: payload.toolType,
+              description: payload.description ?? `Execute ${payload.toolName ?? 'tool'}`,
+              parameters: payload.parameters,
+            },
+          };
+          emitMessage(approvalMessage);
+        } else if (payloadType === "step_await" && payload.awaitReason === "approval_required") {
+          const approvalId = payload.approvalId ?? `approval-${nextSequence()}`;
+          const approvalMessage: AgentWidgetMessage = {
+            id: `approval-${approvalId}`,
+            role: "assistant",
+            content: "",
+            createdAt: new Date().toISOString(),
+            streaming: false,
+            variant: "approval",
+            sequence: nextSequence(),
+            approval: {
+              id: approvalId,
+              status: "pending",
+              agentId: agentExecution?.agentId ?? 'virtual',
+              executionId: payload.executionId ?? agentExecution?.executionId ?? '',
+              toolName: payload.toolName ?? '',
+              toolType: payload.toolType,
+              description: payload.description ?? `Execute ${payload.toolName ?? 'tool'}`,
+              parameters: payload.parameters,
+            },
+          };
+          emitMessage(approvalMessage);
+        } else if (payloadType === "agent_approval_complete") {
+          const approvalId = payload.approvalId;
+          if (approvalId) {
+            // Find and update the existing approval message
+            const approvalMessageId = `approval-${approvalId}`;
+            const existingMessage: AgentWidgetMessage = {
+              id: approvalMessageId,
+              role: "assistant",
+              content: "",
+              createdAt: new Date().toISOString(),
+              streaming: false,
+              variant: "approval",
+              sequence: nextSequence(),
+              approval: {
+                id: approvalId,
+                status: (payload.decision as "approved" | "denied") ?? "approved",
+                agentId: agentExecution?.agentId ?? 'virtual',
+                executionId: payload.executionId ?? agentExecution?.executionId ?? '',
+                toolName: payload.toolName ?? '',
+                description: payload.description ?? '',
+                resolvedAt: Date.now(),
+              },
+            };
+            emitMessage(existingMessage);
+          }
         } else if (payloadType === "error" && payload.error) {
           onEvent({
             type: "error",

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -684,6 +684,24 @@ export class AgentWidgetClient {
     }
   }
 
+  /**
+   * Process an external SSE stream through the SDK's event pipeline.
+   * This allows piping responses from endpoints like agent approval
+   * through the same message/tool/reasoning handling as dispatch().
+   */
+  public async processStream(
+    body: ReadableStream<Uint8Array>,
+    onEvent: SSEHandler,
+    assistantMessageId?: string
+  ): Promise<void> {
+    onEvent({ type: "status", status: "connected" });
+    try {
+      await this.streamResponse(body, onEvent, assistantMessageId);
+    } finally {
+      onEvent({ type: "status", status: "idle" });
+    }
+  }
+
   private async buildAgentPayload(
     messages: AgentWidgetMessage[]
   ): Promise<AgentWidgetAgentRequestPayload> {

--- a/packages/widget/src/components/approval-bubble.ts
+++ b/packages/widget/src/components/approval-bubble.ts
@@ -1,0 +1,223 @@
+import { createElement } from "../utils/dom";
+import { AgentWidgetMessage, AgentWidgetConfig } from "../types";
+import { formatUnknownValue } from "../utils/formatting";
+import { renderLucideIcon } from "../utils/icons";
+
+/**
+ * Update an existing approval bubble's UI after status changes.
+ */
+export const updateApprovalBubbleUI = (
+  _messageId: string,
+  bubble: HTMLElement,
+  config?: AgentWidgetConfig,
+  approval?: AgentWidgetMessage["approval"]
+): void => {
+  if (!approval) return;
+
+  const approvalConfig = config?.approval !== false ? config?.approval : undefined;
+
+  // Update status badge
+  const statusBadge = bubble.querySelector('[data-approval-status]') as HTMLElement;
+  if (statusBadge) {
+    statusBadge.textContent = approval.status === "approved" ? "Approved"
+      : approval.status === "denied" ? "Denied"
+      : approval.status === "timeout" ? "Timeout"
+      : "Pending";
+
+    // Update badge color
+    if (approval.status === "approved") {
+      statusBadge.className = "tvw-inline-flex tvw-items-center tvw-px-2 tvw-py-0.5 tvw-rounded-full tvw-text-xs tvw-font-medium tvw-approval-badge-approved";
+    } else if (approval.status === "denied") {
+      statusBadge.className = "tvw-inline-flex tvw-items-center tvw-px-2 tvw-py-0.5 tvw-rounded-full tvw-text-xs tvw-font-medium tvw-approval-badge-denied";
+    } else if (approval.status === "timeout") {
+      statusBadge.className = "tvw-inline-flex tvw-items-center tvw-px-2 tvw-py-0.5 tvw-rounded-full tvw-text-xs tvw-font-medium tvw-approval-badge-timeout";
+    }
+    statusBadge.setAttribute("data-approval-status", approval.status);
+  }
+
+  // Update icon
+  const iconContainer = bubble.querySelector('[data-approval-icon]') as HTMLElement;
+  if (iconContainer) {
+    iconContainer.innerHTML = "";
+    const iconName = approval.status === "denied" ? "shield-x"
+      : approval.status === "timeout" ? "shield-alert"
+      : "shield-check";
+    const iconColor = approval.status === "approved" ? "#16a34a"
+      : approval.status === "denied" ? "#dc2626"
+      : approval.status === "timeout" ? "#ca8a04"
+      : (approvalConfig?.titleColor ?? "currentColor");
+    const icon = renderLucideIcon(iconName, 20, iconColor, 2);
+    if (icon) {
+      iconContainer.appendChild(icon);
+    }
+  }
+
+  // Show/hide buttons based on status
+  const buttonsContainer = bubble.querySelector('[data-approval-buttons]') as HTMLElement;
+  if (buttonsContainer) {
+    buttonsContainer.style.display = approval.status === "pending" ? "" : "none";
+  }
+};
+
+/**
+ * Create an approval bubble element for inline display in the chat.
+ */
+export const createApprovalBubble = (
+  message: AgentWidgetMessage,
+  config?: AgentWidgetConfig
+): HTMLElement => {
+  const approval = message.approval;
+  const approvalConfig = config?.approval !== false ? config?.approval : undefined;
+  const isPending = approval?.status === "pending";
+
+  const bubble = createElement(
+    "div",
+    [
+      "vanilla-message-bubble",
+      "vanilla-approval-bubble",
+      "tvw-w-full",
+      "tvw-max-w-[85%]",
+      "tvw-rounded-2xl",
+      "tvw-border",
+      "tvw-shadow-sm",
+      "tvw-overflow-hidden",
+    ].join(" ")
+  );
+
+  // Set id for idiomorph matching
+  bubble.id = `bubble-${message.id}`;
+  bubble.setAttribute("data-message-id", message.id);
+
+  // Apply styling — only set inline styles when config overrides exist (CSS defaults handle the rest)
+  if (approvalConfig?.backgroundColor) {
+    bubble.style.backgroundColor = approvalConfig.backgroundColor;
+  }
+  if (approvalConfig?.borderColor) {
+    bubble.style.borderColor = approvalConfig.borderColor;
+  }
+
+  if (!approval) {
+    return bubble;
+  }
+
+  // Header section with icon, title, and status badge
+  const header = createElement(
+    "div",
+    "tvw-flex tvw-items-start tvw-gap-3 tvw-px-4 tvw-py-3"
+  );
+
+  // Icon container
+  const iconContainer = createElement("div", "tvw-flex-shrink-0 tvw-mt-0.5");
+  iconContainer.setAttribute("data-approval-icon", "true");
+  const iconName = approval.status === "denied" ? "shield-x"
+    : approval.status === "timeout" ? "shield-alert"
+    : "shield-check";
+  const iconColor = approval.status === "approved" ? "#16a34a"
+    : approval.status === "denied" ? "#dc2626"
+    : approval.status === "timeout" ? "#ca8a04"
+    : (approvalConfig?.titleColor ?? "currentColor");
+  const icon = renderLucideIcon(iconName, 20, iconColor, 2);
+  if (icon) {
+    iconContainer.appendChild(icon);
+  }
+
+  // Content area
+  const content = createElement("div", "tvw-flex-1 tvw-min-w-0");
+
+  // Title row with status badge
+  const titleRow = createElement("div", "tvw-flex tvw-items-center tvw-gap-2");
+  const title = createElement("span", "tvw-text-sm tvw-font-medium tvw-text-cw-primary");
+  if (approvalConfig?.titleColor) {
+    title.style.color = approvalConfig.titleColor;
+  }
+  title.textContent = approvalConfig?.title ?? "Approval Required";
+  titleRow.appendChild(title);
+
+  // Status badge (shown when resolved)
+  if (!isPending) {
+    const badge = createElement("span", "tvw-inline-flex tvw-items-center tvw-px-2 tvw-py-0.5 tvw-rounded-full tvw-text-xs tvw-font-medium");
+    badge.setAttribute("data-approval-status", approval.status);
+    if (approval.status === "approved") {
+      badge.className += " tvw-approval-badge-approved";
+      badge.textContent = "Approved";
+    } else if (approval.status === "denied") {
+      badge.className += " tvw-approval-badge-denied";
+      badge.textContent = "Denied";
+    } else if (approval.status === "timeout") {
+      badge.className += " tvw-approval-badge-timeout";
+      badge.textContent = "Timeout";
+    }
+    titleRow.appendChild(badge);
+  }
+
+  content.appendChild(titleRow);
+
+  // Description
+  const description = createElement("p", "tvw-text-sm tvw-mt-0.5 tvw-text-cw-muted");
+  if (approvalConfig?.descriptionColor) {
+    description.style.color = approvalConfig.descriptionColor;
+  }
+  description.textContent = approval.description;
+  content.appendChild(description);
+
+  // Parameters block
+  if (approval.parameters) {
+    const paramsPre = createElement(
+      "pre",
+      "tvw-mt-2 tvw-text-xs tvw-p-2 tvw-rounded tvw-overflow-x-auto tvw-max-h-32 tvw-bg-cw-container tvw-text-cw-primary"
+    );
+    if (approvalConfig?.parameterBackgroundColor) {
+      paramsPre.style.backgroundColor = approvalConfig.parameterBackgroundColor;
+    }
+    if (approvalConfig?.parameterTextColor) {
+      paramsPre.style.color = approvalConfig.parameterTextColor;
+    }
+    paramsPre.style.fontSize = "0.75rem";
+    paramsPre.style.lineHeight = "1rem";
+    paramsPre.textContent = formatUnknownValue(approval.parameters);
+    content.appendChild(paramsPre);
+  }
+
+  // Action buttons (only shown when pending)
+  if (isPending) {
+    const buttonsContainer = createElement("div", "tvw-flex tvw-gap-2 tvw-mt-2");
+    buttonsContainer.setAttribute("data-approval-buttons", "true");
+
+    // Approve button
+    const approveBtn = createElement("button", "tvw-inline-flex tvw-items-center tvw-px-3 tvw-py-1.5 tvw-rounded-md tvw-text-xs tvw-font-medium tvw-border-none tvw-cursor-pointer") as HTMLButtonElement;
+    approveBtn.type = "button";
+    approveBtn.style.backgroundColor = approvalConfig?.approveButtonColor ?? "#16a34a";
+    approveBtn.style.color = approvalConfig?.approveButtonTextColor ?? "#ffffff";
+    approveBtn.setAttribute("data-approval-action", "approve");
+    const approveIcon = renderLucideIcon("shield-check", 14, approvalConfig?.approveButtonTextColor ?? "#ffffff", 2);
+    if (approveIcon) {
+      approveIcon.style.marginRight = "4px";
+      approveBtn.appendChild(approveIcon);
+    }
+    const approveLabel = document.createTextNode(approvalConfig?.approveLabel ?? "Approve");
+    approveBtn.appendChild(approveLabel);
+
+    // Deny button
+    const denyBtn = createElement("button", "tvw-inline-flex tvw-items-center tvw-px-3 tvw-py-1.5 tvw-rounded-md tvw-text-xs tvw-font-medium tvw-cursor-pointer") as HTMLButtonElement;
+    denyBtn.type = "button";
+    denyBtn.style.backgroundColor = approvalConfig?.denyButtonColor ?? "transparent";
+    denyBtn.style.color = approvalConfig?.denyButtonTextColor ?? "#dc2626";
+    denyBtn.style.border = `1px solid ${approvalConfig?.denyButtonTextColor ?? "#fca5a5"}`;
+    denyBtn.setAttribute("data-approval-action", "deny");
+    const denyIcon = renderLucideIcon("shield-x", 14, approvalConfig?.denyButtonTextColor ?? "#dc2626", 2);
+    if (denyIcon) {
+      denyIcon.style.marginRight = "4px";
+      denyBtn.appendChild(denyIcon);
+    }
+    const denyLabel = document.createTextNode(approvalConfig?.denyLabel ?? "Deny");
+    denyBtn.appendChild(denyLabel);
+
+    buttonsContainer.append(approveBtn, denyBtn);
+    content.appendChild(buttonsContainer);
+  }
+
+  header.append(iconContainer, content);
+  bubble.appendChild(header);
+
+  return bubble;
+};

--- a/packages/widget/src/components/reasoning-bubble.ts
+++ b/packages/widget/src/components/reasoning-bubble.ts
@@ -103,7 +103,7 @@ export const createReasoningBubble = (message: AgentWidgetMessage): HTMLElement 
 
   const content = createElement(
     "div",
-    "tvw-border-t tvw-border-gray-200 tvw-bg-gray-50 tvw-px-4 tvw-py-3"
+    "tvw-border-t tvw-px-4 tvw-py-3"
   );
   content.style.display = expanded ? "" : "none";
 

--- a/packages/widget/src/components/tool-bubble.ts
+++ b/packages/widget/src/components/tool-bubble.ts
@@ -126,7 +126,7 @@ export const createToolBubble = (message: AgentWidgetMessage, config?: AgentWidg
 
   const content = createElement(
     "div",
-    "tvw-border-t tvw-border-gray-200 tvw-bg-gray-50 tvw-space-y-3 tvw-px-4 tvw-py-3"
+    "tvw-border-t tvw-space-y-3 tvw-px-4 tvw-py-3"
   );
   content.style.display = expanded ? "" : "none";
 
@@ -170,7 +170,7 @@ export const createToolBubble = (message: AgentWidgetMessage, config?: AgentWidg
     argsLabel.textContent = "Arguments";
     const argsPre = createElement(
       "pre",
-      "tvw-max-h-48 tvw-overflow-auto tvw-whitespace-pre-wrap tvw-rounded-lg tvw-border tvw-border-gray-100 tvw-bg-white tvw-px-3 tvw-py-2 tvw-text-xs tvw-text-cw-primary"
+      "tvw-max-h-48 tvw-overflow-auto tvw-whitespace-pre-wrap tvw-rounded-lg tvw-border tvw-px-3 tvw-py-2 tvw-text-xs tvw-text-cw-primary"
     );
     // Ensure font size matches header text (0.75rem / 12px)
     argsPre.style.fontSize = "0.75rem";
@@ -201,7 +201,7 @@ export const createToolBubble = (message: AgentWidgetMessage, config?: AgentWidg
     logsLabel.textContent = "Activity";
     const logsPre = createElement(
       "pre",
-      "tvw-max-h-48 tvw-overflow-auto tvw-whitespace-pre-wrap tvw-rounded-lg tvw-border tvw-border-gray-100 tvw-bg-white tvw-px-3 tvw-py-2 tvw-text-xs tvw-text-cw-primary"
+      "tvw-max-h-48 tvw-overflow-auto tvw-whitespace-pre-wrap tvw-rounded-lg tvw-border tvw-px-3 tvw-py-2 tvw-text-xs tvw-text-cw-primary"
     );
     // Ensure font size matches header text (0.75rem / 12px)
     logsPre.style.fontSize = "0.75rem";
@@ -232,7 +232,7 @@ export const createToolBubble = (message: AgentWidgetMessage, config?: AgentWidg
     resultLabel.textContent = "Result";
     const resultPre = createElement(
       "pre",
-      "tvw-max-h-48 tvw-overflow-auto tvw-whitespace-pre-wrap tvw-rounded-lg tvw-border tvw-border-gray-100 tvw-bg-white tvw-px-3 tvw-py-2 tvw-text-xs tvw-text-cw-primary"
+      "tvw-max-h-48 tvw-overflow-auto tvw-whitespace-pre-wrap tvw-rounded-lg tvw-border tvw-px-3 tvw-py-2 tvw-text-xs tvw-text-cw-primary"
     );
     // Ensure font size matches header text (0.75rem / 12px)
     resultPre.style.fontSize = "0.75rem";

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -66,6 +66,9 @@ export type {
   AgentExecutionState,
   AgentMessageMetadata,
   AgentWidgetAgentRequestPayload,
+  // Approval types
+  AgentWidgetApproval,
+  AgentWidgetApprovalConfig,
   // Event stream types
   SSEEventRecord,
   EventStreamConfig,

--- a/packages/widget/src/plugins/types.ts
+++ b/packages/widget/src/plugins/types.ts
@@ -85,6 +85,16 @@ export interface AgentWidgetPlugin {
   }) => HTMLElement | null;
 
   /**
+   * Custom renderer for approval bubbles
+   * Return null to use default renderer
+   */
+  renderApproval?: (context: {
+    message: AgentWidgetMessage;
+    defaultRenderer: () => HTMLElement;
+    config: AgentWidgetConfig;
+  }) => HTMLElement | null;
+
+  /**
    * Custom renderer for loading indicator
    * Return null to use default renderer (or config-based renderer)
    *

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -540,6 +540,34 @@ export class AgentWidgetSession {
     }
   }
 
+  /**
+   * Connect an external SSE stream (e.g. from an approval endpoint) and
+   * process it through the SDK's native event pipeline.
+   */
+  public async connectStream(
+    stream: ReadableStream<Uint8Array>,
+    options?: { assistantMessageId?: string }
+  ): Promise<void> {
+    if (this.streaming) return;
+    this.abortController?.abort();
+    this.setStreaming(true);
+
+    try {
+      await this.client.processStream(
+        stream,
+        this.handleEvent,
+        options?.assistantMessageId
+      );
+    } catch (error) {
+      this.setStatus("error");
+      this.setStreaming(false);
+      this.abortController = null;
+      this.callbacks.onError?.(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+
   public cancel() {
     this.abortController?.abort();
     this.abortController = null;

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -3,6 +3,7 @@ import {
   AgentWidgetConfig,
   AgentWidgetEvent,
   AgentWidgetMessage,
+  AgentWidgetApproval,
   AgentExecutionState,
   ClientSession,
   ContentPart,
@@ -562,6 +563,97 @@ export class AgentWidgetSession {
       this.setStatus("error");
       this.setStreaming(false);
       this.abortController = null;
+      this.callbacks.onError?.(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+
+  /**
+   * Resolve a tool approval request (approve or deny).
+   * Updates the approval message status, calls the API (or custom onDecision),
+   * and pipes the response stream through connectStream().
+   */
+  public async resolveApproval(
+    approval: AgentWidgetApproval,
+    decision: 'approved' | 'denied'
+  ): Promise<void> {
+    // 1. Update approval message status immediately for responsive UI
+    const approvalMessageId = `approval-${approval.id}`;
+    const updatedApproval: AgentWidgetApproval = {
+      ...approval,
+      status: decision,
+      resolvedAt: Date.now(),
+    };
+    const updatedMessage: AgentWidgetMessage = {
+      id: approvalMessageId,
+      role: "assistant",
+      content: "",
+      createdAt: new Date().toISOString(),
+      streaming: false,
+      variant: "approval",
+      approval: updatedApproval,
+    };
+    this.upsertMessage(updatedMessage);
+
+    // 2. Call onDecision callback if provided, otherwise use client.resolveApproval()
+    const approvalConfig = this.config.approval;
+    const onDecision = approvalConfig && typeof approvalConfig === 'object' ? approvalConfig.onDecision : undefined;
+
+    try {
+      let response: Response | ReadableStream<Uint8Array> | void;
+
+      if (onDecision) {
+        response = await onDecision(
+          {
+            approvalId: approval.id,
+            executionId: approval.executionId,
+            agentId: approval.agentId,
+            toolName: approval.toolName,
+          },
+          decision
+        );
+      } else {
+        response = await this.client.resolveApproval(
+          {
+            agentId: approval.agentId,
+            executionId: approval.executionId,
+            approvalId: approval.id,
+          },
+          decision
+        );
+      }
+
+      // 3. Pipe through connectStream if we got a response with a body
+      if (response) {
+        let stream: ReadableStream<Uint8Array> | null = null;
+        if (response instanceof Response) {
+          if (!response.ok) {
+            const errorData = await response.json().catch(() => null);
+            throw new Error(
+              errorData?.error ?? `Approval request failed: ${response.status}`
+            );
+          }
+          stream = response.body;
+        } else if (response instanceof ReadableStream) {
+          stream = response;
+        }
+
+        if (stream) {
+          await this.connectStream(stream);
+        } else if (decision === 'denied') {
+          // No stream body for denied — inject a denial message
+          this.appendMessage({
+            id: `denial-${approval.id}`,
+            role: "assistant",
+            content: "Tool execution was denied by user.",
+            createdAt: new Date().toISOString(),
+            streaming: false,
+            sequence: this.nextSequence(),
+          });
+        }
+      }
+    } catch (error) {
       this.callbacks.onError?.(
         error instanceof Error ? error : new Error(String(error))
       );

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1817,3 +1817,71 @@
 .tvw-feedback-shake {
   animation: tvw-feedback-shake 0.5s ease-in-out;
 }
+
+/* ============================================
+   Tool & Reasoning Bubble Theme Styles
+   ============================================ */
+
+/* Content areas: replace ghost tvw-bg-gray-50 / tvw-border-gray-200 */
+.vanilla-tool-bubble .tvw-border-t,
+.vanilla-reasoning-bubble .tvw-border-t {
+  border-top-color: var(--cw-border, #e5e7eb);
+  background-color: var(--cw-container, #f9fafb);
+}
+
+/* Tool bubble code blocks: replace ghost tvw-bg-white / tvw-border-gray-100 */
+.vanilla-tool-bubble pre {
+  background-color: var(--cw-surface, #ffffff);
+  border-color: var(--cw-border, #f1f5f9);
+}
+
+/* Collapsible header hover (tool + reasoning) */
+.vanilla-tool-bubble button[data-expand-header],
+.vanilla-reasoning-bubble button[data-expand-header] {
+  transition: background-color 0.15s ease;
+}
+.vanilla-tool-bubble button[data-expand-header]:hover,
+.vanilla-reasoning-bubble button[data-expand-header]:hover {
+  background-color: var(--cw-container, #f8fafc);
+}
+
+/* ============================================
+   Approval Bubble Theme Styles
+   ============================================ */
+
+/* Approval bubble defaults (overridden by inline styles when config exists) */
+.vanilla-approval-bubble {
+  background-color: var(--cw-surface, #ffffff);
+  border-color: var(--cw-border, #e5e7eb);
+}
+
+/* Approval status badges — rgba() so they work on any surface */
+.tvw-approval-badge-approved {
+  background-color: rgba(22, 163, 74, 0.12);
+  color: #16a34a;
+}
+.tvw-approval-badge-denied {
+  background-color: rgba(220, 38, 38, 0.12);
+  color: #dc2626;
+}
+.tvw-approval-badge-timeout {
+  background-color: rgba(202, 138, 4, 0.12);
+  color: #ca8a04;
+}
+
+/* Approval button hover/active states */
+.vanilla-approval-bubble [data-approval-action] {
+  transition: opacity 0.15s ease, transform 0.1s ease, background-color 0.15s ease;
+}
+.vanilla-approval-bubble [data-approval-action="approve"]:hover {
+  opacity: 0.85;
+}
+.vanilla-approval-bubble [data-approval-action="approve"]:active {
+  transform: scale(0.97);
+}
+.vanilla-approval-bubble [data-approval-action="deny"]:hover {
+  background-color: rgba(220, 38, 38, 0.08);
+}
+.vanilla-approval-bubble [data-approval-action="deny"]:active {
+  transform: scale(0.97);
+}

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -357,6 +357,8 @@ export type AgentWidgetControllerEventMap = {
   "message:copy": AgentWidgetMessage;
   "eventStream:opened": { timestamp: number };
   "eventStream:closed": { timestamp: number };
+  "approval:requested": { approval: AgentWidgetApproval; message: AgentWidgetMessage };
+  "approval:resolved": { approval: AgentWidgetApproval; decision: string };
 };
 
 export type AgentWidgetFeatureFlags = {
@@ -691,6 +693,48 @@ export type AgentWidgetVoiceRecognitionConfig = {
   recordingBorderColor?: string;
   showRecordingIndicator?: boolean;
   autoResume?: boolean | "assistant";
+};
+
+/**
+ * Configuration for tool approval bubbles.
+ * Controls styling, labels, and behavior of the approval UI.
+ */
+export type AgentWidgetApprovalConfig = {
+  /** Background color of the approval bubble */
+  backgroundColor?: string;
+  /** Border color of the approval bubble */
+  borderColor?: string;
+  /** Color for the title text */
+  titleColor?: string;
+  /** Color for the description text */
+  descriptionColor?: string;
+  /** Background color for the approve button */
+  approveButtonColor?: string;
+  /** Text color for the approve button */
+  approveButtonTextColor?: string;
+  /** Background color for the deny button */
+  denyButtonColor?: string;
+  /** Text color for the deny button */
+  denyButtonTextColor?: string;
+  /** Background color for the parameters block */
+  parameterBackgroundColor?: string;
+  /** Text color for the parameters block */
+  parameterTextColor?: string;
+  /** Title text displayed above the description */
+  title?: string;
+  /** Label for the approve button */
+  approveLabel?: string;
+  /** Label for the deny button */
+  denyLabel?: string;
+  /**
+   * Custom handler for approval decisions.
+   * Return void to let the SDK auto-resolve via the API,
+   * or return a Response/ReadableStream for custom handling.
+   */
+  onDecision?: (
+    data: { approvalId: string; executionId: string; agentId: string; toolName: string },
+    decision: 'approved' | 'denied'
+  ) => Promise<Response | ReadableStream<Uint8Array> | void>;
 };
 
 export type AgentWidgetToolCallConfig = {
@@ -1781,6 +1825,23 @@ export type AgentWidgetConfig = {
   statusIndicator?: AgentWidgetStatusIndicatorConfig;
   voiceRecognition?: AgentWidgetVoiceRecognitionConfig;
   toolCall?: AgentWidgetToolCallConfig;
+  /**
+   * Configuration for tool approval bubbles.
+   * Set to `false` to disable built-in approval handling entirely.
+   *
+   * @example
+   * ```typescript
+   * config: {
+   *   approval: {
+   *     title: "Permission Required",
+   *     approveLabel: "Allow",
+   *     denyLabel: "Block",
+   *     approveButtonColor: "#16a34a"
+   *   }
+   * }
+   * ```
+   */
+  approval?: AgentWidgetApprovalConfig | false;
   postprocessMessage?: (context: {
     text: string;
     message: AgentWidgetMessage;
@@ -2129,7 +2190,23 @@ export type AgentWidgetToolCall = {
   durationMs?: number;
 };
 
-export type AgentWidgetMessageVariant = "assistant" | "reasoning" | "tool";
+/**
+ * Represents a tool approval request in the chat conversation.
+ * Created when the agent requires human approval before executing a tool.
+ */
+export type AgentWidgetApproval = {
+  id: string;
+  status: "pending" | "approved" | "denied" | "timeout";
+  agentId: string;
+  executionId: string;
+  toolName: string;
+  toolType?: string;
+  description: string;
+  parameters?: unknown;
+  resolvedAt?: number;
+};
+
+export type AgentWidgetMessageVariant = "assistant" | "reasoning" | "tool" | "approval";
 
 /**
  * Represents a message in the chat conversation.
@@ -2165,6 +2242,8 @@ export type AgentWidgetMessage = {
   reasoning?: AgentWidgetReasoning;
   toolCall?: AgentWidgetToolCall;
   tools?: AgentWidgetToolCall[];
+  /** Approval data for messages with variant "approval" */
+  approval?: AgentWidgetApproval;
   viaVoice?: boolean;
   /**
    * Raw structured payload for this message (e.g., JSON action response).

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -259,6 +259,14 @@ type Controller = {
   showNPSFeedback: (options?: Partial<NPSFeedbackOptions>) => void;
   submitCSATFeedback: (rating: number, comment?: string) => Promise<void>;
   submitNPSFeedback: (rating: number, comment?: string) => Promise<void>;
+  /**
+   * Connect an external SSE stream and process it through the SDK's
+   * native event pipeline (tools, reasoning, streaming text, etc.).
+   */
+  connectStream: (
+    stream: ReadableStream<Uint8Array>,
+    options?: { assistantMessageId?: string }
+  ) => Promise<void>;
   /** Push a raw event into the event stream buffer (for testing/debugging) */
   __pushEventStreamEvent: (event: { type: string; payload: unknown }) => void;
   /** Opens the event stream panel */
@@ -3949,6 +3957,12 @@ export const createAgentExperience = (
         setOpenState(true, "system");
       }
       session.injectTestEvent(event);
+    },
+    async connectStream(
+      stream: ReadableStream<Uint8Array>,
+      options?: { assistantMessageId?: string }
+    ): Promise<void> {
+      return session.connectStream(stream, options);
     },
     /** Push a raw event into the event stream buffer (for testing/debugging) */
     __pushEventStreamEvent(event: { type: string; payload: unknown }): void {

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -37,6 +37,7 @@ import { MessageTransform, MessageActionCallbacks, LoadingIndicatorRenderer } fr
 import { createStandardBubble, createTypingIndicator } from "./components/message-bubble";
 import { createReasoningBubble, reasoningExpansionState, updateReasoningBubbleUI } from "./components/reasoning-bubble";
 import { createToolBubble, toolExpansionState, updateToolBubbleUI } from "./components/tool-bubble";
+import { createApprovalBubble, updateApprovalBubbleUI } from "./components/approval-bubble";
 import { createSuggestions } from "./components/suggestions";
 import { EventStreamBuffer } from "./utils/event-stream-buffer";
 import { EventStreamStore } from "./utils/event-stream-store";
@@ -275,6 +276,12 @@ type Controller = {
   hideEventStream: () => void;
   /** Returns current visibility state of the event stream panel */
   isEventStreamVisible: () => boolean;
+  /**
+   * Programmatically resolve a pending approval.
+   * @param approvalId - The approval ID to resolve
+   * @param decision - "approved" or "denied"
+   */
+  resolveApproval: (approvalId: string, decision: 'approved' | 'denied') => Promise<void>;
 };
 
 const buildPostprocessor = (
@@ -967,6 +974,46 @@ export const createAgentExperience = (
     }
   });
 
+  // Add event delegation for approval action buttons (approve/deny)
+  messagesWrapper.addEventListener('click', (event) => {
+    const target = event.target as HTMLElement;
+    const approvalButton = target.closest('button[data-approval-action]') as HTMLElement;
+    if (!approvalButton) return;
+
+    event.preventDefault();
+    event.stopPropagation();
+
+    const approvalBubble = approvalButton.closest('.vanilla-approval-bubble') as HTMLElement;
+    if (!approvalBubble) return;
+
+    const messageId = approvalBubble.getAttribute('data-message-id');
+    if (!messageId) return;
+
+    const action = approvalButton.getAttribute('data-approval-action') as 'approve' | 'deny';
+    if (!action) return;
+
+    const decision = action === 'approve' ? 'approved' as const : 'denied' as const;
+
+    // Find the approval message
+    const messages = session.getMessages();
+    const approvalMessage = messages.find(m => m.id === messageId);
+    if (!approvalMessage?.approval) return;
+
+    // Disable buttons immediately for responsive UI
+    const buttonsContainer = approvalBubble.querySelector('[data-approval-buttons]') as HTMLElement;
+    if (buttonsContainer) {
+      const buttons = buttonsContainer.querySelectorAll('button');
+      buttons.forEach(btn => {
+        (btn as HTMLButtonElement).disabled = true;
+        btn.style.opacity = '0.5';
+        btn.style.cursor = 'not-allowed';
+      });
+    }
+
+    // Resolve the approval
+    session.resolveApproval(approvalMessage.approval, decision);
+  });
+
   panel.appendChild(container);
   mount.appendChild(wrapper);
 
@@ -1422,6 +1469,15 @@ export const createAgentExperience = (
       ) {
         eventBus.emit("assistant:complete", message);
       }
+
+      // Emit approval events
+      if (message.variant === "approval" && message.approval) {
+        if (!previous) {
+          eventBus.emit("approval:requested", { approval: message.approval, message });
+        } else if (message.approval.status !== "pending") {
+          eventBus.emit("approval:resolved", { approval: message.approval, decision: message.approval.status });
+        }
+      }
     });
 
     messageState.clear();
@@ -1470,6 +1526,9 @@ export const createAgentExperience = (
         if (message.variant === "tool" && p.renderToolCall) {
           return true;
         }
+        if (message.variant === "approval" && p.renderApproval) {
+          return true;
+        }
         if (!message.variant && p.renderMessage) {
           return true;
         }
@@ -1492,6 +1551,13 @@ export const createAgentExperience = (
           bubble = matchingPlugin.renderToolCall({
             message,
             defaultRenderer: () => createToolBubble(message, config),
+            config
+          });
+        } else if (message.variant === "approval" && message.approval && matchingPlugin.renderApproval) {
+          if (config.approval === false) return;
+          bubble = matchingPlugin.renderApproval({
+            message,
+            defaultRenderer: () => createApprovalBubble(message, config),
             config
           });
         } else if (matchingPlugin.renderMessage) {
@@ -1574,6 +1640,9 @@ export const createAgentExperience = (
         } else if (message.variant === "tool" && message.toolCall) {
           if (!showToolCalls) return;
           bubble = createToolBubble(message, config);
+        } else if (message.variant === "approval" && message.approval) {
+          if (config.approval === false) return;
+          bubble = createApprovalBubble(message, config);
         } else {
           // Check for custom message renderers in layout config
           const messageLayoutConfig = config.layout?.messages;
@@ -3985,6 +4054,16 @@ export const createAgentExperience = (
     },
     isEventStreamVisible(): boolean {
       return eventStreamVisible;
+    },
+    async resolveApproval(approvalId: string, decision: 'approved' | 'denied'): Promise<void> {
+      const messages = session.getMessages();
+      const approvalMessage = messages.find(
+        m => m.variant === "approval" && m.approval?.id === approvalId
+      );
+      if (!approvalMessage?.approval) {
+        throw new Error(`Approval not found: ${approvalId}`);
+      }
+      return session.resolveApproval(approvalMessage.approval, decision);
     },
     getMessages() {
       return session.getMessages();


### PR DESCRIPTION
## Summary

Adds human-in-the-loop tool approval to the chat widget, letting agents pause and ask users for permission before executing sensitive tools.

- **Approval bubbles** — new `approval` message variant with inline approve/deny buttons, status badges, and parameter preview. Fully themeable via `config.approval`.
- **`connectStream()`** — pipes an external SSE stream through the SDK's native event pipeline so approval responses (and any other external stream) get the same message/tool/reasoning handling as `dispatch()`.
- **`resolveApproval()`** — programmatic API for resolving approvals from outside the widget (custom UIs, automation, etc.).
- **SSE event handling** — parses `agent_approval_start`, `step_await` (with `approval_required`), and `agent_approval_complete` events.
- **Events** — emits `approval:requested` and `approval:resolved` on the event bus.
- **Plugin hook** — `renderApproval` lets plugins replace the default approval bubble.

## How it works

1. Agent streams an approval event → SDK creates a pending approval bubble with approve/deny buttons
2. User clicks approve or deny → `session.resolveApproval()` updates the UI, calls the API (or custom `onDecision` handler), and pipes the response stream back through `connectStream()`
3. Agent continues or stops based on the decision