### PR TITLE
feat: add npm, GitHub, and DeepWiki badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Persona
 
+[![npm](https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=262626&label=npm)](https://www.npmjs.com/package/@runtypelabs/persona)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/runtypelabs/persona)
 
 A themeable, pluggable streaming AI chat widget for websites — built in plain JS with zero framework dependencies.

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -13,6 +13,11 @@
         <h1>Persona</h1>
         <div class="hero-byline">by <a href="https://runtype.com" target="_blank" rel="noopener"><img src="/runtype-logo.svg" alt="Runtype" class="runtype-logo"></a></div>
         <p>A drop-in streaming chat widget for your AI assistant. Themeable, pluggable, zero framework dependencies.</p>
+        <div class="hero-badges">
+          <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=262626&label=npm" alt="npm"></a>
+          <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/runtypelabs/persona?style=flat&color=262626&label=GitHub" alt="GitHub"></a>
+          <a href="https://deepwiki.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+        </div>
       </section>
 
       <section class="card cardFull">

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -120,6 +120,22 @@ code {
   color: var(--muted);
 }
 
+.hero-badges {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+.hero-badges a {
+  display: inline-flex;
+}
+
+.hero-badges img {
+  height: 20px;
+}
+
 .cta-row {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

- Add shields.io badges (npm version, GitHub stars) and DeepWiki badge to the examples landing page hero
- Add npm version badge to the project README alongside the existing DeepWiki badge

## Test plan

- [ ] Badges render correctly in hero section on the examples landing page
- [ ] npm badge links to npmjs.com/package/@runtypelabs/persona
- [ ] GitHub badge links to github.com/runtypelabs/persona
- [ ] DeepWiki badge links to deepwiki.com/runtypelabs/persona
- [ ] README npm badge renders and links correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation/demo-only UI changes that add external badge images/links and minimal CSS, with no impact to runtime logic.
> 
> **Overview**
> Adds an npm version badge to `README.md` alongside the existing DeepWiki badge.
> 
> Updates the `examples/embedded-app` landing page hero to display npm, GitHub stars, and DeepWiki badges, and adds small CSS styling (`.hero-badges`) to lay them out cleanly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7ba1577d068df3185bd015b0115d9cf84c6ec97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->