### PR TITLE
feat: focus input control, typing indicator fix, event stream copy-all fallback

### DIFF
--- a/.changeset/fix-event-stream-copy-all.md
+++ b/.changeset/fix-event-stream-copy-all.md
@@ -1,0 +1,7 @@
+---
+"@runtypelabs/persona": patch
+---
+
+fix(event-stream): fall back to buffer when Copy All gets empty from store
+
+When "All events" is selected and Copy All is clicked, the code used getFullHistory() which reads from IndexedDB. If the store's DB isn't ready (e.g. open failed, private browsing), getAll() returns []. Now fall back to buffer.getAll() when the store returns empty so users get the visible in-memory events instead of [].

--- a/.changeset/fix-typing-indicator-after-approval.md
+++ b/.changeset/fix-typing-indicator-after-approval.md
@@ -1,0 +1,7 @@
+---
+"@runtypelabs/persona": patch
+---
+
+fix(ui): keep typing indicator visible while agent resumes after approval
+
+Exclude approval-variant messages from the hasRecentAssistantResponse check so the typing indicator still shows while the agent resumes after user approval, instead of flickering away.

--- a/.changeset/hot-shoes-wash.md
+++ b/.changeset/hot-shoes-wash.md
@@ -1,0 +1,10 @@
+---
+"@runtypelabs/persona": minor
+---
+
+feat: add chat input focus control via autoFocusInput config, controller.focusInput(), and persona:focusInput DOM event
+
+- Add `autoFocusInput` init parameter to focus input after panel open animation
+- Add `controller.focusInput()` method for programmatic focus
+- Add `persona:focusInput` DOM event with instance scoping
+- Add focus-input-demo example page with localStorage-persisted toggle

