### PR TITLE
chore: prepare repo for open-source release

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,18 @@
+# Code of Conduct
+
+We are committed to providing a welcoming and inclusive environment for everyone who participates in this project.
+
+## Our standards
+
+- Be respectful and considerate in all interactions.
+- Welcome differing viewpoints and experiences.
+- Accept constructive feedback gracefully.
+- Focus on what is best for the community and project.
+
+## Unacceptable behavior
+
+Harassment, personal attacks, discriminatory language, and other conduct that creates an unwelcoming environment are not acceptable.
+
+## Enforcement
+
+Instances of unacceptable behavior may be reported by opening a GitHub issue or contacting the maintainers directly. All reports will be reviewed and addressed appropriately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,44 @@
+# Contributing to Persona
+
+Thanks for your interest in contributing!
+
+## Setup
+
+**Requirements:** Node.js ≥18.17.0, pnpm
+
+```bash
+pnpm install
+pnpm dev        # starts proxy (port 43111) + widget demo (port 5173)
+```
+
+## Development workflow
+
+```bash
+pnpm build          # build both packages
+pnpm lint           # lint
+pnpm typecheck      # type check
+
+# Tests (from packages/widget)
+cd packages/widget
+pnpm test:run       # run once
+pnpm test           # watch mode
+```
+
+## Submitting changes
+
+1. Fork the repo and create a branch from `main`.
+2. Make your changes and ensure `pnpm lint`, `pnpm typecheck`, and tests all pass.
+3. **Create a changeset** — this is required for any change to a published package:
+   ```bash
+   pnpm changeset
+   ```
+   Select the affected packages, choose a semver bump type, and write a short description. Commit the generated file in `.changeset/` alongside your code changes.
+4. Open a pull request against `main`.
+
+## What needs a changeset
+
+Changes to `packages/widget` or `packages/proxy` need a changeset. Changes to `examples/`, docs, CI, or tooling do not.
+
+## Reporting bugs
+
+Open an issue at https://github.com/runtypelabs/persona/issues. Include a minimal reproduction if possible.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Runtype
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest  | Yes       |
+
+## Reporting a vulnerability
+
+Please do **not** open a public GitHub issue for security vulnerabilities.
+
+Instead, use [GitHub's private security advisory feature](https://github.com/runtypelabs/persona/security/advisories/new) to report the issue confidentially.
+
+We aim to acknowledge reports within 48 hours and will keep you updated as we investigate and resolve the issue.

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -38,6 +38,7 @@
   "engines": {
     "node": ">=18.17.0"
   },
+  "author": "Runtype",
   "license": "MIT",
   "keywords": [
     "ai",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -58,6 +58,7 @@
   "engines": {
     "node": ">=18.17.0"
   },
+  "author": "Runtype",
   "license": "MIT",
   "keywords": [
     "ai",

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -45,7 +45,6 @@ const DEFAULT_CLIENT_API_BASE = "https://api.runtype.com";
  * Check if a message has valid (non-empty) content for sending to the API.
  * Filters out messages with empty content that would cause validation errors.
  *
- * @see https://github.com/anthropics/claude-code/issues/XXX - Empty assistant messages from failed requests
  */
 const hasValidContent = (message: AgentWidgetMessage): boolean => {
   // Check contentParts (multi-modal content)


### PR DESCRIPTION
## Summary

- Adds root `LICENSE` file (MIT, 2026 Runtype) so GitHub recognizes the license
- Adds `CONTRIBUTING.md` covering dev setup, test/lint commands, PR workflow, and the changeset requirement
- Adds `SECURITY.md` directing reporters to GitHub private advisories
- Adds `CODE_OF_CONDUCT.md`
- Adds `"author": "Runtype"` to both published `package.json` files
- Removes a broken `@see` comment in `client.ts` that linked to the wrong repo with a placeholder issue number

## Test plan

- [ ] Confirm GitHub shows the MIT license badge on the repo after merge
- [ ] `pnpm build && pnpm lint && pnpm typecheck` pass
- [ ] `pnpm --filter @runtypelabs/persona test:run` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to new repository policy/docs files, package metadata, and removing a broken comment with no runtime behavior impact.
> 
> **Overview**
> Prepares the repository for open-source distribution by adding **community and policy documentation**: `LICENSE` (MIT), `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md`, and `SECURITY.md`.
> 
> Updates published package metadata by adding `"author": "Runtype"` to `packages/widget/package.json` and `packages/proxy/package.json`, and removes a broken placeholder `@see` comment in `packages/widget/src/client.ts`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb7e57dba1f29102d0c44068ad10993071c41388. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->