### PR TITLE
Interrupt, cancellation and barge-in support for voice mode

### DIFF
--- a/.changeset/voice-barge-in-support.md
+++ b/.changeset/voice-barge-in-support.md
@@ -1,0 +1,12 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add barge-in voice interruption mode with always-on mic and speech detection
+
+- New `VoiceActivityDetector` class provides reusable RMS-based VAD with two modes: `silence` (user stopped talking) and `speech` (user started talking)
+- In barge-in mode the mic stays hot between turns — audio pipeline is reused instead of torn down after each utterance
+- During agent playback, VAD monitors for sustained speech and automatically interrupts playback to begin recording
+- Mic button shows recording state during agent speech in barge-in mode and acts as a "hang up" to end the session
+- New `isBargeInActive()` and `deactivateBargeIn()` methods on `VoiceProvider` and `Session` for UI coordination
+- Guard against late `audio_end` and audio chunks from cancelled requests

--- a/.changeset/voice-interruption-support.md
+++ b/.changeset/voice-interruption-support.md
@@ -1,0 +1,13 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add voice interruption and cancellation support to RuntypeVoiceProvider
+
+- Handle `session_config` WebSocket message to receive server-side interruption mode (`none`, `cancel`, `barge-in`)
+- New `cancelCurrentPlayback()` method stops audio playback and sends cancel request to server
+- When interruption is enabled, `startListening()` cancels in-flight responses instead of throwing
+- Track current audio element and request IDs for reliable cancellation and cleanup
+- Handle `cancelled` WebSocket message for server-acknowledged cancellation
+- Clean up audio resources on disconnect
+- Demo: conditionally show browser voice controls based on active TTS provider

--- a/examples/embedded-app/voice-integration-demo.html
+++ b/examples/embedded-app/voice-integration-demo.html
@@ -334,73 +334,7 @@
             </select>
 
             <div id="ttsOptions" style="display: none; margin-top: 0.5rem">
-              <select
-                id="ttsVoice"
-                style="
-                  width: 100%;
-                  padding: 0.5rem;
-                  border-radius: 4px;
-                  border: 1px solid #30363d;
-                  background: #0d1117;
-                  color: #c9d1d9;
-                  font-family: monospace;
-                  margin-bottom: 0.5rem;
-                "
-              >
-                <option value="">Auto-detect best voice</option>
-              </select>
-              <button
-                id="ttsTestVoice"
-                style="
-                  width: 100%;
-                  padding: 0.4rem;
-                  border-radius: 4px;
-                  border: 1px solid #30363d;
-                  background: #161b22;
-                  color: #c9d1d9;
-                  font-family: monospace;
-                  font-size: 0.8rem;
-                  cursor: pointer;
-                  margin-bottom: 0.5rem;
-                "
-              >&#9654; Test voice</button>
-              <div style="display: flex; gap: 0.5rem">
-                <input
-                  type="range"
-                  id="ttsRate"
-                  min="0.5"
-                  max="2"
-                  step="0.1"
-                  value="1"
-                  style="flex: 1"
-                />
-                <span
-                  id="ttsRateValue"
-                  style="color: #c9d1d9; font-size: 0.8rem"
-                  >1.0</span
-                >
-              </div>
-              <label style="color: #94a3b8; font-size: 0.7rem">Rate</label>
-
-              <div style="display: flex; gap: 0.5rem; margin-top: 0.5rem">
-                <input
-                  type="range"
-                  id="ttsPitch"
-                  min="0.5"
-                  max="2"
-                  step="0.1"
-                  value="1"
-                  style="flex: 1"
-                />
-                <span
-                  id="ttsPitchValue"
-                  style="color: #c9d1d9; font-size: 0.8rem"
-                  >1.0</span
-                >
-              </div>
-              <label style="color: #94a3b8; font-size: 0.7rem">Pitch</label>
-
-              <div id="ttsBrowserFallbackOption" style="display: none; margin-top: 0.75rem">
+              <div id="ttsBrowserFallbackOption" style="display: none; margin-top: 0.75rem; margin-bottom: 0.75rem">
                 <label style="display: flex; align-items: center; gap: 0.5rem; color: #c9d1d9; font-size: 0.8rem; cursor: pointer">
                   <input type="checkbox" id="ttsBrowserFallback" />
                   Browser fallback for text messages
@@ -408,6 +342,74 @@
                 <span style="color: #94a3b8; font-size: 0.7rem; display: block; margin-top: 0.25rem">
                   When TTS provider is "Runtype", also use browser TTS for text-typed responses that the server didn't speak.
                 </span>
+              </div>
+
+              <div id="ttsBrowserVoiceControls">
+                <select
+                  id="ttsVoice"
+                  style="
+                    width: 100%;
+                    padding: 0.5rem;
+                    border-radius: 4px;
+                    border: 1px solid #30363d;
+                    background: #0d1117;
+                    color: #c9d1d9;
+                    font-family: monospace;
+                    margin-bottom: 0.5rem;
+                  "
+                >
+                  <option value="">Auto-detect best voice</option>
+                </select>
+                <button
+                  id="ttsTestVoice"
+                  style="
+                    width: 100%;
+                    padding: 0.4rem;
+                    border-radius: 4px;
+                    border: 1px solid #30363d;
+                    background: #161b22;
+                    color: #c9d1d9;
+                    font-family: monospace;
+                    font-size: 0.8rem;
+                    cursor: pointer;
+                    margin-bottom: 0.5rem;
+                  "
+                >&#9654; Test voice</button>
+                <div style="display: flex; gap: 0.5rem">
+                  <input
+                    type="range"
+                    id="ttsRate"
+                    min="0.5"
+                    max="2"
+                    step="0.1"
+                    value="1"
+                    style="flex: 1"
+                  />
+                  <span
+                    id="ttsRateValue"
+                    style="color: #c9d1d9; font-size: 0.8rem"
+                    >1.0</span
+                  >
+                </div>
+                <label style="color: #94a3b8; font-size: 0.7rem">Rate</label>
+
+                <div style="display: flex; gap: 0.5rem; margin-top: 0.5rem">
+                  <input
+                    type="range"
+                    id="ttsPitch"
+                    min="0.5"
+                    max="2"
+                    step="0.1"
+                    value="1"
+                    style="flex: 1"
+                  />
+                  <span
+                    id="ttsPitchValue"
+                    style="color: #c9d1d9; font-size: 0.8rem"
+                    >1.0</span
+                  >
+                </div>
+                <label style="color: #94a3b8; font-size: 0.7rem">Pitch</label>
               </div>
             </div>
           </div>
@@ -575,6 +577,16 @@
                  }
                }
              },
