### PR TITLE
feat: HTML sanitization and security hardening

### DIFF
--- a/.changeset/blocked-image-preview.md
+++ b/.changeset/blocked-image-preview.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Prevent blocked image attachments from being appended as empty broken-image placeholders when a message also contains valid image previews.

--- a/.changeset/security-hardening.md
+++ b/.changeset/security-hardening.md
@@ -1,0 +1,6 @@
+---
+"@runtypelabs/persona": minor
+"@runtypelabs/persona-proxy": patch
+---
+
+Add built-in HTML sanitization via DOMPurify, enabled by default. Configure with the new `sanitize` option: `true` (default), `false` (disable), or a custom `(html: string) => string` function. Also fixes proxy dev-mode CORS defaults, adds prototype pollution protection in config parsing, and validates image URL schemes to block SVG data URIs and javascript: sources.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,6 +112,8 @@ The widget uses a layered architecture:
 
 **Theme System:** CSS custom properties (variables) + Tailwind with the `tvw-` prefix. The `tokens.ts` and `theme.ts` utilities manage runtime theme application. See `packages/widget/THEME-CONFIG.md` for the full theming reference.
 
+**HTML Sanitization:** All rendered markdown is sanitized via DOMPurify by default (`utils/sanitize.ts`). Configurable per-widget via the `sanitize` option: `true` (default), `false`, or a custom `(html: string) => string` function. When writing sanitization hooks, always compare URI schemes case-insensitively (e.g. `val.toLowerCase().startsWith("data:")`) per RFC 3986.
+
 ### Proxy Package (`packages/proxy/src/`)
 
 Hono-based server that proxies requests to the Runtype API:
@@ -121,6 +123,8 @@ Hono-based server that proxies requests to the Runtype API:
   - `shopping-assistant.ts` - E-commerce flow
   - `scheduling.ts` - Calendar/scheduling flow
   - `bakery-assistant.ts` - Example specialized flow
+
+**CORS / `NODE_ENV`:** The proxy only enables permissive CORS when `NODE_ENV` is **exactly** `"development"`. An unset `NODE_ENV` is treated as production (origins must match the `allowedOrigins` list). The root `pnpm dev` script sets `NODE_ENV=development` automatically. If you start the proxy directly (e.g. `pnpm dev:vercel`), set it yourself or configure it in your `.env` file.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev:widget": "pnpm --filter embedded-app dev",
     "dev:vercel": "pnpm --filter vercel-edge dev",
     "dev:cloudflare": "pnpm --filter cloudflare-workers dev",
-    "dev": "pnpm --filter @runtypelabs/persona build:styles && concurrently \"pnpm dev:vercel\" \"pnpm dev:widget\"",
+    "dev": "pnpm --filter @runtypelabs/persona build:styles && NODE_ENV=development concurrently \"pnpm dev:vercel\" \"pnpm dev:widget\"",
     "changeset": "changeset",
     "release": "changeset publish"
   },

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -33,7 +33,8 @@
     "eslint-config-prettier": "^9.1.0",
     "rimraf": "^5.0.5",
     "tsup": "^8.0.1",
-    "typescript": "^5.4.5"
+    "typescript": "^5.4.5",
+    "vitest": "^4.1.0"
   },
   "engines": {
     "node": ">=18.17.0"

--- a/packages/proxy/src/index.test.ts
+++ b/packages/proxy/src/index.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { createChatProxyApp } from "./index";
+
+describe("CORS middleware", () => {
+  const savedEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedEnv;
+  });
+
+  const preflight = (app: ReturnType<typeof createChatProxyApp>, origin: string, headers?: Record<string, string>) =>
+    app.request("/api/chat/dispatch", {
+      method: "OPTIONS",
+      headers: { Origin: origin, ...headers },
+    });
+
+  it("allows any origin when allowedOrigins is not configured", async () => {
+    const app = createChatProxyApp();
+    const res = await preflight(app, "https://evil.com");
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://evil.com");
+  });
+
+  it("allows matching origin from allowlist", async () => {
+    const app = createChatProxyApp({ allowedOrigins: ["https://good.com"] });
+    const res = await preflight(app, "https://good.com");
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://good.com");
+  });
+
+  it("rejects non-matching origin in production with 403", async () => {
+    process.env.NODE_ENV = "production";
+    const app = createChatProxyApp({ allowedOrigins: ["https://good.com"] });
+    const res = await preflight(app, "https://evil.com");
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects non-matching origin when NODE_ENV is unset", async () => {
+    delete process.env.NODE_ENV;
+    const app = createChatProxyApp({ allowedOrigins: ["https://good.com"] });
+    const res = await preflight(app, "https://evil.com");
+    expect(res.status).toBe(403);
+  });
+
+  it("allows non-matching origin in explicit development mode", async () => {
+    process.env.NODE_ENV = "development";
+    const app = createChatProxyApp({ allowedOrigins: ["https://good.com"] });
+    const res = await preflight(app, "https://localhost:3000");
+    expect(res.status).toBe(204);
+    expect(res.headers.get("Access-Control-Allow-Origin")).toBe("https://localhost:3000");
+  });
+
+  it("uses static Access-Control-Allow-Headers (not reflected)", async () => {
+    const app = createChatProxyApp();
+    const res = await preflight(app, "https://example.com", {
+      "Access-Control-Request-Headers": "X-Evil-Header, X-Custom",
+    });
+    expect(res.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type, Authorization");
+  });
+
+  it("returns 204 for OPTIONS preflight", async () => {
+    const app = createChatProxyApp();
+    const res = await preflight(app, "https://example.com");
+    expect(res.status).toBe(204);
+  });
+
+  it("includes Vary: Origin header", async () => {
+    const app = createChatProxyApp();
+    const res = await preflight(app, "https://example.com");
+    expect(res.headers.get("Vary")).toBe("Origin");
+  });
+});

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -93,7 +93,7 @@ const withCors =
   (allowedOrigins: string[] | undefined) =>
     async (c: Context, next: () => Promise<void>) => {
       const origin = c.req.header("origin");
-      const isDevelopment = process.env.NODE_ENV === "development" || !process.env.NODE_ENV;
+      const isDevelopment = process.env.NODE_ENV === "development";
       
       // Determine the CORS origin to allow
       let corsOrigin: string;
@@ -120,9 +120,7 @@ const withCors =
 
       const headers: Record<string, string> = {
         "Access-Control-Allow-Origin": corsOrigin,
-        "Access-Control-Allow-Headers":
-          c.req.header("access-control-request-headers") ??
-          "Content-Type, Authorization",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
         "Access-Control-Allow-Methods": "POST, OPTIONS",
         Vary: "Origin"
       };
@@ -169,7 +167,7 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
     payload.timestamp = payload.timestamp ?? new Date().toISOString();
 
     const isDevelopment =
-      process.env.NODE_ENV === "development" || !process.env.NODE_ENV;
+      process.env.NODE_ENV === "development";
 
     if (isDevelopment) {
       console.log("\n=== Feedback Received ===");
@@ -224,7 +222,7 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
       );
     }
 
