### PR TITLE
fix: add public dir for Vercel proxy function routing

### DIFF
--- a/examples/vercel-edge/vercel.json
+++ b/examples/vercel-edge/vercel.json
@@ -1,6 +1,5 @@
 {
   "buildCommand": "pnpm --filter @runtypelabs/persona-proxy build",
   "installCommand": "pnpm install",
-  "framework": null,
-  "outputDirectory": "."
+  "framework": null
 }


### PR DESCRIPTION
## Summary
- Vercel expects a `public/` output directory by default — without it, the previous fix used `outputDirectory: "."` which broke serverless function routing (404 on all routes)
- Added an empty `public/` directory and removed `outputDirectory` override so Vercel uses its default behavior while discovering `api/` functions

## Test plan
- [ ] Deploy and verify `curl -X OPTIONS https://proxy.persona-chat.dev/api/chat/dispatch` returns CORS headers instead of 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change affecting only the Vercel example deployment; main risk is misconfiguration causing 404s if Vercel expectations differ.
> 
> **Overview**
> Restores Vercel’s default output directory behavior for `examples/vercel-edge` by removing the `outputDirectory: "."` override in `vercel.json`, which was interfering with serverless `api/` route discovery.
> 
> Adds an empty `public/` directory (`public/.gitkeep`) so Vercel’s expected static output folder exists and function routing works as intended.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6fa25f90e6ee0cedff58ab58c3bd145d6b75cf95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->