### PR TITLE
fix: design alignment follow-ups

### DIFF
--- a/examples/embedded-app/src/demo-shared.css
+++ b/examples/embedded-app/src/demo-shared.css
@@ -150,6 +150,13 @@ a {
   color: inherit;
 }
 
+.panel-header p {
+  color: inherit;
+  opacity: 0.8;
+  margin: 0.5rem 0 0;
+  font-size: 0.85rem;
+}
+
 .panel-content {
   padding: 1.5rem;
 }

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -118,7 +118,6 @@ code {
   margin-bottom: 0;
   font-size: 16px;
   color: var(--muted);
-  text-align: left;
 }
 
 .cta-row {
@@ -129,9 +128,8 @@ code {
   margin-top: 16px;
 }
 
-/* Buttons — scoped to .shell so they don't leak into the widget
-   when useShadowDom is false (e.g. the launcher on this page). */
-.shell button, .shell select, .btn {
+/* Buttons */
+button, select, .btn {
   font-family: var(--font-sans);
   font-size: 14px;
   font-weight: 600;

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -143,7 +143,6 @@ const inlineController = createAgentExperience(inlineMount, {
 
 const launcherController = initAgentWidget({
   target: "#launcher-root",
-  useShadowDom: false,
   config: {
     ...DEFAULT_WIDGET_CONFIG,
     apiUrl: proxyUrl,
@@ -154,11 +153,16 @@ const launcherController = initAgentWidget({
       keyPrefix: "launcher-"
     },
     theme: {
+      ...DEFAULT_WIDGET_CONFIG.theme,
+      primary: "#0f172a",
+      surface: "#ffffff",
+      muted: "#64748b",
       launcherRadius: ".5rem"
     },
     launcher: {
       ...DEFAULT_WIDGET_CONFIG.launcher,
       iconUrl: "https://dummyimage.com/96x96/111827/ffffff&text=AI",
+      closeButtonColor: "#6b7280",
     },
     suggestionChips: [
       "How do I embed the widget?",


### PR DESCRIPTION
## Summary

Follow-up fixes after merging #98 (Runtype design alignment):

- **Enable Shadow DOM on home page launcher** — `useShadowDom: false` was causing host page CSS to leak into the widget, breaking the close button and suggestion chip borders
- **Set explicit theme colors and `closeButtonColor`** on the launcher for proper contrast
- **Revert `.shell button` scoping** — no longer needed with Shadow DOM enabled
- **Remove `text-align: left`** from hero paragraph (should be centered)
- **Fix `.panel-header p` contrast** — global `p { color: var(--muted) }` was overriding the panel header's light foreground, making subtitle text unreadable on dark backgrounds (BugBot finding)

## Test plan

- [ ] Home page launcher: close button (X) visible, suggestion chips have borders
- [ ] Hero paragraph text is centered
- [ ] Feedback integration demo: panel header subtitle readable on dark bg
- [ ] Docked panel demo: FAB still inside workspace container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to example app CSS and widget demo configuration, mainly affecting styling and theme defaults.
> 
> **Overview**
> Improves the `examples/embedded-app` launcher demo styling by relying on Shadow DOM isolation (removing `useShadowDom: false`) and setting explicit launcher theme colors plus `closeButtonColor` for better contrast.
> 
> Cleans up host-page CSS by removing the hero paragraph’s forced left alignment, unscoping button styles to global `button/select` rules, and adding `.panel-header p` styling so panel subtitles inherit header foreground on dark backgrounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6b639aa0656afbbe85139ba7b5d0d4290dea91ce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->