### PR TITLE
fix: add Vercel serverless entrypoint for proxy

### DIFF
--- a/examples/vercel-edge/api/[[...route]].ts
+++ b/examples/vercel-edge/api/[[...route]].ts
@@ -1,0 +1,181 @@
+import { handle } from "hono/vercel";
+import {
+  createChatProxyApp,
+  FORM_DIRECTIVE_FLOW,
+  SHOPPING_ASSISTANT_FLOW,
+  COMPONENT_FLOW,
+  BAKERY_ASSISTANT_FLOW,
+  createCheckoutSession,
+} from "@runtypelabs/persona-proxy";
+
+const allowedOrigins = process.env.ALLOWED_ORIGINS
+  ? process.env.ALLOWED_ORIGINS.split(",").map((o) => o.trim())
+  : ["http://localhost:5173", "http://localhost:4173"];
+
+const upstreamUrl = process.env.UPSTREAM_URL || undefined;
+
+const app = createChatProxyApp({
+  path: "/api/chat/dispatch",
+  allowedOrigins,
+  upstreamUrl,
+});
+
+const directiveApp = createChatProxyApp({
+  path: "/api/chat/dispatch-directive",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_FORM_DIRECTIVE || undefined,
+  flowConfig: process.env.FLOW_ID_FORM_DIRECTIVE ? undefined : FORM_DIRECTIVE_FLOW,
+  upstreamUrl,
+});
+
+const actionApp = createChatProxyApp({
+  path: "/api/chat/dispatch-action",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_SHOPPING_ASSISTANT || undefined,
+  flowConfig: process.env.FLOW_ID_SHOPPING_ASSISTANT ? undefined : SHOPPING_ASSISTANT_FLOW,
+  upstreamUrl,
+});
+
+const componentApp = createChatProxyApp({
+  path: "/api/chat/dispatch-component",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_COMPONENT || undefined,
+  flowConfig: process.env.FLOW_ID_COMPONENT ? undefined : COMPONENT_FLOW,
+  upstreamUrl,
+});
+
+const bakeryApp = createChatProxyApp({
+  path: "/api/chat/dispatch-bakery",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_BAKERY || undefined,
+  flowConfig: process.env.FLOW_ID_BAKERY ? undefined : BAKERY_ASSISTANT_FLOW,
+  upstreamUrl,
+});
+
+app.route("/", directiveApp);
+app.route("/", actionApp);
+app.route("/", componentApp);
+app.route("/", bakeryApp);
+
+app.post("/api/checkout", async (c) => {
+  const origin = c.req.header("origin");
+  const corsOrigin = (origin && allowedOrigins.includes(origin)) ? origin : allowedOrigins[0];
+
+  if (c.req.method === "OPTIONS") {
+    return c.json({}, 200, {
+      "Access-Control-Allow-Origin": corsOrigin,
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+  }
+
+  try {
+    const body = await c.req.json();
+    const { items } = body;
+
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return c.json(
+        { success: false, error: "Stripe is not configured." },
+        500,
+        { "Access-Control-Allow-Origin": corsOrigin },
+      );
+    }
+
+    const result = await createCheckoutSession({
+      secretKey: process.env.STRIPE_SECRET_KEY,
+      items,
+      successUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/action-middleware.html?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancelUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/action-middleware.html?checkout=cancelled`,
+    });
+
+    return c.json(result, result.success ? 200 : 400, {
+      "Access-Control-Allow-Origin": corsOrigin,
+    });
+  } catch (error) {
+    return c.json(
+      { success: false, error: error instanceof Error ? error.message : "Failed to create checkout session" },
+      500,
+      { "Access-Control-Allow-Origin": corsOrigin },
+    );
+  }
+});
+
+app.post("/api/checkout/bakery", async (c) => {
+  const origin = c.req.header("origin");
+  const corsOrigin = (origin && allowedOrigins.includes(origin)) ? origin : allowedOrigins[0];
+
+  if (c.req.method === "OPTIONS") {
+    return c.json({}, 200, {
+      "Access-Control-Allow-Origin": corsOrigin,
+      "Access-Control-Allow-Methods": "POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type",
+    });
+  }
+
+  try {
+    const body = await c.req.json();
+    const { items } = body;
+
+    if (!process.env.STRIPE_SECRET_KEY) {
+      return c.json(
+        { success: false, error: "Stripe is not configured." },
+        500,
+        { "Access-Control-Allow-Origin": corsOrigin },
+      );
+    }
+
+    const result = await createCheckoutSession({
+      secretKey: process.env.STRIPE_SECRET_KEY,
+      items,
+      successUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/bakery-goods.html?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancelUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/bakery-goods.html?checkout=cancelled`,
+    });
+
+    return c.json(result, result.success ? 200 : 400, {
+      "Access-Control-Allow-Origin": corsOrigin,
+    });
+  } catch (error) {
+    return c.json(
+      { success: false, error: error instanceof Error ? error.message : "Failed to create checkout session" },
+      500,
+      { "Access-Control-Allow-Origin": corsOrigin },
+    );
+  }
+});
+
+app.post("/form", async (c) => {
+  let body: Record<string, unknown>;
+  try {
+    body = await c.req.json();
+  } catch (error) {
+    return c.json(
+      { success: false, message: "Invalid JSON payload", error: String(error) },
+      400,
+    );
+  }
+
+  const type = typeof body.type === "string" ? body.type : "init";
+  const name = typeof body.name === "string" ? body.name : undefined;
+  const email = typeof body.email === "string" ? body.email : undefined;
+
+  const summaryLines = [
+    type === "init"
+      ? "We'll follow up shortly to confirm your demo slot."
+      : "Thanks for the additional context.",
+  ];
+  if (name) summaryLines.push(`Name: ${name}`);
+  if (email) summaryLines.push(`Email: ${email}`);
+
+  return c.json({
+    success: true,
+    message: summaryLines.join(" "),
+    nextPrompt:
+      type === "init"
+        ? `Demo request captured for ${name ?? "this prospect"}. What should we prepare next?`
+        : `Captured extra information for ${name ?? "the request"}.`,
+  });
+});
+
+export const GET = handle(app);
+export const POST = handle(app);
+export const OPTIONS = handle(app);

--- a/examples/vercel-edge/vercel.json
+++ b/examples/vercel-edge/vercel.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "pnpm --filter @runtypelabs/persona-proxy build",
   "installCommand": "pnpm install",
-  "framework": null
+  "framework": null,
+  "outputDirectory": "."
 }

