### PR TITLE
fix: build widget before embedded-app on Vercel

### DIFF
--- a/examples/embedded-app/package.json
+++ b/examples/embedded-app/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
+    "build": "pnpm --filter @runtypelabs/persona build && vite build",
     "preview": "vite preview"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- The previous PR (#77) added a `writeBundle` hook to copy widget dist files into the build output
- However, on Vercel only the embedded-app's `vite build` runs — the widget package is never built, so `packages/widget/dist/` is empty and the copy has nothing to work with
- Changes the embedded-app build script to run `pnpm --filter @runtypelabs/persona build` before `vite build`, ensuring `widget.css` and other dist files exist

## Test plan
- [ ] Verify Vercel deployment loads `/widget-dist/widget.css` successfully (no 404)
- [ ] Verify theme editor at `/theme.html` renders with full styles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only changes the `examples/embedded-app` build script to add a prebuild step, with no runtime code or data handling changes.
> 
> **Overview**
> Updates `examples/embedded-app`’s `build` script to run `pnpm --filter @runtypelabs/persona build` before `vite build`, ensuring the workspace `@runtypelabs/persona` (widget) dist artifacts are generated when deploying/building the embedded app (e.g., on Vercel).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df740ff34d13cd72c6076738bc2e1e7c3ad896c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->