### PR TITLE
chore(embedded-app): increase DeepWiki MCP timeout to 30s

### DIFF
--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -205,7 +205,7 @@ const homeDemoSharedAssistant = {
           name: "DeepWiki",
           url: "https://mcp.deepwiki.com/mcp",
           auth: { type: "none" },
-          timeout: 10000,
+          timeout: 30000,
         },
       ],
       maxToolCalls: 3,


### PR DESCRIPTION
## Summary
- Increases the DeepWiki MCP server timeout from 10s to 30s to avoid timeouts on slower wiki lookups

## Test plan
- [ ] `pnpm typecheck` passes
- [ ] Run `pnpm dev`, ask the home assistant a deep question — DeepWiki tool call completes without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk configuration tweak that only increases the DeepWiki MCP server request timeout, affecting responsiveness but not data handling or security logic.
> 
> **Overview**
> In the embedded app demo (`examples/embedded-app/src/main.ts`), increases the DeepWiki MCP server `timeout` from **10s to 30s** to reduce tool-call timeouts on slower documentation lookups.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b37956af0b5fa5d6539022d3520ff935ed9ee5f5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->