### PR TITLE
feat(widget): launcher teaser max width, ellipsis, and Action Middleware copy

### DIFF
--- a/.changeset/launcher-collapsed-max-width.md
+++ b/.changeset/launcher-collapsed-max-width.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add `launcher.collapsedMaxWidth` to cap the width of the floating launcher pill when the panel is closed. Launcher title and subtitle use single-line ellipsis truncation with full text in the native `title` tooltip; the text column uses `persona-flex-1 persona-min-w-0` so truncation works inside the flex row. Add `persona-break-words` utility (e.g. for artifact pane monospace lines).

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -64,7 +64,7 @@
           <h2 class="card-title">Examples</h2>
           <p>Explore different use cases and widget configurations.</p>
           <ul class="examples-list">
-            <li><a class="example-item" href="/action-middleware.html">Action Middleware <small>AI-driven page interactions and cart management</small></a></li>
+            <li><a class="example-item" href="/action-middleware.html">Action Middleware <small>Live DOM context on every message; structured actions for navigation, cart, and checkout</small></a></li>
             <li><a class="example-item" href="/agent-demo.html">Agent Loop <small>Multi-turn reasoning with tool calls</small></a></li>
             <li><a class="example-item" href="/feedback-demo.html">Message Feedback <small>Copy, Upvote, Downvote</small></a></li>
             <li><a class="example-item" href="/feedback-integration-demo.html">Feedback Integration <small>Wire feedback events to your backend</small></a></li>

--- a/examples/embedded-app/src/action-middleware-demo.ts
+++ b/examples/embedded-app/src/action-middleware-demo.ts
@@ -101,8 +101,9 @@ const getWelcomeConfig = () => {
   }
 
   return {
-    title: "Hi, what can I help you with?",
-    subtitle: "Try asking for products or adding items to your cart"
+    title: "Persona reads this page on every message",
+    subtitle:
+      "Most assistants only see the chat—they have no idea which page you're on, what's on screen, or what you're doing. Here, each request includes live storefront context (URL, visible products, actionable controls), and action middleware lets the assistant click, navigate, and checkout—not just describe. Ask what's on this page or to add something to your cart."
   };
 };
 
@@ -443,8 +444,10 @@ clearChatHistoryStorageKey: "persona-action-middleware",  // Automatically clear
     enabled: true,
     autoExpand: shouldAutoOpen,
     width: "min(920px, 95vw)",
+    collapsedMaxWidth: "min(380px, calc(100vw - 48px))",
     title: "Shopping Assistant",
