### PR TITLE
feat: redesign Examples Index page to match Runtype branding

### DIFF
--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -1,70 +1,70 @@
 <!DOCTYPE html>
 <html lang="en">
-
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Persona Widget Demo</title>
 </head>
-
 <body>
-  <main class="demo-container">
-    <section>
-      <h1>Persona Widget Demo</h1>
-      <p>
-        This page renders the widget two ways: once through the vanilla
-        initializer and once as a floating launcher wired up to user actions.
-      </p>
-      <p>
-        The frontend proxy below lives at <code>/api/chat/dispatch</code>
-        and is powered by a Hono server.
-      </p>
-      <p>
-        Looking for other examples?
-      </p>
-      <ul>
-        <li><a href="/theme.html">Agent Editor (Style it visually)</a></li>
-        <li><a href="/action-middleware.html">Action middleware / e-commerce example</a></li>
-        <li><a href="/bakery.html">Bakery assistant demo</a></li>
-        <li><a href="/docked-panel-demo.html">Docked Panel Demo</a></li>
-        <li><a href="/feedback-demo.html">Message Feedback Demo (Copy, Upvote, Downvote)</a></li>
-        <li><a href="/feedback-integration-demo.html">Feedback Integration Demo</a></li>
-        <li><a href="/custom-loading-indicator.html">Custom Loading Indicator</a></li>
-        <li><a href="/agent-demo.html">Agent Loop Execution Demo</a></li>
-        <li><a href="/approval-demo.html">Tool Approval Demo</a></li>
-        <li><a href="/focus-input-demo.html">Focus Input Demo</a></li>
-        <li><a href="/artifact-demo.html">Artifact sidebar demo</a></li>
-        <li><a href="/fullscreen-assistant-demo.html">Fullscreen assistant (split chat + artifact)</a></li>
-        <li><a href="/voice-integration-demo.html">🎤 Voice Integration Demo (ElevenLabs)</a></li>
-      </ul>
-      <h3>Standalone (CDN / Copy-Paste)</h3>
-      <p><small>These load the widget via IIFE build (local on localhost, CDN in production). Run <code>pnpm build:widget</code> first.</small></p>
-      <ul>
-        <li><a href="/standalone/example-shop.html">Example Shop (Manual)</a></li>
-        <li><a href="/standalone/example-shop-metadata.html">Example Shop (Metadata)</a></li>
-        <li><a href="/standalone/example-shop-installer.html">Example Shop (Installer)</a></li>
-        <li><a href="/standalone/example-shop-installer-voice-metadata.html">Example Shop (Installer + Voice + Metadata)</a></li>
-        <li><a href="/standalone/sample.html">Sample Widget</a></li>
-        <li><a href="/standalone/preview-mode.html">Preview Mode</a></li>
-      </ul>
-      <div class="cta-row">
-        <button id="open-chat" type="button">Open Launcher</button>
-        <button id="toggle-chat" type="button">Toggle Launcher</button>
-        <select id="target-widget">
-          <option value="inline">Inline Widget</option>
-          <option value="launcher">Launcher Widget</option>
-        </select>
-        <button id="load-messages" type="button">Load 1000 Messages</button>
+  <div class="page">
+    <main class="shell">
+      <section class="hero cardFull">
+        <h1>Persona Widget Demo</h1>
+        <p>This page renders the widget two ways: once through the vanilla initializer and once as a floating launcher wired up to user actions.</p>
+        <p><small>The frontend proxy below lives at <code>/api/chat/dispatch</code> and is powered by a Hono server.</small></p>
+        
+        <div class="cta-row">
+          <button id="open-chat" class="primaryButton" type="button">Open Launcher</button>
+          <button id="toggle-chat" class="secondaryButton" type="button">Toggle Launcher</button>
+          <select id="target-widget">
+            <option value="inline">Inline Widget</option>
+            <option value="launcher">Launcher Widget</option>
+          </select>
+          <button id="load-messages" class="secondaryButton" type="button">Load 1000 Messages</button>
+        </div>
+      </section>
+
+      <div class="section-grid">
+        <section class="card">
+          <h2 class="card-title">More Examples</h2>
+          <p>Explore different use-cases and widget configurations below.</p>
+          <ul class="examples-list">
+            <li><a class="example-item" href="/theme.html">Agent Editor <small>Style it visually</small></a></li>
+            <li><a class="example-item" href="/action-middleware.html">Action Middleware <small>E-commerce example</small></a></li>
+            <li><a class="example-item" href="/bakery.html">Bakery Assistant Demo <small>Industry specific persona</small></a></li>
+            <li><a class="example-item" href="/docked-panel-demo.html">Docked Panel Demo <small>Alternative layout</small></a></li>
+            <li><a class="example-item" href="/feedback-demo.html">Message Feedback Demo <small>Copy, Upvote, Downvote</small></a></li>
+            <li><a class="example-item" href="/feedback-integration-demo.html">Feedback Integration Demo <small>With external API</small></a></li>
+            <li><a class="example-item" href="/custom-loading-indicator.html">Custom Loading Indicator <small>Unique UX</small></a></li>
+            <li><a class="example-item" href="/agent-demo.html">Agent Loop Execution Demo <small>Internal thought processes</small></a></li>
+            <li><a class="example-item" href="/approval-demo.html">Tool Approval Demo <small>Action confirmation</small></a></li>
+            <li><a class="example-item" href="/focus-input-demo.html">Focus Input Demo <small>Input state handling</small></a></li>
+            <li><a class="example-item" href="/artifact-demo.html">Artifact Sidebar Demo <small>Multi-pane interface</small></a></li>
+            <li><a class="example-item" href="/fullscreen-assistant-demo.html">Fullscreen Assistant <small>Split chat + artifact</small></a></li>
+            <li><a class="example-item" href="/voice-integration-demo.html">🎤 Voice Integration Demo <small>Powered by ElevenLabs</small></a></li>
+          </ul>
+        </section>
+
+        <section class="card">
+          <h2 class="card-title">Standalone Scripts</h2>
+          <p>These load the widget via IIFE build (local on localhost, CDN in production). Run <code>pnpm build:widget</code> first.</p>
+          <ul class="examples-list">
+            <li><a class="example-item" href="/standalone/example-shop.html">Example Shop (Manual)</a></li>
+            <li><a class="example-item" href="/standalone/example-shop-metadata.html">Example Shop (Metadata)</a></li>
+            <li><a class="example-item" href="/standalone/example-shop-installer.html">Example Shop (Installer)</a></li>
+            <li><a class="example-item" href="/standalone/example-shop-installer-voice-metadata.html">Example Shop (Installer + Voice + Metadata)</a></li>
+            <li><a class="example-item" href="/standalone/sample.html">Sample Widget</a></li>
+            <li><a class="example-item" href="/standalone/preview-mode.html">Preview Mode</a></li>
+          </ul>
+        </section>
       </div>
