### PR TITLE
fix(embedded-app): scope demo button styles to .page to prevent theme editor regression

### DIFF
--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -147,14 +147,15 @@ code {
 }
 
 /*
- * Demo chrome only — do not style Persona controls.
- * The widget mounts in the light DOM by default (`useShadowDom` is opt-in), so a bare
- * `button { padding: 10px 18px }` applies to the header close control. With `width`/`height`
- * 32px and `box-sizing: border-box`, horizontal padding 18+18px leaves no room for the SVG.
+ * Demo chrome only — scoped to `.page` (index.html) so other pages that import this file
+ * (theme.html, bakery, json, etc.) are not affected. The widget mounts in the light DOM by
+ * default (`useShadowDom` is opt-in), so a bare `button { padding: 10px 18px }` applies to
+ * the header close control. With `width`/`height` 32px and `box-sizing: border-box`,
+ * horizontal padding 18+18px leaves no room for the SVG.
  */
-button:not([data-persona-root] *),
-select:not([data-persona-root] *),
-.btn:not([data-persona-root] *) {
+.page button:not([data-persona-root] *),
+.page select:not([data-persona-root] *),
+.page .btn:not([data-persona-root] *) {
   font-family: var(--font-sans);
   font-size: 14px;
   font-weight: 600;
@@ -181,7 +182,8 @@ select:not([data-persona-root] *),
   box-shadow: 0 6px 16px -4px rgba(0, 0, 0, 0.25);
 }
 
-.secondaryButton, select {
+.secondaryButton,
+.page select:not([data-persona-root] *) {
   background: #ffffff;
   color: var(--foreground);
   border: 1px solid var(--border);
@@ -193,7 +195,7 @@ select:not([data-persona-root] *),
   transform: translateY(-1px);
 }
 
-select {
+.page select:not([data-persona-root] *) {
   padding-right: 32px;
   appearance: auto;
 }

--- a/examples/embedded-app/src/theme-configurator.css
+++ b/examples/embedded-app/src/theme-configurator.css
@@ -71,7 +71,7 @@ body {
   margin: 0;
   font-size: 12px;
   color: #6b7280;
-  line-height: 0.5;
+  line-height: 1.5;
 }
 
 /* Mobile shell (shown ≤767px — see media query) */


### PR DESCRIPTION
## Summary

- Global `button`/`select` rules in `index.css` were winning the cascade over `.toolbar-btn` and `.segment-btn` on `theme.html`, stretching every control in the theme editor toolbar and sidebar (tall URL bar, chunky device toggle, oversized Presets/Actions/Conversation buttons).
- Fixed by scoping these rules under `.page` (the `index.html` wrapper) rather than using opt-out `:not()` exclusions — any page that imports `index.css` without `.page` is unaffected automatically.
- Also fixes a `line-height: 0.5` typo in `.config-header .subtitle` in `theme-configurator.css` (should be `1.5`).

## Test plan

- [ ] Open `/theme.html` — toolbar controls, device toggle, URL bar, Presets, and Actions buttons should all appear compact and correctly sized
- [ ] Open `index.html` — demo page CTA buttons should look unchanged

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that narrows selector scope; main risk is minor visual regressions on pages that relied on the previous global button/select styling.
> 
> **Overview**
> Fixes a theme editor styling regression by **scoping the demo `button`/`select`/`.btn` styling in `index.css` under `.page`**, preventing global controls (including Persona widget UI) from being stretched on other example pages that import this stylesheet.
> 
> Also corrects the `.config-header .subtitle` `line-height` in `theme-configurator.css` from `0.5` to `1.5` to restore normal subtitle spacing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cabae130775e6e1e2e7f26e16babd2fdcee8c580. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->