### PR TITLE
chore: switch all example models to mercury-2

### DIFF
--- a/examples/embedded-app/agent-demo.html
+++ b/examples/embedded-app/agent-demo.html
@@ -190,7 +190,7 @@
 {
   <span class="prop">agent</span>: {
     <span class="prop">name</span>: <span class="string">'Travel Planner Assistant'</span>,
-    <span class="prop">model</span>: <span class="string">'qwen/qwen3-8b'</span>,
+    <span class="prop">model</span>: <span class="string">'mercury-2'</span>,
     <span class="prop">systemPrompt</span>: <span class="string">'You are a travel planning assistant...'</span>,
     <span class="prop">tools</span>: {
       <span class="prop">toolIds</span>: [<span class="string">'builtin:exa'</span>]

--- a/examples/embedded-app/src/agent-demo.ts
+++ b/examples/embedded-app/src/agent-demo.ts
@@ -26,9 +26,7 @@ const controller = createAgentExperience(mount, {
   // Agent execution config (replaces flowId)
   agent: {
     name: "Travel Planner Assistant",
-    // Primary: qwen/qwen3-8b (fast, cheap, supports tool calling)
-    // Alternative if tool calling is unreliable: "openai:gpt-4o-mini"
-    model: "qwen/qwen3-8b",
+    model: "mercury-2",
     systemPrompt:
       "You are a travel planning assistant with access to the Exa web search tool. " +
       "For itinerary requests, complete work in exactly 3 iterations: " +

--- a/examples/embedded-app/src/fullscreen-assistant-demo.ts
+++ b/examples/embedded-app/src/fullscreen-assistant-demo.ts
@@ -710,7 +710,7 @@ const config = mergeWithDefaults({
   apiUrl,
   agent: {
     name: "Chat Assistant",
-    model: "claude-sonnet-4-5",
+    model: "mercury-2",
     systemPrompt: "You are a helpful assistant. Be friendly, concise, and helpful. If you don't know something, say so.",
     artifacts: { enabled: true, types: ["markdown", "component"] },
   },

--- a/packages/proxy/src/flows/bakery-assistant.ts
+++ b/packages/proxy/src/flows/bakery-assistant.ts
@@ -20,7 +20,7 @@ export const BAKERY_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "qwen/qwen3-8b",
+        model: "mercury-2",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/components.ts
+++ b/packages/proxy/src/flows/components.ts
@@ -14,7 +14,7 @@ export const COMPONENT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "qwen/qwen3-8b",
+        model: "mercury-2",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/conversational.ts
+++ b/packages/proxy/src/flows/conversational.ts
@@ -14,7 +14,7 @@ export const CONVERSATIONAL_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "meta/llama3.1-8b-instruct-free",
+        model: "mercury-2",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/scheduling.ts
+++ b/packages/proxy/src/flows/scheduling.ts
@@ -14,7 +14,7 @@ export const FORM_DIRECTIVE_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "qwen/qwen3-8b",
+        model: "mercury-2",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/shopping-assistant.ts
+++ b/packages/proxy/src/flows/shopping-assistant.ts
@@ -18,7 +18,7 @@ export const SHOPPING_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "qwen/qwen3-8b",
+        model: "mercury-2",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",
@@ -97,7 +97,7 @@ export const SHOPPING_ASSISTANT_METADATA_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "qwen/qwen3-8b",
+        model: "mercury-2",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -73,8 +73,7 @@ const DEFAULT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-2.5-flash",
-        // model: "gpt-4o",
+        model: "mercury-2",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",


### PR DESCRIPTION
## Summary
- Replaced all model references across examples and proxy flows with `mercury-2`
- Models replaced: `qwen/qwen3-8b`, `claude-sonnet-4-5`, `meta/llama3.1-8b-instruct-free`, `gemini-2.5-flash`

## Test plan
- [ ] Run `pnpm dev` and verify the widget connects and streams responses using `mercury-2`
- [ ] Verify agent-demo, fullscreen-assistant-demo, and bakery flows all work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default model IDs used by embedded app demos and the proxy’s built-in flow configs, which can affect runtime behavior, cost, and model capabilities for anyone relying on these defaults.
> 
> **Overview**
> Updates all embedded app demos and proxy flow configurations to use `mercury-2` as the configured/default model.
> 
> This replaces previous model IDs across agent demos (including the fullscreen assistant) and all shipped proxy flows/default flow config, so out-of-the-box runs now dispatch to `mercury-2` without changing prompts or flow structure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b473c9eb0218de77a1ca6dc18d6b7af2f20ff03c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->