--- a/examples/vercel-edge/vercel.json
+++ b/examples/vercel-edge/vercel.json
@@ -1,7 +1,5 @@
 {
-  "buildCommand": "pnpm build",
-  "devCommand": "pnpm dev",
+  "buildCommand": "pnpm --filter @runtypelabs/persona-proxy build",
   "installCommand": "pnpm install",
-  "framework": null,
-  "outputDirectory": "dist"
+  "framework": null
 }


### PR DESCRIPTION
## Summary
- The vercel-edge example used `@hono/node-server` with `serve()` — a long-running Node process that doesn't work on Vercel serverless (all routes 404'd)
- Added `api/[[...route]].ts` catch-all serverless function that mounts all Hono apps via `hono/vercel` `handle()`
- Updated `vercel.json` to build the proxy package dependency and let Vercel auto-detect the `api/` directory
- Includes all routes: dispatch, directive, action, component, bakery, checkout, and form endpoints
- Uses the `ALLOWED_ORIGINS` env var from PR #79

## Test plan
- [ ] Deploy to Vercel and verify `curl -X OPTIONS -H "Origin: https://www.persona-chat.dev" https://proxy.persona-chat.dev/api/chat/dispatch` returns CORS headers
- [ ] Verify chat dispatch works end-to-end from the frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Vercel deployment entrypoint and routing for the `vercel-edge` example, so misconfiguration could still lead to 404s or CORS issues. Adds serverless Stripe checkout endpoints that rely on env vars and request payload validation.
> 
> **Overview**
> Adds a Vercel Serverless catch-all function (`api/[[...route]].ts`) for the `vercel-edge` example that mounts the existing Hono chat proxy apps via `hono/vercel` `handle()`, including multiple flow-specific dispatch routes and a simple `/form` JSON endpoint.
> 
> Also introduces two serverless Stripe checkout endpoints (`/api/checkout` and `/api/checkout/bakery`) with basic CORS handling and updates `vercel.json` to build only `@runtypelabs/persona-proxy` and use `.` as the output directory so Vercel detects the `api/` routes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe2dfa89550abd9d112b4cee8e555a10523c46e8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->