### PR TITLE
fix: copy widget dist files to build output for Vercel

### DIFF
--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -172,8 +172,11 @@ function registerPreviewEmbedCheckMiddleware(
 
 // Serve the widget's built dist files at /widget-dist/ so standalone examples
 // can load the local IIFE build instead of the CDN version during development.
+// During production builds, copies the files into the output directory.
 function serveWidgetDist(): Plugin {
   const distDir = path.resolve(__dirname, "../../packages/widget/dist");
+  const filesToCopy = ["widget.css", "index.global.js", "index.global.js.map"];
+
   return {
     name: "serve-widget-dist",
     configureServer(server) {
@@ -211,6 +214,19 @@ function serveWidgetDist(): Plugin {
           next();
         }
       });
+    },
+    writeBundle(options) {
+      const outDir = options.dir ?? path.resolve(__dirname, "dist");
+      const targetDir = path.join(outDir, "widget-dist");
+      if (!fs.existsSync(targetDir)) {
+        fs.mkdirSync(targetDir, { recursive: true });
+      }
+      for (const file of filesToCopy) {
+        const src = path.join(distDir, file);
+        if (fs.existsSync(src)) {
+          fs.copyFileSync(src, path.join(targetDir, file));
+        }
+      }
     },
   };
 }


### PR DESCRIPTION
## Summary
- The `serveWidgetDist()` Vite plugin only served `/widget-dist/` files via middleware during dev/preview mode
- On static deployments (Vercel), `widget.css` 404'd because no middleware runs and the files weren't in the build output
- Added a `writeBundle` hook that copies `widget.css`, `index.global.js`, and its source map into the build output's `widget-dist/` directory

## Test plan
- [x] Verified `pnpm build` produces `dist/widget-dist/widget.css` in the embedded-app output
- [ ] Verify Vercel preview deployment loads the theme editor with styles applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-time change that only affects how `widget-dist` static assets are emitted; main risk is missing/incorrect paths causing 404s in production deployments.
> 
> **Overview**
> Ensures `examples/embedded-app` production builds include the widget’s static assets under `dist/widget-dist/`, fixing deployments where `/widget-dist/widget.css` and related files previously 404’d.
> 
> Updates the `serveWidgetDist()` Vite plugin to add a `writeBundle` step that copies `widget.css`, `index.global.js`, and `index.global.js.map` from `packages/widget/dist` into the build output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7edf76eb4ac13ab1674feb6fbf157f8a3ba11042. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->