### PR TITLE
feat: add AI coding agent suggestion pill to landing page widget

### DIFF
--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -33,14 +33,29 @@
         </div>
       </section>
 
+      <section class="card cardFull theme-editor-section">
+        <h2 class="card-title">Theme Editor</h2>
+        <p>Customize every color, font, and layout token — then copy the config straight into your project.</p>
+        <a class="theme-editor-link" href="/theme.html">
+          <div class="theme-backdrop">
+            <div class="theme-smoke"></div>
+            <div class="theme-grain"></div>
+            <div class="theme-fade"></div>
+            <div class="theme-cta">
+              <span class="theme-cta-label">Open Theme Editor</span>
+              <span class="theme-cta-arrow">&rarr;</span>
+            </div>
+          </div>
+        </a>
+      </section>
+
       <section class="card cardFull">
         <h2 class="card-title">Featured</h2>
         <p>See what Persona can do across different use cases.</p>
         <div class="featured-grid">
-          <a class="example-item" href="/theme.html">Theme Editor <small>Customize colors, fonts, and layout in real time</small></a>
+          <a class="example-item" href="/fullscreen-assistant-demo.html">Fullscreen Assistant <small>Full-viewport dark layout with artifacts</small></a>
           <a class="example-item" href="/bakery.html">Bakery Assistant <small>Full business site with context-aware chat</small></a>
           <a class="example-item" href="/agent-demo.html">Agent Loop <small>Multi-turn reasoning with tool calls</small></a>
