### PR TITLE
fix: bakery demo 404 on deployed proxy

### DIFF
--- a/examples/embedded-app/src/bakery-demo.ts
+++ b/examples/embedded-app/src/bakery-demo.ts
@@ -55,8 +55,9 @@ let widgetControllerRef: ReturnType<typeof initAgentWidget> | null = null;
 
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
 const proxyUrl =
-  import.meta.env.VITE_PROXY_URL ??
-  `http://localhost:${proxyPort}/api/chat/dispatch-bakery`;
+  import.meta.env.VITE_PROXY_URL ?
+    `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-bakery` :
+    `http://localhost:${proxyPort}/api/chat/dispatch-bakery`;
 
 // ============================================================================
 // Cart Management


### PR DESCRIPTION
## Summary
- Fixed bakery demo using `??` instead of a ternary for `VITE_PROXY_URL`, which caused the bare URL to be used without appending `/api/chat/dispatch-bakery`
- Now follows the same pattern as `main.ts` — appends the API route path to the env var value

## Test plan
- [ ] Deploy and verify `/bakery.html` chat no longer returns 404 on `proxy.persona-chat.dev`
- [ ] Verify local dev (`localhost:43111`) still works for bakery demo

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small URL construction change in the bakery demo to avoid 404s when `VITE_PROXY_URL` is set; only affects where the widget sends requests.
> 
> **Overview**
> Fixes the bakery demo’s proxy URL construction so deployed `VITE_PROXY_URL` values have the `/api/chat/dispatch-bakery` route appended, instead of using the bare env var URL.
> 
> Local fallback to `http://localhost:${proxyPort}/api/chat/dispatch-bakery` remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 931d0de2f33da3fe97c5bc0948a4599ed732317b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->