### PR TITLE
fix(proxy): dev-only dispatch debug logging + full payload

### DIFF
--- a/.changeset/proxy-dev-logging.md
+++ b/.changeset/proxy-dev-logging.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Read `NODE_ENV` and `RUNTYPE_API_KEY` through a runtime-safe env helper (works when `process` is absent), and keep verbose dispatch logs—API key prefix and full JSON payload—strictly in development.

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -64,51 +64,15 @@ const DEFAULT_ENDPOINT = "https://api.runtype.com/v1/dispatch";
 const DEFAULT_PATH = "/api/chat/dispatch";
 
 const getRuntimeEnv = (): RuntimeEnv | undefined => {
-  const maybeProcess = (globalThis as typeof globalThis & {
-    process?: { env?: RuntimeEnv };
-  }).process;
+  const maybeProcess = (
+    globalThis as typeof globalThis & { process?: { env?: RuntimeEnv } }
+  ).process;
   return maybeProcess?.env;
 };
 
+/** True only when `NODE_ENV` is exactly `"development"` (unset = production). Safe when `process` is missing (e.g. some Workers runtimes). */
 const isDevelopmentRuntime = (): boolean =>
   getRuntimeEnv()?.NODE_ENV === "development";
-
-const summarizeRequestPayload = (
-  payload: Record<string, unknown>,
-  isAgentMode: boolean
-): Record<string, unknown> => {
-  if (isAgentMode) {
-    return {
-      topLevelKeys: Object.keys(payload).sort()
-    };
-  }
-
-  const messages = Array.isArray(payload.messages) ? payload.messages : [];
-  const inputs =
-    payload.inputs && typeof payload.inputs === "object" && !Array.isArray(payload.inputs)
-      ? Object.keys(payload.inputs as Record<string, unknown>).sort()
-      : [];
-  const flow =
-    payload.flow && typeof payload.flow === "object" && !Array.isArray(payload.flow)
-      ? (payload.flow as Record<string, unknown>)
-      : undefined;
-  const record =
-    payload.record && typeof payload.record === "object" && !Array.isArray(payload.record)
-      ? (payload.record as Record<string, unknown>)
-      : undefined;
-  const metadata =
-    record?.metadata && typeof record.metadata === "object" && !Array.isArray(record.metadata)
-      ? (record.metadata as Record<string, unknown>)
-      : undefined;
-
-  return {
-    messageCount: messages.length,
-    inputKeys: inputs,
-    flowId: typeof flow?.id === "string" ? flow.id : undefined,
-    hasInlineFlow: typeof flow?.id !== "string" && !!flow,
-    metadataKeys: metadata ? Object.keys(metadata).sort() : []
-  };
-};
 
 const DEFAULT_FLOW: RuntypeFlowConfig = {
   name: "Streaming Prompt Flow",
@@ -318,14 +282,13 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
       }
     }
 
+    // Development only: do not log key material or full bodies in production.
     if (isDevelopment) {
       console.log(`\n=== Runtype Proxy Request (${isAgentMode ? "agent" : "flow"}) ===`);
       console.log("URL:", upstream);
       console.log("API Key Used:", apiKey ? "Yes" : "No");
-      console.log(
-        "Request Summary:",
-        JSON.stringify(summarizeRequestPayload(runtypePayload, isAgentMode), null, 2)
-      );
+      console.log("API Key (first 12 chars):", apiKey ? apiKey.substring(0, 12) : "N/A");
+      console.log("Request Payload:", JSON.stringify(runtypePayload, null, 2));
     }
 
     const response = await fetch(upstream, {


### PR DESCRIPTION
## Summary
Restores verbose **development-only** dispatch logs in `@runtypelabs/persona-proxy`: API key prefix (first 12 chars) and the full JSON body sent to Runtype, replacing the abbreviated request summary from `main`.

## Details
- All of that output stays behind `NODE_ENV === "development"` (unset is treated as production, matching existing CORS behavior).
- `getRuntimeEnv` / `isDevelopmentRuntime` read env via `globalThis.process?.env` so runtimes without Node`s `process` do not break.
- Removes `summarizeRequestPayload` since the full payload is logged in dev.

## Changeset
Patch bump for `@runtypelabs/persona-proxy` (`.changeset/proxy-dev-logging.md`).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional risk, but it changes logging to include API key prefixes and full request bodies in development; misconfigured `NODE_ENV` could leak sensitive data to logs.
> 
> **Overview**
> Restores **development-only** verbose dispatch logging in `@runtypelabs/persona-proxy`, logging the upstream URL, API key prefix (first 12 chars), and the full JSON payload sent to Runtype (replacing the prior summarized payload logging).
> 
> Reads `NODE_ENV` and `RUNTYPE_API_KEY` via a runtime-safe `globalThis.process?.env` helper to avoid breaking in runtimes where `process` is absent, and includes a patch changeset for release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d581a067f02011d9ec4b3e8643c969085ce64264. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->