### PR TITLE
examples: constrain index launcher pill with collapsedMaxWidth

### DIFF
--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -261,6 +261,7 @@ const launcherController = initAgentWidget({
       subtitle: homeDemoWelcomeSubtitle,
       iconUrl: "https://dummyimage.com/96x96/111827/ffffff&text=AI",
       closeButtonColor: "#6b7280",
+      collapsedMaxWidth: "min(380px, calc(100vw - 48px))",
     },
     suggestionChips: [...homeDemoSuggestionChips],
     postprocessMessage: ({ text }) => markdownPostprocessor(text)


### PR DESCRIPTION
Uses the Persona widget launcher option `collapsedMaxWidth` (CSS `max-width` on the floating pill when the panel is closed) for the bottom-right widget on the embedded-app index page. Value matches the responsive pattern used in widget launcher tests: `min(380px, calc(100vw - 48px))`.

Theme tokens under `components.launcher` do not expose max-width; this is the supported API per `AgentWidgetLauncherConfig`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single examples-only widget config change that affects only the launcher’s collapsed layout and has no data/auth implications.
> 
> **Overview**
> Sets `launcher.collapsedMaxWidth` for the embedded-app index page’s bottom-right widget so the collapsed launcher pill respects a responsive max width (`min(380px, calc(100vw - 48px))`). This prevents the closed-state launcher from growing too wide on small viewports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a97413066de0ccdd3b18a285388bba7a9e358d2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->