### PR TITLE
docs: update README with Persona branding and current features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,27 @@
-## 💻 Vanilla Agent ✨ A configurable agent widget in plain JS for websites
-It's an AI chat SDK plus local demos and tooling. Flexible foundation to ship an always on custom assistant on a website.
+# Persona
 
-Runtype is pre-integrated as the AI platform powering the agent, while the UI and proxy are written so that you can point them at any SSE-capable platform.
+A themeable, pluggable streaming AI chat widget for websites — built in plain JS with zero framework dependencies.
 
-- `packages/widget` – the installable chat widget (`@runtypelabs/persona`).
-- `packages/proxy` – the optional proxy server library (`@runtypelabs/persona-proxy`) for handling flow configuration using Runtype.
-- `examples/embedded-app` – a Vite vanilla app showcasing runtime configuration (see `json.html` for the directive demo).
-- `examples/vercel-edge` – Node.js proxy server for Vercel, Railway, Fly.io, and traditional servers.
-- `examples/cloudflare-workers` – Edge proxy server optimized for Cloudflare Workers.
+Persona gives you a drop-in UI for your AI assistant that works on any site. It ships with support for streaming responses, voice I/O, multi-modal content, tool call visualization, artifact rendering, and a plugin system so you can customize every layer of the UI.
 
-### Quick start
+Persona works with any SSE-capable backend. It's pre-integrated with [Runtype](https://runtype.com) out of the box, so you can go from install to live assistant with zero configuration.
+
+## Packages
+
+| Package | npm | Description |
+|---------|-----|-------------|
+| [`packages/widget`](./packages/widget) | `@runtypelabs/persona` | The installable chat widget |
+| [`packages/proxy`](./packages/proxy) | `@runtypelabs/persona-proxy` | Optional Hono-based proxy server for flow configuration |
+
+## Examples
+
+| Example | Platform | Description |
+|---------|----------|-------------|
+| [`examples/embedded-app`](./examples/embedded-app) | Vite | Vanilla JS demo with runtime configuration |
+| [`examples/vercel-edge`](./examples/vercel-edge) | Vercel / Railway / Fly.io | Node.js proxy server |
+| [`examples/cloudflare-workers`](./examples/cloudflare-workers) | Cloudflare Workers | Edge proxy server |
+
+## Quick Start
 
 ```bash
 corepack enable
@@ -17,58 +29,82 @@ pnpm install
 pnpm dev
 ```
 
-The script starts the proxy on `http://localhost:43111` (auto-selects another free port if needed) and the embedded demo at `http://localhost:5173`. Both projects depend on the local widget package via workspace linking so changes hot-reload without publishing.
+This starts the proxy on `http://localhost:43111` and the demo app at `http://localhost:5173`. Both depend on the local widget package via workspace linking, so changes hot-reload without publishing.
 
-> **Note:** Make sure you are on Node `v20.19.0` (`nvm use`) before running `pnpm install`. Corepack is bundled with modern Node releases and manages pnpm for you.
+> **Note:** Requires Node.js 20+ (`nvm use` reads `.nvmrc`). Corepack manages pnpm for you.
 
-See `packages/widget/README.md` for publishing details, configuration reference, and Runtype integration notes.
+### Install from npm
 
-Install the widget library with `npm install @runtypelabs/persona`. For the proxy server, use `npm install @runtypelabs/persona-proxy`.
+```bash
+npm install @runtypelabs/persona        # widget
+npm install @runtypelabs/persona-proxy   # proxy (optional)
+```
 
-### Proxy Deployment Examples
+## Features
 
-The repository includes production-ready proxy examples for different deployment platforms. Both examples use shared flow configurations and utilities from the `@runtypelabs/persona-proxy` package to eliminate code duplication.
+Everything below is opt-in and configurable via the widget config, feature flags, or the plugin system.
 
-| Example | Best For | Deployment Platforms | Runtime | Docs |
-|---------|----------|---------------------|---------|------|
-| **[vercel-edge](./examples/vercel-edge)** | Quick start, Node.js environments | Vercel, Railway, Fly.io, Traditional servers | Node.js 20+ | [README](./examples/vercel-edge/README.md) |
-| **[cloudflare-workers](./examples/cloudflare-workers)** | Edge computing, global scale | Cloudflare Workers | Edge runtime | [README](./examples/cloudflare-workers/README.md) |
+### Streaming Chat
+SSE-based message streaming with pluggable parsers (plain text, JSON, XML, regex). Bring your own stream parser or use the built-ins. Supports partial JSON parsing for incomplete chunks.
 
-**Choosing a deployment platform:**
-- Use **vercel-edge** for: Quick deployment to Vercel, compatibility with Node.js hosting, easy local development
-- Use **cloudflare-workers** for: Global edge deployment, low latency worldwide, serverless scaling
+### Multi-Modal Content
+Text, images (PNG, JPEG, GIF, WebP, SVG), and documents (PDF, DOCX, TXT, CSV, JSON, Excel). Configure allowed file types, size limits, and previews through the attachments config.
 