--- a/examples/embedded-app/focus-input-demo.html
+++ b/examples/embedded-app/focus-input-demo.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Focus Input Demo</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      min-height: 100vh;
+      background: #f8fafc;
+      color: #0f172a;
+    }
+    .layout {
+      display: grid;
+      grid-template-columns: 1fr 420px;
+      gap: 1.5rem;
+      padding: 1.5rem;
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+    @media (max-width: 900px) {
+      .layout { grid-template-columns: 1fr; }
+    }
+    .panel {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+      overflow: hidden;
+    }
+    .info-panel {
+      padding: 1.5rem;
+    }
+    .info-panel h1 { margin: 0 0 0.5rem 0; font-size: 1.5rem; }
+    .info-panel p { margin: 0 0 1rem 0; color: #475569; line-height: 1.6; }
+    .section {
+      margin-bottom: 1.5rem;
+    }
+    .section h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.9rem;
+      color: #64748b;
+    }
+    .btn-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .btn {
+      padding: 0.4rem 0.8rem;
+      border-radius: 6px;
+      border: 1px solid #e2e8f0;
+      background: #fff;
+      color: #0f172a;
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
+    .btn:hover { background: #f1f5f9; }
+    .btn-primary { background: #3b82f6; color: white; border-color: #3b82f6; }
+    .btn-primary:hover { background: #2563eb; }
+    .checkbox-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+    }
+    .checkbox-row input { width: 18px; height: 18px; }
+    .log {
+      background: #f1f5f9;
+      border-radius: 6px;
+      padding: 0.75rem;
+      max-height: 120px;
+      overflow-y: auto;
+      font-family: monospace;
+      font-size: 0.75rem;
+      color: #475569;
+    }
+    .back-link {
+      display: inline-block;
+      padding: 0.5rem 1rem;
+      margin: 1rem 1.5rem;
+      border-radius: 6px;
+      text-decoration: none;
+      color: #64748b;
+      font-size: 0.9rem;
+    }
+    .back-link:hover { color: #0f172a; }
+    .widget-container { height: 500px; }
+    #inline-widget { height: 100%; }
+    #launcher-root { height: 100%; }
+  </style>
+</head>
+<body>
+  <a href="/" class="back-link">&larr; Back to examples</a>
+
+  <div class="layout">
+    <div class="info-panel">
+      <h1>Focus Input Demo</h1>
+      <p>Test the three ways to control chat input focus: <code>autoFocusInput</code> config, <code>controller.focusInput()</code>, and <code>persona:focusInput</code> DOM event.</p>
+
+      <div class="section">
+        <h3>1. autoFocusInput (init parameter)</h3>
+        <p>When enabled, the input focuses after the panel opens and the open animation completes (~200ms).</p>
+        <div class="checkbox-row">
+          <input type="checkbox" id="auto-focus-toggle" />
+          <label for="auto-focus-toggle">Enable autoFocusInput</label>
+        </div>
+        <p style="font-size: 0.85rem; margin-top: 0.25rem;">Toggle on, then open the launcher (click the floating button) — the input should auto-focus. For inline, reload the page with the checkbox on.</p>
+      </div>
+
+      <div class="section">
+        <h3>2. controller.focusInput()</h3>
+        <p>Programmatically focus the input. Returns <code>false</code> if the launcher panel is closed.</p>
+        <div class="btn-row">
+          <button class="btn btn-primary" id="focus-inline">Focus Inline</button>
+          <button class="btn btn-primary" id="focus-launcher">Focus Launcher</button>
+        </div>
+      </div>
+
+      <div class="section">
+        <h3>3. persona:focusInput (DOM event)</h3>
+        <p>Dispatch a window event to focus a specific instance or all instances.</p>
+        <div class="btn-row">
+          <button class="btn" id="focus-win-all">Focus All</button>
+          <button class="btn" id="focus-win-inline">Focus Inline Only</button>
+          <button class="btn" id="focus-win-launcher">Focus Launcher Only</button>
+          <button class="btn" id="focus-win-wrong">Focus Wrong ID</button>
+        </div>
+      </div>
+
+      <div class="section">
+        <h3>Log</h3>
+        <div class="log" id="log"></div>
+      </div>
+    </div>
+
+    <div class="panel widget-container">
+      <p style="padding: 1rem; margin: 0; font-size: 0.9rem; color: #64748b;">Inline widget (always visible). Launcher floats bottom-right.</p>
+      <div id="inline-widget" style="height: 400px;"></div>
+    </div>
+  </div>
+
+  <div id="launcher-root" style="position: fixed; bottom: 1rem; right: 1rem; z-index: 50;"></div>
+
+  <script type="module" src="/src/focus-input-demo.ts"></script>
+</body>
+</html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -33,6 +33,7 @@
         <li><a href="/custom-loading-indicator.html">Custom Loading Indicator</a></li>
         <li><a href="/agent-demo.html">Agent Loop Execution Demo</a></li>
         <li><a href="/approval-demo.html">Tool Approval Demo</a></li>
+        <li><a href="/focus-input-demo.html">Focus Input Demo</a></li>
       </ul>
       <div class="cta-row">
         <button id="open-chat" type="button">Open Launcher</button>

--- a/examples/embedded-app/src/focus-input-demo.ts
+++ b/examples/embedded-app/src/focus-input-demo.ts
@@ -1,0 +1,132 @@
+import "@runtypelabs/persona/widget.css";
+
+import {
+  initAgentWidget,
+  createAgentExperience,
+  markdownPostprocessor,
+  DEFAULT_WIDGET_CONFIG,
+} from "@runtypelabs/persona";
+
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const proxyUrl =
+  import.meta.env.VITE_PROXY_URL
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
+    : `http://localhost:${proxyPort}/api/chat/dispatch`;
+
+// ---------------------------------------------------------------------------
+// Log helper
+// ---------------------------------------------------------------------------
+const logEl = document.getElementById("log");
+const log = (msg: string) => {
+  if (logEl) {
+    const time = new Date().toLocaleTimeString();
+    logEl.textContent += `[${time}] ${msg}\n`;
+    logEl.scrollTop = logEl.scrollHeight;
+  }
+  console.log(`[FocusDemo] ${msg}`);
+};
+
+// ---------------------------------------------------------------------------
+// Persisted autoFocusInput state (survives reload)
+// ---------------------------------------------------------------------------
+const STORAGE_KEY = "focus-demo-autoFocusInput";
+const savedAutoFocus = localStorage.getItem(STORAGE_KEY) === "true";
+
+// ---------------------------------------------------------------------------
+// Inline widget
+// ---------------------------------------------------------------------------
+const inlineMount = document.getElementById("inline-widget");
+if (!inlineMount) throw new Error("Inline widget mount missing");
+
+const inlineController = createAgentExperience(inlineMount, {
+  ...DEFAULT_WIDGET_CONFIG,
+  apiUrl: proxyUrl,
+  autoFocusInput: savedAutoFocus,
+  launcher: { ...DEFAULT_WIDGET_CONFIG.launcher, enabled: false, width: "100%" },
+  copy: {
+    ...DEFAULT_WIDGET_CONFIG.copy,
+    welcomeTitle: "Focus Input Demo",
+    welcomeSubtitle: "Test autoFocusInput, controller.focusInput(), and persona:focusInput.",
+    inputPlaceholder: "Type here…",
+  },
+  suggestionChips: ["Hello", "Focus test"],
+  postprocessMessage: ({ text }) => markdownPostprocessor(text),
+});
+
+// ---------------------------------------------------------------------------
+// Launcher widget
+// ---------------------------------------------------------------------------
+const launcherController = initAgentWidget({
+  target: "#launcher-root",
+  useShadowDom: false,
+  config: {
+    ...DEFAULT_WIDGET_CONFIG,
+    apiUrl: proxyUrl,
+    autoFocusInput: savedAutoFocus,
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Launcher",
+      welcomeSubtitle: "Open/close to test autoFocusInput.",
+      inputPlaceholder: "Type here…",
+    },
+    suggestionChips: ["Hi", "Test focus"],
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+  },
+});
+
+// ---------------------------------------------------------------------------
+// 1. autoFocusInput toggle
+// ---------------------------------------------------------------------------
+const autoFocusToggle = document.getElementById("auto-focus-toggle") as HTMLInputElement;
+if (autoFocusToggle) autoFocusToggle.checked = savedAutoFocus;
+autoFocusToggle?.addEventListener("change", () => {
+  const enabled = autoFocusToggle.checked;
+  localStorage.setItem(STORAGE_KEY, enabled ? "true" : "false");
+  inlineController.update({ autoFocusInput: enabled });
+  launcherController.update({ autoFocusInput: enabled });
+  log(`autoFocusInput: ${enabled ? "on" : "off"}`);
+});
+
+// ---------------------------------------------------------------------------
+// 2. controller.focusInput()
+// ---------------------------------------------------------------------------
+document.getElementById("focus-inline")?.addEventListener("click", () => {
+  const ok = inlineController.focusInput();
+  log(`focusInput() on inline: ${ok ? "ok" : "failed (panel closed or no textarea)"}`);
+});
+
+document.getElementById("focus-launcher")?.addEventListener("click", () => {
+  const ok = launcherController.focusInput();
+  log(`focusInput() on launcher: ${ok ? "ok" : "failed (open the panel first)"}`);
+});
+
+// ---------------------------------------------------------------------------
+// 3. persona:focusInput (DOM events)
+// ---------------------------------------------------------------------------
+document.getElementById("focus-win-all")?.addEventListener("click", () => {
+  window.dispatchEvent(new CustomEvent("persona:focusInput"));
+  log("Dispatched persona:focusInput (all instances)");
+});
+
+document.getElementById("focus-win-inline")?.addEventListener("click", () => {
+  window.dispatchEvent(
+    new CustomEvent("persona:focusInput", { detail: { instanceId: "inline-widget" } })
+  );
+  log("Dispatched persona:focusInput (instanceId: inline-widget)");
+});
+
+document.getElementById("focus-win-launcher")?.addEventListener("click", () => {
+  window.dispatchEvent(
+    new CustomEvent("persona:focusInput", { detail: { instanceId: "launcher-root" } })
+  );
+  log("Dispatched persona:focusInput (instanceId: launcher-root)");
+});
+
+document.getElementById("focus-win-wrong")?.addEventListener("click", () => {
+  window.dispatchEvent(
+    new CustomEvent("persona:focusInput", { detail: { instanceId: "wrong-id" } })
+  );
+  log("Dispatched persona:focusInput (instanceId: wrong-id) — no effect expected");
+});
+
+log("Focus Input Demo ready. Enable autoFocusInput and open the launcher to test.");

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -43,6 +43,8 @@ export default defineConfig({
         'bakery-services': path.resolve(__dirname, 'bakery-services.html'),
         // Approval demo
         'approval-demo': path.resolve(__dirname, 'approval-demo.html'),
+        // Focus input demo
+        'focus-input-demo': path.resolve(__dirname, 'focus-input-demo.html'),
       }
     }
   },

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -253,6 +253,22 @@ chat.isEventStreamVisible() // returns boolean
 
 These methods are no-ops if `showEventStreamToggle` is not enabled.
 
+#### Input focus control
+
+Focus the chat input programmatically:
+
+```ts
+const chat = initAgentWidget({
+  target: '#chat-root',
+  config: { apiUrl: '/api/chat/dispatch' }
+})
+
+// Focus the input (returns true if successful, false if panel is closed or unavailable)
+chat.focusInput()
+```
+
+In launcher mode, `focusInput()` returns `false` when the panel is closed and does not auto-open it. Use `chat.open()` first if you want to open and focus in one flow.
+
 #### Accessing from window
 
 To access the controller globally (e.g., from browser console or external scripts), use the `windowKey` option:
@@ -360,6 +376,22 @@ window.dispatchEvent(new CustomEvent('persona:showEventStream', {
 }))
 // ^ No effect — no widget has this instanceId
 ```
+
+#### `persona:focusInput`
+
+Dispatched to programmatically focus the chat input on a widget instance.
+
+```ts
+// Focus input on all widget instances
+window.dispatchEvent(new CustomEvent('persona:focusInput'))
+
+// Focus input on a specific instance
+window.dispatchEvent(new CustomEvent('persona:focusInput', {
+  detail: { instanceId: 'inline-widget' }
+}))
+```
+
+**Instance scoping:** Same as `persona:showEventStream` — use `detail.instanceId` to target a specific widget. Without `instanceId`, all instances receive the event.
 
 ### Controller Events
 
@@ -1251,6 +1283,7 @@ This ensures all configuration values are set to sensible defaults while allowin
 | `copy` | `{ welcomeTitle?, welcomeSubtitle?, inputPlaceholder?, sendButtonLabel? }` | Customize user-facing text. |
 | `theme` | `{ primary?, secondary?, surface?, muted?, accent?, radiusSm?, radiusMd?, radiusLg?, radiusFull? }` | Override CSS variables for the widget. Colors: `primary` (text/UI), `secondary` (unused), `surface` (backgrounds), `muted` (secondary text), `accent` (buttons/links). Border radius: `radiusSm` (0.75rem, inputs), `radiusMd` (1rem, cards), `radiusLg` (1.5rem, panels/bubbles), `radiusFull` (9999px, pills/buttons). |
 | `features` | `AgentWidgetFeatureFlags` | Toggle UI features: `showReasoning?` (show thinking bubbles, default: `true`), `showToolCalls?` (show tool usage bubbles, default: `true`), `showEventStreamToggle?` (show event stream inspector toggle in header, default: `false`). |
+| `autoFocusInput` | `boolean` | When `true`, focus the chat input after the panel opens and the open animation completes. Applies to launcher mode (user click, `controller.open()`, `autoExpand`) and inline mode (on init). Skips when voice is active. Default: `false`. |
 | `launcher` | `{ enabled?, autoExpand?, title?, subtitle?, iconUrl?, position? }` | Controls the floating launcher button. |
 | `initialMessages` | `AgentWidgetMessage[]` | Seed the conversation transcript. |
 | `suggestionChips` | `string[]` | Render quick reply buttons above the composer. |

--- a/packages/widget/src/components/event-stream-view.test.ts
+++ b/packages/widget/src/components/event-stream-view.test.ts
@@ -555,6 +555,32 @@ describe("createEventStreamView", () => {
       // Should call getFullHistory
       expect(getFullHistory).toHaveBeenCalled();
     });
+
+    it("should fall back to buffer when getFullHistory returns empty", async () => {
+      const { createEventStreamView } = await loadModule();
+      const events = [
+        makeEvent("step_chunk", 1),
+        makeEvent("flow_complete", 2),
+      ];
+      const buffer = createMockBuffer(events);
+      const getFullHistory = vi.fn().mockResolvedValue([]);
+      const { element } = createEventStreamView({
+        buffer: buffer as any,
+        getFullHistory,
+      });
+
+      const copyAllBtn = getCopyAllBtn(element);
+
+      // Click copy all with no filters (All events)
+      await copyAllBtn.__listeners.click[0]();
+
+      expect(getFullHistory).toHaveBeenCalled();
+      const writeCall = (globalThis.navigator.clipboard.writeText as any).mock.calls[0][0];
+      const parsed = JSON.parse(writeCall);
+      expect(parsed).toHaveLength(2);
+      expect(parsed[0].index).toBe(1);
+      expect(parsed[1].index).toBe(2);
+    });
   });
 
   describe("keyboard shortcuts", () => {

--- a/packages/widget/src/components/event-stream-view.ts
+++ b/packages/widget/src/components/event-stream-view.ts
@@ -1010,9 +1010,12 @@ export function createEventStreamView(
         if (hasActiveFilters()) {
           events = filteredEvents;
         } else {
-          events = getFullHistory
-            ? await getFullHistory()
-            : buffer.getAll();
+          if (getFullHistory) {
+            events = await getFullHistory();
+            if (events.length === 0) events = buffer.getAll();
+          } else {
+            events = buffer.getAll();
+          }
         }
         const parsed = events.map((e) => {
           try {

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1814,6 +1814,13 @@ export type AgentWidgetConfig = {
    */
   colorScheme?: 'auto' | 'light' | 'dark';
   features?: AgentWidgetFeatureFlags;
+  /**
+   * When true, focus the chat input after the panel opens and the open animation completes.
+   * Applies to launcher mode (user click, controller.open(), autoExpand) and inline mode (on init).
+   * Skip when voice is active to avoid stealing focus from voice UI.
+   * @default false
+   */
+  autoFocusInput?: boolean;
   launcher?: AgentWidgetLauncherConfig;
   initialMessages?: AgentWidgetMessage[];
   suggestionChips?: string[];

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -277,6 +277,11 @@ type Controller = {
   /** Returns current visibility state of the event stream panel */
   isEventStreamVisible: () => boolean;
   /**
+   * Focus the chat input. Returns true if focus succeeded, false if panel is closed
+   * (launcher mode) or textarea is unavailable.
+   */
+  focusInput: () => boolean;
+  /**
    * Programmatically resolve a pending approval.
    * @param approvalId - The approval ID to resolve
    * @param decision - "approved" or "denied"
@@ -457,6 +462,7 @@ export const createAgentExperience = (
 
   let launcherEnabled = config.launcher?.enabled ?? true;
   let autoExpand = config.launcher?.autoExpand ?? false;
+  const autoFocusInput = config.autoFocusInput ?? false;
   let prevAutoExpand = autoExpand;
   let prevLauncherEnabled = launcherEnabled;
   let prevHeaderLayout = config.layout?.header?.layout;
@@ -1920,6 +1926,16 @@ export const createAgentExperience = (
     });
   };
 
+  const maybeFocusInput = () => {
+    if (voiceState.active) return;
+    if (!textarea) return;
+    textarea.focus();
+  };
+
+  eventBus.on("widget:opened", () => {
+    if (config.autoFocusInput) setTimeout(() => maybeFocusInput(), 200);
+  });
+
   const updateCopy = () => {
     introTitle.textContent = config.copy?.welcomeTitle ?? "Hello 👋";
     introSubtitle.textContent =
@@ -2501,6 +2517,14 @@ export const createAgentExperience = (
   setComposerDisabled(session.isStreaming());
   scheduleAutoScroll(true);
   maybeRestoreVoiceFromMetadata();
+
+  if (autoFocusInput) {
+    if (!launcherEnabled) {
+      setTimeout(() => maybeFocusInput(), 0);
+    } else if (open) {
+      setTimeout(() => maybeFocusInput(), 200);
+    }
+  }
 
   const recalcPanelHeight = () => {
     const sidebarMode = config.launcher?.sidebarMode ?? false;
@@ -4055,6 +4079,12 @@ export const createAgentExperience = (
     isEventStreamVisible(): boolean {
       return eventStreamVisible;
     },
+    focusInput(): boolean {
+      if (launcherEnabled && !open) return false;
+      if (!textarea) return false;
+      textarea.focus();
+      return true;
+    },
     async resolveApproval(approvalId: string, decision: 'approved' | 'denied'): Promise<void> {
       const messages = session.getMessages();
       const approvalMessage = messages.find(
@@ -4200,26 +4230,40 @@ export const createAgentExperience = (
   // ============================================================================
   // INSTANCE-SCOPED WINDOW EVENTS FOR PROGRAMMATIC CONTROL
   // ============================================================================
-  if (showEventStreamToggle && typeof window !== "undefined") {
+  if (typeof window !== "undefined") {
     const instanceId = mount.getAttribute("data-persona-instance") || mount.id || "persona-" + Math.random().toString(36).slice(2, 8);
-    const handleShowEvent = (e: Event) => {
+
+    const handleFocusInput = (e: Event) => {
       const detail = (e as CustomEvent).detail;
       if (!detail?.instanceId || detail.instanceId === instanceId) {
-        controller.showEventStream();
+        controller.focusInput();
       }
     };
-    const handleHideEvent = (e: Event) => {
-      const detail = (e as CustomEvent).detail;
-      if (!detail?.instanceId || detail.instanceId === instanceId) {
-        controller.hideEventStream();
-      }
-    };
-    window.addEventListener("persona:showEventStream", handleShowEvent);
-    window.addEventListener("persona:hideEventStream", handleHideEvent);
+    window.addEventListener("persona:focusInput", handleFocusInput);
     destroyCallbacks.push(() => {
-      window.removeEventListener("persona:showEventStream", handleShowEvent);
-      window.removeEventListener("persona:hideEventStream", handleHideEvent);
+      window.removeEventListener("persona:focusInput", handleFocusInput);
     });
+
+    if (showEventStreamToggle) {
+      const handleShowEvent = (e: Event) => {
+        const detail = (e as CustomEvent).detail;
+        if (!detail?.instanceId || detail.instanceId === instanceId) {
+          controller.showEventStream();
+        }
+      };
+      const handleHideEvent = (e: Event) => {
+        const detail = (e as CustomEvent).detail;
+        if (!detail?.instanceId || detail.instanceId === instanceId) {
+          controller.hideEventStream();
+        }
+      };
+      window.addEventListener("persona:showEventStream", handleShowEvent);
+      window.addEventListener("persona:hideEventStream", handleHideEvent);
+      destroyCallbacks.push(() => {
+        window.removeEventListener("persona:showEventStream", handleShowEvent);
+        window.removeEventListener("persona:hideEventStream", handleHideEvent);
+      });
+    }
   }
 
   // ============================================================================

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1704,8 +1704,10 @@ export const createAgentExperience = (
     
     // Also check if there's a recently completed assistant message (streaming just ended)
     // This prevents flicker when the message completes but isStreaming hasn't updated yet
+    // Approval-variant messages are UI controls, not content — exclude them so the typing
+    // indicator still shows while the agent resumes after approval
     const lastMessage = messages[messages.length - 1];
-    const hasRecentAssistantResponse = lastMessage?.role === "assistant" && !lastMessage.streaming;
+    const hasRecentAssistantResponse = lastMessage?.role === "assistant" && !lastMessage.streaming && lastMessage.variant !== "approval";
 
     if (isStreaming && messages.some((msg) => msg.role === "user") && !hasStreamingAssistantMessage && !hasRecentAssistantResponse) {
       // Get loading indicator using priority chain: plugin -> config -> default

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -37,7 +37,7 @@ import { MessageTransform, MessageActionCallbacks, LoadingIndicatorRenderer } fr
 import { createStandardBubble, createTypingIndicator } from "./components/message-bubble";
 import { createReasoningBubble, reasoningExpansionState, updateReasoningBubbleUI } from "./components/reasoning-bubble";
 import { createToolBubble, toolExpansionState, updateToolBubbleUI } from "./components/tool-bubble";
-import { createApprovalBubble, updateApprovalBubbleUI } from "./components/approval-bubble";
+import { createApprovalBubble } from "./components/approval-bubble";
 import { createSuggestions } from "./components/suggestions";
 import { EventStreamBuffer } from "./utils/event-stream-buffer";
 import { EventStreamStore } from "./utils/event-stream-store";


### PR DESCRIPTION
## Summary

This PR bundles three improvements to the Persona widget:

### 1. Chat input focus control (minor)
- **`autoFocusInput`** – Init parameter to focus the input after panel open animation
- **`controller.focusInput()`** – Programmatic focus method
- **`persona:focusInput`** – DOM event with instance scoping for external focus control
- Adds `focus-input-demo` example page with localStorage-persisted toggle

### 2. Typing indicator fix (patch)
- Keep typing indicator visible while agent resumes after approval
- Excludes approval-variant messages from `hasRecentAssistantResponse` so the indicator doesn’t flicker away during human-in-the-loop flows

### 3. Event stream copy-all fallback (patch)
- When "All events" is selected and Copy All is clicked, fall back to buffer when IndexedDB store returns empty (e.g. private browsing, DB not ready)
- Ensures users get visible in-memory events instead of an empty result

## Changes
- `packages/widget/src/ui.ts` – Focus control logic
- `packages/widget/src/types.ts` – New config types
- `packages/widget/src/components/event-stream-view.ts` – Copy-all fallback
- `examples/embedded-app/` – Focus input demo
- Changesets included for release

Made with [Cursor](https://cursor.com)