+             <span class="comment">// Processing state (while agent is thinking)</span>
+             <span class="prop">processingIconName</span>: <span class="string">'loader'</span>,     <span class="comment">// spins automatically</span>
+             <span class="prop">processingBackgroundColor</span>: <span class="string">'#6366f1'</span>, <span class="comment">// optional: indigo</span>
+             <span class="prop">processingIconColor</span>: <span class="string">'#ffffff'</span>,
+
+             <span class="comment">// Speaking state (while agent TTS is playing)</span>
+             <span class="prop">speakingIconName</span>: <span class="string">'volume-2'</span>,     <span class="comment">// or 'square' for cancel mode</span>
+             <span class="prop">speakingBackgroundColor</span>: <span class="string">'#3b82f6'</span>, <span class="comment">// optional: blue</span>
+             <span class="prop">speakingIconColor</span>: <span class="string">'#ffffff'</span>,
+
              <span class="comment">// Custom rendering via voiceProcessing flag</span>
              <span class="prop">postprocessMessage</span>: ({ <span class="prop">text</span>, <span class="prop">message</span> }) =&gt; {
                <span class="keyword">if</span> (<span class="prop">message</span>.<span class="prop">voiceProcessing</span>) {
@@ -1020,6 +1032,13 @@
         if (ttsBrowserFallbackOptionLoad && currentConfig.voiceOutputProvider === "runtype") {
           ttsBrowserFallbackOptionLoad.style.display = "block";
         }
+        // Show browser voice controls only when browser TTS is active
+        const browserVoiceControlsLoad = document.getElementById("ttsBrowserVoiceControls");
+        if (browserVoiceControlsLoad) {
+          const showBrowserControls = currentConfig.voiceOutputProvider === "browser" ||
+            (currentConfig.voiceOutputProvider === "runtype" && currentConfig.ttsBrowserFallback);
+          browserVoiceControlsLoad.style.display = showBrowserControls ? "block" : "none";
+        }
 
         // Recreate config with loaded values
         config = createConfig();
@@ -1343,6 +1362,17 @@
         const ttsOptionsDiv = document.getElementById("ttsOptions");
 
         const ttsBrowserFallbackOption = document.getElementById("ttsBrowserFallbackOption");
+        const ttsBrowserVoiceControls = document.getElementById("ttsBrowserVoiceControls");
+        const ttsBrowserFallbackCheckbox = document.getElementById("ttsBrowserFallback");
+
+        function updateBrowserVoiceControlsVisibility() {
+          if (!ttsBrowserVoiceControls) return;
+          const provider = voiceOutputProviderSelect ? voiceOutputProviderSelect.value : "none";
+          const fallbackChecked = ttsBrowserFallbackCheckbox ? ttsBrowserFallbackCheckbox.checked : false;
+          const show = provider === "browser" || (provider === "runtype" && fallbackChecked);
+          ttsBrowserVoiceControls.style.display = show ? "block" : "none";
+        }
+
         if (voiceOutputProviderSelect && ttsOptionsDiv) {
           voiceOutputProviderSelect.addEventListener("change", function () {
             if (this.value !== "none") {
@@ -1354,6 +1384,15 @@
             if (ttsBrowserFallbackOption) {
               ttsBrowserFallbackOption.style.display = this.value === "runtype" ? "block" : "none";
             }
+            updateBrowserVoiceControlsVisibility();
+          });
+        }
+
+        // Toggle browser voice controls when fallback checkbox changes
+        if (ttsBrowserFallbackCheckbox) {
+          ttsBrowserFallbackCheckbox.addEventListener("change", function () {
+            currentConfig.ttsBrowserFallback = this.checked;
+            updateBrowserVoiceControlsVisibility();
           });
         }
 

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -247,9 +247,12 @@ export class AgentWidgetSession {
             this.injectAssistantMessage({ content: result.text.trim() });
           }
 
-          // If Runtype provider returned audio (server-side TTS), mark the
-          // assistant message as already spoken so browser TTS doesn't double-speak
-          if (result.audio?.base64) {
+          // Mark assistant message as already spoken so browser TTS doesn't
+          // double-speak. This covers both paths:
+          //   - Batch: audio.base64 is present in the voice_response
+          //   - Streaming: audio arrives as binary PCM chunks (no base64 here)
+          // In either case, the Runtype provider handles TTS — browser TTS must skip.
+          {
             const spokenId = this.pendingVoiceAssistantMessageId
               ?? [...this.messages].reverse().find(m => m.role === 'assistant')?.id;
             if (spokenId) this.ttsSpokenMessageIds.add(spokenId);

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -156,6 +156,18 @@ export class AgentWidgetSession {
     }
   }
 
+  /** Returns true if the barge-in mic stream is alive (hot mic between turns) */
+  public isBargeInActive(): boolean {
+    return this.voiceProvider?.isBargeInActive?.() ?? false;
+  }
+
+  /** Tear down the barge-in mic pipeline — "hang up" the always-on mic */
+  public async deactivateBargeIn(): Promise<void> {
+    if (this.voiceProvider?.deactivateBargeIn) {
+      await this.voiceProvider.deactivateBargeIn();
+    }
+  }
+
   // Pending placeholder IDs for Runtype two-phase voice flow
   private pendingVoiceUserMessageId: string | null = null;
   private pendingVoiceAssistantMessageId: string | null = null;

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -136,6 +136,26 @@ export class AgentWidgetSession {
     return this.voiceStatus;
   }
 
+  /**
+   * Get the voice interruption mode from the provider (none/cancel/barge-in)
+   */
+  public getVoiceInterruptionMode(): "none" | "cancel" | "barge-in" {
+    if (this.voiceProvider?.getInterruptionMode) {
+      return this.voiceProvider.getInterruptionMode();
+    }
+    return "none";
+  }
+
+  /**
+   * Stop voice playback / cancel in-flight request without starting recording.
+   * Returns to idle state.
+   */
+  public stopVoicePlayback(): void {
+    if (this.voiceProvider?.stopPlayback) {
+      this.voiceProvider.stopPlayback();
+    }
+  }
+
   // Pending placeholder IDs for Runtype two-phase voice flow
   private pendingVoiceUserMessageId: string | null = null;
   private pendingVoiceAssistantMessageId: string | null = null;

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1060,6 +1060,30 @@
   animation: tvw-voice-recording-pulse 1.5s ease-in-out infinite;
 }
 
+/* Voice processing animation (spinner) */
+@keyframes tvw-voice-processing-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.tvw-voice-processing svg {
+  animation: tvw-voice-processing-spin 1.2s linear infinite;
+}
+
+/* Voice speaking animation (gentle pulse — slower/subtler than recording) */
+@keyframes tvw-voice-speaking-pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.85; transform: scale(1.03); }
+}
+
+.tvw-voice-speaking {
+  animation: tvw-voice-speaking-pulse 2s ease-in-out infinite;
+}
+
+.tvw-voice-speaking svg {
+  animation: tvw-voice-speaking-pulse 2s ease-in-out infinite;
+}
+
 /* Markdown content overflow handling */
 .vanilla-message-bubble pre {
   overflow-x: auto;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -696,6 +696,26 @@ export type AgentWidgetVoiceRecognitionConfig = {
   recordingBackgroundColor?: string;
   recordingBorderColor?: string;
   showRecordingIndicator?: boolean;
+
+  // Processing state (after recording stops, waiting for agent response)
+  /** Icon name shown while processing voice input. Default: "loader" */
+  processingIconName?: string;
+  /** Icon color during processing. Inherits idle iconColor if not set */
+  processingIconColor?: string;
+  /** Button background color during processing. Inherits idle backgroundColor if not set */
+  processingBackgroundColor?: string;
+  /** Button border color during processing. Inherits idle borderColor if not set */
+  processingBorderColor?: string;
+
+  // Speaking state (agent TTS audio is playing)
+  /** Icon name shown while agent is speaking. Default: "volume-2" (or "square" in cancel mode) */
+  speakingIconName?: string;
+  /** Icon color while speaking. Inherits idle iconColor if not set */
+  speakingIconColor?: string;
+  /** Button background color while speaking. Inherits idle backgroundColor if not set */
+  speakingBackgroundColor?: string;
+  /** Button border color while speaking. Inherits idle borderColor if not set */
+  speakingBorderColor?: string;
   autoResume?: boolean | "assistant";
   
   // Voice provider configuration
@@ -794,11 +814,12 @@ export type VoiceResult = {
 /**
  * Voice provider status states
  */
-export type VoiceStatus = 
+export type VoiceStatus =
   | 'disconnected'
   | 'connected'
   | 'listening'
   | 'processing'
+  | 'speaking'
   | 'error'
   | 'idle';
 
@@ -843,6 +864,12 @@ export interface VoiceProvider {
 
   /** Register a callback fired when recording stops and audio is about to be sent */
   onProcessingStart?(callback: () => void): void;
+
+  /** Returns the current interruption mode (only meaningful for Runtype provider) */
+  getInterruptionMode?(): "none" | "cancel" | "barge-in";
+
+  /** Stop playback / cancel in-flight request without starting recording */
+  stopPlayback?(): void;
 }
 
 /**

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -868,6 +868,12 @@ export interface VoiceProvider {
   /** Returns the current interruption mode (only meaningful for Runtype provider) */
   getInterruptionMode?(): "none" | "cancel" | "barge-in";
 
+  /** Returns true if the barge-in mic stream is alive (hot mic between turns) */
+  isBargeInActive?(): boolean;
+
+  /** Tear down the barge-in mic pipeline — "hang up" the always-on mic */
+  deactivateBargeIn?(): Promise<void>;
+
   /** Stop playback / cancel in-flight request without starting recording */
   stopPlayback?(): void;
 }

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2069,10 +2069,17 @@ export const createAgentExperience = (
           break;
         default:
           // idle, connected, disconnected, error
-          voiceState.active = false;
-          removeRuntypeMicStateStyles();
-          emitVoiceState("system");
-          persistVoiceMetadata();
+          if (status === 'idle' && session.isBargeInActive()) {
+            // Barge-in mic is still hot between turns — show it as active
+            removeRuntypeMicStateStyles();
+            applyRuntypeMicRecordingStyles();
+            micButton?.setAttribute("aria-label", "End voice session");
+          } else {
+            voiceState.active = false;
+            removeRuntypeMicStateStyles();
+            emitVoiceState("system");
+            persistVoiceMetadata();
+          }
           break;
       }
     }
@@ -2532,12 +2539,18 @@ export const createAgentExperience = (
     storeOriginalMicStyles();
     const voiceConfig = config.voiceRecognition ?? {};
     const interruptionMode = session.getVoiceInterruptionMode();
-    // Default icon depends on interruption mode: "square" for cancel, "volume-2" otherwise
-    const defaultSpeakingIcon = interruptionMode === "cancel" ? "square" : "volume-2";
+    // Default icon depends on interruption mode:
+    // "square" for cancel, "mic" for barge-in (hot mic), "volume-2" otherwise
+    const defaultSpeakingIcon = interruptionMode === "cancel" ? "square"
+      : interruptionMode === "barge-in" ? "mic"
+      : "volume-2";
     const iconName = voiceConfig.speakingIconName ?? defaultSpeakingIcon;
-    const iconColor = voiceConfig.speakingIconColor ?? originalMicStyles?.color ?? "";
-    const bgColor = voiceConfig.speakingBackgroundColor ?? originalMicStyles?.backgroundColor ?? "";
-    const borderColor = voiceConfig.speakingBorderColor ?? originalMicStyles?.borderColor ?? "";
+    const iconColor = voiceConfig.speakingIconColor
+      ?? (interruptionMode === "barge-in" ? (voiceConfig.recordingIconColor ?? originalMicStyles?.color ?? "") : (originalMicStyles?.color ?? ""));
+    const bgColor = voiceConfig.speakingBackgroundColor
+      ?? (interruptionMode === "barge-in" ? (voiceConfig.recordingBackgroundColor ?? "#ef4444") : (originalMicStyles?.backgroundColor ?? ""));
+    const borderColor = voiceConfig.speakingBorderColor
+      ?? (interruptionMode === "barge-in" ? (voiceConfig.recordingBorderColor ?? "") : (originalMicStyles?.borderColor ?? ""));
 
     removeAllVoiceStateClasses();
     micButton.classList.add("tvw-voice-speaking");
@@ -2550,11 +2563,17 @@ export const createAgentExperience = (
     // aria-label varies by interruption mode
     const ariaLabel = interruptionMode === "cancel"
       ? "Stop playback and re-record"
+      : interruptionMode === "barge-in"
+      ? "Speak to interrupt"
       : "Agent is speaking";
     micButton.setAttribute("aria-label", ariaLabel);
     // In "none" mode the button is not actionable during speaking
     if (interruptionMode === "none") {
       micButton.style.cursor = "default";
+    }
+    // In "barge-in" mode, add recording class to show mic is hot
+    if (interruptionMode === "barge-in") {
+      micButton.classList.add("tvw-voice-recording");
     }
   };
 
@@ -2586,12 +2605,24 @@ export const createAgentExperience = (
         return;
       }
 
-      // In "cancel" mode during processing/speaking: stop only, don't start recording.
-      // The button shows a stop icon — clicking it should stop playback and return to
-      // idle. The user can then click the mic again to start a new recording.
+      // In "cancel" mode during processing/speaking: stop playback only
       if (interruptionMode === "cancel" &&
           (voiceStatus === "processing" || voiceStatus === "speaking")) {
         session.stopVoicePlayback();
+        return;
+      }
+
+      // In barge-in mode, clicking mic = "hang up" (any state: speaking, idle, etc.)
+      // Stops playback if active, tears down the always-on mic.
+      if (session.isBargeInActive()) {
+        session.stopVoicePlayback();
+        session.deactivateBargeIn().then(() => {
+          voiceState.active = false;
+          voiceState.manuallyDeactivated = true;
+          persistVoiceMetadata();
+          emitVoiceState("user");
+          removeRuntypeMicStateStyles();
+        });
         return;
       }
 

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2053,12 +2053,27 @@ export const createAgentExperience = (
       }
     },
     onVoiceStatusChanged(status: VoiceStatus) {
-      // When Runtype provider auto-stops (e.g. silence detection), update mic button
-      if (config.voiceRecognition?.provider?.type === 'runtype' && status !== 'listening') {
-        voiceState.active = false;
-        removeRuntypeMicRecordingStyles();
-        emitVoiceState("system");
-        persistVoiceMetadata();
+      if (config.voiceRecognition?.provider?.type !== 'runtype') return;
+
+      switch (status) {
+        case 'listening':
+          // Recording styles are applied by toggleVoice() / startVoiceRecognition() flows
+          break;
+        case 'processing':
+          removeRuntypeMicStateStyles();
+          applyRuntypeMicProcessingStyles();
+          break;
+        case 'speaking':
+          removeRuntypeMicStateStyles();
+          applyRuntypeMicSpeakingStyles();
+          break;
+        default:
+          // idle, connected, disconnected, error
+          voiceState.active = false;
+          removeRuntypeMicStateStyles();
+          emitVoiceState("system");
+          persistVoiceMetadata();
+          break;
       }
     }
   });
@@ -2176,6 +2191,8 @@ export const createAgentExperience = (
     backgroundColor: string;
     color: string;
     borderColor: string;
+    iconName: string;
+    iconSize: number;
   } | null = null;
 
   const getSpeechRecognitionClass = (): any => {
@@ -2273,15 +2290,17 @@ export const createAgentExperience = (
       emitVoiceState(source);
       persistVoiceMetadata();
       if (micButton) {
-        // Store original styles
+        // Store original styles (including icon info for restoration)
+        const voiceConfig = config.voiceRecognition ?? {};
         originalMicStyles = {
           backgroundColor: micButton.style.backgroundColor,
           color: micButton.style.color,
-          borderColor: micButton.style.borderColor
+          borderColor: micButton.style.borderColor,
+          iconName: voiceConfig.iconName ?? "mic",
+          iconSize: parseFloat(voiceConfig.iconSize ?? config.sendButton?.size ?? "40") || 24,
         };
-        
+
         // Apply recording state styles from config
-        const voiceConfig = config.voiceRecognition ?? {};
         const recordingBackgroundColor = voiceConfig.recordingBackgroundColor ?? "#ef4444";
         const recordingIconColor = voiceConfig.recordingIconColor;
         const recordingBorderColor = voiceConfig.recordingBorderColor;
@@ -2334,24 +2353,7 @@ export const createAgentExperience = (
     persistVoiceMetadata();
 
     if (micButton) {
-      micButton.classList.remove("tvw-voice-recording");
-      
-      // Restore original styles
-      if (originalMicStyles) {
-        micButton.style.backgroundColor = originalMicStyles.backgroundColor;
-        micButton.style.color = originalMicStyles.color;
-        micButton.style.borderColor = originalMicStyles.borderColor;
-        
-        // Restore SVG stroke color if present
-        const svg = micButton.querySelector("svg");
-        if (svg) {
-          svg.setAttribute("stroke", originalMicStyles.color || "currentColor");
-        }
-        
-        originalMicStyles = null;
-      }
-      
-      micButton.setAttribute("aria-label", "Start voice recognition");
+      removeRuntypeMicStateStyles();
     }
   };
 
@@ -2450,18 +2452,46 @@ export const createAgentExperience = (
     return { micButton, micButtonWrapper };
   };
 
-  // Helpers to apply/remove Runtype mic recording styles (mirrors start/stopVoiceRecognition)
-  const applyRuntypeMicRecordingStyles = () => {
-    if (!micButton) return;
+  // --- Helpers to store/restore original mic button state ---
+
+  const storeOriginalMicStyles = () => {
+    if (!micButton || originalMicStyles) return; // Already stored
+    const voiceConfig = config.voiceRecognition ?? {};
     originalMicStyles = {
       backgroundColor: micButton.style.backgroundColor,
       color: micButton.style.color,
-      borderColor: micButton.style.borderColor
+      borderColor: micButton.style.borderColor,
+      iconName: voiceConfig.iconName ?? "mic",
+      iconSize: parseFloat(voiceConfig.iconSize ?? config.sendButton?.size ?? "40") || 24,
     };
+  };
+
+  /** Swap the mic button's SVG icon */
+  const swapMicIcon = (iconName: string, color: string) => {
+    if (!micButton) return;
+    const existingSvg = micButton.querySelector("svg");
+    if (existingSvg) existingSvg.remove();
+    const size = originalMicStyles?.iconSize ?? (parseFloat(config.voiceRecognition?.iconSize ?? config.sendButton?.size ?? "40") || 24);
+    const newSvg = renderLucideIcon(iconName, size, color, 1.5);
+    if (newSvg) micButton.appendChild(newSvg);
+  };
+
+  /** Remove all voice state CSS classes */
+  const removeAllVoiceStateClasses = () => {
+    if (!micButton) return;
+    micButton.classList.remove("tvw-voice-recording", "tvw-voice-processing", "tvw-voice-speaking");
+  };
+
+  // --- Per-state style application ---
+
+  const applyRuntypeMicRecordingStyles = () => {
+    if (!micButton) return;
+    storeOriginalMicStyles();
     const voiceConfig = config.voiceRecognition ?? {};
     const recordingBackgroundColor = voiceConfig.recordingBackgroundColor ?? "#ef4444";
     const recordingIconColor = voiceConfig.recordingIconColor;
     const recordingBorderColor = voiceConfig.recordingBorderColor;
+    removeAllVoiceStateClasses();
     micButton.classList.add("tvw-voice-recording");
     micButton.style.backgroundColor = recordingBackgroundColor;
     if (recordingIconColor) {
@@ -2472,17 +2502,74 @@ export const createAgentExperience = (
     if (recordingBorderColor) micButton.style.borderColor = recordingBorderColor;
     micButton.setAttribute("aria-label", "Stop voice recognition");
   };
-  const removeRuntypeMicRecordingStyles = () => {
+
+  const applyRuntypeMicProcessingStyles = () => {
     if (!micButton) return;
-    micButton.classList.remove("tvw-voice-recording");
+    storeOriginalMicStyles();
+    const voiceConfig = config.voiceRecognition ?? {};
+    const interruptionMode = session.getVoiceInterruptionMode();
+    const iconName = voiceConfig.processingIconName ?? "loader";
+    const iconColor = voiceConfig.processingIconColor ?? originalMicStyles?.color ?? "";
+    const bgColor = voiceConfig.processingBackgroundColor ?? originalMicStyles?.backgroundColor ?? "";
+    const borderColor = voiceConfig.processingBorderColor ?? originalMicStyles?.borderColor ?? "";
+
+    removeAllVoiceStateClasses();
+    micButton.classList.add("tvw-voice-processing");
+    micButton.style.backgroundColor = bgColor;
+    micButton.style.borderColor = borderColor;
+    const resolvedColor = iconColor || "currentColor";
+    micButton.style.color = resolvedColor;
+    swapMicIcon(iconName, resolvedColor);
+    micButton.setAttribute("aria-label", "Processing voice input");
+    // In "none" mode the button is not actionable during processing
+    if (interruptionMode === "none") {
+      micButton.style.cursor = "default";
+    }
+  };
+
+  const applyRuntypeMicSpeakingStyles = () => {
+    if (!micButton) return;
+    storeOriginalMicStyles();
+    const voiceConfig = config.voiceRecognition ?? {};
+    const interruptionMode = session.getVoiceInterruptionMode();
+    // Default icon depends on interruption mode: "square" for cancel, "volume-2" otherwise
+    const defaultSpeakingIcon = interruptionMode === "cancel" ? "square" : "volume-2";
+    const iconName = voiceConfig.speakingIconName ?? defaultSpeakingIcon;
+    const iconColor = voiceConfig.speakingIconColor ?? originalMicStyles?.color ?? "";
+    const bgColor = voiceConfig.speakingBackgroundColor ?? originalMicStyles?.backgroundColor ?? "";
+    const borderColor = voiceConfig.speakingBorderColor ?? originalMicStyles?.borderColor ?? "";
+
+    removeAllVoiceStateClasses();
+    micButton.classList.add("tvw-voice-speaking");
+    micButton.style.backgroundColor = bgColor;
+    micButton.style.borderColor = borderColor;
+    const resolvedColor = iconColor || "currentColor";
+    micButton.style.color = resolvedColor;
+    swapMicIcon(iconName, resolvedColor);
+
+    // aria-label varies by interruption mode
+    const ariaLabel = interruptionMode === "cancel"
+      ? "Stop playback and re-record"
+      : "Agent is speaking";
+    micButton.setAttribute("aria-label", ariaLabel);
+    // In "none" mode the button is not actionable during speaking
+    if (interruptionMode === "none") {
+      micButton.style.cursor = "default";
+    }
+  };
+
+  /** Restore mic button to idle state (icon, colors, aria-label, cursor) */
+  const removeRuntypeMicStateStyles = () => {
+    if (!micButton) return;
+    removeAllVoiceStateClasses();
     if (originalMicStyles) {
       micButton.style.backgroundColor = originalMicStyles.backgroundColor ?? "";
       micButton.style.color = originalMicStyles.color ?? "";
       micButton.style.borderColor = originalMicStyles.borderColor ?? "";
-      const svg = micButton.querySelector("svg");
-      if (svg) svg.setAttribute("stroke", originalMicStyles.color || "currentColor");
+      swapMicIcon(originalMicStyles.iconName, originalMicStyles.color || "currentColor");
       originalMicStyles = null;
     }
+    micButton.style.cursor = "";
     micButton.setAttribute("aria-label", "Start voice recognition");
   };
 
@@ -2490,6 +2577,24 @@ export const createAgentExperience = (
   const handleMicButtonClick = () => {
     // Runtype provider: use session.toggleVoice() (WebSocket-based STT)
     if (config.voiceRecognition?.provider?.type === 'runtype') {
+      const voiceStatus = session.getVoiceStatus();
+      const interruptionMode = session.getVoiceInterruptionMode();
+
+      // In "none" mode, ignore clicks while processing or speaking
+      if (interruptionMode === "none" &&
+          (voiceStatus === "processing" || voiceStatus === "speaking")) {
+        return;
+      }
+
+      // In "cancel" mode during processing/speaking: stop only, don't start recording.
+      // The button shows a stop icon — clicking it should stop playback and return to
+      // idle. The user can then click the mic again to start a new recording.
+      if (interruptionMode === "cancel" &&
+          (voiceStatus === "processing" || voiceStatus === "speaking")) {
+        session.stopVoicePlayback();
+        return;
+      }
+
       session.toggleVoice().then(() => {
         voiceState.active = session.isVoiceActive();
         voiceState.manuallyDeactivated = !session.isVoiceActive();
@@ -2498,7 +2603,7 @@ export const createAgentExperience = (
         if (session.isVoiceActive()) {
           applyRuntypeMicRecordingStyles();
         } else {
-          removeRuntypeMicRecordingStyles();
+          removeRuntypeMicStateStyles();
         }
       });
       return;
@@ -2530,7 +2635,7 @@ export const createAgentExperience = (
     destroyCallbacks.push(() => {
       if (config.voiceRecognition?.provider?.type === 'runtype') {
         if (session.isVoiceActive()) session.toggleVoice();
-        removeRuntypeMicRecordingStyles();
+        removeRuntypeMicStateStyles();
       } else {
         stopVoiceRecognition("system");
       }
@@ -4102,7 +4207,7 @@ export const createAgentExperience = (
           voiceState.manuallyDeactivated = true;
           persistVoiceMetadata();
           emitVoiceState("user");
-          removeRuntypeMicRecordingStyles();
+          removeRuntypeMicStateStyles();
         });
         return true;
       }

--- a/packages/widget/src/voice/audio-playback-manager.ts
+++ b/packages/widget/src/voice/audio-playback-manager.ts
@@ -1,0 +1,187 @@
+/**
+ * AudioPlaybackManager
+ *
+ * Manages streaming playback of PCM audio chunks via the Web Audio API.
+ * Receives raw PCM data (24 kHz, 16-bit signed little-endian, mono),
+ * converts to Float32 AudioBuffers, and schedules gap-free sequential
+ * playback using AudioBufferSourceNode.
+ *
+ * Works on all browsers including iOS Safari (no MediaSource dependency).
+ */
+export class AudioPlaybackManager {
+  private ctx: AudioContext | null = null;
+  private nextStartTime = 0;
+  private activeSources: AudioBufferSourceNode[] = [];
+  private finishedCallbacks: (() => void)[] = [];
+  private playing = false;
+  private streamEnded = false;
+  private pendingCount = 0;
+
+  // PCM format constants
+  private readonly sampleRate: number;
+
+  // Remainder byte from a previous chunk when the chunk had an odd byte count.
+  // Network chunks don't respect 2-byte sample boundaries, so we carry over
+  // the orphaned byte and prepend it to the next chunk.
+  private remainder: Uint8Array | null = null;
+
+  constructor(sampleRate = 24000) {
+    this.sampleRate = sampleRate;
+  }
+
+  /**
+   * Ensure AudioContext is created and running.
+   * Must be called after a user gesture on iOS Safari.
+   */
+  private ensureContext(): AudioContext {
+    if (!this.ctx) {
+      const w = typeof window !== "undefined" ? (window as any) : undefined;
+      if (!w) throw new Error("AudioPlaybackManager requires a browser environment");
+      const AudioCtx = w.AudioContext || w.webkitAudioContext;
+      this.ctx = new AudioCtx({ sampleRate: this.sampleRate }) as AudioContext;
+    }
+    const ctx = this.ctx!;
+    // Resume if suspended (autoplay policy)
+    if (ctx.state === "suspended") {
+      ctx.resume();
+    }
+    return ctx;
+  }
+
+  /**
+   * Enqueue a PCM chunk for playback.
+   * @param pcmData Raw PCM bytes (16-bit signed LE mono)
+   */
+  enqueue(pcmData: Uint8Array): void {
+    if (pcmData.length === 0) return;
+
+    // Prepend any remainder byte from the previous chunk
+    let data = pcmData;
+    if (this.remainder) {
+      const merged = new Uint8Array(this.remainder.length + pcmData.length);
+      merged.set(this.remainder);
+      merged.set(pcmData, this.remainder.length);
+      data = merged;
+      this.remainder = null;
+    }
+
+    // If odd byte count, save the trailing byte for next chunk
+    if (data.length % 2 !== 0) {
+      this.remainder = new Uint8Array([data[data.length - 1]]);
+      data = data.subarray(0, data.length - 1);
+    }
+
+    if (data.length === 0) return;
+
+    const ctx = this.ensureContext();
+    const float32 = this.pcmToFloat32(data);
+
+    const buffer = ctx.createBuffer(1, float32.length, this.sampleRate);
+    buffer.getChannelData(0).set(float32);
+
+    const source = ctx.createBufferSource();
+    source.buffer = buffer;
+    source.connect(ctx.destination);
+
+    // Schedule gap-free playback
+    const now = ctx.currentTime;
+    if (this.nextStartTime < now) {
+      this.nextStartTime = now;
+    }
+    source.start(this.nextStartTime);
+    this.nextStartTime += buffer.duration;
+
+    this.activeSources.push(source);
+    this.pendingCount++;
+    this.playing = true;
+
+    source.onended = () => {
+      const idx = this.activeSources.indexOf(source);
+      if (idx !== -1) this.activeSources.splice(idx, 1);
+      this.pendingCount--;
+      this.checkFinished();
+    };
+  }
+
+  /**
+   * Signal that no more chunks will arrive.
+   * The onFinished callback fires after all queued audio has played.
+   */
+  markStreamEnd(): void {
+    this.streamEnded = true;
+    this.checkFinished();
+  }
+
+  /**
+   * Immediately stop all playback and discard queued audio.
+   */
+  flush(): void {
+    for (const source of this.activeSources) {
+      try {
+        source.stop();
+        source.disconnect();
+      } catch {
+        // Ignore errors from already-stopped sources
+      }
+    }
+    this.activeSources = [];
+    this.pendingCount = 0;
+    this.nextStartTime = 0;
+    this.playing = false;
+    this.streamEnded = false;
+    this.finishedCallbacks = [];
+    this.remainder = null;
+  }
+
+  /**
+   * Whether audio is currently playing or queued.
+   */
+  isPlaying(): boolean {
+    return this.playing;
+  }
+
+  /**
+   * Register a callback for when all queued audio finishes playing.
+   */
+  onFinished(callback: () => void): void {
+    this.finishedCallbacks.push(callback);
+  }
+
+  /**
+   * Clean up AudioContext resources.
+   */
+  async destroy(): Promise<void> {
+    this.flush();
+    if (this.ctx) {
+      await this.ctx.close();
+      this.ctx = null;
+    }
+  }
+
+  private checkFinished(): void {
+    if (this.streamEnded && this.pendingCount <= 0 && this.playing) {
+      this.playing = false;
+      this.streamEnded = false;
+      const cbs = this.finishedCallbacks.slice();
+      this.finishedCallbacks = [];
+      for (const cb of cbs) cb();
+    }
+  }
+
+  /**
+   * Convert 16-bit signed LE PCM to Float32 samples in [-1, 1].
+   */
+  private pcmToFloat32(pcmData: Uint8Array): Float32Array {
+    // 2 bytes per sample (16-bit)
+    const numSamples = Math.floor(pcmData.length / 2);
+    const float32 = new Float32Array(numSamples);
+    const view = new DataView(pcmData.buffer, pcmData.byteOffset, pcmData.byteLength);
+
+    for (let i = 0; i < numSamples; i++) {
+      const int16 = view.getInt16(i * 2, true); // little-endian
+      float32[i] = int16 / 32768;
+    }
+
+    return float32;
+  }
+}

--- a/packages/widget/src/voice/runtype-voice-provider.ts
+++ b/packages/widget/src/voice/runtype-voice-provider.ts
@@ -20,6 +20,7 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   private processingStartCallbacks: (() => void)[] = [];
   private audioChunks: Blob[] = [];
   private isProcessing = false;
+  private isSpeaking = false;
 
   // Silence detection
   private analyserNode: AnalyserNode | null = null;
@@ -27,7 +28,18 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   private silenceCheckInterval: ReturnType<typeof setInterval> | null = null;
   private silenceStart: number | null = null;
 
+  // Cancellation / interruption support
+  private currentAudio: HTMLAudioElement | null = null;
+  private currentAudioUrl: string | null = null;
+  private currentRequestId: string | null = null;
+  private interruptionMode: "none" | "cancel" | "barge-in" = "none";
+
   constructor(private config: VoiceConfig["runtype"]) {}
+
+  /** Returns the current interruption mode received from the server */
+  getInterruptionMode(): "none" | "cancel" | "barge-in" {
+    return this.interruptionMode;
+  }
 
   async connect() {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) {
@@ -151,15 +163,16 @@ export class RuntypeVoiceProvider implements VoiceProvider {
 
   private handleWebSocketMessage(message: any) {
     switch (message.type) {
-      case "voice_response":
-        // Play TTS audio if present
-        if (message.response.audio?.base64) {
-          this.playAudio(message.response.audio).catch((err) =>
-            this.errorCallbacks.forEach((cb) => cb(err instanceof Error ? err : new Error(String(err)))),
-          );
+      case "session_config":
+        // Server sends voice settings on session init
+        if (message.interruptionMode) {
+          this.interruptionMode = message.interruptionMode;
         }
-        // Use agentResponseText (the agent's reply) as the text result,
-        // falling back to transcript (user's STT input) for backwards compat
+        break;
+
+      case "voice_response":
+        // Deliver text result immediately
+        this.isProcessing = false;
         this.resultCallbacks.forEach((cb) =>
           cb({
             text: message.response.agentResponseText || message.response.transcript,
@@ -169,8 +182,22 @@ export class RuntypeVoiceProvider implements VoiceProvider {
             provider: "runtype",
           }),
         );
+
+        // Play TTS audio if present — stay in "speaking" state until playback ends
+        if (message.response.audio?.base64) {
+          this.isSpeaking = true;
+          this.statusCallbacks.forEach((cb) => cb("speaking"));
+          this.playAudio(message.response.audio).catch((err) =>
+            this.errorCallbacks.forEach((cb) => cb(err instanceof Error ? err : new Error(String(err)))),
+          );
+        } else {
+          this.statusCallbacks.forEach((cb) => cb("idle"));
+        }
+        break;
+
+      case "cancelled":
+        // Server acknowledged cancellation — discard any late-arriving responses
         this.isProcessing = false;
-        this.statusCallbacks.forEach((cb) => cb("idle"));
         break;
 
       case "error":
@@ -185,10 +212,57 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     }
   }
 
+  /**
+   * Stop playback / cancel in-flight request and return to idle.
+   * This is the public "stop only" action — does NOT start recording.
+   */
+  stopPlayback(): void {
+    if (!this.isProcessing && !this.isSpeaking) return;
+    this.cancelCurrentPlayback();
+    this.statusCallbacks.forEach((cb) => cb("idle"));
+  }
+
+  /**
+   * Cancel the current playback and in-flight server request.
+   * Internal helper — does NOT fire status callbacks (caller decides next state).
+   */
+  private cancelCurrentPlayback(): void {
+    // Stop playing audio
+    if (this.currentAudio) {
+      this.currentAudio.pause();
+      this.currentAudio.src = "";
+      this.currentAudio = null;
+    }
+    if (this.currentAudioUrl) {
+      URL.revokeObjectURL(this.currentAudioUrl);
+      this.currentAudioUrl = null;
+    }
+
+    // Tell server to abort the in-flight request
+    if (this.currentRequestId && this.ws && this.ws.readyState === WebSocket.OPEN) {
+      this.ws.send(
+        JSON.stringify({
+          type: "cancel",
+          requestId: this.currentRequestId,
+        }),
+      );
+    }
+
+    this.currentRequestId = null;
+    this.isProcessing = false;
+    this.isSpeaking = false;
+  }
+
   async startListening() {
     try {
-      if (this.isProcessing) {
-        throw new Error("Already processing audio");
+      if (this.isProcessing || this.isSpeaking) {
+        // If interruption is enabled, cancel current playback and proceed
+        if (this.interruptionMode !== "none") {
+          this.cancelCurrentPlayback();
+        } else {
+          // Mode is "none" — block mic while processing or speaking
+          return;
+        }
       }
 
       const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
@@ -293,6 +367,10 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     this.statusCallbacks.forEach((cb) => cb("idle"));
   }
 
+  private generateRequestId(): string {
+    return "vreq_" + Math.random().toString(36).substring(2, 10) + Date.now().toString(36);
+  }
+
   private async sendAudio(audioBlob: Blob) {
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       this.errorCallbacks.forEach((cb) =>
@@ -305,6 +383,8 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     try {
       const base64Audio = await this.blobToBase64(audioBlob);
       const format = this.getFormatFromMimeType(audioBlob.type);
+      const requestId = this.generateRequestId();
+      this.currentRequestId = requestId;
 
       this.ws.send(
         JSON.stringify({
@@ -313,6 +393,7 @@ export class RuntypeVoiceProvider implements VoiceProvider {
           format,
           sampleRate: 16000,
           voiceId: this.config?.voiceId,
+          requestId,
         }),
       );
     } catch (error) {
@@ -357,7 +438,20 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     const blob = new Blob([bytes], { type: mimeType });
     const url = URL.createObjectURL(blob);
     const audioEl = new Audio(url);
-    audioEl.onended = () => URL.revokeObjectURL(url);
+
+    // Store references so playback can be cancelled
+    this.currentAudio = audioEl;
+    this.currentAudioUrl = url;
+
+    audioEl.onended = () => {
+      URL.revokeObjectURL(url);
+      if (this.currentAudio === audioEl) {
+        this.currentAudio = null;
+        this.currentAudioUrl = null;
+        this.isSpeaking = false;
+        this.statusCallbacks.forEach((cb) => cb("idle"));
+      }
+    };
     await audioEl.play();
   }
 
@@ -378,6 +472,19 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   }
 
   async disconnect(): Promise<void> {
+    // Stop any playing audio
+    if (this.currentAudio) {
+      this.currentAudio.pause();
+      this.currentAudio.src = "";
+      this.currentAudio = null;
+    }
+    if (this.currentAudioUrl) {
+      URL.revokeObjectURL(this.currentAudioUrl);
+      this.currentAudioUrl = null;
+    }
+    this.currentRequestId = null;
+    this.isSpeaking = false;
+
     await this.stopListening();
 
     if (this.ws) {

--- a/packages/widget/src/voice/runtype-voice-provider.ts
+++ b/packages/widget/src/voice/runtype-voice-provider.ts
@@ -8,6 +8,7 @@ import type {
   VoiceConfig,
 } from "../types";
 import { AudioPlaybackManager } from "./audio-playback-manager";
+import { VoiceActivityDetector } from "./voice-activity-detector";
 
 export class RuntypeVoiceProvider implements VoiceProvider {
   type: "runtype" = "runtype";
@@ -23,11 +24,9 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   private isProcessing = false;
   private isSpeaking = false;
 
-  // Silence detection
-  private analyserNode: AnalyserNode | null = null;
+  // Voice activity detection (silence auto-stop + barge-in speech detection)
+  private vad = new VoiceActivityDetector();
   private mediaStream: MediaStream | null = null;
-  private silenceCheckInterval: ReturnType<typeof setInterval> | null = null;
-  private silenceStart: number | null = null;
 
   // Cancellation / interruption support
   private currentAudio: HTMLAudioElement | null = null;
@@ -43,6 +42,24 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   /** Returns the current interruption mode received from the server */
   getInterruptionMode(): "none" | "cancel" | "barge-in" {
     return this.interruptionMode;
+  }
+
+  /** Returns true if the barge-in mic stream is alive (hot mic between turns) */
+  isBargeInActive(): boolean {
+    return this.interruptionMode === "barge-in" && this.mediaStream !== null;
+  }
+
+  /** Tear down the barge-in mic pipeline — "hang up" the always-on mic */
+  async deactivateBargeIn(): Promise<void> {
+    this.vad.stop();
+    if (this.mediaStream) {
+      this.mediaStream.getTracks().forEach((track) => track.stop());
+      this.mediaStream = null;
+    }
+    if (this.audioContext) {
+      await this.audioContext.close();
+      this.audioContext = null;
+    }
   }
 
   async connect() {
@@ -129,6 +146,11 @@ export class RuntypeVoiceProvider implements VoiceProvider {
           { once: true }
         );
       });
+
+      // Send a ping immediately so the server replies with session_config
+      // (which includes interruptionMode). This ensures the client knows
+      // about barge-in mode before the first recording starts.
+      this.sendHeartbeat();
     } catch (error) {
       this.ws = null;
       this.errorCallbacks.forEach((cb) => cb(error as Error));
@@ -213,6 +235,8 @@ export class RuntypeVoiceProvider implements VoiceProvider {
         break;
 
       case "audio_end":
+        // Guard: discard late audio_end from a cancelled request
+        if (message.requestId && message.requestId !== this.currentRequestId) break;
         // All PCM chunks have been sent — signal the playback manager
         if (this.playbackManager) {
           this.playbackManager.markStreamEnd();
@@ -246,6 +270,7 @@ export class RuntypeVoiceProvider implements VoiceProvider {
    */
   private handleAudioChunk(pcmData: Uint8Array): void {
     if (pcmData.length === 0) return;
+    if (!this.currentRequestId) return; // discard late chunks after cancel
 
     // Lazily create playback manager on first chunk
     if (!this.playbackManager) {
@@ -253,6 +278,7 @@ export class RuntypeVoiceProvider implements VoiceProvider {
       this.playbackManager.onFinished(() => {
         this.isSpeaking = false;
         this.playbackManager = null;
+        this.vad.stop(); // stop speech monitoring — audio ended naturally
         this.statusCallbacks.forEach((cb) => cb("idle"));
       });
     }
@@ -261,6 +287,7 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     if (!this.isSpeaking) {
       this.isSpeaking = true;
       this.statusCallbacks.forEach((cb) => cb("speaking"));
+      this.startBargeInMonitoring().catch(() => {}); // no-op if not barge-in mode
     }
 
     this.playbackManager.enqueue(pcmData);
@@ -325,48 +352,31 @@ export class RuntypeVoiceProvider implements VoiceProvider {
         }
       }
 
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      this.mediaStream = stream;
+      // Reuse existing mic stream in barge-in mode (mic stays hot)
+      if (!this.mediaStream) {
+        const constraints =
+          this.interruptionMode === "barge-in"
+            ? { audio: { echoCancellation: true, noiseSuppression: true } }
+            : { audio: true };
+        this.mediaStream = await navigator.mediaDevices.getUserMedia(constraints);
+      }
       const w = this.w!;
-      this.audioContext = new (w.AudioContext || w.webkitAudioContext)();
+      if (!this.audioContext) {
+        this.audioContext = new (w.AudioContext || w.webkitAudioContext)();
+      }
 
-      // Set up silence detection via AnalyserNode
-      const audioCtx = this.audioContext!;
-      const source = audioCtx.createMediaStreamSource(stream);
-      this.analyserNode = audioCtx.createAnalyser();
-      this.analyserNode.fftSize = 2048;
-      source.connect(this.analyserNode);
-
+      // VAD-based silence detection — fires once when user stops talking
       const pauseDuration = this.config?.pauseDuration ?? 2000;
       const silenceThreshold = this.config?.silenceThreshold ?? 0.01;
-      this.silenceStart = null;
+      this.vad.start(
+        this.audioContext,
+        this.mediaStream,
+        "silence",
+        { threshold: silenceThreshold, duration: pauseDuration },
+        () => this.stopListening(),
+      );
 
-      const dataArray = new Float32Array(this.analyserNode.fftSize);
-      this.silenceCheckInterval = setInterval(() => {
-        if (!this.analyserNode) return;
-        this.analyserNode.getFloatTimeDomainData(dataArray);
-
-        // Compute RMS volume
-        let sum = 0;
-        for (let i = 0; i < dataArray.length; i++) {
-          sum += dataArray[i] * dataArray[i];
-        }
-        const rms = Math.sqrt(sum / dataArray.length);
-
-        if (rms < silenceThreshold) {
-          if (this.silenceStart === null) {
-            this.silenceStart = Date.now();
-          } else if (Date.now() - this.silenceStart >= pauseDuration) {
-            // Silence exceeded threshold — auto-stop
-            this.stopListening();
-          }
-        } else {
-          // Sound detected — reset silence timer
-          this.silenceStart = null;
-        }
-      }, 100);
-
-      this.mediaRecorder = new MediaRecorder(stream);
+      this.mediaRecorder = new MediaRecorder(this.mediaStream);
       this.audioChunks = [];
 
       this.mediaRecorder.ondataavailable = (event) => {
@@ -399,32 +409,73 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   }
 
   async stopListening() {
-    // Clean up silence detection
-    if (this.silenceCheckInterval) {
-      clearInterval(this.silenceCheckInterval);
-      this.silenceCheckInterval = null;
-    }
-    this.analyserNode = null;
-    this.silenceStart = null;
+    this.vad.stop();
 
     if (this.mediaRecorder) {
+      if (this.interruptionMode !== "barge-in") {
+        this.mediaRecorder.stream.getTracks().forEach((track) => track.stop());
+      }
       this.mediaRecorder.stop();
-      this.mediaRecorder.stream.getTracks().forEach((track) => track.stop());
       this.mediaRecorder = null;
     }
 
-    // Clean up media stream reference
-    if (this.mediaStream) {
-      this.mediaStream.getTracks().forEach((track) => track.stop());
-      this.mediaStream = null;
-    }
-
-    if (this.audioContext) {
-      await this.audioContext.close();
-      this.audioContext = null;
+    // Only tear down mic pipeline in non-barge-in modes
+    if (this.interruptionMode !== "barge-in") {
+      if (this.mediaStream) {
+        this.mediaStream.getTracks().forEach((track) => track.stop());
+        this.mediaStream = null;
+      }
+      if (this.audioContext) {
+        await this.audioContext.close();
+        this.audioContext = null;
+      }
     }
 
     this.statusCallbacks.forEach((cb) => cb("idle"));
+  }
+
+  /**
+   * Start VAD in speech mode during agent playback — detects when the user
+   * starts talking so we can interrupt (barge-in). No-op in other modes.
+   * Acquires mic if needed (e.g., first response where stopListening tore it down).
+   */
+  private async startBargeInMonitoring(): Promise<void> {
+    if (this.interruptionMode !== "barge-in") return;
+
+    // Acquire mic pipeline if not already available (first response scenario)
+    const w = this.w;
+    if (!this.mediaStream && w) {
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        audio: { echoCancellation: true, noiseSuppression: true },
+      });
+    }
+    if (!this.audioContext && w) {
+      this.audioContext = new (w.AudioContext || w.webkitAudioContext)();
+    }
+    if (!this.audioContext || !this.mediaStream) return;
+
+    const speechThreshold = this.config?.silenceThreshold ?? 0.01;
+    const speechDebounce = 200; // 200ms sustained sound = real speech, not echo blip
+
+    this.vad.start(
+      this.audioContext,
+      this.mediaStream,
+      "speech",
+      { threshold: speechThreshold, duration: speechDebounce },
+      () => this.handleBargeIn(),
+    );
+  }
+
+  /**
+   * Handle a barge-in event: cancel playback and immediately start recording.
+   */
+  private handleBargeIn(): void {
+    this.cancelCurrentPlayback();
+    this.startListening().catch((err) => {
+      this.errorCallbacks.forEach((cb) =>
+        cb(err instanceof Error ? err : new Error(String(err))),
+      );
+    });
   }
 
   private generateRequestId(): string {
@@ -550,7 +601,18 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     this.currentRequestId = null;
     this.isSpeaking = false;
 
+    this.vad.stop();
     await this.stopListening();
+
+    // Force mic teardown (barge-in mode skips this in stopListening)
+    if (this.mediaStream) {
+      this.mediaStream.getTracks().forEach((track) => track.stop());
+      this.mediaStream = null;
+    }
+    if (this.audioContext) {
+      await this.audioContext.close();
+      this.audioContext = null;
+    }
 
     if (this.ws) {
       try {

--- a/packages/widget/src/voice/runtype-voice-provider.ts
+++ b/packages/widget/src/voice/runtype-voice-provider.ts
@@ -7,6 +7,7 @@ import type {
   VoiceStatus,
   VoiceConfig,
 } from "../types";
+import { AudioPlaybackManager } from "./audio-playback-manager";
 
 export class RuntypeVoiceProvider implements VoiceProvider {
   type: "runtype" = "runtype";
@@ -33,6 +34,9 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   private currentAudioUrl: string | null = null;
   private currentRequestId: string | null = null;
   private interruptionMode: "none" | "cancel" | "barge-in" = "none";
+
+  // Streaming audio playback (PCM chunks)
+  private playbackManager: AudioPlaybackManager | null = null;
 
   constructor(private config: VoiceConfig["runtype"]) {}
 
@@ -149,7 +153,17 @@ export class RuntypeVoiceProvider implements VoiceProvider {
       this.statusCallbacks.forEach((cb) => cb("error"));
     };
 
+    // Receive binary frames for streaming audio (set binaryType to arraybuffer)
+    this.ws.binaryType = "arraybuffer";
+
     this.ws.onmessage = (event) => {
+      // Binary frame = raw PCM audio chunk for streaming playback
+      if (event.data instanceof ArrayBuffer) {
+        this.handleAudioChunk(new Uint8Array(event.data));
+        return;
+      }
+
+      // Text frame = JSON control message
       try {
         const message = JSON.parse(event.data);
         this.handleWebSocketMessage(message);
@@ -183,14 +197,29 @@ export class RuntypeVoiceProvider implements VoiceProvider {
           }),
         );
 
-        // Play TTS audio if present — stay in "speaking" state until playback ends
+        // Batch path: play TTS audio if present in the response (backward compat)
         if (message.response.audio?.base64) {
           this.isSpeaking = true;
           this.statusCallbacks.forEach((cb) => cb("speaking"));
           this.playAudio(message.response.audio).catch((err) =>
             this.errorCallbacks.forEach((cb) => cb(err instanceof Error ? err : new Error(String(err)))),
           );
+        } else if (!message.response.audio?.base64) {
+          // Streaming path: text-only voice_response — audio will arrive as
+          // binary chunks followed by audio_end. Transition to speaking state
+          // once the first audio chunk arrives (see handleAudioChunk).
+          // Stay in processing state until then.
+        }
+        break;
+
+      case "audio_end":
+        // All PCM chunks have been sent — signal the playback manager
+        if (this.playbackManager) {
+          this.playbackManager.markStreamEnd();
         } else {
+          // No audio chunks arrived — go idle
+          this.isSpeaking = false;
+          this.isProcessing = false;
           this.statusCallbacks.forEach((cb) => cb("idle"));
         }
         break;
@@ -213,6 +242,31 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   }
 
   /**
+   * Handle a binary audio chunk (raw PCM 24kHz 16-bit LE) for streaming playback.
+   */
+  private handleAudioChunk(pcmData: Uint8Array): void {
+    if (pcmData.length === 0) return;
+
+    // Lazily create playback manager on first chunk
+    if (!this.playbackManager) {
+      this.playbackManager = new AudioPlaybackManager(24000);
+      this.playbackManager.onFinished(() => {
+        this.isSpeaking = false;
+        this.playbackManager = null;
+        this.statusCallbacks.forEach((cb) => cb("idle"));
+      });
+    }
+
+    // Transition to speaking on first chunk
+    if (!this.isSpeaking) {
+      this.isSpeaking = true;
+      this.statusCallbacks.forEach((cb) => cb("speaking"));
+    }
+
+    this.playbackManager.enqueue(pcmData);
+  }
+
+  /**
    * Stop playback / cancel in-flight request and return to idle.
    * This is the public "stop only" action — does NOT start recording.
    */
@@ -227,7 +281,7 @@ export class RuntypeVoiceProvider implements VoiceProvider {
    * Internal helper — does NOT fire status callbacks (caller decides next state).
    */
   private cancelCurrentPlayback(): void {
-    // Stop playing audio
+    // Stop batch playback (Audio element)
     if (this.currentAudio) {
       this.currentAudio.pause();
       this.currentAudio.src = "";
@@ -236,6 +290,12 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     if (this.currentAudioUrl) {
       URL.revokeObjectURL(this.currentAudioUrl);
       this.currentAudioUrl = null;
+    }
+
+    // Stop streaming playback (AudioPlaybackManager)
+    if (this.playbackManager) {
+      this.playbackManager.flush();
+      this.playbackManager = null;
     }
 
     // Tell server to abort the in-flight request
@@ -472,7 +532,7 @@ export class RuntypeVoiceProvider implements VoiceProvider {
   }
 
   async disconnect(): Promise<void> {
-    // Stop any playing audio
+    // Stop any playing audio (batch)
     if (this.currentAudio) {
       this.currentAudio.pause();
       this.currentAudio.src = "";
@@ -481,6 +541,11 @@ export class RuntypeVoiceProvider implements VoiceProvider {
     if (this.currentAudioUrl) {
       URL.revokeObjectURL(this.currentAudioUrl);
       this.currentAudioUrl = null;
+    }
+    // Stop streaming playback
+    if (this.playbackManager) {
+      await this.playbackManager.destroy();
+      this.playbackManager = null;
     }
     this.currentRequestId = null;
     this.isSpeaking = false;

--- a/packages/widget/src/voice/voice-activity-detector.ts
+++ b/packages/widget/src/voice/voice-activity-detector.ts
@@ -1,0 +1,90 @@
+/**
+ * Voice Activity Detector (VAD)
+ *
+ * Reusable RMS-based voice activity detection that monitors a mic stream
+ * and fires a callback when a condition is sustained for a given duration.
+ *
+ * - mode 'silence': fires when volume stays below threshold (user stopped talking)
+ * - mode 'speech':  fires when volume stays above threshold (user started talking)
+ *
+ * Fires callback exactly once per start() call, then stops checking.
+ * Calling start() again implicitly calls stop() first.
+ */
+export class VoiceActivityDetector {
+  private sourceNode: MediaStreamAudioSourceNode | null = null;
+  private analyserNode: AnalyserNode | null = null;
+  private interval: ReturnType<typeof setInterval> | null = null;
+  private conditionStart: number | null = null;
+  private fired = false;
+
+  /**
+   * Begin monitoring the given stream for voice activity.
+   *
+   * @param audioContext  Active AudioContext
+   * @param stream       MediaStream from getUserMedia
+   * @param mode         'silence' fires when quiet for duration, 'speech' fires when loud for duration
+   * @param config       threshold (RMS level) and duration (ms)
+   * @param callback     Fires exactly once when the condition is met
+   */
+  start(
+    audioContext: AudioContext,
+    stream: MediaStream,
+    mode: "silence" | "speech",
+    config: { threshold: number; duration: number },
+    callback: () => void,
+  ): void {
+    this.stop();
+
+    this.fired = false;
+    this.conditionStart = null;
+
+    this.sourceNode = audioContext.createMediaStreamSource(stream);
+    this.analyserNode = audioContext.createAnalyser();
+    this.analyserNode.fftSize = 2048;
+    this.sourceNode.connect(this.analyserNode);
+
+    const dataArray = new Float32Array(this.analyserNode.fftSize);
+
+    this.interval = setInterval(() => {
+      if (!this.analyserNode || this.fired) return;
+      this.analyserNode.getFloatTimeDomainData(dataArray);
+
+      // Compute RMS volume
+      let sum = 0;
+      for (let i = 0; i < dataArray.length; i++) {
+        sum += dataArray[i] * dataArray[i];
+      }
+      const rms = Math.sqrt(sum / dataArray.length);
+
+      const conditionMet =
+        mode === "silence"
+          ? rms < config.threshold
+          : rms >= config.threshold;
+
+      if (conditionMet) {
+        if (this.conditionStart === null) {
+          this.conditionStart = Date.now();
+        } else if (Date.now() - this.conditionStart >= config.duration) {
+          this.fired = true;
+          callback();
+        }
+      } else {
+        this.conditionStart = null;
+      }
+    }, 100);
+  }
+
+  stop(): void {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null;
+    }
+    if (this.sourceNode) {
+      this.sourceNode.disconnect();
+      this.sourceNode = null;
+    }
+    this.analyserNode = null;
+    this.conditionStart = null;
+    this.fired = false;
+  }
+}


### PR DESCRIPTION
### Add voice interruption and cancellation support to RuntypeVoiceProvider

- Handle `session_config` WebSocket message to receive server-side interruption mode (`none`, `cancel`, `barge-in`)
- New `cancelCurrentPlayback()` method stops audio playback and sends cancel request to server
- When interruption is enabled, `startListening()` cancels in-flight responses instead of throwing
- Track current audio element and request IDs for reliable cancellation and cleanup
- Handle `cancelled` WebSocket message for server-acknowledged cancellation
- Clean up audio resources on disconnect
- Demo: conditionally show browser voice controls based on active TTS provider

### Add barge-in voice interruption mode with always-on mic and speech detection

- New `VoiceActivityDetector` class provides reusable RMS-based VAD with two modes: `silence` (user stopped talking) and `speech` (user started talking)
- In barge-in mode the mic stays hot between turns — audio pipeline is reused instead of torn down after each utterance
- During agent playback, VAD monitors for sustained speech and automatically interrupts playback to begin recording
- Mic button shows recording state during agent speech in barge-in mode and acts as a "hang up" to end the session
- New `isBargeInActive()` and `deactivateBargeIn()` methods on `VoiceProvider` and `Session` for UI coordination
- Guard against late `audio_end` and audio chunks from cancelled requests