### PR TITLE
fix: add custom-loading-indicator to Vite build inputs

### DIFF
--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -272,9 +272,6 @@ export default defineConfig({
         'feedback-integration-demo': path.resolve(__dirname, 'feedback-integration-demo.html'),
         'client-token-demo': path.resolve(__dirname, 'client-token-demo.html'),
         'client-token-feedback-demo': path.resolve(__dirname, 'client-token-feedback-demo.html'),
-        'navigation-persist-demo': path.resolve(__dirname, 'navigation-persist-demo.html'),
-        'navigation-persist-page2': path.resolve(__dirname, 'navigation-persist-page2.html'),
-        'preview-mode-demo': path.resolve(__dirname, 'preview-mode-demo.html'),
         'docked-panel-demo': path.resolve(__dirname, 'docked-panel-demo.html'),
         // Agent demo
         'agent-demo': path.resolve(__dirname, 'agent-demo.html'),
@@ -291,6 +288,7 @@ export default defineConfig({
         'artifact-demo': path.resolve(__dirname, 'artifact-demo.html'),
         'fullscreen-assistant-demo': path.resolve(__dirname, 'fullscreen-assistant-demo.html'),
         'custom-loading-indicator': path.resolve(__dirname, 'custom-loading-indicator.html'),
+        'voice-integration-demo': path.resolve(__dirname, 'voice-integration-demo.html'),
       }).filter(([, entryPath]) => fs.existsSync(entryPath))
       )
     }

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -290,6 +290,7 @@ export default defineConfig({
         'focus-input-demo': path.resolve(__dirname, 'focus-input-demo.html'),
         'artifact-demo': path.resolve(__dirname, 'artifact-demo.html'),
         'fullscreen-assistant-demo': path.resolve(__dirname, 'fullscreen-assistant-demo.html'),
+        'custom-loading-indicator': path.resolve(__dirname, 'custom-loading-indicator.html'),
       }).filter(([, entryPath]) => fs.existsSync(entryPath))
       )
     }


### PR DESCRIPTION
## Summary
- Added `custom-loading-indicator` and `voice-integration-demo` to the Rollup `input` entries in `examples/embedded-app/vite.config.ts` — both HTML files existed but weren't registered in the build config, causing 404s in production/preview builds
- Removed dead entries for `navigation-persist-demo`, `navigation-persist-page2`, and `preview-mode-demo` whose HTML files no longer exist

## Test plan
- [ ] Run `pnpm build` and verify `custom-loading-indicator.html` and `voice-integration-demo.html` appear in `examples/embedded-app/dist/`
- [ ] Run `pnpm preview` and confirm both pages load without a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)