### PR TITLE
fix: finalize stage of streaming messages before starting new stream

### DIFF
--- a/.changeset/finalize-stale-streaming-messages.md
+++ b/.changeset/finalize-stale-streaming-messages.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix finalizing stale streaming messages when starting a new stream (e.g., tool messages interrupted by approval pause)

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -551,6 +551,20 @@ export class AgentWidgetSession {
   ): Promise<void> {
     if (this.streaming) return;
     this.abortController?.abort();
+
+    // Finalize any stale streaming messages from the previous stream
+    // (e.g., tool messages interrupted by approval pause)
+    let hasStale = false;
+    for (const msg of this.messages) {
+      if (msg.streaming) {
+        msg.streaming = false;
+        hasStale = true;
+      }
+    }
+    if (hasStale) {
+      this.callbacks.onMessagesChanged([...this.messages]);
+    }
+
     this.setStreaming(true);
 
     try {


### PR DESCRIPTION
This issue was causing the thinking indicator to not show after response to approval request