-          <a class="example-item" href="/fullscreen-assistant-demo.html">Fullscreen Assistant <small>Full-viewport dark layout with artifacts</small></a>
         </div>
       </section>
 

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -519,12 +519,12 @@ select {
 /* Mobile Responsive */
 @media (max-width: 640px) {
   .shell {
-    padding: 24px 16px 48px;
-    gap: 20px;
+    padding: 20px 12px 40px;
+    gap: 16px;
   }
 
   .hero {
-    padding: 24px 20px;
+    padding: 20px 16px;
   }
 
   .hero h1 {
@@ -537,12 +537,12 @@ select {
   }
 
   .card {
-    padding: 20px 16px;
+    padding: 16px 12px;
   }
 
   .section-grid {
     grid-template-columns: 1fr;
-    gap: 20px;
+    gap: 16px;
   }
 
   .featured-grid {
@@ -554,7 +554,7 @@ select {
   }
 
   .theme-backdrop {
-    padding: 40px 20px;
+    padding: 36px 16px;
     border-radius: 12px;
   }
 
@@ -563,7 +563,7 @@ select {
   }
 
   .tryit-backdrop {
-    padding: 20px;
+    padding: 16px;
     border-radius: 12px;
   }
 

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -15,6 +15,10 @@
   --font-mono: 'JetBrains Mono', monospace;
 }
 
+*, *::before, *::after {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   min-height: 100vh;

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -398,6 +398,118 @@ select {
   box-shadow: 0 8px 32px -8px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
 
+/* Theme Editor Section */
+.theme-editor-section .card-title {
+  font-size: 22px;
+}
+
+.theme-editor-link {
+  display: block;
+  text-decoration: none;
+  border-radius: 16px;
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+
+.theme-editor-link:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 40px -12px rgba(139, 92, 246, 0.35);
+}
+
+.theme-backdrop {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  padding: 56px 32px;
+}
+
+.theme-smoke {
+  position: absolute;
+  inset: -50%;
+  background:
+    radial-gradient(ellipse 70% 60% at 20% 30%, rgba(139, 92, 246, 0.85) 0%, transparent 55%),
+    radial-gradient(ellipse 60% 70% at 80% 70%, rgba(236, 72, 153, 0.7) 0%, transparent 50%),
+    radial-gradient(ellipse 80% 50% at 50% 80%, rgba(6, 182, 212, 0.6) 0%, transparent 55%),
+    radial-gradient(ellipse 50% 80% at 70% 20%, rgba(249, 115, 22, 0.55) 0%, transparent 50%),
+    radial-gradient(ellipse 90% 60% at 30% 70%, rgba(16, 185, 129, 0.45) 0%, transparent 55%),
+    radial-gradient(ellipse 100% 100% at 50% 50%, rgba(15, 23, 42, 0.75) 0%, transparent 70%);
+  filter: blur(55px) saturate(1.6);
+  animation: theme-smoke-drift 18s ease-in-out infinite alternate;
+  z-index: 0;
+}
+
+@keyframes theme-smoke-drift {
+  0% {
+    transform: translate(0, 0) scale(1) rotate(0deg);
+  }
+  25% {
+    transform: translate(-3%, 2%) scale(1.04) rotate(-1.5deg);
+  }
+  50% {
+    transform: translate(2%, -3%) scale(0.98) rotate(1deg);
+  }
+  75% {
+    transform: translate(-1%, 1%) scale(1.03) rotate(-0.5deg);
+  }
+  100% {
+    transform: translate(2%, -1%) scale(1.01) rotate(0.8deg);
+  }
+}
+
+.theme-grain {
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  opacity: 0.3;
+  mix-blend-mode: overlay;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-size: 200px 200px;
+  pointer-events: none;
+}
+
+.theme-fade {
+  position: absolute;
+  inset: 0;
+  z-index: 2;
+  background: linear-gradient(
+    135deg,
+    rgba(0, 0, 0, 0.25) 0%,
+    rgba(0, 0, 0, 0.1) 40%,
+    rgba(0, 0, 0, 0.05) 70%,
+    rgba(0, 0, 0, 0.2) 100%
+  );
+  pointer-events: none;
+}
+
+.theme-cta {
+  position: relative;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.theme-cta-label {
+  font-family: var(--font-serif);
+  font-size: 22px;
+  font-weight: 600;
+  color: #ffffff;
+  letter-spacing: -0.02em;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.theme-cta-arrow {
+  font-size: 24px;
+  color: rgba(255, 255, 255, 0.8);
+  transition: transform 0.2s ease;
+  text-shadow: 0 2px 8px rgba(0, 0, 0, 0.3);
+}
+
+.theme-editor-link:hover .theme-cta-arrow {
+  transform: translateX(4px);
+}
+
 /* Inline Embed Target */
 .embedded-target {
   min-height: 500px;
@@ -439,6 +551,15 @@ select {
 
   .embedded-target {
     min-height: 400px;
+  }
+
+  .theme-backdrop {
+    padding: 40px 20px;
+    border-radius: 12px;
+  }
+
+  .theme-cta-label {
+    font-size: 18px;
   }
 
   .tryit-backdrop {

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -88,35 +88,48 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 
 ## Setting Up Persona With an AI Coding Agent
 
-When a user asks what to tell their AI coding agent to set up Persona, give them a step-by-step prompt they can paste into their agent (Claude Code, Cursor, Copilot, Windsurf, etc.) to implement the widget from scratch. The prompt should be implementation-focused — a one-time setup skill, not a reference doc.
+When a user asks what to tell their AI coding agent to set up Persona, give them a step-by-step prompt they can paste into their agent (Claude Code, Cursor, Copilot, Windsurf, etc.) to implement the widget from scratch. The prompt should be implementation-focused — a one-time setup task, not a reference doc. Adapt it based on the user's context (framework, SSE format, launcher vs inline).
 
-Here is the prompt template. Adapt it based on the user's context (e.g. their framework, whether they need the proxy, launcher vs inline):
+Here is the prompt template:
 
 \`\`\`
-Add the Persona chat widget to this project. Here's what to do:
+Add the Persona chat widget (@runtypelabs/persona) to this project.
 
-1. Install the packages:
+1. Install:
    npm install @runtypelabs/persona
-   npm install @runtypelabs/persona-proxy  # only if we need a local proxy
 
-2. Set up the proxy (skip if we already have a backend endpoint):
-   - Create a proxy server file using @runtypelabs/persona-proxy
-   - Import createChatProxyApp from '@runtypelabs/persona-proxy' and serve it
-   - The proxy needs a RUNTYPE_API_KEY env var
+2. Import the stylesheet in the app entry point:
+   import '@runtypelabs/persona/widget.css';
 
-3. Add the widget to the frontend:
-   - Import '@runtypelabs/persona/widget.css' in the app entry point
-   - Import { initAgentWidget, DEFAULT_WIDGET_CONFIG } from '@runtypelabs/persona'
-   - Call initAgentWidget with a target element and config:
-     - apiUrl: point to the proxy endpoint (e.g. '/api/chat/dispatch')
-     - agent: { name, model, systemPrompt } — set the system prompt for the use case
-     - theme: override primary, accent, surface colors to match the site
-     - suggestionChips: array of starter prompts for users
-     - For an inline embed instead of a launcher, use createAgentExperience() and set launcher.enabled = false
+3. Initialize the widget:
+   import { initAgentWidget, DEFAULT_WIDGET_CONFIG } from '@runtypelabs/persona';
 
-4. Spread DEFAULT_WIDGET_CONFIG as the base config — it has sensible defaults for theming, copy, and features.
+   initAgentWidget({
+     target: '#chat-root',
+     config: {
+       ...DEFAULT_WIDGET_CONFIG,
+       apiUrl: '/api/chat',  // your SSE endpoint
+     }
+   });
 
-Refer to https://deepwiki.com/runtypelabs/persona for full API docs and configuration options. The repo also has 35+ example pages under examples/embedded-app/ covering theming, voice, artifacts, agent loops, tool approval, and more.
+   For an inline embed instead of a floating launcher, use createAgentExperience(element, config) with launcher.enabled = false.
+
+4. Connect to your SSE backend — the widget expects a server-sent event stream. Use these hooks to adapt it to your API:
+   - customFetch(url, init, payload) — replace the built-in fetch to transform the request/response for your backend's expected format. Return a Response with a ReadableStream.
+   - parseSSEEvent(eventData) — parse each incoming SSE event into { text, done, error } so the widget can render it. Return null to skip an event.
+   - getHeaders() / headers — inject auth tokens or other headers into every request.
+   - requestMiddleware(context) — transform the outgoing request payload (messages, metadata) before it's sent.
+
+5. Customize appearance:
+   - theme: { primary, accent, surface, container, muted } to match site colors
+   - copy: { welcomeTitle, welcomeSubtitle, inputPlaceholder }
+   - suggestionChips: ['Question 1', 'Question 2'] for starter prompts
+
+For full API docs: https://deepwiki.com/runtypelabs/persona
+NPM: https://www.npmjs.com/package/@runtypelabs/persona
+Source & examples: https://github.com/runtypelabs/persona (35+ demo pages in examples/embedded-app/)
+
+Note: if you don't have an SSE backend yet, @runtypelabs/persona-proxy is an optional Hono-based proxy that sits between the widget and the Runtype API. Install it separately with npm install @runtypelabs/persona-proxy.
 \`\`\`
 
 Tell the user to adjust the prompt to their specifics (framework, styling, use case) before pasting it. If they mention a specific agent, mention any relevant tips (e.g. for Claude Code they can save it as a skill in \`.claude/commands/\`).

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -86,6 +86,30 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Fullscreen Assistant](/fullscreen-assistant-demo.html) — dark full-viewport split layout (chat + artifacts)
 - [Voice Integration](/voice-integration-demo.html) — voice input powered by ElevenLabs
 
+## Telling Your AI Coding Agent to Use Persona
+
+When a user asks how to instruct their AI coding agent (Claude Code, Cursor, Copilot, Windsurf, etc.) to work with Persona, give them a ready-to-paste instruction block they can add to their project's agent instructions file (e.g. \`CLAUDE.md\`, \`.cursorrules\`, \`.github/copilot-instructions.md\`). Tailor the block to the specific agent if they mention one; otherwise give a generic version.
+
+Here is a good template they can adapt:
+
+\`\`\`markdown
+# Chat Widget — Persona (@runtypelabs/persona)
+
+This project uses the Persona chat widget. Key facts for working with it:
+
+- **Packages**: \`@runtypelabs/persona\` (widget) and optionally \`@runtypelabs/persona-proxy\` (Hono proxy server).
+- **Install**: \`npm install @runtypelabs/persona\` (or pnpm/yarn). Import the CSS: \`import '@runtypelabs/persona/widget.css'\`.
+- **Initialization**: Use \`initAgentWidget({ target, config })\` for a launcher-style widget, or \`createAgentExperience(element, config)\` for an inline embed.
+- **Config shape**: Spread \`DEFAULT_WIDGET_CONFIG\` then override \`apiUrl\`, \`agent\` (name, model, systemPrompt), \`theme\`, \`copy\`, \`suggestionChips\`, etc.
+- **Proxy**: The widget talks to a proxy, not the LLM directly. Set up \`@runtypelabs/persona-proxy\` or point \`apiUrl\` at your own backend that forwards to the Runtype API.
+- **CSS prefix**: All Tailwind classes inside the widget use the \`tvw-\` prefix.
+- **Shadow DOM**: The widget renders inside a Shadow DOM by default — host page styles won't affect it.
+- **Docs & examples**: See the README and the \`examples/embedded-app\` directory for 35+ demo pages covering theming, voice, artifacts, agent loops, tool approval, and more.
+- **DeepWiki**: Full codebase documentation is available at https://deepwiki.com/runtypelabs/persona
+\`\`\`
+
+Remind them to adjust the model, systemPrompt, and apiUrl to match their own setup. If they ask about a specific agent (e.g. "Claude Code"), mention the exact file name for that agent's instructions.
+
 Keep answers concise. Use markdown formatting. When recommending a demo, briefly explain why it is relevant to the user's question.`;
 
 const inlineMount = document.getElementById("inline-widget");
@@ -137,7 +161,8 @@ const inlineController = createAgentExperience(inlineMount, {
     "What is Persona and how does it work?",
     "How does streaming work?",
     "What can I customize?",
-    "How do I add a chat widget to my website?"
+    "How do I add a chat widget to my website?",
+    "What do I tell my AI coding agent to use this?"
   ],
   postprocessMessage: ({ text }) => markdownPostprocessor(text)
 });

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -86,29 +86,40 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Fullscreen Assistant](/fullscreen-assistant-demo.html) — dark full-viewport split layout (chat + artifacts)
 - [Voice Integration](/voice-integration-demo.html) — voice input powered by ElevenLabs
 
-## Telling Your AI Coding Agent to Use Persona
+## Setting Up Persona With an AI Coding Agent
 
-When a user asks how to instruct their AI coding agent (Claude Code, Cursor, Copilot, Windsurf, etc.) to work with Persona, give them a ready-to-paste instruction block they can add to their project's agent instructions file (e.g. \`CLAUDE.md\`, \`.cursorrules\`, \`.github/copilot-instructions.md\`). Tailor the block to the specific agent if they mention one; otherwise give a generic version.
+When a user asks what to tell their AI coding agent to set up Persona, give them a step-by-step prompt they can paste into their agent (Claude Code, Cursor, Copilot, Windsurf, etc.) to implement the widget from scratch. The prompt should be implementation-focused — a one-time setup skill, not a reference doc.
 
-Here is a good template they can adapt:
+Here is the prompt template. Adapt it based on the user's context (e.g. their framework, whether they need the proxy, launcher vs inline):
 
-\`\`\`markdown
-# Chat Widget — Persona (@runtypelabs/persona)
+\`\`\`
+Add the Persona chat widget to this project. Here's what to do:
 
-This project uses the Persona chat widget. Key facts for working with it:
+1. Install the packages:
+   npm install @runtypelabs/persona
+   npm install @runtypelabs/persona-proxy  # only if we need a local proxy
 
-- **Packages**: \`@runtypelabs/persona\` (widget) and optionally \`@runtypelabs/persona-proxy\` (Hono proxy server).
-- **Install**: \`npm install @runtypelabs/persona\` (or pnpm/yarn). Import the CSS: \`import '@runtypelabs/persona/widget.css'\`.
-- **Initialization**: Use \`initAgentWidget({ target, config })\` for a launcher-style widget, or \`createAgentExperience(element, config)\` for an inline embed.
-- **Config shape**: Spread \`DEFAULT_WIDGET_CONFIG\` then override \`apiUrl\`, \`agent\` (name, model, systemPrompt), \`theme\`, \`copy\`, \`suggestionChips\`, etc.
-- **Proxy**: The widget talks to a proxy, not the LLM directly. Set up \`@runtypelabs/persona-proxy\` or point \`apiUrl\` at your own backend that forwards to the Runtype API.
-- **CSS prefix**: All Tailwind classes inside the widget use the \`tvw-\` prefix.
-- **Shadow DOM**: The widget renders inside a Shadow DOM by default — host page styles won't affect it.
-- **Docs & examples**: See the README and the \`examples/embedded-app\` directory for 35+ demo pages covering theming, voice, artifacts, agent loops, tool approval, and more.
-- **DeepWiki**: Full codebase documentation is available at https://deepwiki.com/runtypelabs/persona
+2. Set up the proxy (skip if we already have a backend endpoint):
+   - Create a proxy server file using @runtypelabs/persona-proxy
+   - Import createChatProxyApp from '@runtypelabs/persona-proxy' and serve it
+   - The proxy needs a RUNTYPE_API_KEY env var
+
+3. Add the widget to the frontend:
+   - Import '@runtypelabs/persona/widget.css' in the app entry point
+   - Import { initAgentWidget, DEFAULT_WIDGET_CONFIG } from '@runtypelabs/persona'
+   - Call initAgentWidget with a target element and config:
+     - apiUrl: point to the proxy endpoint (e.g. '/api/chat/dispatch')
+     - agent: { name, model, systemPrompt } — set the system prompt for the use case
+     - theme: override primary, accent, surface colors to match the site
+     - suggestionChips: array of starter prompts for users
+     - For an inline embed instead of a launcher, use createAgentExperience() and set launcher.enabled = false
+
+4. Spread DEFAULT_WIDGET_CONFIG as the base config — it has sensible defaults for theming, copy, and features.
+
+Refer to https://deepwiki.com/runtypelabs/persona for full API docs and configuration options. The repo also has 35+ example pages under examples/embedded-app/ covering theming, voice, artifacts, agent loops, tool approval, and more.
 \`\`\`
 
-Remind them to adjust the model, systemPrompt, and apiUrl to match their own setup. If they ask about a specific agent (e.g. "Claude Code"), mention the exact file name for that agent's instructions.
+Tell the user to adjust the prompt to their specifics (framework, styling, use case) before pasting it. If they mention a specific agent, mention any relevant tips (e.g. for Claude Code they can save it as a skill in \`.claude/commands/\`).
 
 Keep answers concise. Use markdown formatting. When recommending a demo, briefly explain why it is relevant to the user's question.`;
 


### PR DESCRIPTION
## Summary
- Adds a new suggestion chip **"What do I tell my AI coding agent to use this?"** to the inline widget on the landing page
- Adds a corresponding system prompt section that instructs the assistant to produce a ready-to-paste instruction block for agent config files (`CLAUDE.md`, `.cursorrules`, `.github/copilot-instructions.md`, etc.) covering install, init, config, proxy setup, and docs links

## Test plan
- [ ] Run `pnpm dev` and verify the new pill appears in the inline widget on the index page
- [ ] Click the pill and confirm the assistant responds with a well-formatted, copy-pasteable instruction block
- [ ] Verify existing suggestion chips still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to the `examples/embedded-app` UI and the demo assistant’s system prompt/suggestion chips, with no production logic or security-sensitive paths touched.
> 
> **Overview**
> **Improves the `examples/embedded-app` landing experience** by adding a dedicated, styled “Theme Editor” CTA section and adjusting the Featured list ordering to highlight key demos.
> 
> **Enhances the inline documentation assistant** by adding a new suggestion chip (“What do I tell my AI coding agent to use this?”) and extending the system prompt with a copy/pasteable setup template for coding agents (install, init, SSE hooks, theming, and proxy note).
> 
> Includes small layout tweaks: global `box-sizing: border-box` and tighter mobile spacing/padding for the landing page sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 74d7b14758bd478f5e0815ebe6e1089140efd056. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->