-    const isDevelopment = process.env.NODE_ENV === "development" || !process.env.NODE_ENV;
+    const isDevelopment = process.env.NODE_ENV === "development";
 
     // Detect agent mode: if the payload contains an `agent` field, forward it directly
     const isAgentMode = !!clientPayload.agent;

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -34,6 +34,7 @@
     "test:run": "vitest run"
   },
   "dependencies": {
+    "dompurify": "^3.3.3",
     "idiomorph": "^0.7.4",
     "lucide": "^0.552.0",
     "marked": "^12.0.2",

--- a/packages/widget/src/components/artifact-pane.ts
+++ b/packages/widget/src/components/artifact-pane.ts
@@ -1,6 +1,7 @@
 import { createElement } from "../utils/dom";
 import type { AgentWidgetConfig, AgentWidgetMessage, PersonaArtifactRecord } from "../types";
 import { escapeHtml, createMarkdownProcessorFromConfig } from "../postprocessors";
+import { resolveSanitizer } from "../utils/sanitize";
 import { componentRegistry, type ComponentContext } from "./registry";
 import { renderLucideIcon } from "../utils/icons";
 
@@ -102,7 +103,11 @@ export function createArtifactPane(
   const panePadding = layout?.panePadding?.trim();
 
   const md = config.markdown ? createMarkdownProcessorFromConfig(config.markdown) : null;
-  const toHtml = (text: string) => (md ? md(text) : escapeHtml(text));
+  const sanitize = resolveSanitizer(config.sanitize);
+  const toHtml = (text: string) => {
+    const raw = md ? md(text) : escapeHtml(text);
+    return sanitize ? sanitize(raw) : raw;
+  };
 
   const backdrop =
     typeof document !== "undefined"

--- a/packages/widget/src/components/message-bubble.test.ts
+++ b/packages/widget/src/components/message-bubble.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { isSafeImageSrc } from "./message-bubble";
+
+describe("isSafeImageSrc", () => {
+  it("allows https URLs", () => {
+    expect(isSafeImageSrc("https://example.com/img.png")).toBe(true);
+  });
+
+  it("allows http URLs", () => {
+    expect(isSafeImageSrc("http://example.com/img.png")).toBe(true);
+  });
+
+  it("allows blob URLs", () => {
+    expect(isSafeImageSrc("blob:http://example.com/abc-123")).toBe(true);
+  });
+
+  it("allows data:image/png URIs", () => {
+    expect(isSafeImageSrc("data:image/png;base64,abc123")).toBe(true);
+  });
+
+  it("allows data:image/jpeg URIs", () => {
+    expect(isSafeImageSrc("data:image/jpeg;base64,abc123")).toBe(true);
+  });
+
+  it("allows data:image/gif URIs", () => {
+    expect(isSafeImageSrc("data:image/gif;base64,abc123")).toBe(true);
+  });
+
+  it("allows data:image/webp URIs", () => {
+    expect(isSafeImageSrc("data:image/webp;base64,abc123")).toBe(true);
+  });
+
+  it("blocks data:image/svg+xml URIs", () => {
+    expect(isSafeImageSrc("data:image/svg+xml,<svg onload=alert(1)>")).toBe(false);
+  });
+
+  it("blocks data:image/svg+xml with base64", () => {
+    expect(isSafeImageSrc("data:image/svg+xml;base64,PHN2Zz4=")).toBe(false);
+  });
+
+  it("blocks mixed-case SVG data URIs", () => {
+    expect(isSafeImageSrc("data:image/Svg+xml,<svg onload=alert(1)>")).toBe(false);
+    expect(isSafeImageSrc("data:image/SVG+XML,<svg>")).toBe(false);
+    expect(isSafeImageSrc("data:Image/SVG+XML;base64,abc")).toBe(false);
+  });
+
+  it("blocks javascript: URIs", () => {
+    expect(isSafeImageSrc("javascript:alert(1)")).toBe(false);
+  });
+
+  it("blocks data:text/html URIs", () => {
+    expect(isSafeImageSrc("data:text/html,<script>alert(1)</script>")).toBe(false);
+  });
+
+  it("allows relative paths (no colon)", () => {
+    expect(isSafeImageSrc("relative/path.png")).toBe(true);
+  });
+
+  it("allows dot-relative paths", () => {
+    expect(isSafeImageSrc("./image.png")).toBe(true);
+  });
+
+  it("allows empty string", () => {
+    expect(isSafeImageSrc("")).toBe(true);
+  });
+});

--- a/packages/widget/src/components/message-bubble.test.ts
+++ b/packages/widget/src/components/message-bubble.test.ts
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, it, expect } from "vitest";
 import { createStandardBubble, isSafeImageSrc } from "./message-bubble";
 import type { AgentWidgetMessage } from "../types";

--- a/packages/widget/src/components/message-bubble.test.ts
+++ b/packages/widget/src/components/message-bubble.test.ts
@@ -1,5 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { isSafeImageSrc } from "./message-bubble";
+import { createStandardBubble, isSafeImageSrc } from "./message-bubble";
+import type { AgentWidgetMessage } from "../types";
+
+const makeMessage = (overrides: Partial<AgentWidgetMessage> = {}): AgentWidgetMessage => ({
+  id: "msg-1",
+  role: "assistant",
+  content: "",
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
 
 describe("isSafeImageSrc", () => {
   it("allows https URLs", () => {
@@ -62,5 +71,26 @@ describe("isSafeImageSrc", () => {
 
   it("allows empty string", () => {
     expect(isSafeImageSrc("")).toBe(true);
+  });
+});
+
+describe("createStandardBubble", () => {
+  it("skips rendering blocked image previews while keeping safe ones", () => {
+    const bubble = createStandardBubble(
+      makeMessage({
+        content: "Image attachments",
+        contentParts: [
+          { type: "image", image: "https://example.com/safe.png", alt: "Safe image" },
+          { type: "image", image: "data:image/svg+xml,<svg onload=alert(1)>", alt: "Blocked image" },
+        ],
+      }),
+      ({ text }) => text
+    );
+
+    const previewImages = bubble.querySelectorAll('[data-message-attachments="images"] img');
+
+    expect(previewImages).toHaveLength(1);
+    expect(previewImages[0]?.getAttribute("src")).toBe("https://example.com/safe.png");
+    expect(previewImages[0]?.getAttribute("alt")).toBe("Safe image");
   });
 });

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -113,13 +113,13 @@ const createMessageImagePreviews = (
 
       if (isSafeImageSrc(imagePart.image)) {
         imageElement.src = imagePart.image;
+        container.appendChild(imageElement);
       } else {
         // Treat blocked images like load errors so fallback triggers correctly
         settled = true;
         visiblePreviewCount = Math.max(0, visiblePreviewCount - 1);
         imageElement.remove();
       }
-      container.appendChild(imageElement);
     });
 
     if (visiblePreviewCount === 0) {

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -12,6 +12,17 @@ import {
 import { renderLucideIcon } from "../utils/icons";
 import { IMAGE_ONLY_MESSAGE_FALLBACK_TEXT } from "../utils/content";
 
+/** Validate that an image src URL uses a safe scheme (blocks javascript: and SVG data URIs). */
+export const isSafeImageSrc = (src: string): boolean => {
+  const lower = src.toLowerCase();
+  if (lower.startsWith("data:image/svg+xml")) return false;
+  if (/^(?:https?|blob):/i.test(src)) return true;
+  if (lower.startsWith("data:image/")) return true;
+  // Relative URLs are safe
+  if (!src.includes(":")) return true;
+  return false;
+};
+
 export type LoadingIndicatorRenderer = (context: LoadingIndicatorRenderContext) => HTMLElement | null;
 
 export type MessageTransform = (context: {
@@ -100,7 +111,14 @@ const createMessageImagePreviews = (
         settled = true;
       });
 
-      imageElement.src = imagePart.image;
+      if (isSafeImageSrc(imagePart.image)) {
+        imageElement.src = imagePart.image;
+      } else {
+        // Treat blocked images like load errors so fallback triggers correctly
+        settled = true;
+        visiblePreviewCount = Math.max(0, visiblePreviewCount - 1);
+        imageElement.remove();
+      }
       container.appendChild(imageElement);
     });
 

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -122,6 +122,11 @@ export {
 } from "./postprocessors";
 export type { MarkdownProcessorOptions } from "./postprocessors";
 export {
+  createDefaultSanitizer,
+  resolveSanitizer
+} from "./utils/sanitize";
+export type { SanitizeFunction } from "./utils/sanitize";
+export {
   createPlainTextParser,
   createJsonStreamParser,
   createFlexibleJsonStreamParser,

--- a/packages/widget/src/install-config.test.ts
+++ b/packages/widget/src/install-config.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+
+describe("prototype pollution guard", () => {
+  it("strips __proto__, constructor, and prototype from parsed config", () => {
+    // Simulates the destructuring pattern used in install.ts
+    const malicious = JSON.parse(
+      '{"config":{"apiUrl":"http://localhost"},"__proto__":{"polluted":true},"constructor":{"polluted":true},"prototype":{"polluted":true}}'
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { __proto__: _a, constructor: _b, prototype: _c, ...safeConfig } = malicious;
+
+    const target: Record<string, unknown> = {};
+    Object.assign(target, safeConfig);
+
+    // The dangerous keys should not be on the target
+    expect(Object.keys(target)).toEqual(["config"]);
+    expect((target as any).__proto__).toBe(Object.prototype); // normal prototype, not polluted
+    expect((target as any).constructor).toBe(Object); // normal constructor
+
+    // Global prototype should not be polluted
+    expect(({} as any).polluted).toBeUndefined();
+  });
+
+  it("preserves safe config properties", () => {
+    const parsed = JSON.parse(
+      '{"config":{"apiUrl":"http://localhost"},"clientToken":"tok_123","flowId":"flow-1"}'
+    );
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { __proto__: _a, constructor: _b, prototype: _c, ...safeConfig } = parsed;
+
+    expect(safeConfig).toEqual({
+      config: { apiUrl: "http://localhost" },
+      clientToken: "tok_123",
+      flowId: "flow-1",
+    });
+  });
+});

--- a/packages/widget/src/install.ts
+++ b/packages/widget/src/install.ts
@@ -58,7 +58,9 @@ declare global {
         const parsedConfig = JSON.parse(configJson);
         // If it has nested 'config' property, use it; otherwise treat as widget config
         if (parsedConfig.config) {
-          Object.assign(scriptConfig, parsedConfig);
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { __proto__: _a, constructor: _b, prototype: _c, ...safeConfig } = parsedConfig;
+          Object.assign(scriptConfig, safeConfig);
         } else {
           // Treat the entire object as widget config
           scriptConfig.config = parsedConfig;

--- a/packages/widget/src/postprocessors.test.ts
+++ b/packages/widget/src/postprocessors.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import {
+  createMarkdownProcessor,
+  createDirectivePostprocessor,
+  escapeHtml,
+} from "./postprocessors";
+import { createDefaultSanitizer } from "./utils/sanitize";
+
+describe("markdown + sanitization integration", () => {
+  const md = createMarkdownProcessor();
+  const sanitize = createDefaultSanitizer();
+
+  it("strips script tags from markdown output", () => {
+    const html = sanitize(md("# Title\n<script>alert(1)</script>"));
+    expect(html).toContain("<h1>Title</h1>");
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("alert(1)");
+  });
+
+  it("strips onerror handlers from img tags in markdown", () => {
+    const html = sanitize(md('<img src="x" onerror="alert(1)">'));
+    expect(html).not.toContain("onerror");
+  });
+
+  it("strips javascript: URIs from markdown links", () => {
+    const html = sanitize(md('[click](javascript:alert(1))'));
+    expect(html).not.toContain("javascript:");
+  });
+
+  it("preserves safe markdown headings", () => {
+    const html = sanitize(md("## Hello\n\nParagraph text."));
+    expect(html).toContain("<h2>Hello</h2>");
+    expect(html).toContain("<p>Paragraph text.</p>");
+  });
+
+  it("preserves safe markdown code blocks", () => {
+    const html = sanitize(md("```js\nconst x = 1;\n```"));
+    expect(html).toContain("<code");
+    expect(html).toContain("const x = 1;");
+  });
+
+  it("preserves safe links", () => {
+    const html = sanitize(md("[example](https://example.com)"));
+    expect(html).toContain('href="https://example.com"');
+  });
+});
+
+describe("directive postprocessor + sanitization", () => {
+  const directive = createDirectivePostprocessor();
+  const sanitize = createDefaultSanitizer();
+
+  it("preserves form directive placeholders", () => {
+    const html = sanitize(directive('<Form type="init" />'));
+    expect(html).toContain('data-tv-form="init"');
+    expect(html).toContain("persona-form-directive");
+  });
+
+  it("sanitizes content surrounding directives", () => {
+    const html = sanitize(directive('<Form type="init" />\n<script>bad</script>'));
+    expect(html).toContain('data-tv-form="init"');
+    expect(html).not.toContain("<script>");
+    expect(html).not.toContain("bad");
+  });
+
+  it("handles JSON-style directives", () => {
+    const html = sanitize(
+      directive('<Directive>{"component":"form","type":"contact"}</Directive>')
+    );
+    expect(html).toContain('data-tv-form="contact"');
+  });
+});
+
+describe("escapeHtml", () => {
+  it("escapes all HTML special characters", () => {
+    expect(escapeHtml('<script>alert("xss")&</script>')).toBe(
+      "&lt;script&gt;alert(&quot;xss&quot;)&amp;&lt;/script&gt;"
+    );
+  });
+
+  it("escapes single quotes", () => {
+    expect(escapeHtml("it's")).toBe("it&#39;s");
+  });
+});

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -2571,7 +2571,21 @@ export type AgentWidgetConfig = {
    * ```
    */
   markdown?: AgentWidgetMarkdownConfig;
-  
+
+  /**
+   * HTML sanitization for rendered message content.
+   *
+   * The widget renders AI-generated markdown as HTML. By default, all HTML
+   * output is sanitized using DOMPurify to prevent XSS attacks.
+   *
+   * - `true` (default): sanitize using built-in DOMPurify
+   * - `false`: disable sanitization (only use with fully trusted content sources)
+   * - `(html: string) => string`: custom sanitizer function
+   *
+   * @default true
+   */
+  sanitize?: boolean | ((html: string) => string);
+
   /**
    * Configuration for message action buttons (copy, upvote, downvote).
    * Shows action buttons on assistant messages for user feedback.

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1,4 +1,5 @@
 import { escapeHtml, createMarkdownProcessorFromConfig } from "./postprocessors";
+import { resolveSanitizer } from "./utils/sanitize";
 import { AgentWidgetSession, AgentWidgetSessionStatus } from "./session";
 import {
   AgentWidgetConfig,
@@ -321,6 +322,9 @@ const buildPostprocessor = (
     ? createMarkdownProcessorFromConfig(cfg.markdown)
     : null;
 
+  // Resolve sanitizer: enabled by default, can be disabled or replaced
+  const sanitize = resolveSanitizer(cfg?.sanitize);
+
   return (context) => {
     let nextText = context.text ?? "";
     const rawPayload = context.message.rawContent ?? null;
@@ -347,20 +351,20 @@ const buildPostprocessor = (
     }
 
     // Priority: postprocessMessage > markdown config > escapeHtml
+    let html: string;
     if (cfg?.postprocessMessage) {
-      return cfg.postprocessMessage({
+      html = cfg.postprocessMessage({
         ...context,
         text: nextText,
         raw: rawPayload ?? context.text ?? ""
       });
+    } else if (markdownProcessor) {
+      html = markdownProcessor(nextText);
+    } else {
+      html = escapeHtml(nextText);
     }
 
-    // Use markdown processor if markdown config is provided
-    if (markdownProcessor) {
-      return markdownProcessor(nextText);
-    }
-
-    return escapeHtml(nextText);
+    return sanitize ? sanitize(html) : html;
   };
 };
 

--- a/packages/widget/src/utils/actions.test.ts
+++ b/packages/widget/src/utils/actions.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  defaultJsonActionParser,
+  defaultActionHandlers,
+  createActionManager,
+} from "./actions";
+import type { AgentWidgetMessage } from "../types";
+
+const makeMessage = (overrides: Partial<AgentWidgetMessage> = {}): AgentWidgetMessage => ({
+  id: "msg-1",
+  role: "assistant",
+  content: "",
+  createdAt: new Date().toISOString(),
+  ...overrides,
+});
+
+describe("defaultJsonActionParser", () => {
+  it("parses valid action JSON", () => {
+    const result = defaultJsonActionParser({
+      text: '{"action":"message","text":"hi"}',
+      message: makeMessage(),
+    });
+    expect(result).toEqual({
+      type: "message",
+      payload: { text: "hi" },
+      raw: { action: "message", text: "hi" },
+    });
+  });
+
+  it("returns null for non-action JSON", () => {
+    const result = defaultJsonActionParser({
+      text: '{"foo":"bar"}',
+      message: makeMessage(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for non-JSON text", () => {
+    const result = defaultJsonActionParser({
+      text: "hello world",
+      message: makeMessage(),
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null for empty text", () => {
+    expect(defaultJsonActionParser({ text: "", message: makeMessage() })).toBeNull();
+  });
+
+  it("strips code fences before parsing", () => {
+    const text = '```json\n{"action":"message","text":"fenced"}\n```';
+    const result = defaultJsonActionParser({ text, message: makeMessage() });
+    expect(result).toEqual({
+      type: "message",
+      payload: { text: "fenced" },
+      raw: { action: "message", text: "fenced" },
+    });
+  });
+});
+
+describe("createActionManager.process", () => {
+  const makeManager = (overrides?: Record<string, unknown>) => {
+    let metadata: Record<string, unknown> = {};
+    return createActionManager({
+      parsers: [defaultJsonActionParser],
+      handlers: [defaultActionHandlers.message],
+      getSessionMetadata: () => metadata,
+      updateSessionMetadata: (updater) => { metadata = updater(metadata); },
+      emit: vi.fn(),
+      documentRef: null,
+      ...overrides,
+    });
+  };
+
+  it("skips streaming messages", () => {
+    const manager = makeManager();
+    const result = manager.process({
+      text: '{"action":"message","text":"hi"}',
+      message: makeMessage(),
+      streaming: true,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("skips non-assistant messages", () => {
+    const manager = makeManager();
+    const result = manager.process({
+      text: '{"action":"message","text":"hi"}',
+      message: makeMessage({ role: "user" }),
+      streaming: false,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("deduplicates by message ID", () => {
+    const manager = makeManager();
+    const msg = makeMessage({ content: '{"action":"message","text":"hi"}' });
+    const first = manager.process({ text: msg.content, message: msg, streaming: false });
+    expect(first).not.toBeNull();
+
+    const second = manager.process({ text: msg.content, message: msg, streaming: false });
+    expect(second).toBeNull();
+  });
+
+  it("processes valid action and returns display text", () => {
+    const manager = makeManager();
+    const result = manager.process({
+      text: '{"action":"message","text":"hello"}',
+      message: makeMessage(),
+      streaming: false,
+    });
+    expect(result).toEqual({ text: "hello", persist: true, resubmit: undefined });
+  });
+});

--- a/packages/widget/src/utils/sanitize.test.ts
+++ b/packages/widget/src/utils/sanitize.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { createDefaultSanitizer, resolveSanitizer } from "./sanitize";
+
+describe("createDefaultSanitizer", () => {
+  const sanitize = createDefaultSanitizer();
+
+  it("strips <script> tags", () => {
+    expect(sanitize("<p>Hello</p><script>alert(1)</script>")).toBe("<p>Hello</p>");
+  });
+
+  it("strips onerror event handlers from img tags", () => {
+    const result = sanitize('<img src="x" onerror="alert(1)">');
+    expect(result).not.toContain("onerror");
+    expect(result).toContain("<img");
+  });
+
+  it("strips javascript: URIs from links", () => {
+    const result = sanitize('<a href="javascript:alert(1)">click</a>');
+    expect(result).not.toContain("javascript:");
+  });
+
+  it("strips onclick handlers", () => {
+    const result = sanitize('<div onclick="alert(1)">click</div>');
+    expect(result).not.toContain("onclick");
+  });
+
+  it("allows safe markdown output: headings", () => {
+    expect(sanitize("<h1>Title</h1>")).toBe("<h1>Title</h1>");
+    expect(sanitize("<h2>Subtitle</h2>")).toBe("<h2>Subtitle</h2>");
+  });
+
+  it("allows safe markdown output: paragraphs and formatting", () => {
+    expect(sanitize("<p><strong>bold</strong> and <em>italic</em></p>"))
+      .toBe("<p><strong>bold</strong> and <em>italic</em></p>");
+  });
+
+  it("allows safe markdown output: lists", () => {
+    const html = "<ul><li>one</li><li>two</li></ul>";
+    expect(sanitize(html)).toBe(html);
+  });
+
+  it("allows safe markdown output: code blocks", () => {
+    const html = '<pre><code class="language-js">const x = 1;</code></pre>';
+    expect(sanitize(html)).toBe(html);
+  });
+
+  it("allows safe markdown output: tables", () => {
+    const html = "<table><thead><tr><th>Col</th></tr></thead><tbody><tr><td>Val</td></tr></tbody></table>";
+    expect(sanitize(html)).toBe(html);
+  });
+
+  it("allows safe links with href", () => {
+    const html = '<a href="https://example.com" target="_blank">link</a>';
+    expect(sanitize(html)).toBe(html);
+  });
+
+  it("allows safe images with https src", () => {
+    const html = '<img src="https://example.com/img.png" alt="pic">';
+    expect(sanitize(html)).toBe(html);
+  });
+
+  it("allows data:image/ URIs (non-SVG)", () => {
+    const html = '<img src="data:image/png;base64,abc123" alt="pic">';
+    expect(sanitize(html)).toBe(html);
+  });
+
+  it("blocks data:image/svg+xml URIs", () => {
+    const result = sanitize('<img src="data:image/svg+xml,<svg onload=alert(1)>">');
+    expect(result).not.toContain("data:image/svg+xml");
+  });
+
+  it("preserves widget-specific data attributes", () => {
+    const html = '<div class="persona-form-directive" data-tv-form="init"></div>';
+    expect(sanitize(html)).toBe(html);
+  });
+
+  it("preserves data-persona-component-directive", () => {
+    const html = '<div data-persona-component-directive="card"></div>';
+    expect(sanitize(html)).toBe(html);
+  });
+});
+
+describe("resolveSanitizer", () => {
+  it("returns default sanitizer for undefined", () => {
+    const fn = resolveSanitizer(undefined);
+    expect(fn).toBeTypeOf("function");
+    expect(fn!("<script>bad</script>")).toBe("");
+  });
+
+  it("returns default sanitizer for true", () => {
+    const fn = resolveSanitizer(true);
+    expect(fn).toBeTypeOf("function");
+    expect(fn!("<script>bad</script>")).toBe("");
+  });
+
+  it("returns null for false (disabled)", () => {
+    expect(resolveSanitizer(false)).toBeNull();
+  });
+
+  it("returns the custom function as-is", () => {
+    const custom = (html: string) => html.toUpperCase();
+    const fn = resolveSanitizer(custom);
+    expect(fn).toBe(custom);
+    expect(fn!("hello")).toBe("HELLO");
+  });
+});

--- a/packages/widget/src/utils/sanitize.test.ts
+++ b/packages/widget/src/utils/sanitize.test.ts
@@ -70,6 +70,13 @@ describe("createDefaultSanitizer", () => {
     expect(result).not.toContain("data:image/svg+xml");
   });
 
+  it("blocks mixed-case data: URI scheme bypass", () => {
+    const result = sanitize('<img src="Data:image/svg+xml,<svg onload=alert(1)>">');
+    expect(result).not.toContain("Data:image/svg+xml");
+    const result2 = sanitize('<img src="DATA:image/svg+xml,<svg onload=alert(1)>">');
+    expect(result2).not.toContain("DATA:image/svg+xml");
+  });
+
   it("preserves widget-specific data attributes", () => {
     const html = '<div class="persona-form-directive" data-tv-form="init"></div>';
     expect(sanitize(html)).toBe(html);

--- a/packages/widget/src/utils/sanitize.ts
+++ b/packages/widget/src/utils/sanitize.ts
@@ -1,0 +1,83 @@
+import DOMPurify from "dompurify";
+
+/**
+ * A function that sanitizes an HTML string, returning safe HTML.
+ */
+export type SanitizeFunction = (html: string) => string;
+
+const DEFAULT_PURIFY_CONFIG: DOMPurify.Config = {
+  // Tags safe for markdown-rendered content
+  ALLOWED_TAGS: [
+    // Headings & structure
+    "h1", "h2", "h3", "h4", "h5", "h6", "p", "br", "hr", "div", "span",
+    // Lists
+    "ul", "ol", "li", "dl", "dt", "dd",
+    // Inline formatting
+    "strong", "em", "b", "i", "u", "s", "del", "ins", "mark", "small", "sub", "sup",
+    "abbr", "kbd", "var", "samp", "code",
+    // Links & media
+    "a", "img",
+    // Block elements
+    "blockquote", "pre", "details", "summary",
+    // Tables
+    "table", "thead", "tbody", "tfoot", "tr", "th", "td", "caption", "colgroup", "col",
+    // Forms (used by widget directive system)
+    "input", "label", "select", "option", "textarea", "button",
+  ],
+  ALLOWED_ATTR: [
+    // Link/media attributes
+    "href", "src", "alt", "title", "target", "rel", "loading", "width", "height",
+    // Table attributes
+    "colspan", "rowspan", "scope",
+    // Styling & identity
+    "class", "id",
+    // Form attributes
+    "type", "name", "value", "placeholder", "disabled", "checked", "for",
+    // Accessibility
+    "aria-label", "aria-hidden", "aria-expanded", "role", "tabindex",
+    // Widget-internal data attributes
+    "data-tv-form", "data-message-id", "data-persona-component-directive",
+    "data-preserve-animation", "data-persona-instance",
+  ],
+};
+
+/** Raster image data URI pattern — blocks SVG and other non-image types. */
+const SAFE_DATA_URI = /^data:image\/(?:png|jpe?g|gif|webp|bmp|x-icon|avif)/i;
+
+/**
+ * Creates the default DOMPurify-based sanitizer.
+ * Uses the global window when available (browser).
+ */
+export const createDefaultSanitizer = (): SanitizeFunction => {
+  // DOMPurify needs a DOM context. In the browser, pass `window`.
+  // The widget only runs in browsers, so `window` is always available at runtime.
+  const purify = DOMPurify(typeof window !== "undefined" ? window : (undefined as never));
+
+  // Hook: strip data:image/svg+xml and other unsafe data: URIs from src/href
+  purify.addHook("uponSanitizeAttribute", (_node, data) => {
+    if (data.attrName === "src" || data.attrName === "href") {
+      const val = data.attrValue;
+      if (val.startsWith("data:") && !SAFE_DATA_URI.test(val)) {
+        data.attrValue = "";
+        data.forceKeepAttr = false;
+      }
+    }
+  });
+
+  return (html: string): string => purify.sanitize(html, DEFAULT_PURIFY_CONFIG) as string;
+};
+
+/**
+ * Resolves a `sanitize` config value into a concrete function or null.
+ *
+ * - `undefined` / `true` → built-in DOMPurify sanitizer
+ * - `false` → `null` (no sanitization)
+ * - custom function → returned as-is
+ */
+export const resolveSanitizer = (
+  option: boolean | SanitizeFunction | undefined,
+): SanitizeFunction | null => {
+  if (option === false) return null;
+  if (typeof option === "function") return option;
+  return createDefaultSanitizer();
+};

--- a/packages/widget/src/utils/sanitize.ts
+++ b/packages/widget/src/utils/sanitize.ts
@@ -57,7 +57,7 @@ export const createDefaultSanitizer = (): SanitizeFunction => {
   purify.addHook("uponSanitizeAttribute", (_node, data) => {
     if (data.attrName === "src" || data.attrName === "href") {
       const val = data.attrValue;
-      if (val.startsWith("data:") && !SAFE_DATA_URI.test(val)) {
+      if (val.toLowerCase().startsWith("data:") && !SAFE_DATA_URI.test(val)) {
         data.attrValue = "";
         data.forceKeepAttr = false;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,9 +120,15 @@ importers:
       typescript:
         specifier: ^5.4.5
         version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@20.19.35)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))
 
   packages/widget:
     dependencies:
+      dompurify:
+        specifier: ^3.3.3
+        version: 3.3.3
       idiomorph:
         specifier: ^0.7.4
         version: 0.7.4
@@ -715,89 +721,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -919,66 +941,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1034,6 +1069,9 @@ packages:
 
   '@types/node@20.19.35':
     resolution: {integrity: sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
@@ -1099,6 +1137,9 @@ packages:
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
 
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
+
   '@vitest/mocker@4.0.18':
     resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
     peerDependencies:
@@ -1110,17 +1151,40 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@4.0.18':
     resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
   '@vitest/runner@4.0.18':
     resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
 
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
   '@vitest/snapshot@4.0.18':
     resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
 
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
+
   '@vitest/spy@4.0.18':
     resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
 
   '@vitest/ui@4.0.18':
     resolution: {integrity: sha512-CGJ25bc8fRi8Lod/3GHSvXRKi7nBo3kxh0ApW4yCjmrWmRmlT53B5E08XRSZRliygG0aVNxLrBEqPYdz/KcCtQ==}
@@ -1129,6 +1193,9 @@ packages:
 
   '@vitest/utils@4.0.18':
     resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -1289,6 +1356,9 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
@@ -1355,6 +1425,9 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
+  dompurify@3.3.3:
+    resolution: {integrity: sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==}
+
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
     engines: {node: '>=12'}
@@ -1381,6 +1454,9 @@ packages:
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -2142,6 +2218,9 @@ packages:
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
+
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2415,6 +2494,41 @@ packages:
       '@vitest/ui': 4.0.18
       happy-dom: '*'
       jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
@@ -3225,6 +3339,9 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -3317,9 +3434,26 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
   '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)
+
+  '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
@@ -3329,9 +3463,18 @@ snapshots:
     dependencies:
       tinyrainbow: 3.0.3
 
+  '@vitest/pretty-format@4.1.0':
+    dependencies:
+      tinyrainbow: 3.0.3
+
   '@vitest/runner@4.0.18':
     dependencies:
       '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/runner@4.1.0':
+    dependencies:
+      '@vitest/utils': 4.1.0
       pathe: 2.0.3
 
   '@vitest/snapshot@4.0.18':
@@ -3340,7 +3483,16 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
   '@vitest/spy@4.0.18': {}
+
+  '@vitest/spy@4.1.0': {}
 
   '@vitest/ui@4.0.18(vitest@4.0.18)':
     dependencies:
@@ -3356,6 +3508,12 @@ snapshots:
   '@vitest/utils@4.0.18':
     dependencies:
       '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
       tinyrainbow: 3.0.3
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -3501,6 +3659,8 @@ snapshots:
 
   consola@3.4.2: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie@1.1.1: {}
 
   cross-spawn@7.0.6:
@@ -3558,6 +3718,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dompurify@3.3.3:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   dotenv@16.6.1: {}
 
   eastasianwidth@0.2.0: {}
@@ -3576,6 +3740,8 @@ snapshots:
   error-stack-parser-es@1.0.5: {}
 
   es-module-lexer@1.7.0: {}
+
+  es-module-lexer@2.0.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -4392,6 +4558,8 @@ snapshots:
 
   std-env@3.10.0: {}
 
+  std-env@4.0.0: {}
+
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -4647,6 +4815,34 @@ snapshots:
       - terser
       - tsx
       - yaml
+
+  vitest@4.1.0(@types/node@20.19.35)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)):
+    dependencies:
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 20.19.35
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - msw
 
   w3c-xmlserializer@5.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

- **Add DOMPurify-based HTML sanitization** to the markdown rendering pipeline, enabled by default. Configurable via `sanitize` option on `AgentWidgetConfig`: `true` (default), `false` (disable), or a custom `(html: string) => string` function.
- **Fix proxy dev-mode default** — `NODE_ENV` must be explicitly set to `"development"` to get permissive CORS. Previously, an unset `NODE_ENV` silently bypassed all origin restrictions.
- **Fix CORS header reflection** — proxy now uses a static header allowlist instead of reflecting `Access-Control-Request-Headers` verbatim.
- **Fix prototype pollution vector** in `install.ts` config parsing — strips `__proto__`, `constructor`, `prototype` keys.
- **Add image URL validation** — blocks `javascript:` and `data:image/svg+xml` URIs in image content parts.

Addresses findings from the security review at `docs/security/2026-03-22-security-review.md`.

### Key files
| File | Change |
|------|--------|
| `packages/widget/src/utils/sanitize.ts` | **New** — DOMPurify wrapper with safe markdown allowlist |
| `packages/widget/src/utils/sanitize.test.ts` | **New** — 19 tests for sanitizer |
| `packages/widget/src/types.ts` | Add `sanitize` config option |
| `packages/widget/src/ui.ts` | Wire sanitizer into `buildPostprocessor` |
| `packages/widget/src/components/artifact-pane.ts` | Wire sanitizer into artifact rendering |
| `packages/widget/src/components/message-bubble.ts` | Image URL scheme validation |
| `packages/widget/src/install.ts` | Prototype pollution guard |
| `packages/proxy/src/index.ts` | Dev-mode, CORS header fixes |

### New test coverage
| Test file | Tests |
|---|---|
| `sanitize.test.ts` | 19 — DOMPurify config, XSS vectors, custom sanitizer |
| `actions.test.ts` | 9 — JSON parser, action manager deduplication |
| `message-bubble.test.ts` | 14 — image URL scheme validation |
| `postprocessors.test.ts` | 11 — markdown + sanitization pipeline |
| `install-config.test.ts` | 2 — prototype pollution guard |
| `proxy/index.test.ts` | 8 — CORS origin enforcement |

## Test plan

- [x] All 393 widget tests pass + 8 proxy tests pass
- [x] `pnpm build` succeeds
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [ ] Manual: `pnpm dev` — verify markdown messages render correctly with sanitization on
- [ ] Manual: verify `sanitize: false` config disables sanitization

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new default DOMPurify sanitization layer and additional input validation, which can change rendered output and potentially affect integrations relying on previously-allowed HTML/URLs. Also tightens proxy CORS behavior based on `NODE_ENV`, which may break dev setups that depended on the prior permissive default.
> 
> **Overview**
> **Adds default HTML sanitization for widget-rendered content.** Introduces `utils/sanitize.ts` (DOMPurify allowlist + data-URI filtering) and wires it into message rendering and artifact markdown rendering, configurable via new `AgentWidgetConfig.sanitize` (`true`/`false`/custom function).
> 
> **Hardens client and proxy surfaces.** Blocks unsafe image `src` schemes (notably `javascript:` and `data:image/svg+xml`) and avoids rendering blocked image previews; guards installer `data-config` parsing against prototype pollution; and tightens proxy CORS so permissive behavior only applies when `NODE_ENV === "development"` while also avoiding reflected `Access-Control-Request-Headers`. Adds targeted Vitest coverage for these behaviors and updates dev scripts/deps accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a65611c794b23a0c726ea1e69d941b3bc901617f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->