### PR TITLE
docs(readme): add live demo link (persona-chat.dev)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Persona
 
 [![npm](https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=262626&label=npm)](https://www.npmjs.com/package/@runtypelabs/persona)
+[![Live demo](https://img.shields.io/badge/live_demo-persona--chat.dev-0d9488?style=flat)](https://persona-chat.dev)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/runtypelabs/persona)
 
 A themeable, pluggable streaming AI chat widget for websites — built in plain JS with zero framework dependencies.
@@ -8,6 +9,10 @@ A themeable, pluggable streaming AI chat widget for websites — built in plain 
 Persona gives you a drop-in UI for your AI assistant that works on any site. It ships with support for streaming responses, voice I/O, multi-modal content, tool call visualization, artifact rendering, and a plugin system so you can customize every layer of the UI.
 
 Persona works with any SSE-capable backend. It's pre-integrated with [Runtype](https://runtype.com) out of the box, so you can go from install to live assistant with zero configuration.
+
+## Live demo
+
+**[persona-chat.dev](https://persona-chat.dev)** hosts the interactive gallery (35+ pages): streaming chat, voice, docked and fullscreen layouts, themes, tool calls, artifacts, and more. It mirrors [`examples/embedded-app`](./examples/embedded-app). To run the same pages on your machine with hot reload while you edit code, run `pnpm dev` from the repository root: the Vite dev server reloads the demo, and the app resolves `@runtypelabs/persona` from the workspace (`packages/widget`), so widget changes apply without publishing to npm.
 
 ## Packages
 
@@ -20,7 +25,7 @@ Persona works with any SSE-capable backend. It's pre-integrated with [Runtype](h
 
 | Example | Platform | Description |
 |---------|----------|-------------|
-| [`examples/embedded-app`](./examples/embedded-app) | Vite | Vanilla JS demo with runtime configuration |
+| [`examples/embedded-app`](./examples/embedded-app) | Vite | Vanilla JS demo with runtime configuration ([live](https://persona-chat.dev)) |
 | [`examples/vercel-edge`](./examples/vercel-edge) | Vercel / Railway / Fly.io | Node.js proxy server |
 | [`examples/cloudflare-workers`](./examples/cloudflare-workers) | Cloudflare Workers | Edge proxy server |
 


### PR DESCRIPTION
## Summary

Adds a clear, discoverable link to the hosted interactive demo at [persona-chat.dev](https://persona-chat.dev), using the same URL already set as this repository's GitHub **Website** field.

## Changes

- **Badge row:** A "Live demo" shield next to the existing npm and DeepWiki badges (common README pattern for primary entry points).
- **Live demo section:** Short section after the intro that explains what is on the site, how it relates to `examples/embedded-app`, and how to run the same experience locally with `pnpm dev`.
- **Examples table:** The embedded-app row now includes a direct "live" link for readers scanning the table.

No package or API changes; changeset not required.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates that add external links and guidance; no runtime, API, or dependency changes.
> 
> **Overview**
> Adds a **live demo entry point** to the README via a new `persona-chat.dev` badge and a dedicated *Live demo* section describing what the hosted gallery contains and how to run the same experience locally with `pnpm dev`.
> 
> Updates the `examples/embedded-app` row to include a direct live link for quick discovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2a6b5b31629f66115f34e00bc5a9cfbafcf07a60. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->