-    </section>
-    <section>
-      <h2>Programmatic Control</h2>
-      <p>
-        The widget controller returned by <code>initAgentWidget</code> provides methods to programmatically control the
-        widget:
-      </p>
-      <div class="code-example">
-        <pre><code>const launcherController = initAgentWidget({
+
+      <div class="section-grid">
+        <section class="card">
+          <h2 class="card-title">Programmatic Control</h2>
+          <p>The widget controller returned by <code>initAgentWidget</code> provides methods to programmatically control the widget:</p>
+          <div class="code-example">
+            <pre><code>const launcherController = initAgentWidget({
   target: "#launcher-root",
   config: { /* ... */ }
 });
@@ -75,48 +75,54 @@ launcherController.open();
 // Close the widget
 launcherController.close();
 
-// Toggle the widget (open if closed, close if open)
+// Toggle the widget
 launcherController.toggle();</code></pre>
+          </div>
+        </section>
+
+        <section class="card">
+          <h2 class="card-title">Event Stream Testing</h2>
+          <p>Test the event stream SDK methods, window events, and instance scoping.</p>
+          
+          <h3>Controller Methods</h3>
+          <div class="cta-row" style="justify-content: flex-start;">
+            <select id="event-stream-target">
+              <option value="inline">Inline Widget</option>
+              <option value="launcher">Launcher Widget</option>
+            </select>
+            <button id="es-show" class="secondaryButton" type="button">Show Event Stream</button>
+            <button id="es-hide" class="secondaryButton" type="button">Hide Event Stream</button>
+            <button id="es-check" class="secondaryButton" type="button">Check Visibility</button>
+          </div>
+          
+          <h3 style="margin-top: 16px;">Window Events</h3>
+          <div class="cta-row" style="justify-content: flex-start;">
+            <button id="es-win-show-all" class="secondaryButton" type="button">Show All (window)</button>
+            <button id="es-win-hide-all" class="secondaryButton" type="button">Hide All (window)</button>
+            <button id="es-win-show-inline" class="secondaryButton" type="button">Show Inline Only</button>
+            <button id="es-win-show-launcher" class="secondaryButton" type="button">Show Launcher Only</button>
+            <button id="es-win-show-wrong" class="secondaryButton" type="button">Show Wrong ID</button>
+          </div>
+          
+          <h3 style="margin-top: 16px;">Event Listeners</h3>
+          <div class="cta-row" style="justify-content: flex-start;">
+            <button id="es-listen" class="secondaryButton" type="button">Register Listeners</button>
+          </div>
+          
+          <div id="es-log" class="code-example" style="margin-top: 16px; max-height:150px; overflow-y:auto; display:none;">
+            <pre id="es-log-pre"></pre>
+          </div>
+        </section>
       </div>
-      <p>
-        You can use these methods with your own UI elements, event handlers, or any JavaScript code. The buttons above
-        demonstrate this functionality.
-      </p>
-    </section>
-    <section>
-      <h2>Event Stream Testing</h2>
-      <p>Test the event stream SDK methods, window events, and instance scoping.</p>
-      <h3>Controller Methods</h3>
-      <div class="cta-row">
-        <select id="event-stream-target">
-          <option value="inline">Inline Widget</option>
-          <option value="launcher">Launcher Widget</option>
-        </select>
-        <button id="es-show" type="button">Show Event Stream</button>
-        <button id="es-hide" type="button">Hide Event Stream</button>
-        <button id="es-check" type="button">Check Visibility</button>
-      </div>
-      <h3>Window Events</h3>
-      <div class="cta-row">
-        <button id="es-win-show-all" type="button">Show All (window)</button>
-        <button id="es-win-hide-all" type="button">Hide All (window)</button>
-        <button id="es-win-show-inline" type="button">Show Inline Only</button>
-        <button id="es-win-show-launcher" type="button">Show Launcher Only</button>
-        <button id="es-win-show-wrong" type="button">Show Wrong ID</button>
-      </div>
-      <h3>Event Listeners</h3>
-      <div class="cta-row">
-        <button id="es-listen" type="button">Register Listeners</button>
-      </div>
-      <div id="es-log" class="code-example" style="max-height:150px;overflow-y:auto;display:none"><pre id="es-log-pre"></pre></div>
-    </section>
-    <section>
-      <h2>Inline Embed</h2>
-      <div class="embedded-target" id="inline-widget"></div>
-    </section>
-  </main>
+
+      <section class="card cardFull">
+        <h2 class="card-title">Inline Embed</h2>
+        <div class="embedded-target" id="inline-widget"></div>
+      </section>
+    </main>
+  </div>
+  
   <div id="launcher-root"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>
-
 </html>

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -1,10 +1,247 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;1,6..72,400&family=JetBrains+Mono:wght@400;700&display=swap');
+
 :root {
   color-scheme: light;
-  background: #f1f5f9;
+  --background: #fcfcfa;
+  --foreground: #0f172a;
+  --primary: #0f172a;
+  --primary-foreground: #f8fafc;
+  --border: #e2e8f0;
+  --muted: #64748b;
+  --accent: #f1f5f9;
+  
+  --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  --font-serif: 'Newsreader', Georgia, serif;
+  --font-mono: 'JetBrains Mono', monospace;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: #f1f5f9;
+  background-color: var(--background);
+  background-image: linear-gradient(135deg, rgba(15, 23, 42, 0.02), transparent 55%);
+  color: var(--foreground);
+  font-family: var(--font-sans);
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+
+.page {
+  position: relative;
+  overflow: hidden;
+  min-height: 100vh;
+}
+
+.shell {
+  width: 100%;
+  max-width: 980px;
+  margin: 0 auto;
+  padding: 48px 24px 72px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+  position: relative;
+  z-index: 1;
+}
+
+/* Headers */
+h1, h2, h3 {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+}
+
+h1 { font-size: 32px; }
+h2 { font-size: 24px; }
+h3 { font-size: 18px; }
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+  color: #475569;
+}
+
+code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: var(--accent);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+
+/* Hero Section */
+.hero {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 36px 32px;
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.95);
+  border: 1px solid var(--border);
+  box-shadow: 0 20px 50px -35px rgba(15, 23, 42, 0.45);
+  text-align: center;
+  align-items: center;
+}
+
+.hero h1 { margin: 0; font-size: 36px; }
+
+.hero p {
+  max-width: 650px;
+  margin-bottom: 0;
+  font-size: 16px;
+  color: var(--muted);
+}
+
+.cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin-top: 16px;
+}
+
+/* Buttons */
+button, select, .btn {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: 6px;
+  padding: 10px 18px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid transparent;
+  outline: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-decoration: none;
+}
+
+.primaryButton {
+  background: var(--primary);
+  color: var(--primary-foreground);
+  box-shadow: 0 10px 20px -12px rgba(15, 23, 42, 0.6);
+}
+
+.primaryButton:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px -12px rgba(15, 23, 42, 0.7);
+}
+
+.secondaryButton, select {
+  background: #ffffff;
+  color: var(--foreground);
+  border: 1px solid var(--border);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+.secondaryButton:hover {
+  background: var(--accent);
+  transform: translateY(-1px);
+}
+
+select {
+  padding-right: 32px;
+  appearance: auto;
+}
+
+/* Cards & Layouts */
+.section-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 24px;
+}
+
+.card {
+  background: rgba(255, 255, 255, 0.92);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  box-shadow: 0 18px 40px -35px rgba(15, 23, 42, 0.35);
+}
+
+.cardFull {
+  grid-column: 1 / -1;
+}
+
+.card-title {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  margin: 0;
+  color: var(--foreground);
+}
+
+/* Lists */
+.examples-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.example-item {
+  display: flex;
+  flex-direction: column;
+  padding: 12px 16px;
+  border-radius: 6px;
+  background: var(--accent);
+  border: 1px solid var(--border);
+  text-decoration: none;
+  color: var(--foreground);
+  font-weight: 600;
+  transition: all 0.2s ease;
+  font-size: 14px;
+  line-height: 1.4;
+}
+
+.example-item:hover {
+  background: #e2e8f0;
+  border-color: #cbd5e1;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px -8px rgba(15, 23, 42, 0.3);
+}
+
+.example-item small {
+  display: block;
+  font-weight: 400;
+  color: var(--muted);
+  font-size: 13px;
+  margin-top: 2px;
+}
+
+/* Code Blocks */
+.code-example {
+  background: #0f172a;
+  border-radius: 6px;
+  padding: 16px;
+  overflow-x: auto;
+}
+
+.code-example pre {
+  margin: 0;
+}
+
+.code-example code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: transparent;
+  color: #e2e8f0;
+  padding: 0;
+}
+
+/* Inline Embed Target */
+.embedded-target {
+  min-height: 500px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #ffffff;
+  overflow: hidden;
+  box-shadow: inset 0 2px 4px rgba(0,0,0,0.02);
 }


### PR DESCRIPTION
Redesigned the persona embedded-app examples index page to match the Runtype design system. Replaced the default font with Inter and Newsreader, added the polished .card layouts, adjusted buttons to primary/secondary styling, and adopted the wireframe-meets-paper light theme.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a pure examples-page HTML/CSS redesign with no changes to widget logic, APIs, or data handling.
> 
> **Overview**
> Redesigns the `examples/embedded-app` index into a branded, card-based layout with a new hero section and reorganized example links while keeping the same demo controls and sections.
> 
> Overhauls styling in `src/index.css` by introducing a new font stack (Inter/Newsreader/JetBrains Mono), theme tokens, and new components (`.shell`, `.card`, primary/secondary buttons, lists, and code block styling) to match the updated look and feel.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e379f156ae39ffc17b126384045490b12d104a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->