### PR TITLE
Polish embedded app examples and widget styling

### DIFF
--- a/.changeset/fair-pigs-prove.md
+++ b/.changeset/fair-pigs-prove.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Prevent host page paragraph and list styles from overriding message bubble text colors.

--- a/examples/embedded-app/bakery.html
+++ b/examples/embedded-app/bakery.html
@@ -48,7 +48,12 @@
       color: #D4A574;
     }
     .hero-overlay {
-      background: linear-gradient(to bottom, rgba(0,0,0,0.1) 0%, rgba(0,0,0,0.4) 100%);
+      background:
+        radial-gradient(ellipse 90% 75% at 50% 42%, rgba(0, 0, 0, 0.58) 0%, rgba(0, 0, 0, 0.2) 55%, transparent 72%),
+        linear-gradient(to bottom, rgba(0, 0, 0, 0.35) 0%, rgba(0, 0, 0, 0.55) 100%);
+    }
+    .hero-subtitle {
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.85), 0 2px 16px rgba(0, 0, 0, 0.45);
     }
     .category-card {
       transition: transform 0.3s ease, box-shadow 0.3s ease;
@@ -115,7 +120,7 @@
       <h1 class="font-serif text-5xl md:text-7xl tracking-tight mb-6">
         Artisan Bakes,<br/>Crafted Daily
       </h1>
-      <p class="text-lg md:text-xl font-light tracking-wide mb-10 max-w-xl opacity-90">
+      <p class="hero-subtitle text-lg md:text-xl font-normal tracking-wide mb-10 max-w-xl text-white">
         Handcrafted sourdough, pastries, and more from our ovens to your table
       </p>
       <a

--- a/examples/embedded-app/docked-panel-demo.html
+++ b/examples/embedded-app/docked-panel-demo.html
@@ -273,7 +273,8 @@
      * Selected: clearly darker “well” vs bar (#0f172a), soft sky rim + brighter icon = obvious “on”.
      * Still inset (dark top, lighter floor), not a flat raised chip.
      */
-    #assistant-toggle.is-active {
+    #assistant-toggle.is-active,
+    #assistant-toggle.assistant-toggle--persist-highlight {
       background: linear-gradient(
         180deg,
         #010409 0%,
@@ -290,7 +291,8 @@
         inset 0 -12px 22px rgba(125, 211, 252, 0.14),
         inset 0 -2px 0 rgba(255, 255, 255, 0.22);
     }
-    #assistant-toggle.is-active:hover {
+    #assistant-toggle.is-active:hover,
+    #assistant-toggle.assistant-toggle--persist-highlight:hover {
       border-color: rgba(56, 189, 248, 0.6);
       color: #f0f9ff;
       box-shadow:
@@ -319,53 +321,76 @@
     .icon-btn--ghost:hover {
       background: rgba(255, 255, 255, 0.08);
     }
+    /* Coachmark: label + arrow pointing at the assistant control (demo-only). */
     .assistant-coachmark {
       display: flex;
       align-items: center;
-      gap: 6px;
-      margin-right: 8px;
-      padding: 6px 12px 6px 14px;
+      gap: 8px;
+      margin-right: 10px;
+      padding: 8px 14px 8px 16px;
       border-radius: 999px;
-      background: rgba(255, 255, 255, 0.14);
-      border: 1px solid rgba(255, 255, 255, 0.28);
-      font-size: 12px;
-      font-weight: 600;
+      background: linear-gradient(
+        145deg,
+        rgba(14, 165, 233, 0.42) 0%,
+        rgba(56, 189, 248, 0.28) 48%,
+        rgba(125, 211, 252, 0.2) 100%
+      );
+      border: 2px solid rgba(186, 230, 253, 0.85);
+      box-shadow:
+        0 0 0 1px rgba(0, 0, 0, 0.25),
+        0 4px 18px rgba(56, 189, 248, 0.45),
+        inset 0 1px 0 rgba(255, 255, 255, 0.35);
+      font-size: 13px;
+      font-weight: 700;
       letter-spacing: 0.02em;
       color: #f8fafc;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
       white-space: nowrap;
-      opacity: 0;
-      pointer-events: none;
       flex-shrink: 0;
+      pointer-events: none;
+      animation: assistant-coachmark-glow 2.4s ease-in-out infinite;
     }
-    .assistant-coachmark[hidden] {
-      display: none !important;
-    }
-    .assistant-coachmark--play {
-      display: flex !important;
-      animation: assistant-coachmark-fade 3.4s ease-in-out forwards;
-    }
-    @keyframes assistant-coachmark-fade {
-      0% {
-        opacity: 0;
-        transform: translateX(6px);
-      }
-      14% {
-        opacity: 1;
-        transform: translateX(0);
-      }
-      72% {
-        opacity: 1;
-        transform: translateX(0);
-      }
+    @keyframes assistant-coachmark-glow {
+      0%,
       100% {
-        opacity: 0;
-        transform: translateX(4px);
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.25),
+          0 4px 18px rgba(56, 189, 248, 0.45),
+          inset 0 1px 0 rgba(255, 255, 255, 0.35);
+      }
+      50% {
+        box-shadow:
+          0 0 0 1px rgba(0, 0, 0, 0.25),
+          0 4px 22px rgba(56, 189, 248, 0.65),
+          0 0 28px rgba(125, 211, 252, 0.35),
+          inset 0 1px 0 rgba(255, 255, 255, 0.45);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .assistant-coachmark {
+        animation: none;
       }
     }
     .assistant-coachmark__arrow {
       display: block;
       flex-shrink: 0;
-      color: #7dd3fc;
+      color: #e0f2fe;
+      filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
+      animation: assistant-coachmark-nudge 1.1s ease-in-out infinite;
+    }
+    @keyframes assistant-coachmark-nudge {
+      0%,
+      100% {
+        transform: translateX(0);
+      }
+      50% {
+        transform: translateX(5px);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      .assistant-coachmark__arrow {
+        animation: none;
+      }
     }
     .workspace-shell {
       flex: 1;
@@ -799,23 +824,17 @@
         </span>
       </div>
       <div class="admin-topbar__right">
-        <div
-          id="assistant-coachmark"
-          class="assistant-coachmark"
-          hidden
-          role="status"
-          aria-live="polite"
-        >
-          <span class="assistant-coachmark__label">assistant triggered</span>
+        <div id="assistant-coachmark" class="assistant-coachmark" role="note">
+          <span class="assistant-coachmark__label">Click the sparkles — open Copilot</span>
           <svg
             class="assistant-coachmark__arrow"
-            width="18"
-            height="18"
+            width="20"
+            height="20"
             viewBox="0 0 24 24"
             fill="none"
             aria-hidden="true"
             stroke="currentColor"
-            stroke-width="2.25"
+            stroke-width="2.5"
             stroke-linecap="round"
             stroke-linejoin="round"
           >
@@ -826,7 +845,9 @@
         <button
           type="button"
           id="assistant-toggle"
+          class="assistant-toggle--persist-highlight"
           aria-expanded="false"
+          aria-describedby="assistant-coachmark"
           aria-label="Open assistant"
           title="Open assistant"
         >

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -55,7 +55,7 @@
         <div class="featured-grid">
           <a class="example-item" href="/fullscreen-assistant-demo.html">Fullscreen Assistant <small>Full-viewport dark layout with artifacts</small></a>
           <a class="example-item" href="/bakery.html">Bakery Assistant <small>Full business site with context-aware chat</small></a>
-          <a class="example-item" href="/agent-demo.html">Agent Loop <small>Multi-turn reasoning with tool calls</small></a>
+          <a class="example-item" href="/docked-panel-demo.html">Docked Panel <small>Side-docked assistant layout</small></a>
         </div>
       </section>
 
@@ -65,7 +65,7 @@
           <p>Explore different use cases and widget configurations.</p>
           <ul class="examples-list">
             <li><a class="example-item" href="/action-middleware.html">Action Middleware <small>AI-driven page interactions and cart management</small></a></li>
-            <li><a class="example-item" href="/docked-panel-demo.html">Docked Panel <small>Side-docked assistant layout</small></a></li>
+            <li><a class="example-item" href="/agent-demo.html">Agent Loop <small>Multi-turn reasoning with tool calls</small></a></li>
             <li><a class="example-item" href="/feedback-demo.html">Message Feedback <small>Copy, Upvote, Downvote</small></a></li>
             <li><a class="example-item" href="/feedback-integration-demo.html">Feedback Integration <small>Wire feedback events to your backend</small></a></li>
             <li><a class="example-item" href="/custom-loading-indicator.html">Custom Loading Indicator <small>Replace the default loading animation</small></a></li>

--- a/examples/embedded-app/src/docked-panel-demo.ts
+++ b/examples/embedded-app/src/docked-panel-demo.ts
@@ -39,11 +39,6 @@ function parseDockReveal(raw: string): DockRevealOption {
   return "emerge";
 }
 
-/** Clear in dev tools to replay the first-visit intro: localStorage.removeItem(INTRO_STORAGE_KEY) */
-const INTRO_STORAGE_KEY = "persona-dock-demo:assistant-intro-shown";
-const INTRO_DELAY_MS = 1500;
-const COACHMARK_ANIM_MS = 2250;
-
 let controller: AgentWidgetInitHandle;
 
 function getDockConfig() {
@@ -95,6 +90,16 @@ function syncToggleUi(): void {
   assistantToggle.setAttribute("aria-label", open ? "Hide assistant" : "Open assistant");
   assistantToggle.classList.toggle("is-active", open);
   assistantToggle.title = open ? "Hide assistant" : "Open assistant";
+
+  const coachEl = document.getElementById("assistant-coachmark");
+  if (coachEl) {
+    coachEl.toggleAttribute("hidden", open);
+  }
+  if (open) {
+    assistantToggle.removeAttribute("aria-describedby");
+  } else {
+    assistantToggle.setAttribute("aria-describedby", "assistant-coachmark");
+  }
 }
 
 function updateStatus(label: string): void {
@@ -211,42 +216,3 @@ assistantToggle.addEventListener("mousedown", (e) => {
 assistantToggle.addEventListener("click", () => {
   controller.toggle();
 });
-
-function hasSeenIntro(): boolean {
-  try {
-    return localStorage.getItem(INTRO_STORAGE_KEY) === "1";
-  } catch {
-    return true;
-  }
-}
-
-function markIntroShown(): void {
-  try {
-    localStorage.setItem(INTRO_STORAGE_KEY, "1");
-  } catch {
-    /* private / quota */
-  }
-}
-
-function runFirstVisitAssistantIntro(): void {
-  if (hasSeenIntro()) return;
-
-  window.setTimeout(() => {
-    markIntroShown();
-
-    controller.open();
-    syncToggleUi();
-
-    const coach = document.getElementById("assistant-coachmark");
-    if (coach) {
-      coach.hidden = false;
-      coach.classList.add("assistant-coachmark--play");
-      window.setTimeout(() => {
-        coach.classList.remove("assistant-coachmark--play");
-        coach.hidden = true;
-      }, COACHMARK_ANIM_MS);
-    }
-  }, INTRO_DELAY_MS);
-}
-
-runFirstVisitAssistantIntro();

--- a/examples/embedded-app/src/fullscreen-assistant-demo-sse.ts
+++ b/examples/embedded-app/src/fullscreen-assistant-demo-sse.ts
@@ -39,6 +39,22 @@ Use the \`/research\` tool against **acme.com** to pull positioning signals.
 - Technical integration path
 
 [Get Started with Runtype](https://runtype.com)
+
+---
+
+### What this pane is showing
+
+> **TL;DR** — You’re looking at **rendered Markdown** beside the thread, in a **near-fullscreen split**—the same “chat + canvas” rhythm as today’s flagship AI assistants, embedded on *your* domain.
+
+**Rendered document, not source**
+
+- Headings, lists, \`inline code\`, **bold**, *italic*, and [links](https://runtype.com) are typeset for **reading**, not pasted as plain text.
+- Long-form answers, specs, and checklists stay **scannable** in the right-hand pane.
+
+**Layout**
+
+1. **Thread** — the conversation column on the left.
+2. **Canvas** — the artifact column on the right (this document).
 `;
 
 /** Default artifact id for the scripted stream and file card (keep in sync). */

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -17,6 +17,8 @@ const inlineDemoTheme: DeepPartial<PersonaTheme> = {
       accent: { 600: "#ea580c" },
       gray: {
         50: "#f8fafc",
+        // 100: "#eaedf1",
+        200: "#e4e8ee",
         500: "#64748b"
       }
     }
@@ -27,6 +29,13 @@ const inlineDemoTheme: DeepPartial<PersonaTheme> = {
       accent: "palette.colors.accent.600",
       surface: "palette.colors.gray.50",
       textMuted: "palette.colors.gray.500"
+    }
+  },
+  components: {
+    message: {
+      assistant: {
+        border: "palette.colors.gray.200"
+      }
     }
   }
 };

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1299,6 +1299,7 @@
 /* Ensure user message paragraphs and lists have proper styling too */
 .vanilla-message-user-bubble p {
   margin: 0;
+  color: inherit;
 }
 
 .vanilla-message-user-bubble p + p {
@@ -1322,6 +1323,12 @@
 .vanilla-message-user-bubble li {
   margin: 0.25rem 0;
   padding-left: 0.25rem;
+  color: inherit;
+}
+
+.vanilla-message-assistant-bubble p,
+.vanilla-message-assistant-bubble li {
+  color: inherit;
 }
 
 /* ============================================


### PR DESCRIPTION
## Summary
- improve embedded app example polish across the index, docked panel, bakery, and fullscreen assistant demos
- harden widget message bubble styling against host-page CSS overrides and soften the inline docs assistant border treatment
- add the related changeset and demo SSE support needed by the branch changes

## Test plan
- [ ] Review the updated examples in the embedded app locally
- [ ] Verify assistant and user bubble styling still renders correctly when host page CSS is present
- [ ] Confirm docked panel and fullscreen assistant demos behave as expected

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CSS scoping for message bubble text color inheritance and small demo/marketing copy polish; no runtime logic or data handling is modified.
> 
> **Overview**
> **Hardens widget message bubble styling against host-page CSS overrides** by forcing paragraph/list text within `vanilla-message-user-bubble` and `vanilla-message-assistant-bubble` to `color: inherit`.
> 
> **Polishes embedded-app demos**: updates the bakery hero overlay/subtitle styling, tweaks the docked panel demo coachmark (persistent highlight, animations, accessibility attributes) and simplifies its intro behavior to just hide/show based on open state, reorders the examples list on the embedded app index, and expands the fullscreen assistant demo artifact markdown content.
> 
> Adds a patch `changeset` for the widget styling fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ea251c66ba7efd4a8ad16fc81e3b834eaffacddd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->