### PR TITLE
docs: add DeepWiki badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Persona
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/runtypelabs/persona)
+
 A themeable, pluggable streaming AI chat widget for websites — built in plain JS with zero framework dependencies.
 
 Persona gives you a drop-in UI for your AI assistant that works on any site. It ships with support for streaming responses, voice I/O, multi-modal content, tool call visualization, artifact rendering, and a plugin system so you can customize every layer of the UI.


### PR DESCRIPTION
## Summary
- Adds a DeepWiki badge to the top of the README, linking to the project's DeepWiki page

## Test plan
- [ ] Verify badge renders correctly on GitHub
- [ ] Verify badge link points to https://deepwiki.com/runtypelabs/persona

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds a README badge/link and does not affect runtime behavior or dependencies.
> 
> **Overview**
> Adds an **“Ask DeepWiki”** badge at the top of `README.md` linking to the project’s DeepWiki page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b4a5f307ec69aa1640c7fdeaf8a48dac04e1c5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->