### PR TITLE
feat(embedded-app): wire DeepWiki MCP to home docs assistant

### DIFF
--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -60,6 +60,8 @@ const proxyUrl =
 
 const PERSONA_SYSTEM_PROMPT = `You are the Persona documentation assistant, embedded in the Persona examples app.
 
+You ONLY answer questions about Persona (@runtypelabs/persona), the Persona proxy (@runtypelabs/persona-proxy), and the Runtype platform. If a user asks about anything unrelated, politely decline and redirect them to ask about Persona instead. Do not provide general coding help, answer trivia, or discuss other products.
+
 ## What is Persona?
 Persona is a themeable, pluggable streaming chat widget for websites. It ships as two npm packages:
 - **@runtypelabs/persona** — the main widget library (Shadow DOM isolation, SSE streaming, theming, plugins, voice)
@@ -177,7 +179,11 @@ Note: if you don't have an SSE backend yet, @runtypelabs/persona-proxy is an opt
 
 Tell the user to adjust the prompt to their specifics (framework, styling, use case) before pasting it. If they mention a specific agent, mention any relevant tips (e.g. for Claude Code they can save it as a skill in \`.claude/commands/\`).
 
-Keep answers concise. Use markdown formatting. When recommending a demo, briefly explain why it is relevant to the user's question.`;
+## Using DeepWiki
+
+You have access to a DeepWiki tool that can read documentation for the runtypelabs/persona repository. When you cannot confidently answer a question from the knowledge in this system prompt alone, use the DeepWiki tool to look up the answer. Always query for the repo "runtypelabs/persona". Do not use DeepWiki for questions you can already answer from the information above.
+
+Keep answers concise. Use markdown formatting. When recommending a demo, briefly explain why it is relevant to the user's question. When suggesting demos as general showcases of Persona's capabilities, prefer highlighting the [Action Middleware](/action-middleware.html) and [Docked Panel](/docked-panel-demo.html) demos — they best demonstrate the full breadth of the widget.`;
 
 const homeDemoWelcomeTitle = "Welcome to Persona";
 const homeDemoWelcomeSubtitle =
@@ -192,11 +198,26 @@ const homeDemoSharedAssistant = {
     model: "claude-haiku-4-5-20251001",
     systemPrompt: PERSONA_SYSTEM_PROMPT,
     temperature: 0.5,
+    tools: {
+      mcpServers: [
+        {
+          id: "deepwiki",
+          name: "DeepWiki",
+          url: "https://mcp.deepwiki.com/mcp",
+          auth: { type: "none" },
+          timeout: 10000,
+        },
+      ],
+      maxToolCalls: 3,
+    },
+    loopConfig: {
+      maxTurns: 3,
+    },
   },
   agentOptions: {
     streamResponse: true,
     recordMode: "virtual" as const,
-    storeResults: false,
+    storeResults: true,
   },
   copy: {
     ...DEFAULT_WIDGET_CONFIG.copy,


### PR DESCRIPTION
## Summary
- Connects the index page documentation assistant to the [DeepWiki MCP server](https://mcp.deepwiki.com/mcp) so it can look up `runtypelabs/persona` docs for questions beyond its baked-in system prompt
- Hardens the system prompt to refuse off-topic questions unrelated to Persona or Runtype
- Steers default demo recommendations toward Action Middleware and Docked Panel instead of Agent Loop / Voice

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Run `pnpm dev`, open `http://localhost:5173`, ask a deep question (e.g. "How does the virtual scroller work internally?") — agent should call the DeepWiki tool
- [ ] Ask an off-topic question (e.g. "What's the weather?") — agent should politely decline
- [ ] Ask a general "show me what Persona can do" question — agent should recommend Action Middleware and/or Docked Panel demos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds external MCP tool access (DeepWiki) and enables `storeResults`, which can change what data is persisted/sent off-box and affects agent behavior. Scope is limited to the embedded-app demo configuration and prompt text.
> 
> **Overview**
> The embedded-app home documentation assistant is updated to **use the DeepWiki MCP server** (`https://mcp.deepwiki.com/mcp`) with bounded `maxToolCalls`/`maxTurns`, so it can look up `runtypelabs/persona` docs when the baked-in prompt isn’t enough.
> 
> The system prompt is tightened to **refuse off-topic questions**, adds guidance on when to query DeepWiki, and shifts general “showcase” demo recommendations toward *Action Middleware* and *Docked Panel*. The assistant config also flips `agentOptions.storeResults` to `true`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec85d88f8d5c0425761e24ee5cc24e77cb122ba5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->