-    subtitle: "I can help you find products and add them to your cart",
+    subtitle:
+      "I see this storefront with every message—URL, what's on screen, what you can click—then I can shop it with you",
     agentIconText: "🛍️"
   },
   theme: {

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -146,8 +146,15 @@ code {
   margin-top: 16px;
 }
 
-/* Buttons */
-button, select, .btn {
+/*
+ * Demo chrome only — do not style Persona controls.
+ * The widget mounts in the light DOM by default (`useShadowDom` is opt-in), so a bare
+ * `button { padding: 10px 18px }` applies to the header close control. With `width`/`height`
+ * 32px and `box-sizing: border-box`, horizontal padding 18+18px leaves no room for the SVG.
+ */
+button:not([data-persona-root] *),
+select:not([data-persona-root] *),
+.btn:not([data-persona-root] *) {
   font-family: var(--font-sans);
   font-size: 14px;
   font-weight: 600;

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -104,7 +104,7 @@ CDN URLs follow the pattern \`https://cdn.jsdelivr.net/npm/@runtypelabs/persona@
 When a user asks about a feature or use case, recommend the most relevant demo from this list. Format links as markdown, e.g. [Demo Name](/path.html).
 
 - [Theme Editor](/theme.html) — visually customize the widget theme and styling in real time
-- [Action Middleware](/action-middleware.html) — e-commerce action handling with AI-driven page interactions
+- [Action Middleware](/action-middleware.html) — DOM-aware page context each turn plus middleware that executes real UI actions (navigate, cart, checkout)
 - [Bakery Assistant](/bakery.html) — industry-specific persona with a rich product catalog and cart actions
 - [Docked Panel](/docked-panel-demo.html) — alternative layout with the widget docked to the side of the page
 - [Message Feedback](/feedback-demo.html) — copy, upvote, and downvote buttons on messages

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -1745,6 +1745,7 @@ Controls the floating launcher button and panel.
 | `clearChat` | `AgentWidgetClearChatConfig?` | Clear chat button configuration (enabled, placement, icon, styling). |
 | `border` | `string?` | Border style for the launcher button. Default: `'1px solid #e5e7eb'`. |
 | `shadow` | `string?` | Box shadow for the launcher button. |
+| `collapsedMaxWidth` | `string?` | CSS `max-width` for the floating launcher pill when the panel is closed (title/subtitle truncate with ellipsis; full text in `title` tooltip). Does not affect the open panel (`width`). |
 
 In docked mode, `position`, `fullHeight`, and `sidebarMode` are ignored because the widget fills the dock slot created around the target container.
 

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -520,6 +520,7 @@ When `mountMode` is `"docked"`, `initAgentWidget({ target })` wraps the target c
 |----------|---------|-------------|
 | `border` | `"1px solid #e5e7eb"` | Border style for the launcher button |
 | `shadow` | `"0 10px 15px -3px rgba(0,0,0,0.1), ..."` | Box shadow for the launcher button |
+| `collapsedMaxWidth` | *(unset)* | CSS `max-width` for the floating launcher pill when the panel is closed; title/subtitle truncate with ellipsis (full text in `title` tooltip). Does not change the open panel width (`width`). |
 
 ### Header Icon
 | Property | Description |

--- a/packages/widget/src/components/launcher.test.ts
+++ b/packages/widget/src/components/launcher.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { createLauncherButton } from "./launcher";
+import { DEFAULT_WIDGET_CONFIG } from "../defaults";
+
+describe("createLauncherButton", () => {
+  it("applies collapsedMaxWidth when set", () => {
+    const { element, update } = createLauncherButton(undefined, () => {});
+    update({
+      ...DEFAULT_WIDGET_CONFIG,
+      launcher: {
+        ...DEFAULT_WIDGET_CONFIG.launcher,
+        collapsedMaxWidth: "min(380px, calc(100vw - 48px))",
+      },
+    });
+    expect(element.style.maxWidth).toBe("min(380px, calc(100vw - 48px))");
+    element.remove();
+  });
+
+  it("sets title tooltip on launcher title and subtitle for truncated text", () => {
+    const { element, update } = createLauncherButton(undefined, () => {});
+    update({
+      ...DEFAULT_WIDGET_CONFIG,
+      launcher: {
+        ...DEFAULT_WIDGET_CONFIG.launcher,
+        title: "Hello",
+        subtitle: "Long subtitle for tooltip",
+      },
+    });
+    const titleEl = element.querySelector("[data-role='launcher-title']");
+    const subtitleEl = element.querySelector("[data-role='launcher-subtitle']");
+    expect(titleEl?.getAttribute("title")).toBe("Hello");
+    expect(subtitleEl?.getAttribute("title")).toBe("Long subtitle for tooltip");
+    element.remove();
+  });
+
+  it("clears maxWidth when collapsedMaxWidth is unset", () => {
+    const { element, update } = createLauncherButton(undefined, () => {});
+    update({
+      ...DEFAULT_WIDGET_CONFIG,
+      launcher: {
+        ...DEFAULT_WIDGET_CONFIG.launcher,
+        collapsedMaxWidth: "320px",
+      },
+    });
+    expect(element.style.maxWidth).toBe("320px");
+    update({
+      ...DEFAULT_WIDGET_CONFIG,
+      launcher: {
+        ...DEFAULT_WIDGET_CONFIG.launcher,
+        collapsedMaxWidth: undefined,
+      },
+    });
+    expect(element.style.maxWidth).toBe("");
+    element.remove();
+  });
+});

--- a/packages/widget/src/components/launcher.ts
+++ b/packages/widget/src/components/launcher.ts
@@ -19,9 +19,9 @@ export const createLauncherButton = (
   button.innerHTML = `
     <span class="persona-inline-flex persona-items-center persona-justify-center persona-rounded-full persona-bg-persona-primary persona-text-white" data-role="launcher-icon">💬</span>
     <img data-role="launcher-image" class="persona-rounded-full persona-object-cover" alt="" style="display:none" />
-    <span class="persona-flex persona-flex-col persona-items-start persona-text-left">
-      <span class="persona-text-sm persona-font-semibold persona-text-persona-primary" data-role="launcher-title"></span>
-      <span class="persona-text-xs persona-text-persona-muted" data-role="launcher-subtitle"></span>
+    <span class="persona-flex persona-min-w-0 persona-flex-1 persona-flex-col persona-items-start persona-text-left">
+      <span class="persona-block persona-w-full persona-truncate persona-text-sm persona-font-semibold persona-text-persona-primary" data-role="launcher-title"></span>
+      <span class="persona-block persona-w-full persona-truncate persona-text-xs persona-text-persona-muted" data-role="launcher-subtitle"></span>
     </span>
     <span class="persona-ml-2 persona-grid persona-place-items-center persona-rounded-full persona-bg-persona-primary persona-text-persona-call-to-action" data-role="launcher-call-to-action-icon">↗</span>
   `;
@@ -33,12 +33,16 @@ export const createLauncherButton = (
 
     const titleEl = button.querySelector("[data-role='launcher-title']");
     if (titleEl) {
-      titleEl.textContent = launcher.title ?? "Chat Assistant";
+      const t = launcher.title ?? "Chat Assistant";
+      titleEl.textContent = t;
+      titleEl.setAttribute("title", t);
     }
 
     const subtitleEl = button.querySelector("[data-role='launcher-subtitle']");
     if (subtitleEl) {
-      subtitleEl.textContent = launcher.subtitle ?? "Get answers fast";
+      const s = launcher.subtitle ?? "Get answers fast";
+      subtitleEl.textContent = s;
+      subtitleEl.setAttribute("title", s);
     }
 
     // Hide/show text container
@@ -186,7 +190,7 @@ export const createLauncherButton = (
     } else {
       button.style.width = "";
       button.style.minWidth = "";
-      button.style.maxWidth = "";
+      button.style.maxWidth = launcher.collapsedMaxWidth ?? "";
       button.style.justifyContent = "";
       button.style.padding = "";
       button.style.overflow = "";

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -349,6 +349,11 @@
   word-break: break-all;
 }
 
+.persona-break-words {
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
 .persona-px-4 {
   padding-left: 1rem;
   padding-right: 1rem;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -827,6 +827,13 @@ export type AgentWidgetLauncherConfig = {
    * @default "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)"
    */
   shadow?: string;
+  /**
+   * CSS `max-width` for the floating launcher button when the panel is closed.
+   * Title and subtitle each truncate with an ellipsis when space is tight; full strings are available via the native `title` tooltip. Does not affect the open chat panel (`width` / `launcherWidth`).
+   *
+   * @example "min(380px, calc(100vw - 48px))"
+   */
+  collapsedMaxWidth?: string;
 };
 
 export type AgentWidgetSendButtonConfig = {


### PR DESCRIPTION
## Summary

- **Widget:** Add `launcher.collapsedMaxWidth` so the floating launcher pill can be width-capped when closed. Title and subtitle use single-line ellipsis truncation with full text in the native `title` tooltip; text column uses `flex-1` / `min-w-0` so truncation works in the flex row. Adds `persona-break-words` utility, `launcher.test.ts`, docs, and a changeset (minor).
- **Examples:** Action middleware demo welcome/launcher copy, scoped demo `index.css` button rules (`:not([data-persona-root] *)`), and updated **Action Middleware** descriptions on the examples index + theme assistant demo list (DOM awareness + structured actions).

## Test plan

- [ ] `pnpm --filter @runtypelabs/persona test:run` / CI
- [ ] Open `/action-middleware.html`: closed launcher respects max width, subtitle truncates with tooltip; Persona header buttons render correctly vs demo chrome

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new launcher sizing option and changes launcher DOM/CSS behavior; risk is limited but could affect launcher layout/appearance across embed contexts and CSS interactions with host pages.
> 
> **Overview**
> Adds `launcher.collapsedMaxWidth` to cap the floating launcher pill’s width when *closed*, without affecting the open panel `width`.
> 
> Updates the launcher text layout to support single-line ellipsis truncation and sets native `title` tooltips for full title/subtitle strings; adds a `persona-break-words` utility and Vitest coverage for the new launcher behavior.
> 
> Refreshes embedded-app demos with clearer Action Middleware messaging and scopes demo `button/select` styles to avoid leaking into Persona controls when mounted in the light DOM; includes docs updates and a minor changeset release note.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dab1ef02b79b27877954e47841693a5806cdbfb1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->