### PR TITLE
fix: ensure widget styles load on first dev server start

### DIFF
--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -232,14 +232,14 @@ export default defineConfig({
   plugins: [serveWidgetDist(), previewEmbedCheck()],
   resolve: {
     alias: {
+      "@runtypelabs/persona/widget.css": path.resolve(
+        __dirname,
+        "../../packages/widget/src/styles/widget.css"
+      ),
       "@runtypelabs/persona": path.resolve(
         __dirname,
         "../../packages/widget/src"
       ),
-      "@runtypelabs/persona/widget.css": path.resolve(
-        __dirname,
-        "../../packages/widget/src/styles/widget.css"
-      )
     }
   },
   build: {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:widget": "pnpm --filter embedded-app dev",
     "dev:vercel": "pnpm --filter vercel-edge dev",
     "dev:cloudflare": "pnpm --filter cloudflare-workers dev",
-    "dev": "concurrently \"pnpm dev:vercel\" \"pnpm dev:widget\"",
+    "dev": "pnpm --filter @runtypelabs/persona build:styles && concurrently \"pnpm dev:vercel\" \"pnpm dev:widget\"",
     "changeset": "changeset",
     "release": "changeset publish"
   },


### PR DESCRIPTION
## Summary

- Run `build:styles` before starting dev servers so `dist/widget.css` exists from the start — Vite may use the `\"default\"` condition from the package `exports` field when resolving the CSS import, which points to `./dist/widget.css`
- Fix Vite alias order so the specific `@runtypelabs/persona/widget.css` alias is checked before the `@runtypelabs/persona` prefix alias — previously the shorter prefix was winning via prefix-match, routing through `src/widget.css → @import` instead of directly to `src/styles/widget.css`

## Test plan

- [ ] Clone fresh, run `pnpm dev`, confirm styles load immediately without needing to run `pnpm build` first
- [ ] Confirm `pnpm dev` still works normally after a build

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to dev scripts and Vite aliasing to ensure CSS is available/resolved correctly during local development.
> 
> **Overview**
> Ensures widget CSS loads on the first `pnpm dev` run by prebuilding styles (`pnpm --filter @runtypelabs/persona build:styles`) before starting the concurrent dev servers.
> 
> Fixes Vite CSS resolution in `examples/embedded-app/vite.config.ts` by ordering the more specific `@runtypelabs/persona/widget.css` alias ahead of the broader `@runtypelabs/persona` alias so the CSS import maps directly to the source stylesheet.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1360af6cc8a5cbdec5882bae0c3003c486342de9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->