-Both examples include:
-- Secure API key handling (never exposed to browser)
-- Multiple flow configurations (basic chat, directives, shopping assistant)
-- Stripe checkout integration using REST API
-- CORS support
+### Voice Input & Output
+Optional speech-to-text via the Web Speech API or Runtype's WebSocket voice service with barge-in interruption and voice activity detection. Text-to-speech playback for assistant responses. Enable via the voice config.
 
-### Publishing
+### Reasoning & Extended Thinking
+Collapsible reasoning bubbles that display model chain-of-thought with duration tracking and streaming. Controlled by `features.showReasoning` — on by default, or override the renderer with a plugin hook.
 
-This monorepo uses [Changesets](https://github.com/changesets/changesets) for version management and publishing.
+### Tool Calls & Approvals
+Expandable tool call bubbles showing name, status, arguments, and results. Optional human-in-the-loop approval system with configurable timeout. Controlled by `features.showToolCalls` with a plugin hook for custom rendering.
 
-**Creating a release:**
+### Artifacts
+Optional side-panel for rendering markdown and component content. Desktop split layout (resizable) or mobile drawer. Enable via `features.artifacts`, configure toolbar presets, copy behavior, and appearance.
 
-1. **Create a changeset** (after making changes):
-   ```bash
-   pnpm changeset
-   ```
-   Select which packages changed and the type of change (patch/minor/major). This creates a markdown file in `.changeset/` describing the change.
+### Event Stream Inspector
+Optional real-time event capture with search/filter, badge coloring, timestamps, and expandable payloads. Enable via `features.showEventStreamToggle`. Customize rows, toolbar, and payload rendering through plugin hooks.
 
-2. **Version packages**:
-   ```bash
-   pnpm changeset version
-   ```
-   This reads all changesets, updates package versions, generates changelogs, and removes used changesets.
+### Themes & Styling
+Light and dark themes included. Full design token system (palette, semantic, component-level) with CSS variable support. Extend with built-in plugins for accessibility, reduced motion, high contrast, and branding — or create your own.
 
-3. **Build and publish**:
-   ```bash
-   pnpm release
-   ```
-   This builds both packages and publishes them to npm.
+### Layout & Presets
+Start from a built-in preset (shop, minimal, fullscreen) or configure from scratch. Header layouts, message layouts, avatars, timestamps, and slot-based rendering are all customizable. Dock as a floating widget or embed inline.
 
-**Workflow:**
-- Make changes → Create changeset → Commit → Version → Release
-- You can accumulate multiple changesets before versioning
-- Each package can be versioned independently
+### Plugin System
+14 render hooks covering the launcher, header, composer, messages, reasoning, tool calls, approvals, loading/idle indicators, and the event stream. Priority-based ordering with automatic fallback to defaults. Replace any piece of the UI without forking.
+
+### Feedback & Analytics
+Optional message-level upvote/downvote/copy with automatic backend submission. CSAT and NPS survey components. Wire up custom callbacks for your own analytics.
+
+### Agent Execution
+Renders multi-turn agent loops as they stream from the backend — displaying iteration progress, reflections, and stop reasons. Agent metadata is attached to every message. Customize how execution events appear through plugin hooks.
+
+### Component System
+Register custom components and render them inline via directives. Stream-aware parser and middleware for dynamic UI insertion during streaming.
+
+### Message Injection
+Programmatically insert messages (`injectMessage`, `injectAssistantMessage`, `injectUserMessage`, `injectSystemMessage`) with dual-content support — display one thing to the user while sending different content to the LLM.
+
+## Proxy Deployment
+
+Both proxy examples handle secure API key management, CORS, and multiple flow configurations.
+
+- **vercel-edge** — best for quick deployment to Vercel or any Node.js host
+- **cloudflare-workers** — best for global edge deployment with low latency
+
+## Publishing
+
+This monorepo uses [Changesets](https://github.com/changesets/changesets) for version management.
+
+```bash
+pnpm changeset            # create a changeset after making changes
+pnpm changeset version    # bump versions and generate changelogs
+pnpm release              # build and publish to npm
+```
+
+See [`packages/widget/README.md`](./packages/widget/README.md) for the full configuration reference.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- Replaces outdated "Vanilla Agent" branding with **Persona** project name
- Adds comprehensive feature documentation covering streaming, voice I/O, multi-modal content, reasoning/thinking, tool calls & approvals, artifacts, event stream, theming, layout presets, plugin system, feedback, agent execution, component system, and message injection
- Reorganizes structure with tables for packages/examples and cleaner sections

## Test plan
- [ ] Verify all internal links resolve correctly
- [ ] Confirm feature descriptions match current widget capabilities

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that restructure the root README and expand feature descriptions; risk is limited to potential confusion from inaccurate claims or broken links.
> 
> **Overview**
> Rebrands the project in `README.md` from the older “Vanilla Agent” positioning to **Persona**, updating the high-level description and onboarding narrative.
> 
> Reorganizes the README into clearer **Packages/Examples** tables and expands the **Features** section into a detailed, categorized capability list (streaming, multimodal, voice, reasoning, tool calls/approvals, artifacts, event stream inspector, themes/layout/presets, plugins, feedback/analytics, agent execution, components, and message injection), plus updated install and publishing instructions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f6116c4bc70888c80d75b85844281a8c075dfe1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->