### PR TITLE
fix: improve contrast for header buttons and demo code blocks

### DIFF
--- a/examples/embedded-app/src/App.css
+++ b/examples/embedded-app/src/App.css
@@ -85,6 +85,7 @@
 .code-example code {
   font-family: inherit;
   font-size: inherit;
+  color: inherit;
 }
 
 .demo-container code {

--- a/packages/widget/src/components/header-builder.ts
+++ b/packages/widget/src/components/header-builder.ts
@@ -145,7 +145,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
       clearChatIconName,
       "20px",
       clearChatIconColor || "",
-      1
+      2
     );
     if (iconSvg) {
       clearChatButton.appendChild(iconSvg);
@@ -303,7 +303,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
     closeButtonIconName,
     "20px",
     launcher.closeButtonColor || "",
-    1
+    2
   );
   if (closeIconSvg) {
     closeButton.appendChild(closeIconSvg);

--- a/packages/widget/src/defaults.ts
+++ b/packages/widget/src/defaults.ts
@@ -114,10 +114,10 @@ export const DEFAULT_WIDGET_CONFIG: Partial<AgentWidgetConfig> = {
     callToActionIconPadding: "5px",
     callToActionIconColor: "#000000",
     callToActionIconBackgroundColor: "#ffffff",
-    closeButtonColor: "#6b7280",
+    closeButtonColor: "#4b5563",
     closeButtonBackgroundColor: "transparent",
     clearChat: {
-      iconColor: "#6b7280",
+      iconColor: "#4b5563",
       backgroundColor: "transparent",
       borderColor: "transparent",
       enabled: true,


### PR DESCRIPTION
## Summary
- **Close & clear-chat button icons**: Increased stroke width from 1 to 2 and changed default color from `#6b7280` (gray-500) to `#4b5563` (gray-600) in `defaults.ts`
- **Demo code blocks**: Added `color: inherit` to `.code-example code` in `App.css` to fix light-on-light text caused by CSS cascade conflict

## Test plan
- [ ] Verify close (X) and clear chat (refresh) icons are clearly visible in the widget header
- [ ] Verify code blocks on the demo landing page have readable dark text
- [ ] `pnpm test:run` — all 396 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk visual-only changes (CSS and icon rendering tweaks) with no business logic, data handling, or API behavior changes.
> 
> **Overview**
> Improves readability/contrast in the embedded app demo by ensuring `.code-example code` inherits the intended text color.
> 
> In the widget header, increases the Lucide stroke width for the close and clear-chat icons and adjusts default `launcher.closeButtonColor`/`launcher.clearChat.iconColor` to a darker gray for better visibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b73d597c185ef5c272a1d0352eb4d4abfacb7cd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->