### PR TITLE
Fix default header action hover styles

### DIFF
--- a/.changeset/soft-lobsters-dance.md
+++ b/.changeset/soft-lobsters-dance.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix header close and clear-chat buttons so the default launcher config preserves their hover text and background styles instead of forcing static inline colors.

--- a/examples/embedded-app/src/App.css
+++ b/examples/embedded-app/src/App.css
@@ -85,6 +85,7 @@
 .code-example code {
   font-family: inherit;
   font-size: inherit;
+  color: inherit;
 }
 
 .demo-container code {

--- a/packages/widget/src/components/header-builder.test.ts
+++ b/packages/widget/src/components/header-builder.test.ts
@@ -1,7 +1,62 @@
 // @vitest-environment jsdom
 
 import { describe, expect, it } from "vitest";
+import { mergeWithDefaults } from "../defaults";
 import { buildHeader } from "./header-builder";
+
+describe("buildHeader button styling", () => {
+  it("preserves default hover classes when using merged default config", () => {
+    const { closeButton, clearChatButton } = buildHeader({
+      config: mergeWithDefaults() as any
+    });
+
+    expect(closeButton.classList.contains("persona-text-persona-muted")).toBe(true);
+    expect(closeButton.classList.contains("hover:persona-text-persona-primary")).toBe(true);
+    expect(closeButton.classList.contains("hover:persona-bg-gray-100")).toBe(true);
+    expect(closeButton.style.color).toBe("");
+    expect(closeButton.style.backgroundColor).toBe("");
+    expect(closeButton.querySelector("svg")?.getAttribute("stroke")).toBe("currentColor");
+
+    expect(clearChatButton).not.toBeNull();
+    expect(clearChatButton?.classList.contains("persona-text-persona-muted")).toBe(true);
+    expect(clearChatButton?.classList.contains("hover:persona-text-persona-primary")).toBe(true);
+    expect(clearChatButton?.classList.contains("hover:persona-bg-gray-100")).toBe(true);
+    expect(clearChatButton?.style.color).toBe("");
+    expect(clearChatButton?.style.backgroundColor).toBe("");
+    expect(clearChatButton?.querySelector("svg")?.getAttribute("stroke")).toBe("currentColor");
+  });
+
+  it("treats explicit header action colors as static overrides", () => {
+    const { closeButton, clearChatButton } = buildHeader({
+      config: mergeWithDefaults({
+        launcher: {
+          closeButtonColor: "#123456",
+          closeButtonBackgroundColor: "transparent",
+          clearChat: {
+            enabled: true,
+            iconColor: "#654321",
+            backgroundColor: "transparent"
+          }
+        }
+      }) as any
+    });
+
+    expect(closeButton.classList.contains("persona-text-persona-muted")).toBe(false);
+    expect(closeButton.classList.contains("hover:persona-text-persona-primary")).toBe(false);
+    expect(closeButton.classList.contains("hover:persona-bg-gray-100")).toBe(false);
+    expect(closeButton.style.color).not.toBe("");
+    expect(closeButton.style.backgroundColor).not.toBe("");
+    expect(closeButton.querySelector("svg")?.getAttribute("stroke")).toBe("currentColor");
+
+    expect(clearChatButton).not.toBeNull();
+    expect(clearChatButton?.classList.contains("persona-text-persona-muted")).toBe(false);
+    expect(clearChatButton?.classList.contains("hover:persona-text-persona-primary")).toBe(false);
+    expect(clearChatButton?.classList.contains("hover:persona-bg-gray-100")).toBe(false);
+    expect(clearChatButton?.style.color).not.toBe("");
+    expect(clearChatButton?.style.backgroundColor).not.toBe("");
+    expect(clearChatButton?.querySelector("svg")?.getAttribute("stroke")).toBe("currentColor");
+  });
+});
 
 describe("buildHeader tooltips", () => {
   it("portals the close-button tooltip into the mounted document", () => {

--- a/packages/widget/src/components/header-builder.ts
+++ b/packages/widget/src/components/header-builder.ts
@@ -145,7 +145,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
       clearChatIconName,
       "20px",
       clearChatIconColor || "",
-      1
+      2
     );
     if (iconSvg) {
       clearChatButton.appendChild(iconSvg);
@@ -303,7 +303,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
     closeButtonIconName,
     "20px",
     launcher.closeButtonColor || "",
-    1
+    2
   );
   if (closeIconSvg) {
     closeButton.appendChild(closeIconSvg);

--- a/packages/widget/src/components/header-builder.ts
+++ b/packages/widget/src/components/header-builder.ts
@@ -1,6 +1,10 @@
 import { createElement, createElementInDocument } from "../utils/dom";
 import { renderLucideIcon } from "../utils/icons";
-import { AgentWidgetConfig } from "../types";
+import {
+  AgentWidgetClearChatConfig,
+  AgentWidgetConfig,
+  AgentWidgetLauncherConfig
+} from "../types";
 
 export interface HeaderElements {
   header: HTMLElement;
@@ -19,6 +23,162 @@ export interface HeaderBuildContext {
   onClose?: () => void;
   onClearChat?: () => void;
 }
+
+const HEADER_ACTION_DEFAULT_TEXT_CLASS = "persona-text-persona-muted";
+const HEADER_ACTION_HOVER_TEXT_CLASS = "hover:persona-text-persona-primary";
+const HEADER_ACTION_HOVER_BG_CLASS = "hover:persona-bg-gray-100";
+const HEADER_ACTION_BORDERLESS_CLASS = "persona-border-none";
+const HEADER_ACTION_ROUNDED_CLASS = "persona-rounded-full";
+
+const normalizeHeaderActionValue = (value?: string | null): string => {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : "";
+};
+
+export const renderCloseButtonIcon = (
+  closeButton: HTMLButtonElement,
+  launcher: Partial<AgentWidgetLauncherConfig> = {}
+): void => {
+  const closeButtonIconName = launcher.closeButtonIconName ?? "x";
+  const closeButtonIconText = launcher.closeButtonIconText ?? "×";
+
+  closeButton.innerHTML = "";
+  const closeIconSvg = renderLucideIcon(closeButtonIconName, "20px", "currentColor", 2);
+  if (closeIconSvg) {
+    closeButton.appendChild(closeIconSvg);
+  } else {
+    closeButton.textContent = closeButtonIconText;
+  }
+};
+
+export const renderClearChatButtonIcon = (
+  clearChatButton: HTMLButtonElement,
+  clearChatConfig: Partial<AgentWidgetClearChatConfig> = {}
+): void => {
+  const clearChatIconName = clearChatConfig.iconName ?? "refresh-cw";
+
+  clearChatButton.innerHTML = "";
+  const iconSvg = renderLucideIcon(clearChatIconName, "20px", "currentColor", 2);
+  if (iconSvg) {
+    clearChatButton.appendChild(iconSvg);
+  }
+};
+
+export const applyHeaderActionColor = (
+  button: HTMLButtonElement,
+  color?: string | null
+): void => {
+  const resolvedColor = normalizeHeaderActionValue(color);
+  if (resolvedColor) {
+    button.style.color = resolvedColor;
+    button.classList.remove(HEADER_ACTION_DEFAULT_TEXT_CLASS);
+    button.classList.remove(HEADER_ACTION_HOVER_TEXT_CLASS);
+    return;
+  }
+
+  button.style.color = "";
+  button.classList.add(HEADER_ACTION_DEFAULT_TEXT_CLASS);
+  button.classList.add(HEADER_ACTION_HOVER_TEXT_CLASS);
+};
+
+export const applyHeaderActionBackground = (
+  button: HTMLButtonElement,
+  backgroundColor?: string | null
+): void => {
+  const resolvedBackground = normalizeHeaderActionValue(backgroundColor);
+  if (resolvedBackground) {
+    button.style.backgroundColor = resolvedBackground;
+    button.classList.remove(HEADER_ACTION_HOVER_BG_CLASS);
+    return;
+  }
+
+  button.style.backgroundColor = "";
+  button.classList.add(HEADER_ACTION_HOVER_BG_CLASS);
+};
+
+export const applyCloseButtonStyles = (
+  closeButton: HTMLButtonElement,
+  launcher: Partial<AgentWidgetLauncherConfig> = {}
+): void => {
+  applyHeaderActionColor(closeButton, launcher.closeButtonColor);
+  applyHeaderActionBackground(closeButton, launcher.closeButtonBackgroundColor);
+
+  if (launcher.closeButtonBorderWidth || launcher.closeButtonBorderColor) {
+    const borderWidth = launcher.closeButtonBorderWidth || "0px";
+    const borderColor = launcher.closeButtonBorderColor || "transparent";
+    closeButton.style.border = `${borderWidth} solid ${borderColor}`;
+    closeButton.classList.remove(HEADER_ACTION_BORDERLESS_CLASS);
+  } else {
+    closeButton.style.border = "";
+    closeButton.classList.add(HEADER_ACTION_BORDERLESS_CLASS);
+  }
+
+  if (launcher.closeButtonBorderRadius) {
+    closeButton.style.borderRadius = launcher.closeButtonBorderRadius;
+    closeButton.classList.remove(HEADER_ACTION_ROUNDED_CLASS);
+  } else {
+    closeButton.style.borderRadius = "";
+    closeButton.classList.add(HEADER_ACTION_ROUNDED_CLASS);
+  }
+
+  if (launcher.closeButtonPaddingX) {
+    closeButton.style.paddingLeft = launcher.closeButtonPaddingX;
+    closeButton.style.paddingRight = launcher.closeButtonPaddingX;
+  } else {
+    closeButton.style.paddingLeft = "";
+    closeButton.style.paddingRight = "";
+  }
+
+  if (launcher.closeButtonPaddingY) {
+    closeButton.style.paddingTop = launcher.closeButtonPaddingY;
+    closeButton.style.paddingBottom = launcher.closeButtonPaddingY;
+  } else {
+    closeButton.style.paddingTop = "";
+    closeButton.style.paddingBottom = "";
+  }
+};
+
+export const applyClearChatButtonStyles = (
+  clearChatButton: HTMLButtonElement,
+  clearChatConfig: Partial<AgentWidgetClearChatConfig> = {}
+): void => {
+  applyHeaderActionColor(clearChatButton, clearChatConfig.iconColor);
+  applyHeaderActionBackground(clearChatButton, clearChatConfig.backgroundColor);
+
+  if (clearChatConfig.borderWidth || clearChatConfig.borderColor) {
+    const borderWidth = clearChatConfig.borderWidth || "0px";
+    const borderColor = clearChatConfig.borderColor || "transparent";
+    clearChatButton.style.border = `${borderWidth} solid ${borderColor}`;
+    clearChatButton.classList.remove(HEADER_ACTION_BORDERLESS_CLASS);
+  } else {
+    clearChatButton.style.border = "";
+    clearChatButton.classList.add(HEADER_ACTION_BORDERLESS_CLASS);
+  }
+
+  if (clearChatConfig.borderRadius) {
+    clearChatButton.style.borderRadius = clearChatConfig.borderRadius;
+    clearChatButton.classList.remove(HEADER_ACTION_ROUNDED_CLASS);
+  } else {
+    clearChatButton.style.borderRadius = "";
+    clearChatButton.classList.add(HEADER_ACTION_ROUNDED_CLASS);
+  }
+
+  if (clearChatConfig.paddingX) {
+    clearChatButton.style.paddingLeft = clearChatConfig.paddingX;
+    clearChatButton.style.paddingRight = clearChatConfig.paddingX;
+  } else {
+    clearChatButton.style.paddingLeft = "";
+    clearChatButton.style.paddingRight = "";
+  }
+
+  if (clearChatConfig.paddingY) {
+    clearChatButton.style.paddingTop = clearChatConfig.paddingY;
+    clearChatButton.style.paddingBottom = clearChatConfig.paddingY;
+  } else {
+    clearChatButton.style.paddingTop = "";
+    clearChatButton.style.paddingBottom = "";
+  }
+};
 
 /**
  * Build the header section of the panel.
@@ -103,14 +263,6 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
 
   if (clearChatEnabled) {
     const clearChatSize = clearChatConfig.size ?? "32px";
-    const clearChatIconName = clearChatConfig.iconName ?? "refresh-cw";
-    const clearChatIconColor = clearChatConfig.iconColor ?? "";
-    const clearChatBgColor = clearChatConfig.backgroundColor ?? "";
-    const clearChatBorderWidth = clearChatConfig.borderWidth ?? "";
-    const clearChatBorderColor = clearChatConfig.borderColor ?? "";
-    const clearChatBorderRadius = clearChatConfig.borderRadius ?? "";
-    const clearChatPaddingX = clearChatConfig.paddingX ?? "";
-    const clearChatPaddingY = clearChatConfig.paddingY ?? "";
     const clearChatTooltipText = clearChatConfig.tooltipText ?? "Clear chat";
     const clearChatShowTooltip = clearChatConfig.showTooltip ?? true;
 
@@ -132,7 +284,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
 
     clearChatButton = createElement(
       "button",
-      "persona-inline-flex persona-items-center persona-justify-center persona-rounded-full persona-text-persona-muted hover:persona-bg-gray-100 persona-cursor-pointer persona-border-none"
+      "persona-inline-flex persona-items-center persona-justify-center persona-rounded-full persona-text-persona-muted hover:persona-text-persona-primary hover:persona-bg-gray-100 persona-cursor-pointer persona-border-none"
     ) as HTMLButtonElement;
 
     clearChatButton.style.height = clearChatSize;
@@ -141,54 +293,8 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
     clearChatButton.setAttribute("aria-label", clearChatTooltipText);
 
     // Add icon
-    const iconSvg = renderLucideIcon(
-      clearChatIconName,
-      "20px",
-      clearChatIconColor || "",
-      2
-    );
-    if (iconSvg) {
-      clearChatButton.appendChild(iconSvg);
-    }
-
-    // Apply styling from config
-    if (clearChatIconColor) {
-      clearChatButton.style.color = clearChatIconColor;
-      clearChatButton.classList.remove("persona-text-persona-muted");
-    }
-
-    if (clearChatBgColor) {
-      clearChatButton.style.backgroundColor = clearChatBgColor;
-      clearChatButton.classList.remove("hover:persona-bg-gray-100");
-    }
-
-    if (clearChatBorderWidth || clearChatBorderColor) {
-      const borderWidth = clearChatBorderWidth || "0px";
-      const borderColor = clearChatBorderColor || "transparent";
-      clearChatButton.style.border = `${borderWidth} solid ${borderColor}`;
-      clearChatButton.classList.remove("persona-border-none");
-    }
-
-    if (clearChatBorderRadius) {
-      clearChatButton.style.borderRadius = clearChatBorderRadius;
-      clearChatButton.classList.remove("persona-rounded-full");
-    }
-
-    // Apply padding styling
-    if (clearChatPaddingX) {
-      clearChatButton.style.paddingLeft = clearChatPaddingX;
-      clearChatButton.style.paddingRight = clearChatPaddingX;
-    } else {
-      clearChatButton.style.paddingLeft = "";
-      clearChatButton.style.paddingRight = "";
-    }
-    if (clearChatPaddingY) {
-      clearChatButton.style.paddingTop = clearChatPaddingY;
-      clearChatButton.style.paddingBottom = clearChatPaddingY;
-    } else {
-      clearChatButton.style.paddingTop = "";
-      clearChatButton.style.paddingBottom = "";
-    }
+    renderClearChatButtonIcon(clearChatButton, clearChatConfig);
+    applyClearChatButtonStyles(clearChatButton, clearChatConfig);
 
     clearChatButtonWrapper.appendChild(clearChatButton);
 
@@ -281,7 +387,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
   // Create close button with base classes
   const closeButton = createElement(
     "button",
-    "persona-inline-flex persona-items-center persona-justify-center persona-rounded-full persona-text-persona-muted hover:persona-bg-gray-100 persona-cursor-pointer persona-border-none"
+    "persona-inline-flex persona-items-center persona-justify-center persona-rounded-full persona-text-persona-muted hover:persona-text-persona-primary hover:persona-bg-gray-100 persona-cursor-pointer persona-border-none"
   ) as HTMLButtonElement;
   closeButton.style.height = closeButtonSize;
   closeButton.style.width = closeButtonSize;
@@ -294,74 +400,8 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
   closeButton.setAttribute("aria-label", closeButtonTooltipText);
   closeButton.style.display = showClose ? "" : "none";
 
-  // Add icon or fallback text
-  const closeButtonIconName = launcher.closeButtonIconName ?? "x";
-  const closeButtonIconText = launcher.closeButtonIconText ?? "×";
-
-  // Try to render Lucide icon, fallback to text if not provided or fails
-  const closeIconSvg = renderLucideIcon(
-    closeButtonIconName,
-    "20px",
-    launcher.closeButtonColor || "",
-    2
-  );
-  if (closeIconSvg) {
-    closeButton.appendChild(closeIconSvg);
-  } else {
-    closeButton.textContent = closeButtonIconText;
-  }
-
-  // Apply close button styling from config
-  if (launcher.closeButtonColor) {
-    closeButton.style.color = launcher.closeButtonColor;
-    closeButton.classList.remove("persona-text-persona-muted");
-  } else {
-    closeButton.style.color = "";
-    closeButton.classList.add("persona-text-persona-muted");
-  }
-
-  if (launcher.closeButtonBackgroundColor) {
-    closeButton.style.backgroundColor = launcher.closeButtonBackgroundColor;
-    closeButton.classList.remove("hover:persona-bg-gray-100");
-  } else {
-    closeButton.style.backgroundColor = "";
-    closeButton.classList.add("hover:persona-bg-gray-100");
-  }
-
-  // Apply border if width and/or color are provided
-  if (launcher.closeButtonBorderWidth || launcher.closeButtonBorderColor) {
-    const borderWidth = launcher.closeButtonBorderWidth || "0px";
-    const borderColor = launcher.closeButtonBorderColor || "transparent";
-    closeButton.style.border = `${borderWidth} solid ${borderColor}`;
-    closeButton.classList.remove("persona-border-none");
-  } else {
-    closeButton.style.border = "";
-    closeButton.classList.add("persona-border-none");
-  }
-
-  if (launcher.closeButtonBorderRadius) {
-    closeButton.style.borderRadius = launcher.closeButtonBorderRadius;
-    closeButton.classList.remove("persona-rounded-full");
-  } else {
-    closeButton.style.borderRadius = "";
-    closeButton.classList.add("persona-rounded-full");
-  }
-
-  // Apply padding styling
-  if (launcher.closeButtonPaddingX) {
-    closeButton.style.paddingLeft = launcher.closeButtonPaddingX;
-    closeButton.style.paddingRight = launcher.closeButtonPaddingX;
-  } else {
-    closeButton.style.paddingLeft = "";
-    closeButton.style.paddingRight = "";
-  }
-  if (launcher.closeButtonPaddingY) {
-    closeButton.style.paddingTop = launcher.closeButtonPaddingY;
-    closeButton.style.paddingBottom = launcher.closeButtonPaddingY;
-  } else {
-    closeButton.style.paddingTop = "";
-    closeButton.style.paddingBottom = "";
-  }
+  renderCloseButtonIcon(closeButton, launcher);
+  applyCloseButtonStyles(closeButton, launcher);
 
   closeButtonWrapper.appendChild(closeButton);
 

--- a/packages/widget/src/components/header-layouts.ts
+++ b/packages/widget/src/components/header-layouts.ts
@@ -5,7 +5,13 @@ import {
   AgentWidgetHeaderLayoutConfig,
   AgentWidgetHeaderTrailingAction
 } from "../types";
-import { buildHeader, HeaderElements, attachHeaderToContainer as _attachHeaderToContainer } from "./header-builder";
+import {
+  applyCloseButtonStyles,
+  attachHeaderToContainer as _attachHeaderToContainer,
+  buildHeader,
+  HeaderElements,
+  renderCloseButtonIcon
+} from "./header-builder";
 
 export interface HeaderLayoutContext {
   config: AgentWidgetConfig;
@@ -133,7 +139,7 @@ export const buildMinimalHeader: HeaderLayoutRenderer = (context) => {
 
   const closeButton = createElement(
     "button",
-    "persona-inline-flex persona-items-center persona-justify-center persona-rounded-full persona-text-persona-muted hover:persona-bg-gray-100 persona-cursor-pointer persona-border-none"
+    "persona-inline-flex persona-items-center persona-justify-center persona-rounded-full persona-text-persona-muted hover:persona-text-persona-primary hover:persona-bg-gray-100 persona-cursor-pointer persona-border-none"
   ) as HTMLButtonElement;
   closeButton.style.height = closeButtonSize;
   closeButton.style.width = closeButtonSize;
@@ -141,18 +147,8 @@ export const buildMinimalHeader: HeaderLayoutRenderer = (context) => {
   closeButton.setAttribute("aria-label", "Close chat");
   closeButton.style.display = showClose ? "" : "none";
 
-  const closeButtonIconName = launcher.closeButtonIconName ?? "x";
-  const closeIconSvg = renderLucideIcon(
-    closeButtonIconName,
-    "20px",
-    launcher.closeButtonColor || "",
-    2
-  );
-  if (closeIconSvg) {
-    closeButton.appendChild(closeIconSvg);
-  } else {
-    closeButton.textContent = "×";
-  }
+  renderCloseButtonIcon(closeButton, launcher);
+  applyCloseButtonStyles(closeButton, launcher);
 
   if (onClose) {
     closeButton.addEventListener("click", onClose);

--- a/packages/widget/src/components/panel.ts
+++ b/packages/widget/src/components/panel.ts
@@ -2,7 +2,15 @@ import { createElement } from "../utils/dom";
 import { AgentWidgetConfig } from "../types";
 import { positionMap } from "../utils/positioning";
 import { isDockedMountMode } from "../utils/dock";
-import { buildHeader, attachHeaderToContainer, HeaderElements } from "./header-builder";
+import {
+  applyClearChatButtonStyles,
+  applyCloseButtonStyles,
+  attachHeaderToContainer,
+  buildHeader,
+  HeaderElements,
+  renderClearChatButtonIcon,
+  renderCloseButtonIcon
+} from "./header-builder";
 import { buildHeaderWithLayout } from "./header-layouts";
 import { buildComposer, ComposerElements } from "./composer-builder";
 
@@ -232,6 +240,14 @@ export const buildPanel = (config?: AgentWidgetConfig, showClose = true): PanelE
 };
 
 // Re-export builder types and functions for plugin use
-export { buildHeader, buildComposer, attachHeaderToContainer };
+export {
+  applyClearChatButtonStyles,
+  applyCloseButtonStyles,
+  attachHeaderToContainer,
+  buildHeader,
+  buildComposer,
+  renderClearChatButtonIcon,
+  renderCloseButtonIcon
+};
 export type { HeaderElements, HeaderBuildContext } from "./header-builder";
 export type { ComposerElements, ComposerBuildContext } from "./composer-builder";

--- a/packages/widget/src/defaults.ts
+++ b/packages/widget/src/defaults.ts
@@ -114,12 +114,7 @@ export const DEFAULT_WIDGET_CONFIG: Partial<AgentWidgetConfig> = {
     callToActionIconPadding: "5px",
     callToActionIconColor: "#000000",
     callToActionIconBackgroundColor: "#ffffff",
-    closeButtonColor: "#4b5563",
-    closeButtonBackgroundColor: "transparent",
     clearChat: {
-      iconColor: "#4b5563",
-      backgroundColor: "transparent",
-      borderColor: "transparent",
       enabled: true,
       placement: "inline",
       iconName: "refresh-cw",

--- a/packages/widget/src/defaults.ts
+++ b/packages/widget/src/defaults.ts
@@ -114,10 +114,10 @@ export const DEFAULT_WIDGET_CONFIG: Partial<AgentWidgetConfig> = {
     callToActionIconPadding: "5px",
     callToActionIconColor: "#000000",
     callToActionIconBackgroundColor: "#ffffff",
-    closeButtonColor: "#6b7280",
+    closeButtonColor: "#4b5563",
     closeButtonBackgroundColor: "transparent",
     clearChat: {
-      iconColor: "#6b7280",
+      iconColor: "#4b5563",
       backgroundColor: "transparent",
       borderColor: "transparent",
       enabled: true,

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -35,7 +35,17 @@ import { computeMessageFingerprint, createMessageCache, getCachedWrapper, setCac
 import { statusCopy } from "./utils/constants";
 import { isDockedMountMode } from "./utils/dock";
 import { createLauncherButton } from "./components/launcher";
-import { createWrapper, buildPanel, buildHeader, buildComposer, attachHeaderToContainer } from "./components/panel";
+import {
+  applyClearChatButtonStyles,
+  applyCloseButtonStyles,
+  attachHeaderToContainer,
+  buildComposer,
+  buildHeader,
+  buildPanel,
+  createWrapper,
+  renderClearChatButtonIcon,
+  renderCloseButtonIcon
+} from "./components/panel";
 import { buildHeaderWithLayout } from "./components/header-layouts";
 import { positionMap } from "./utils/positioning";
 import type { HeaderElements as _HeaderElements, ComposerElements as _ComposerElements } from "./components/panel";
@@ -3959,70 +3969,9 @@ export const createAgentExperience = (
           }
         }
         
-        // Apply close button styling from config
-        if (launcher.closeButtonColor) {
-          closeButton.style.color = launcher.closeButtonColor;
-          closeButton.classList.remove("persona-text-persona-muted");
-        } else {
-          closeButton.style.color = "";
-          closeButton.classList.add("persona-text-persona-muted");
-        }
-        
-        if (launcher.closeButtonBackgroundColor) {
-          closeButton.style.backgroundColor = launcher.closeButtonBackgroundColor;
-          closeButton.classList.remove("hover:persona-bg-gray-100");
-        } else {
-          closeButton.style.backgroundColor = "";
-          closeButton.classList.add("hover:persona-bg-gray-100");
-        }
-        
-        // Apply border if width and/or color are provided
-        if (launcher.closeButtonBorderWidth || launcher.closeButtonBorderColor) {
-          const borderWidth = launcher.closeButtonBorderWidth || "0px";
-          const borderColor = launcher.closeButtonBorderColor || "transparent";
-          closeButton.style.border = `${borderWidth} solid ${borderColor}`;
-          closeButton.classList.remove("persona-border-none");
-        } else {
-          closeButton.style.border = "";
-          closeButton.classList.add("persona-border-none");
-        }
-        
-        if (launcher.closeButtonBorderRadius) {
-          closeButton.style.borderRadius = launcher.closeButtonBorderRadius;
-          closeButton.classList.remove("persona-rounded-full");
-        } else {
-          closeButton.style.borderRadius = "";
-          closeButton.classList.add("persona-rounded-full");
-        }
+        applyCloseButtonStyles(closeButton, launcher);
 
-        // Update padding
-        if (launcher.closeButtonPaddingX) {
-          closeButton.style.paddingLeft = launcher.closeButtonPaddingX;
-          closeButton.style.paddingRight = launcher.closeButtonPaddingX;
-        } else {
-          closeButton.style.paddingLeft = "";
-          closeButton.style.paddingRight = "";
-        }
-        if (launcher.closeButtonPaddingY) {
-          closeButton.style.paddingTop = launcher.closeButtonPaddingY;
-          closeButton.style.paddingBottom = launcher.closeButtonPaddingY;
-        } else {
-          closeButton.style.paddingTop = "";
-          closeButton.style.paddingBottom = "";
-        }
-
-        // Update icon
-        const closeButtonIconName = launcher.closeButtonIconName ?? "x";
-        const closeButtonIconText = launcher.closeButtonIconText ?? "×";
-
-        // Clear existing content and render new icon
-        closeButton.innerHTML = "";
-        const iconSvg = renderLucideIcon(closeButtonIconName, "20px", launcher.closeButtonColor || "", 2);
-        if (iconSvg) {
-          closeButton.appendChild(iconSvg);
-        } else {
-          closeButton.textContent = closeButtonIconText;
-        }
+        renderCloseButtonIcon(closeButton, launcher);
 
         // Update tooltip
         const closeButtonTooltipText = launcher.closeButtonTooltipText ?? "Close chat";
@@ -4180,70 +4129,8 @@ export const createAgentExperience = (
           clearChatButton.style.height = clearChatSize;
           clearChatButton.style.width = clearChatSize;
 
-          // Update icon
-          const clearChatIconName = clearChatConfig.iconName ?? "refresh-cw";
-          const clearChatIconColor = clearChatConfig.iconColor ?? "";
-
-          // Clear existing icon and render new one
-          clearChatButton.innerHTML = "";
-          const iconSvg = renderLucideIcon(clearChatIconName, "20px", clearChatIconColor || "", 2);
-          if (iconSvg) {
-            clearChatButton.appendChild(iconSvg);
-          }
-
-          // Update icon color
-          if (clearChatIconColor) {
-            clearChatButton.style.color = clearChatIconColor;
-            clearChatButton.classList.remove("persona-text-persona-muted");
-          } else {
-            clearChatButton.style.color = "";
-            clearChatButton.classList.add("persona-text-persona-muted");
-          }
-
-          // Update background color
-          if (clearChatConfig.backgroundColor) {
-            clearChatButton.style.backgroundColor = clearChatConfig.backgroundColor;
-            clearChatButton.classList.remove("hover:persona-bg-gray-100");
-          } else {
-            clearChatButton.style.backgroundColor = "";
-            clearChatButton.classList.add("hover:persona-bg-gray-100");
-          }
-
-          // Update border
-          if (clearChatConfig.borderWidth || clearChatConfig.borderColor) {
-            const borderWidth = clearChatConfig.borderWidth || "0px";
-            const borderColor = clearChatConfig.borderColor || "transparent";
-            clearChatButton.style.border = `${borderWidth} solid ${borderColor}`;
-            clearChatButton.classList.remove("persona-border-none");
-          } else {
-            clearChatButton.style.border = "";
-            clearChatButton.classList.add("persona-border-none");
-          }
-
-          // Update border radius
-          if (clearChatConfig.borderRadius) {
-            clearChatButton.style.borderRadius = clearChatConfig.borderRadius;
-            clearChatButton.classList.remove("persona-rounded-full");
-          } else {
-            clearChatButton.style.borderRadius = "";
-            clearChatButton.classList.add("persona-rounded-full");
-          }
-
-          // Update padding
-          if (clearChatConfig.paddingX) {
-            clearChatButton.style.paddingLeft = clearChatConfig.paddingX;
-            clearChatButton.style.paddingRight = clearChatConfig.paddingX;
-          } else {
-            clearChatButton.style.paddingLeft = "";
-            clearChatButton.style.paddingRight = "";
-          }
-          if (clearChatConfig.paddingY) {
-            clearChatButton.style.paddingTop = clearChatConfig.paddingY;
-            clearChatButton.style.paddingBottom = clearChatConfig.paddingY;
-          } else {
-            clearChatButton.style.paddingTop = "";
-            clearChatButton.style.paddingBottom = "";
-          }
+          renderClearChatButtonIcon(clearChatButton, clearChatConfig);
+          applyClearChatButtonStyles(clearChatButton, clearChatConfig);
 
           const clearChatTooltipText = clearChatConfig.tooltipText ?? "Clear chat";
           const clearChatShowTooltip = clearChatConfig.showTooltip ?? true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove launcher-level default close/clear button style overrides that were suppressing header hover states
- make header action icons inherit `currentColor` and reuse the same styling helpers during initial render and UI updates
- add regression coverage for merged defaults versus explicit header action overrides

## Testing
- `pnpm --filter @runtypelabs/persona test:run src/components/header-builder.test.ts`
- `pnpm --filter @runtypelabs/persona typecheck`
- `pnpm --filter @runtypelabs/persona lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-babceda3-7074-4c9b-a744-ce12a02b0889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-babceda3-7074-4c9b-a744-ce12a02b0889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

