### PR TITLE
fix: sanitize dangerous URI attributes and warn on postprocessor stripping

### DIFF
--- a/.changeset/fix-sanitize-keepattr.md
+++ b/.changeset/fix-sanitize-keepattr.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix DOMPurify hook to fully remove dangerous data: URI attributes instead of leaving empty `src`/`href`, and add a dev-mode warning when a custom `postprocessMessage` is used with the default sanitizer.

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -325,6 +325,16 @@ const buildPostprocessor = (
   // Resolve sanitizer: enabled by default, can be disabled or replaced
   const sanitize = resolveSanitizer(cfg?.sanitize);
 
+  // Warn developers when a custom postprocessor is used with the default sanitizer,
+  // since DOMPurify will strip any tags/attributes not in the allowlist.
+  if (cfg?.postprocessMessage && sanitize && cfg?.sanitize === undefined) {
+    console.warn(
+      "[Persona] A custom postprocessMessage is active with the default HTML sanitizer. " +
+      "Tags or attributes not in the built-in allowlist will be stripped. " +
+      "To keep custom HTML, set `sanitize: false` or provide a custom sanitize function."
+    );
+  }
+
   return (context) => {
     let nextText = context.text ?? "";
     const rawPayload = context.message.rawContent ?? null;

--- a/packages/widget/src/utils/sanitize.ts
+++ b/packages/widget/src/utils/sanitize.ts
@@ -59,7 +59,7 @@ export const createDefaultSanitizer = (): SanitizeFunction => {
       const val = data.attrValue;
       if (val.toLowerCase().startsWith("data:") && !SAFE_DATA_URI.test(val)) {
         data.attrValue = "";
-        data.forceKeepAttr = false;
+        data.keepAttr = false;
       }
     }
   });


### PR DESCRIPTION
## Summary

- **Fix `keepAttr` in DOMPurify hook** (`sanitize.ts`): Changed `data.forceKeepAttr = false` to `data.keepAttr = false` so dangerous `data:` URIs cause the attribute to be fully removed instead of left as `<img src="">` (which triggers a spurious GET to the current page URL).
- **Add dev warning for postprocessor + sanitizer interaction** (`ui.ts`): When a custom `postprocessMessage` is active with the implicit default sanitizer, a `console.warn` alerts developers that non-allowlisted HTML will be stripped — and points them to `sanitize: false` or a custom sanitize function.

Addresses findings from #72: [comment 1](https://github.com/runtypelabs/persona/pull/72#discussion_r2972571360), [comment 2](https://github.com/runtypelabs/persona/pull/72#discussion_r2972571364).

## Test plan

- [x] All 396 existing tests pass
- [x] Build succeeds
- [ ] Verify `<img src="">` no longer appears when sanitizing a dangerous `data:` URI
- [ ] Verify console warning appears when `postprocessMessage` is set without explicit `sanitize` config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized changes to the widget’s HTML sanitization and developer logging; main risk is minor behavior change in how `src`/`href` are stripped and an added console warning in dev usage.
> 
> **Overview**
> **Hardens HTML sanitization for `src`/`href` data URIs.** The DOMPurify hook now fully removes unsafe `data:` attributes (instead of leaving empty `src`/`href`).
> 
> **Adds a developer warning for sanitizer/postprocessor interactions.** When `postprocessMessage` is provided while using the implicit default sanitizer, the widget logs a `console.warn` explaining that non-allowlisted HTML will be stripped and how to opt out or provide a custom sanitizer.
> 
> Includes a patch changeset for `@runtypelabs/persona`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 415e3ed59c80426ba8f33260ee97b54ea95c7365. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->