### PR TITLE
feat(embedded-app): add copy button to code blocks on home page

### DIFF
--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -14,6 +14,65 @@ import {
 /** Same key as the widget default — shared with other embedded-app pages that use persisted chat. */
 const sharedWidgetStorage = createLocalStorageAdapter("persona-state");
 
+// ---------------------------------------------------------------------------
+// Code block copy button postprocessor
+// ---------------------------------------------------------------------------
+/**
+ * Wraps fenced code blocks (<pre>) with a header containing a copy button.
+ * Uses text labels instead of SVG icons to survive DOMPurify sanitization.
+ */
+const codeBlockCopyPostprocessor = (text: string): string => {
+  let html = markdownPostprocessor(text);
+  // Wrap each <pre>…</pre> with a container + header
+  html = html.replace(/<pre><code(?:\s+class="language-(\w+)")?>/g, (_match, lang?: string) => {
+    const label = lang ?? "";
+    return (
+      `<div class="persona-code-block-wrapper">` +
+      `<div class="persona-code-block-header">` +
+      `<span>${label}</span>` +
+      `<button type="button" class="persona-code-copy-btn" title="Copy code">` +
+      `<span class="persona-code-copy-label">Copy</span>` +
+      `</button>` +
+      `</div>` +
+      `<pre><code${lang ? ` class="language-${lang}"` : ""}>`
+    );
+  });
+  html = html.replace(/<\/code><\/pre>/g, `</code></pre></div>`);
+  return html;
+};
+
+/**
+ * Delegated click handler for code copy buttons inside shadow DOM.
+ * Native click events cross shadow boundaries via composedPath().
+ */
+const setupCodeCopyHandler = (root: HTMLElement) => {
+  root.addEventListener("click", (e) => {
+    const path = e.composedPath();
+    // Find the copy button in the composed path (works across shadow DOM)
+    const btn = path.find(
+      (el) => el instanceof HTMLElement && el.classList.contains("persona-code-copy-btn")
+    ) as HTMLElement | undefined;
+    if (!btn) return;
+
+    // Walk up the composed path to find the wrapper div
+    const wrapper = path.find(
+      (el) => el instanceof HTMLElement && el.classList.contains("persona-code-block-wrapper")
+    ) as HTMLElement | undefined;
+    const codeEl = wrapper?.querySelector("pre code");
+    if (!codeEl) return;
+
+    navigator.clipboard.writeText(codeEl.textContent ?? "").then(() => {
+      const label = btn.querySelector(".persona-code-copy-label");
+      if (label) label.textContent = "Copied!";
+      btn.classList.add("persona-code-copied");
+      setTimeout(() => {
+        if (label) label.textContent = "Copy";
+        btn.classList.remove("persona-code-copied");
+      }, 2000);
+    });
+  });
+};
+
 const homeDemoSuggestionChips = [
   "What is Persona and how does it work?",
   "How does streaming work?",
@@ -253,8 +312,9 @@ const inlineController = createAgentExperience(inlineMount, {
   storageAdapter: sharedWidgetStorage,
   theme: inlineDemoTheme,
   suggestionChips: [...homeDemoSuggestionChips],
-  postprocessMessage: ({ text }) => markdownPostprocessor(text)
+  postprocessMessage: ({ text }) => codeBlockCopyPostprocessor(text)
 });
+setupCodeCopyHandler(inlineMount);
 
 const launcherController = initAgentWidget({
   target: "#launcher-root",
@@ -285,9 +345,10 @@ const launcherController = initAgentWidget({
       collapsedMaxWidth: "min(380px, calc(100vw - 48px))",
     },
     suggestionChips: [...homeDemoSuggestionChips],
-    postprocessMessage: ({ text }) => markdownPostprocessor(text)
+    postprocessMessage: ({ text }) => codeBlockCopyPostprocessor(text)
   }
 });
+setupCodeCopyHandler(document.getElementById("launcher-root")!);
 
 // ---------------------------------------------------------------------------
 // Event Stream Testing

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -19,19 +19,22 @@ const sharedWidgetStorage = createLocalStorageAdapter("persona-state");
 // ---------------------------------------------------------------------------
 /**
  * Wraps fenced code blocks (<pre>) with a header containing a copy button.
- * Uses text labels instead of SVG icons to survive DOMPurify sanitization.
+ * While streaming, shows a disabled "Generating…" label instead of "Copy".
  */
-const codeBlockCopyPostprocessor = (text: string): string => {
+const codeBlockCopyPostprocessor = (text: string, streaming: boolean): string => {
   let html = markdownPostprocessor(text);
   // Wrap each <pre>…</pre> with a container + header
   html = html.replace(/<pre><code(?:\s+class="language-(\w+)")?>/g, (_match, lang?: string) => {
     const label = lang ?? "";
+    const btnLabel = streaming ? "Generating\u2026" : "Copy";
+    const disabledAttr = streaming ? " disabled" : "";
+    const extraClass = streaming ? " persona-code-copy-generating" : "";
     return (
       `<div class="persona-code-block-wrapper">` +
       `<div class="persona-code-block-header">` +
       `<span>${label}</span>` +
-      `<button type="button" class="persona-code-copy-btn" title="Copy code">` +
-      `<span class="persona-code-copy-label">Copy</span>` +
+      `<button type="button" class="persona-code-copy-btn${extraClass}" title="Copy code"${disabledAttr}>` +
+      `<span class="persona-code-copy-label">${btnLabel}</span>` +
       `</button>` +
       `</div>` +
       `<pre><code${lang ? ` class="language-${lang}"` : ""}>`
@@ -312,7 +315,7 @@ const inlineController = createAgentExperience(inlineMount, {
   storageAdapter: sharedWidgetStorage,
   theme: inlineDemoTheme,
   suggestionChips: [...homeDemoSuggestionChips],
-  postprocessMessage: ({ text }) => codeBlockCopyPostprocessor(text)
+  postprocessMessage: ({ text, streaming }) => codeBlockCopyPostprocessor(text, streaming)
 });
 setupCodeCopyHandler(inlineMount);
 
@@ -345,7 +348,7 @@ const launcherController = initAgentWidget({
       collapsedMaxWidth: "min(380px, calc(100vw - 48px))",
     },
     suggestionChips: [...homeDemoSuggestionChips],
-    postprocessMessage: ({ text }) => codeBlockCopyPostprocessor(text)
+    postprocessMessage: ({ text, streaming }) => codeBlockCopyPostprocessor(text, streaming)
   }
 });
 setupCodeCopyHandler(document.getElementById("launcher-root")!);

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1222,6 +1222,58 @@
   font-size: 0.8125rem;
 }
 
+/* Code block copy button */
+.persona-code-block-wrapper {
+  position: relative;
+  margin: 0.5rem 0;
+}
+
+.persona-code-block-wrapper pre {
+  margin: 0 !important;
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+}
+
+.persona-code-block-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: var(--persona-md-code-block-bg, #f3f4f6);
+  border: 1px solid var(--persona-md-code-block-border-color, #e5e7eb);
+  border-bottom: none;
+  border-top-left-radius: var(--persona-md-code-block-border-radius, 0.375rem);
+  border-top-right-radius: var(--persona-md-code-block-border-radius, 0.375rem);
+  padding: 0.25rem 0.5rem 0.25rem 0.75rem;
+  font-size: 0.75rem;
+  color: var(--persona-text-muted, #6b7280);
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Consolas, "Liberation Mono", Menlo, monospace;
+}
+
+.persona-code-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 0.25rem;
+  padding: 0.25rem 0.5rem;
+  cursor: pointer;
+  color: var(--persona-text-muted, #6b7280);
+  font-size: 0.75rem;
+  font-family: inherit;
+  line-height: 1;
+  transition: color 0.15s ease, border-color 0.15s ease;
+}
+
+.persona-code-copy-btn:hover {
+  color: var(--persona-text, #111827);
+  border-color: var(--persona-md-code-block-border-color, #e5e7eb);
+}
+
+.persona-code-copy-btn.persona-code-copied {
+  color: #16a34a;
+}
+
 /* Ensure all links in chat bubbles have underlines */
 .vanilla-message-bubble a {
   text-decoration: underline;

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1274,6 +1274,16 @@
   color: #16a34a;
 }
 
+.persona-code-copy-btn.persona-code-copy-generating {
+  cursor: default;
+  opacity: 0.5;
+}
+
+.persona-code-copy-btn.persona-code-copy-generating:hover {
+  color: var(--persona-text-muted, #6b7280);
+  border-color: transparent;
+}
+
 /* Ensure all links in chat bubbles have underlines */
 .vanilla-message-bubble a {
   text-decoration: underline;


### PR DESCRIPTION
## Summary
- Adds a "Copy" button header bar to fenced code blocks rendered in the home page widget (both inline and launcher)
- Displays the language label (e.g. `js`, `html`) on the left and a "Copy" button on the right
- Uses `composedPath()` event delegation to handle clicks through Shadow DOM boundaries
- Shows "Copied!" feedback with green color for 2 seconds after copying

## Test plan
- [ ] Open the home page at http://localhost:5173
- [ ] Ask the assistant a question that produces a code block (e.g. "How do I install Persona?")
- [ ] Verify the code block has a header bar with the language label and "Copy" button
- [ ] Click "Copy" and verify the code is copied to clipboard and the button shows "Copied!"
- [ ] Test in both the inline widget and the floating launcher widget

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that augments markdown rendering and adds new CSS classes; main concern is minor styling/regression around `<pre>` blocks and clipboard availability in some browsers/contexts.
> 
> **Overview**
> Adds a custom `postprocessMessage` on the embedded-app home page that wraps rendered fenced code blocks with a header showing the language label and a **Copy** button, disabled as *Generating…* while streaming.
> 
> Implements delegated click handling via `composedPath()` to copy the code text and show temporary *Copied!* feedback, and extends `widget.css` with styles for the new code-block wrapper/header/button states.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8eba1323769d21c6b88b7f8959c6947627d35e2c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->