### PR TITLE
chore(embedded-app): shared home widget storage + isolated fullscreen demo

### DIFF
--- a/examples/embedded-app/src/fullscreen-assistant-demo.ts
+++ b/examples/embedded-app/src/fullscreen-assistant-demo.ts
@@ -9,6 +9,7 @@ import {
   createDropdownMenu,
   createIconButton,
   createLabelButton,
+  createLocalStorageAdapter,
   mergeWithDefaults,
   DEFAULT_WIDGET_CONFIG,
   type AgentWidgetConfig,
@@ -23,6 +24,12 @@ import {
 
 /** Must match `initAgentWidget` mount element `id` (used for persona:* window events). */
 const FULLSCREEN_ASSISTANT_DEMO_INSTANCE_ID = "fullscreen-assistant-demo-root";
+
+/** Isolated from the main embedded-app `persona-state` bucket (home + shared demos). */
+const FULLSCREEN_ASSISTANT_DEMO_STORAGE_KEY = "persona-fullscreen-assistant-demo";
+const fullscreenAssistantWidgetStorage = createLocalStorageAdapter(
+  FULLSCREEN_ASSISTANT_DEMO_STORAGE_KEY
+);
 
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
 const apiUrl =
@@ -433,6 +440,10 @@ const newFullscreenAssistantScriptStream = () => createFullscreenAssistantScript
 
 const config = mergeWithDefaults({
   apiUrl,
+  storageAdapter: fullscreenAssistantWidgetStorage,
+  persistState: {
+    keyPrefix: `${FULLSCREEN_ASSISTANT_DEMO_STORAGE_KEY}-`
+  },
   agent: {
     name: "Chat Assistant",
     model: "mercury-2",

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -6,9 +6,21 @@ import type { DeepPartial, PersonaTheme } from "@runtypelabs/persona";
 import {
   initAgentWidget,
   createAgentExperience,
+  createLocalStorageAdapter,
   markdownPostprocessor,
   DEFAULT_WIDGET_CONFIG
 } from "@runtypelabs/persona";
+
+/** Same key as the widget default — shared with other embedded-app pages that use persisted chat. */
+const sharedWidgetStorage = createLocalStorageAdapter("persona-state");
+
+const homeDemoSuggestionChips = [
+  "What is Persona and how does it work?",
+  "How does streaming work?",
+  "What can I customize?",
+  "How do I add a chat widget to my website?",
+  "What do I tell my AI coding agent to use this?"
+] as const;
 
 const inlineDemoTheme: DeepPartial<PersonaTheme> = {
   palette: {
@@ -197,6 +209,7 @@ const inlineController = createAgentExperience(inlineMount, {
   persistState: {
     keyPrefix: "persona-assistant-"
   },
+  storageAdapter: sharedWidgetStorage,
   theme: inlineDemoTheme,
   copy: {
     ...DEFAULT_WIDGET_CONFIG.copy,
@@ -205,13 +218,7 @@ const inlineController = createAgentExperience(inlineMount, {
       "I can help you learn about Persona and find the right demo for your use case.",
     inputPlaceholder: "Ask about Persona features, theming, integrations…"
   },
-  suggestionChips: [
-    "What is Persona and how does it work?",
-    "How does streaming work?",
-    "What can I customize?",
-    "How do I add a chat widget to my website?",
-    "What do I tell my AI coding agent to use this?"
-  ],
+  suggestionChips: [...homeDemoSuggestionChips],
   postprocessMessage: ({ text }) => markdownPostprocessor(text)
 });
 
@@ -226,6 +233,7 @@ const launcherController = initAgentWidget({
     persistState: {
       keyPrefix: "launcher-"
     },
+    storageAdapter: sharedWidgetStorage,
     theme: {
       components: {
         launcher: {
@@ -238,11 +246,7 @@ const launcherController = initAgentWidget({
       iconUrl: "https://dummyimage.com/96x96/111827/ffffff&text=AI",
       closeButtonColor: "#6b7280",
     },
-    suggestionChips: [
-      "How do I embed the widget?",
-      "Show me the API docs",
-      "Schedule a demo"
-    ],
+    suggestionChips: [...homeDemoSuggestionChips],
     postprocessMessage: ({ text }) => markdownPostprocessor(text)
   }
 });


### PR DESCRIPTION
## Summary

- **Home (`/`)**: Inline embed and corner launcher now share one `createLocalStorageAdapter("persona-state")` so persisted chat matches the default bucket used elsewhere in the embedded app. Starter suggestion chips are defined once (`homeDemoSuggestionChips`) and reused by both instances.
- **Fullscreen assistant demo**: Uses `persona-fullscreen-assistant-demo` for `storageAdapter` plus a matching `persistState.keyPrefix`, so this page does not read or write the main app’s `persona-state`.

## Notes

Examples-only; no changeset.

## How to test

1. `pnpm dev` from repo root, open `http://localhost:5173/` — chat in inline or launcher, refresh; history should remain aligned when using the same storage key.
2. Open `/fullscreen-assistant-demo.html` — conversation should not appear from the home demo and vice versa after separate usage.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk examples-only change that only affects how demo chat state is persisted in localStorage; main risk is unexpected state sharing/clearing between demo widgets due to key changes.
> 
> **Overview**
> Aligns the embedded-app home page widgets (inline + launcher) to **share a single persisted chat bucket** by introducing a shared `createLocalStorageAdapter("persona-state")` and reusing it across both instances.
> 
> Isolates the fullscreen assistant demo by giving it its own `storageAdapter` key (`persona-fullscreen-assistant-demo`) and a matching `persistState.keyPrefix`, preventing cross-page chat history bleed. Also deduplicates home suggestion chips into a single `homeDemoSuggestionChips` constant used by both widgets.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 399b07f264130540cc6de4a961627c91992ba187. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->