### PR TITLE
feat: developer-first examples landing page with Persona docs assistant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,7 @@ Persona is a pnpm monorepo containing a themeable, pluggable streaming chat widg
 
 ## Requirements
 
-- **Node.js** ≥18.17.0 (see `.nvmrc`)
+- **Node.js** ≥20 (see `.nvmrc`)
 - **pnpm** — managed via corepack (`corepack enable` then `corepack install`)
 
 ## Common Commands

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing!
 
 ## Setup
 
-**Requirements:** Node.js ≥18.17.0, pnpm
+**Requirements:** Node.js 20+, pnpm
 
 ```bash
 pnpm install

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pnpm dev
 
 This starts the proxy on `http://localhost:43111` and the demo app at `http://localhost:5173`. Both depend on the local widget package via workspace linking, so changes hot-reload without publishing.
 
-> **Note:** Requires Node.js ≥18.17 (`nvm use` reads `.nvmrc`). Corepack manages pnpm for you.
+> **Note:** Requires Node.js 20+ (`nvm use` reads `.nvmrc`). Corepack manages pnpm for you.
 
 ### Install from npm
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pnpm dev
 
 This starts the proxy on `http://localhost:43111` and the demo app at `http://localhost:5173`. Both depend on the local widget package via workspace linking, so changes hot-reload without publishing.
 
-> **Note:** Requires Node.js 20+ (`nvm use` reads `.nvmrc`). Corepack manages pnpm for you.
+> **Note:** Requires Node.js ≥18.17 (`nvm use` reads `.nvmrc`). Corepack manages pnpm for you.
 
 ### Install from npm
 

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -36,7 +36,7 @@ A production-ready chat proxy service deployed on Cloudflare Workers, powered by
 
 ## Prerequisites
 
