### PR TITLE
feat(widget): extend onStateLoaded to signal panel open

### DIFF
--- a/.changeset/open-on-state-loaded.md
+++ b/.changeset/open-on-state-loaded.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+`onStateLoaded` can now return `{ state, open: true }` to signal that the widget panel should open after initialization. Useful for post-navigation flows where injecting messages into state should also reveal the panel to the user.

--- a/examples/embedded-app/src/bakery-demo.ts
+++ b/examples/embedded-app/src/bakery-demo.ts
@@ -1106,12 +1106,10 @@ const config: AgentWidgetConfig = {
   persistState: true,
   clearChatHistoryStorageKey: BAKERY_STORAGE_KEY,
   streamParser: createBakeryParser,
-  // Use onStateLoaded to inject navigation messages after page load
   onStateLoaded: (state) => {
-    // Check for pending navigation message
     const navMessage = consumeNavigationFlag();
     if (navMessage) {
-      state = injectMessage(state, navMessage, "nav");
+      return { state: injectMessage(state, navMessage, "nav"), open: true };
     }
     return state;
   },

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -624,13 +624,15 @@ initAgentWidget({
 
 The `onStateLoaded` hook is called after state is loaded from the storage adapter, but before the widget initializes. Use this to transform or inject messages based on external state (e.g., navigation flags, checkout returns).
 
+Returning `{ state, open: true }` also tells the widget to open the panel after initialization — useful when injecting a post-navigation message that the user should immediately see.
+
 ```ts
+// Plain state transform
 initAgentWidget({
   target: 'body',
   config: {
     storageAdapter: createLocalStorageAdapter('my-chat'),
     onStateLoaded: (state) => {
-      // Check for pending navigation message
       const navMessage = consumeNavigationFlag();
       if (navMessage) {
         return {
@@ -647,10 +649,36 @@ initAgentWidget({
     }
   }
 });
+
+// Return { state, open: true } to also open the panel
+initAgentWidget({
+  target: 'body',
+  config: {
+    storageAdapter: createLocalStorageAdapter('my-chat'),
+    onStateLoaded: (state) => {
+      const navMessage = consumeNavigationFlag();
+      if (navMessage) {
+        return {
+          state: {
+            ...state,
+            messages: [...(state.messages || []), {
+              id: `nav-${Date.now()}`,
+              role: 'assistant',
+              content: navMessage,
+              createdAt: new Date().toISOString()
+            }]
+          },
+          open: true
+        };
+      }
+      return state;
+    }
+  }
+});
 ```
 
 **Use cases:**
-- Inject messages after page navigation (e.g., "Here are our products!")
+- Inject messages after page navigation (e.g., "Here are our products!") and open the panel
 - Add confirmation messages after checkout/payment returns
 - Transform or filter loaded messages
 - Inject system messages based on external state
@@ -2019,7 +2047,7 @@ config: {
 | `initialMessages` | `AgentWidgetMessage[]` | Seed the conversation transcript with initial messages. |
 | `persistState` | `boolean \| AgentWidgetPersistStateConfig` | Persist widget state across page navigations. `true` uses defaults (sessionStorage). |
 | `storageAdapter` | `AgentWidgetStorageAdapter` | Custom storage adapter with `load()`, `save(state)`, and `clear()` methods. |
-| `onStateLoaded` | `(state: AgentWidgetStoredState) => AgentWidgetStoredState` | Transform state after loading from storage but before widget initialization. |
+| `onStateLoaded` | `(state: AgentWidgetStoredState) => AgentWidgetStoredState \| { state: AgentWidgetStoredState; open?: boolean }` | Transform state after loading from storage but before widget initialization. Return `{ state, open: true }` to also open the panel. |
 | `clearChatHistoryStorageKey` | `string` | Additional localStorage key to clear on chat reset. The widget clears `"persona-chat-history"` by default. |
 
 **`persistState`** — `AgentWidgetPersistStateConfig`

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -2346,11 +2346,15 @@ export type AgentWidgetConfig = {
    *
    * This hook runs synchronously and must return the (potentially modified) state.
    *
+   * Returning `{ state, open: true }` also signals that the widget panel should
+   * open after initialization — useful when injecting a post-navigation message
+   * that the user should immediately see.
+   *
    * @example
    * ```typescript
+   * // Plain state transform (existing form, still supported)
    * config: {
    *   onStateLoaded: (state) => {
-   *     // Check for pending navigation message
    *     const navMessage = consumeNavigationFlag();
    *     if (navMessage) {
    *       return {
@@ -2367,8 +2371,34 @@ export type AgentWidgetConfig = {
    *   }
    * }
    * ```
+   *
+   * @example
+   * ```typescript
+   * // Return { state, open: true } to also open the panel
+   * config: {
+   *   onStateLoaded: (state) => {
+   *     const navMessage = consumeNavigationFlag();
+   *     if (navMessage) {
+   *       return {
+   *         state: {
+   *           ...state,
+   *           messages: [...(state.messages || []), {
+   *             id: `nav-${Date.now()}`,
+   *             role: 'assistant',
+   *             content: navMessage,
+   *             createdAt: new Date().toISOString()
+   *           }]
+   *         },
+   *         open: true
+   *       };
+   *     }
+   *     return state;
+   *   }
+   * }
+   * ```
    */
-  onStateLoaded?: (state: AgentWidgetStoredState) => AgentWidgetStoredState;
+  onStateLoaded?: (state: AgentWidgetStoredState) =>
+    AgentWidgetStoredState | { state: AgentWidgetStoredState; open?: boolean };
   /**
    * Registry of custom components that can be rendered from JSON directives.
    * Components are registered by name and can be invoked via JSON responses

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -412,11 +412,20 @@ export const createAgentExperience = (
   let persistentMetadata: Record<string, unknown> = {};
   let pendingStoredState: Promise<AgentWidgetStoredState | null> | null = null;
 
-  // Helper to apply onStateLoaded hook and extract state
+  let shouldOpenAfterStateLoaded = false;
+
+  // Helper to apply onStateLoaded hook and extract state.
+  // Supports both the legacy plain-state return and the new { state, open? } return.
   const applyStateLoadedHook = (state: AgentWidgetStoredState): AgentWidgetStoredState => {
     if (config.onStateLoaded) {
       try {
-        return config.onStateLoaded(state);
+        const result = config.onStateLoaded(state);
+        if (result && typeof result === 'object' && 'state' in result) {
+          const { state: processedState, open } = result as { state: AgentWidgetStoredState; open?: boolean };
+          if (open) shouldOpenAfterStateLoaded = true;
+          return processedState;
+        }
+        return result as AgentWidgetStoredState;
       } catch (error) {
         if (typeof console !== "undefined") {
           // eslint-disable-next-line no-console
@@ -5377,6 +5386,13 @@ export const createAgentExperience = (
         });
       }
     }
+  }
+
+  // If onStateLoaded signalled open: true, open the panel after init.
+  // Mirrors the same setTimeout(0) pattern used by persistState restore so both
+  // can fire independently without interfering with each other.
+  if (shouldOpenAfterStateLoaded && launcherEnabled) {
+    setTimeout(() => { controller.open(); }, 0);
   }
 
   return controller;


### PR DESCRIPTION
## Summary

- Extends the `onStateLoaded` hook return type to accept `{ state: AgentWidgetStoredState; open?: boolean }` in addition to the existing plain-state return.
- When `open: true` is returned, the widget opens the launcher panel after initialization using the same `setTimeout(0)` pattern as `persistState` restore (idempotent with it).
- Updates the bakery demo to use this API directly, removing the workaround module flag and manual `controller.open()` call that were added to fix the "I'm looking for a gift" navigation bug.

## Motivation

`persistState` answers "was the widget open before this navigation?" `onStateLoaded` answers "what messages should exist after this navigation?" — but had no way to say "and the panel should open." These are semantically different questions, and the gap forced user-space workarounds. The new return form closes it.

## Test plan

- [ ] Open the bakery demo, click the launcher, send "I'm looking for a gift" — widget should navigate to the goods page and stay open with the follow-up message visible.
- [ ] Confirm that an `onStateLoaded` hook returning plain `AgentWidgetStoredState` (existing form) continues to work unchanged.
- [ ] Run `pnpm --filter @runtypelabs/persona test:run` — all tests pass.
- [ ] Run `pnpm typecheck` — no errors.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends a public config hook (`onStateLoaded`) with new return semantics and adds a new post-init open path, which could subtly affect initialization/open-state behavior (especially alongside `persistState`).
> 
> **Overview**
> **Extends the `onStateLoaded` hook** to optionally return `{ state, open?: boolean }` in addition to the legacy `AgentWidgetStoredState`, allowing state transforms to also request that the launcher panel opens after initialization.
> 
> Implements this in the widget init flow by detecting the new return shape, tracking an `open` signal, and triggering `controller.open()` via `setTimeout(0)` after init (only when the launcher is enabled). Documentation and the embedded bakery demo are updated to demonstrate injecting a navigation message and automatically opening the panel, and a changeset is added for a patch release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24120a2425761dc05d165ec1194dc038af76492e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->