### PR TITLE
feat: improve docs assistant prompt, model, and suggestion chips

### DIFF
--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -36,7 +36,38 @@ Persona is a themeable, pluggable streaming chat widget for websites. It ships a
 - **Multiple install methods** — ESM/bundler, CommonJS, or CDN script tag (IIFE)
 
 ## Installation
-The widget can be installed via npm (\`npm install @runtypelabs/persona\`) and initialized with \`initAgentWidget()\` or \`createAgentExperience()\`. For CDN usage, include the IIFE build via a script tag.
+
+**npm / bundler:**
+\`\`\`
+npm install @runtypelabs/persona
+\`\`\`
+Then import and initialize:
+\`\`\`js
+import { initAgentWidget, DEFAULT_WIDGET_CONFIG } from '@runtypelabs/persona';
+import '@runtypelabs/persona/widget.css';
+
+const controller = initAgentWidget({
+  target: '#persona-root',
+  config: {
+    ...DEFAULT_WIDGET_CONFIG,
+    apiUrl: '/api/chat/dispatch',
+  }
+});
+\`\`\`
+
+**CDN / script tag (no bundler):**
+\`\`\`html
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/widget.css" />
+<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/index.global.js"></script>
+<script>
+  window.AgentWidget.initAgentWidget({
+    target: '#persona-root',
+    config: { apiUrl: '/api/chat/dispatch' }
+  });
+</script>
+\`\`\`
+
+CDN URLs follow the pattern \`https://cdn.jsdelivr.net/npm/@runtypelabs/persona@VERSION/dist/\`. Replace \`VERSION\` with \`latest\` or a pinned version. Available files: \`widget.css\`, \`index.global.js\` (IIFE), \`index.js\` (ESM). Do NOT invent other file names.
 
 ## Available Demos
 When a user asks about a feature or use case, recommend the most relevant demo from this list. Format links as markdown, e.g. [Demo Name](/path.html).
@@ -67,7 +98,7 @@ const inlineController = createAgentExperience(inlineMount, {
   apiUrl: proxyUrl,
   agent: {
     name: "Persona Documentation Assistant",
-    model: "mercury-2",
+    model: "claude-haiku-4-5-20251001",
     systemPrompt: PERSONA_SYSTEM_PROMPT,
     temperature: 0.5,
   },
@@ -103,7 +134,8 @@ const inlineController = createAgentExperience(inlineMount, {
   },
   suggestionChips: [
     "What is Persona and how does it work?",
-    "Which demo shows theming and customization?",
+    "How does streaming work?",
+    "What can I customize?",
     "How do I add a chat widget to my website?"
   ],
   postprocessMessage: ({ text }) => markdownPostprocessor(text)


### PR DESCRIPTION
## Summary

Follow-up to #94. Improves the inline docs assistant on the examples landing page:

- **Fix hallucinated CDN URLs and API signatures** — the assistant was inventing file names like `persona.iife.js` and parameters like `apiKey`. Replaced the vague installation section in the system prompt with exact code snippets for both npm and CDN usage, using the real URLs (`index.global.js`, `widget.css`) and actual `initAgentWidget` API shape
- **Switch model to Claude Haiku 4.5** — from `mercury-2` to `claude-haiku-4-5-20251001`
- **Fix "Agent Editor" → "Theme Editor"** in the system prompt to match the landing page label
- **Update suggestion chips** — replaced "Which demo shows theming and customization?" with "How does streaming work?" and added "What can I customize?"

## Test plan
- [ ] `pnpm dev` — ask "How do I add a chat widget to my website?" and verify the response uses correct CDN URLs and API signatures
- [ ] Verify the assistant refers to "Theme Editor" not "Agent Editor"
- [ ] Confirm all 4 suggestion chips render and produce relevant responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to the examples app’s embedded docs assistant prompt/config and do not affect core widget behavior. Main risk is slightly different assistant output/cost due to the model change.
> 
> **Overview**
> Improves the embedded examples app’s *docs assistant* by replacing the vague installation guidance in `PERSONA_SYSTEM_PROMPT` with explicit, correct npm and CDN snippets (including the real `widget.css` and `index.global.js` URLs) to reduce hallucinated API/URL responses.
> 
> Updates the assistant configuration by switching the model from `mercury-2` to `claude-haiku-4-5-20251001` and refreshing the inline widget `suggestionChips` to better reflect streaming/customization questions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b3492799e4881be6c6669d5fdafbeea9d8658802. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->