-- [Node.js](https://nodejs.org/) 18+ and pnpm installed
+- [Node.js](https://nodejs.org/) 20+ and pnpm installed
 - [Cloudflare account](https://dash.cloudflare.com/sign-up) (free tier works)
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/) installed globally or use via pnpm
 - Runtype API key ([get one here](https://runtype.com))

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -4,57 +4,53 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="/favicon.ico" />
-  <title>Persona Widget Demo</title>
+  <title>Persona — AI Chat Widget</title>
 </head>
 <body>
   <div class="page">
     <main class="shell">
       <section class="hero cardFull">
-        <h1>Persona Widget Demo</h1>
-        <p>This page renders the widget two ways: once through the vanilla initializer and once as a floating launcher wired up to user actions.</p>
-        <p><small>The frontend proxy below lives at <code>/api/chat/dispatch</code> and is powered by a Hono server.</small></p>
-        
-        <div class="cta-row">
-          <button id="open-chat" class="primaryButton" type="button">Open Launcher</button>
-          <button id="toggle-chat" class="secondaryButton" type="button">Toggle Launcher</button>
-          <select id="target-widget">
-            <option value="inline">Inline Widget</option>
-            <option value="launcher">Launcher Widget</option>
-          </select>
-          <button id="load-messages" class="secondaryButton" type="button">Load 1000 Messages</button>
-        </div>
+        <h1>Persona</h1>
+        <p>A drop-in streaming chat widget for your AI assistant. Themeable, pluggable, zero framework dependencies.</p>
       </section>
 
       <section class="card cardFull">
-        <h2 class="card-title">Ask Persona</h2>
-        <p>Chat with our documentation assistant to learn about Persona or find the right demo.</p>
+        <h2 class="card-title">Try it</h2>
+        <p>This is Persona. Ask it anything — or pick a suggestion below to explore.</p>
         <div class="embedded-target" id="inline-widget"></div>
+      </section>
+
+      <section class="card cardFull">
+        <h2 class="card-title">Featured</h2>
+        <p>See what Persona can do across different use cases.</p>
+        <div class="featured-grid">
+          <a class="example-item" href="/theme.html">Theme Editor <small>Customize colors, fonts, and layout in real time</small></a>
+          <a class="example-item" href="/bakery.html">Bakery Assistant <small>Full business site with context-aware chat</small></a>
+          <a class="example-item" href="/agent-demo.html">Agent Loop <small>Multi-turn reasoning with tool calls</small></a>
+          <a class="example-item" href="/fullscreen-assistant-demo.html">Fullscreen Assistant <small>Full-viewport dark layout with artifacts</small></a>
+        </div>
       </section>
 
       <div class="section-grid">
         <section class="card">
-          <h2 class="card-title">More Examples</h2>
-          <p>Explore different use-cases and widget configurations below.</p>
+          <h2 class="card-title">Examples</h2>
+          <p>Explore different use cases and widget configurations.</p>
           <ul class="examples-list">
-            <li><a class="example-item" href="/theme.html">Agent Editor <small>Style it visually</small></a></li>
-            <li><a class="example-item" href="/action-middleware.html">Action Middleware <small>E-commerce example</small></a></li>
-            <li><a class="example-item" href="/bakery.html">Bakery Assistant Demo <small>Industry specific persona</small></a></li>
-            <li><a class="example-item" href="/docked-panel-demo.html">Docked Panel Demo <small>Alternative layout</small></a></li>
-            <li><a class="example-item" href="/feedback-demo.html">Message Feedback Demo <small>Copy, Upvote, Downvote</small></a></li>
-            <li><a class="example-item" href="/feedback-integration-demo.html">Feedback Integration Demo <small>With external API</small></a></li>
-            <li><a class="example-item" href="/custom-loading-indicator.html">Custom Loading Indicator <small>Unique UX</small></a></li>
-            <li><a class="example-item" href="/agent-demo.html">Agent Loop Execution Demo <small>Internal thought processes</small></a></li>
-            <li><a class="example-item" href="/approval-demo.html">Tool Approval Demo <small>Action confirmation</small></a></li>
-            <li><a class="example-item" href="/focus-input-demo.html">Focus Input Demo <small>Input state handling</small></a></li>
-            <li><a class="example-item" href="/artifact-demo.html">Artifact Sidebar Demo <small>Multi-pane interface</small></a></li>
-            <li><a class="example-item" href="/fullscreen-assistant-demo.html">Fullscreen Assistant <small>Split chat + artifact</small></a></li>
-            <li><a class="example-item" href="/voice-integration-demo.html">🎤 Voice Integration Demo <small>Powered by ElevenLabs</small></a></li>
+            <li><a class="example-item" href="/action-middleware.html">Action Middleware <small>AI-driven page interactions and cart management</small></a></li>
+            <li><a class="example-item" href="/docked-panel-demo.html">Docked Panel <small>Side-docked assistant layout</small></a></li>
+            <li><a class="example-item" href="/feedback-demo.html">Message Feedback <small>Copy, Upvote, Downvote</small></a></li>
+            <li><a class="example-item" href="/feedback-integration-demo.html">Feedback Integration <small>Wire feedback events to your backend</small></a></li>
+            <li><a class="example-item" href="/custom-loading-indicator.html">Custom Loading Indicator <small>Replace the default loading animation</small></a></li>
+            <li><a class="example-item" href="/approval-demo.html">Tool Approval <small>Human-in-the-loop confirmation before tool execution</small></a></li>
+            <li><a class="example-item" href="/focus-input-demo.html">Focus Input <small>Programmatic input focus and state control</small></a></li>
+            <li><a class="example-item" href="/artifact-demo.html">Artifact Sidebar <small>Resizable split view for rich content</small></a></li>
+            <li><a class="example-item" href="/voice-integration-demo.html">Voice Integration <small>Speech-to-text and text-to-speech input</small></a></li>
           </ul>
         </section>
 
         <section class="card">
           <h2 class="card-title">Standalone Scripts</h2>
-          <p>These load the widget via IIFE build (local on localhost, CDN in production). Run <code>pnpm build:widget</code> first.</p>
+          <p>Script tag integration — no bundler required. Uses the CDN build in production.</p>
           <ul class="examples-list">
             <li><a class="example-item" href="/standalone/example-shop.html">Example Shop (Manual)</a></li>
             <li><a class="example-item" href="/standalone/example-shop-metadata.html">Example Shop (Metadata)</a></li>
@@ -68,8 +64,17 @@
 
       <div class="section-grid">
         <section class="card">
-          <h2 class="card-title">Programmatic Control</h2>
-          <p>The widget controller returned by <code>initAgentWidget</code> provides methods to programmatically control the widget:</p>
+          <h2 class="card-title">Developer Tools</h2>
+          <p>Test the launcher, load synthetic messages, and explore the programmatic API.</p>
+          <div class="cta-row" style="justify-content: flex-start;">
+            <button id="open-chat" class="primaryButton" type="button">Open Launcher</button>
+            <button id="toggle-chat" class="secondaryButton" type="button">Toggle Launcher</button>
+            <select id="target-widget">
+              <option value="inline">Inline Widget</option>
+              <option value="launcher">Launcher Widget</option>
+            </select>
+            <button id="load-messages" class="secondaryButton" type="button">Load 1000 Messages</button>
+          </div>
           <div class="code-example">
             <pre><code>const launcherController = initAgentWidget({
   target: "#launcher-root",
@@ -90,7 +95,7 @@ launcherController.toggle();</code></pre>
         <section class="card">
           <h2 class="card-title">Event Stream Testing</h2>
           <p>Test the event stream SDK methods, window events, and instance scoping.</p>
-          
+
           <h3>Controller Methods</h3>
           <div class="cta-row" style="justify-content: flex-start;">
             <select id="event-stream-target">
@@ -101,7 +106,7 @@ launcherController.toggle();</code></pre>
             <button id="es-hide" class="secondaryButton" type="button">Hide Event Stream</button>
             <button id="es-check" class="secondaryButton" type="button">Check Visibility</button>
           </div>
-          
+
           <h3 style="margin-top: 16px;">Window Events</h3>
           <div class="cta-row" style="justify-content: flex-start;">
             <button id="es-win-show-all" class="secondaryButton" type="button">Show All (window)</button>
@@ -110,22 +115,20 @@ launcherController.toggle();</code></pre>
             <button id="es-win-show-launcher" class="secondaryButton" type="button">Show Launcher Only</button>
             <button id="es-win-show-wrong" class="secondaryButton" type="button">Show Wrong ID</button>
           </div>
-          
+
           <h3 style="margin-top: 16px;">Event Listeners</h3>
           <div class="cta-row" style="justify-content: flex-start;">
             <button id="es-listen" class="secondaryButton" type="button">Register Listeners</button>
           </div>
-          
+
           <div id="es-log" class="code-example" style="margin-top: 16px; max-height:150px; overflow-y:auto; display:none;">
             <pre id="es-log-pre"></pre>
           </div>
         </section>
       </div>
-
-      <!-- inline-widget mount moved above -->
     </main>
   </div>
-  
+
   <div id="launcher-root"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -25,6 +25,12 @@
         </div>
       </section>
 
+      <section class="card cardFull">
+        <h2 class="card-title">Ask Persona</h2>
+        <p>Chat with our documentation assistant to learn about Persona or find the right demo.</p>
+        <div class="embedded-target" id="inline-widget"></div>
+      </section>
+
       <div class="section-grid">
         <section class="card">
           <h2 class="card-title">More Examples</h2>
@@ -116,10 +122,7 @@ launcherController.toggle();</code></pre>
         </section>
       </div>
 
-      <section class="card cardFull">
-        <h2 class="card-title">Inline Embed</h2>
-        <div class="embedded-target" id="inline-widget"></div>
-      </section>
+      <!-- inline-widget mount moved above -->
     </main>
   </div>
   

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -236,6 +236,13 @@ select {
   padding: 0;
 }
 
+/* Featured Grid */
+.featured-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 12px;
+}
+
 /* Inline Embed Target */
 .embedded-target {
   min-height: 500px;

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -15,6 +15,48 @@ const proxyUrl =
     `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch` :
     `http://localhost:${proxyPort}/api/chat/dispatch`;
 
+const PERSONA_SYSTEM_PROMPT = `You are the Persona documentation assistant, embedded in the Persona examples app.
+
+## What is Persona?
+Persona is a themeable, pluggable streaming chat widget for websites. It ships as two npm packages:
+- **@runtypelabs/persona** — the main widget library (Shadow DOM isolation, SSE streaming, theming, plugins, voice)
+- **@runtypelabs/persona-proxy** — an optional Hono-based proxy server that sits between the widget and the Runtype API
+
+## Key Features
+- **Shadow DOM isolation** — widget styles never leak into or from the host page
+- **SSE streaming** with pluggable parsers (markdown, JSON, XML, plain text)
+- **Theme system** — CSS custom properties + Tailwind with a \`tvw-\` prefix; light and dark presets included
+- **Plugin architecture** for custom functionality
+- **Voice integration** — Web Audio API and ElevenLabs-powered voice input
+- **Agent loop execution** — multi-turn reasoning with tool use
+- **Tool approval** — user confirmation before executing tools
+- **Artifact sidebar** — multi-pane interface for rendering rich content alongside chat
+- **Message feedback** — copy, upvote, downvote on messages
+- **Virtual scrolling** for performance with large message histories
+- **Multiple install methods** — ESM/bundler, CommonJS, or CDN script tag (IIFE)
+
+## Installation
+The widget can be installed via npm (\`npm install @runtypelabs/persona\`) and initialized with \`initAgentWidget()\` or \`createAgentExperience()\`. For CDN usage, include the IIFE build via a script tag.
+
+## Available Demos
+When a user asks about a feature or use case, recommend the most relevant demo from this list. Format links as markdown, e.g. [Demo Name](/path.html).
+
+- [Agent Editor](/theme.html) — visually customize the widget theme and styling in real time
+- [Action Middleware](/action-middleware.html) — e-commerce action handling with AI-driven page interactions
+- [Bakery Assistant](/bakery.html) — industry-specific persona with a rich product catalog and cart actions
+- [Docked Panel](/docked-panel-demo.html) — alternative layout with the widget docked to the side of the page
+- [Message Feedback](/feedback-demo.html) — copy, upvote, and downvote buttons on messages
+- [Feedback Integration](/feedback-integration-demo.html) — wiring feedback events to an external API
+- [Custom Loading Indicator](/custom-loading-indicator.html) — replace the default loading UX with your own
+- [Agent Loop Execution](/agent-demo.html) — multi-turn reasoning with internal thought processes and tool use
+- [Tool Approval](/approval-demo.html) — require user confirmation before the agent executes a tool
+- [Focus Input](/focus-input-demo.html) — programmatic input focus and state handling
+- [Artifact Sidebar](/artifact-demo.html) — multi-pane interface with a resizable artifact panel
+- [Fullscreen Assistant](/fullscreen-assistant-demo.html) — dark full-viewport split layout (chat + artifacts)
+- [Voice Integration](/voice-integration-demo.html) — voice input powered by ElevenLabs
+
+Keep answers concise. Use markdown formatting. When recommending a demo, briefly explain why it is relevant to the user's question.`;
+
 const inlineMount = document.getElementById("inline-widget");
 if (!inlineMount) {
   throw new Error("Inline widget mount node missing");
@@ -23,6 +65,17 @@ if (!inlineMount) {
 const inlineController = createAgentExperience(inlineMount, {
   ...DEFAULT_WIDGET_CONFIG,
   apiUrl: proxyUrl,
+  agent: {
+    name: "Persona Documentation Assistant",
+    model: "mercury-2",
+    systemPrompt: PERSONA_SYSTEM_PROMPT,
+    temperature: 0.5,
+  },
+  agentOptions: {
+    streamResponse: true,
+    recordMode: "virtual",
+    storeResults: false,
+  },
   launcher: {
     ...DEFAULT_WIDGET_CONFIG.launcher,
     width: "100%",
@@ -32,7 +85,7 @@ const inlineController = createAgentExperience(inlineMount, {
     showEventStreamToggle: true
   },
   persistState: {
-    keyPrefix: "inline-"
+    keyPrefix: "persona-assistant-"
   },
   theme: {
     ...DEFAULT_WIDGET_CONFIG.theme,
@@ -43,15 +96,15 @@ const inlineController = createAgentExperience(inlineMount, {
   },
   copy: {
     ...DEFAULT_WIDGET_CONFIG.copy,
-    welcomeTitle: "Inline Demo",
+    welcomeTitle: "Welcome to Persona",
     welcomeSubtitle:
-      "This instance is rendered via createAgentExperience with a neutral theme.",
-    inputPlaceholder: "Ask about embedding, styling, or integrations…"
+      "I can help you learn about Persona and find the right demo for your use case.",
+    inputPlaceholder: "Ask about Persona features, theming, integrations…"
   },
   suggestionChips: [
-    "Do you support streaming?",
-    "How do I theme the widget?",
-    "Show me the proxy setup"
+    "What is Persona and how does it work?",
+    "Which demo shows theming and customization?",
+    "How do I add a chat widget to my website?"
   ],
   postprocessMessage: ({ text }) => markdownPostprocessor(text)
 });

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -41,7 +41,7 @@ The widget can be installed via npm (\`npm install @runtypelabs/persona\`) and i
 ## Available Demos
 When a user asks about a feature or use case, recommend the most relevant demo from this list. Format links as markdown, e.g. [Demo Name](/path.html).
 
-- [Agent Editor](/theme.html) — visually customize the widget theme and styling in real time
+- [Theme Editor](/theme.html) — visually customize the widget theme and styling in real time
 - [Action Middleware](/action-middleware.html) — e-commerce action handling with AI-driven page interactions
 - [Bakery Assistant](/bakery.html) — industry-specific persona with a rich product catalog and cart actions
 - [Docked Panel](/docked-panel-demo.html) — alternative layout with the widget docked to the side of the page

--- a/packages/proxy/package.json
+++ b/packages/proxy/package.json
@@ -37,7 +37,7 @@
     "vitest": "^4.1.0"
   },
   "engines": {
-    "node": ">=18.17.0"
+    "node": ">=20.0.0"
   },
   "author": "Runtype",
   "license": "MIT",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -57,7 +57,7 @@
     "vitest": "^4.0.9"
   },
   "engines": {
-    "node": ">=18.17.0"
+    "node": ">=20.0.0"
   },
   "author": "Runtype",
   "license": "MIT",


### PR DESCRIPTION
## Summary

Restructures the examples app landing page to make a strong first impression for developers discovering Persona. Every change has a specific reason — this isn't cosmetic polish, it's about optimizing the path from curiosity to understanding.

### What changed

**Hero section rewritten for value, not implementation**
- Old: "This page renders the widget two ways: once through the vanilla initializer and once as a floating launcher wired up to user actions."
- New: "A drop-in streaming chat widget for your AI assistant. Themeable, pluggable, zero framework dependencies."
- Removed the proxy implementation note — developers don't need plumbing details on their first visit.

**Live chat widget promoted to first panel**
- Moved the inline embedded widget from the bottom of the page to immediately after the hero.
- Switched it to agent mode with a rich system prompt covering what Persona is, key features, and all 13 demo pages with links — so it can answer questions and direct developers to the right demo.
- Updated welcome copy and suggestion chips to frame it as a "try it" experience, not a documentation chatbot.

**Featured examples grid added**
- 4 demos that show Persona's range: Theme Editor (customization), Bakery Assistant (real-world use case), Agent Loop (technical depth), Fullscreen Assistant (full application).
- Displayed in a 2x2 grid above the full examples list to reduce decision paralysis.

**All demo labels improved**
- Made descriptions specific about what the developer will actually see.
- e.g. "Agent Editor / Style it visually" → "Theme Editor / Customize colors, fonts, and layout in real time"
- "Action Middleware / E-commerce example" → "Action Middleware / AI-driven page interactions and cart management"

**Developer testing tools moved to bottom**
- Launcher controls, Load 1000 Messages, Programmatic Control code example, and Event Stream Testing are still fully functional — just no longer competing with the product demos for attention.
- Grouped under "Developer Tools" to signal their purpose.

**Standalone Scripts description fixed**
- Replaced "These load the widget via IIFE build (local on localhost, CDN in production). Run `pnpm build:widget` first." with "Script tag integration — no bundler required. Uses the CDN build in production."

**Node.js minimum version updated to 20+**
- Node.js 18 reached end-of-life in April 2025. Updated all references across the repo: `package.json` engines in both packages, README, CONTRIBUTING, CLAUDE.md, and cloudflare-workers README. The `.nvmrc` already specified v20.19.0.

## Test plan
- [ ] `pnpm dev` — hero communicates value, chat widget is the second section, featured grid is visible
- [ ] Send a message to the chat widget (e.g. "What demos do you have?") — confirms agent mode + system prompt work
- [ ] Click through featured demo links — all resolve correctly
- [ ] Click through all examples and standalone script links — no broken links
- [ ] Scroll to Developer Tools — launcher controls, Load 1000 Messages, and Event Stream Testing all function
- [ ] `pnpm typecheck` passes
- [ ] Verify `node -v` on Node 18 fails with an engines error on `pnpm install`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to raising the minimum Node.js version to 20 across published packages and docs, which can break consumers/environments pinned to Node 18. The rest is confined to example app UI/content and demo configuration changes.
> 
> **Overview**
> **Updates platform requirements** by bumping minimum Node.js from `>=18.17` to `>=20` across docs and the `engines.node` fields for `@runtypelabs/persona` and `@runtypelabs/persona-proxy`.
> 
> **Restructures the `examples/embedded-app` landing page** into a product-style entry point: moves the inline widget into a prominent *Try it* section, adds a *Featured* grid, refreshes demo link copy, and relocates launcher/event-stream controls under *Developer Tools*.
> 
> **Turns the inline demo widget into an agent-powered “Persona documentation assistant”** by adding a rich system prompt, updated welcome/suggestions, and a new `persistState.keyPrefix` for its stored state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f1f9c932e617ecc38d90923de419b6ba470c98c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->