### PR TITLE
chore(embedded-app): align corner launcher with inline docs assistant

### DIFF
--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -179,14 +179,14 @@ Tell the user to adjust the prompt to their specifics (framework, styling, use c
 
 Keep answers concise. Use markdown formatting. When recommending a demo, briefly explain why it is relevant to the user's question.`;
 
-const inlineMount = document.getElementById("inline-widget");
-if (!inlineMount) {
-  throw new Error("Inline widget mount node missing");
-}
+const homeDemoWelcomeTitle = "Welcome to Persona";
+const homeDemoWelcomeSubtitle =
+  "I can help you learn about Persona and find the right demo for your use case.";
+const homeDemoInputPlaceholder =
+  "Ask about Persona features, theming, integrations…";
 
-const inlineController = createAgentExperience(inlineMount, {
-  ...DEFAULT_WIDGET_CONFIG,
-  apiUrl: proxyUrl,
+/** Same Runtype agent, request options, and welcome copy for inline embed and corner launcher. */
+const homeDemoSharedAssistant = {
   agent: {
     name: "Persona Documentation Assistant",
     model: "claude-haiku-4-5-20251001",
@@ -195,9 +195,29 @@ const inlineController = createAgentExperience(inlineMount, {
   },
   agentOptions: {
     streamResponse: true,
-    recordMode: "virtual",
+    recordMode: "virtual" as const,
     storeResults: false,
   },
+  copy: {
+    ...DEFAULT_WIDGET_CONFIG.copy,
+    welcomeTitle: homeDemoWelcomeTitle,
+    welcomeSubtitle: homeDemoWelcomeSubtitle,
+    inputPlaceholder: homeDemoInputPlaceholder,
+  },
+};
+
+/** One prefix for both widgets so sessionStorage open/voice prefs are not split. */
+const homeDemoPersistKeyPrefix = "persona-home-demo-";
+
+const inlineMount = document.getElementById("inline-widget");
+if (!inlineMount) {
+  throw new Error("Inline widget mount node missing");
+}
+
+const inlineController = createAgentExperience(inlineMount, {
+  ...DEFAULT_WIDGET_CONFIG,
+  apiUrl: proxyUrl,
+  ...homeDemoSharedAssistant,
   launcher: {
     ...DEFAULT_WIDGET_CONFIG.launcher,
     width: "100%",
@@ -207,17 +227,10 @@ const inlineController = createAgentExperience(inlineMount, {
     showEventStreamToggle: true
   },
   persistState: {
-    keyPrefix: "persona-assistant-"
+    keyPrefix: homeDemoPersistKeyPrefix
   },
   storageAdapter: sharedWidgetStorage,
   theme: inlineDemoTheme,
-  copy: {
-    ...DEFAULT_WIDGET_CONFIG.copy,
-    welcomeTitle: "Welcome to Persona",
-    welcomeSubtitle:
-      "I can help you learn about Persona and find the right demo for your use case.",
-    inputPlaceholder: "Ask about Persona features, theming, integrations…"
-  },
   suggestionChips: [...homeDemoSuggestionChips],
   postprocessMessage: ({ text }) => markdownPostprocessor(text)
 });
@@ -227,11 +240,12 @@ const launcherController = initAgentWidget({
   config: {
     ...DEFAULT_WIDGET_CONFIG,
     apiUrl: proxyUrl,
+    ...homeDemoSharedAssistant,
     features: {
       showEventStreamToggle: true
     },
     persistState: {
-      keyPrefix: "launcher-"
+      keyPrefix: homeDemoPersistKeyPrefix
     },
     storageAdapter: sharedWidgetStorage,
     theme: {
@@ -243,6 +257,8 @@ const launcherController = initAgentWidget({
     },
     launcher: {
       ...DEFAULT_WIDGET_CONFIG.launcher,
+      title: homeDemoWelcomeTitle,
+      subtitle: homeDemoWelcomeSubtitle,
       iconUrl: "https://dummyimage.com/96x96/111827/ffffff&text=AI",
       closeButtonColor: "#6b7280",
     },


### PR DESCRIPTION
## Summary

Rebased on latest `main` (includes #116 shared storage / fullscreen isolation).

- **Runtype parity:** Corner `initAgentWidget` now spreads the same `homeDemoSharedAssistant` block as the inline embed (`agent`, `agentOptions`, `copy`) so model, system prompt, and streaming options match.
- **UX parity:** `launcher.title` / `launcher.subtitle` match the welcome card (`Welcome to Persona` + documentation subtitle) instead of default `Chat Assistant` strings.
- **Session prefs:** Single `persistState.keyPrefix` (`persona-home-demo-`) for both widgets so sessionStorage-backed state is not split between mounts.

## Notes

Examples only — no changeset.

## How to test

`pnpm dev`, open `/`. Open the corner launcher: header and empty state should match the inline try-it block; both should hit the same assistant config.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: example/demo-only refactor that centralizes widget config and unifies persisted UI state; no production logic or data handling changes.
> 
> **Overview**
> Aligns the home-page corner launcher with the inline documentation assistant by extracting a shared assistant config (`agent`, `agentOptions`, and welcome `copy`) and applying it to both widget initializations.
> 
> Unifies persisted UI preferences by using a single `persistState.keyPrefix` for both mounts, and updates the launcher header (`title`/`subtitle`) to match the inline welcome copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 638f19ca0258604bfcb3af397df4667a625e421e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->