### PR TITLE
feat: demo carousel, status indicator options, header fix, and embedded-app demo refresh

### DIFF
--- a/.changeset/demo-carousel-and-status-indicator.md
+++ b/.changeset/demo-carousel-and-status-indicator.md
@@ -1,0 +1,9 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add `createDemoCarousel()` — a reusable, exportable component that renders demo pages in scaled iframes with device viewport toggle, zoom controls, light/dark scheme toggle, carousel navigation with dropdown picker, and open-in-new-tab button. Fully self-contained CSS for standalone use on marketing sites.
+
+Add `statusIndicator.align` option (`'left' | 'center' | 'right'`) to control status text alignment without custom CSS.
+
+Add `statusIndicator.idleLink` option to make the idle status text a clickable link that opens in a new tab.

--- a/.changeset/demo-carousel-and-status-indicator.md
+++ b/.changeset/demo-carousel-and-status-indicator.md
@@ -7,3 +7,5 @@ Add `createDemoCarousel()` — a reusable, exportable component that renders dem
 Add `statusIndicator.align` option (`'left' | 'center' | 'right'`) to control status text alignment without custom CSS.
 
 Add `statusIndicator.idleLink` option to make the idle status text a clickable link that opens in a new tab.
+
+Fix header layout so trailing action buttons (event stream toggle, clear chat, close) are pushed to the right edge instead of clustering after the title.

--- a/examples/embedded-app/event-stream-testing.html
+++ b/examples/embedded-app/event-stream-testing.html
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/src/demo-shared.css">
+  <link rel="icon" href="/favicon.ico" />
+  <title>Event Stream Testing</title>
+  <style>
+    .section {
+      margin-bottom: 1.25rem;
+    }
+    .section h3 {
+      margin: 0 0 0.5rem 0;
+      font-size: 0.9rem;
+      color: var(--muted);
+    }
+    .btn-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      margin-bottom: 0.5rem;
+      align-items: center;
+    }
+    .field-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: center;
+      margin-bottom: 0.75rem;
+    }
+    .field-row label {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+    .field-row select {
+      padding: 0.35rem 0.5rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--text);
+    }
+    .log-panel {
+      background: var(--accent);
+      border-radius: var(--radius);
+      padding: 0.75rem;
+      max-height: 180px;
+      overflow-y: auto;
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--muted);
+      margin-top: 0.5rem;
+      display: none;
+    }
+    .widget-frame {
+      border: 1px solid var(--border);
+      border-radius: var(--radius);
+      overflow: hidden;
+      min-height: 420px;
+      height: min(52vh, 520px);
+    }
+    #es-inline-widget {
+      height: 100%;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="back-link">&larr; Back to examples</a>
+
+  <div class="layout">
+    <div class="info-panel">
+      <h1>Event Stream Testing</h1>
+      <p>
+        Exercise <code>showEventStream</code>, <code>hideEventStream</code>, <code>isEventStreamVisible</code>,
+        <code>persona:showEventStream</code> / <code>persona:hideEventStream</code> window events, and
+        <code>instanceId</code> scoping. The page mounts an <strong>inline</strong> widget and a <strong>launcher</strong>
+        so you can compare behavior side by side.
+      </p>
+
+      <div class="section">
+        <h3>Target</h3>
+        <div class="field-row">
+          <label for="es-target-widget">Applies to controller methods &amp; load messages</label>
+          <select id="es-target-widget">
+            <option value="inline">Inline widget</option>
+            <option value="launcher">Launcher widget</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="section">
+        <h3>Launcher panel</h3>
+        <div class="btn-row">
+          <button class="btn btn-primary" type="button" id="es-open-launcher">Open launcher</button>
+          <button class="btn" type="button" id="es-toggle-launcher">Toggle launcher</button>
+        </div>
+      </div>
+
+      <div class="section">
+        <h3>Controller methods</h3>
+        <div class="btn-row">
+          <button class="btn btn-primary" type="button" id="es-show">Show event stream</button>
+          <button class="btn" type="button" id="es-hide">Hide event stream</button>
+          <button class="btn" type="button" id="es-check">Check visibility</button>
+        </div>
+      </div>
+
+      <div class="section">
+        <h3>Window events</h3>
+        <div class="btn-row">
+          <button class="btn" type="button" id="es-win-show-all">Show all (window)</button>
+          <button class="btn" type="button" id="es-win-hide-all">Hide all (window)</button>
+          <button class="btn" type="button" id="es-win-show-inline">Show inline only</button>
+          <button class="btn" type="button" id="es-win-show-launcher">Show launcher only</button>
+          <button class="btn" type="button" id="es-win-show-wrong">Show wrong ID</button>
+        </div>
+      </div>
+
+      <div class="section">
+        <h3>Event listeners</h3>
+        <div class="btn-row">
+          <button class="btn" type="button" id="es-listen">Register listeners</button>
+        </div>
+        <div id="es-log" class="log-panel">
+          <pre id="es-log-pre" style="margin:0; white-space: pre-wrap;"></pre>
+        </div>
+      </div>
+
+      <div class="section">
+        <h3>Synthetic load</h3>
+        <p style="font-size: 0.85rem; color: var(--muted); margin: 0 0 0.5rem 0;">
+          Injects 1000 alternating messages and simulated stream events into the selected widget (opens the launcher first if that target is selected).
+        </p>
+        <div class="btn-row">
+          <button class="btn" type="button" id="es-load-messages">Load 1000 messages</button>
+        </div>
+      </div>
+    </div>
+
+    <div class="panel">
+      <p style="padding: 0 0 0.75rem 0; margin: 0; font-size: 0.9rem; color: var(--muted);">
+        Inline widget (below). Launcher is fixed bottom-right.
+      </p>
+      <div class="widget-frame">
+        <div id="es-inline-widget"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="launcher-root" style="position: fixed; bottom: 1rem; right: 1rem; z-index: 50;"></div>
+
+  <script type="module" src="/src/event-stream-testing.ts"></script>
+</body>
+</html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -12,7 +12,7 @@
 
       <!-- Hero -->
       <section class="hero cardFull reveal-el">
-        <span class="label">Open Source Chat Widget</span>
+        <span class="label">Open Source AI Chat Widget</span>
         <h1 class="kern-tight" style="font-size: 40px; line-height: 1.05;">
           Add a streaming AI chat<br>to any website, in minutes.
         </h1>
@@ -25,12 +25,6 @@
           <span class="hero-feature-pill">Theming</span>
           <span class="hero-feature-pill">Voice Input</span>
           <span class="hero-feature-pill">Zero Dependencies</span>
-        </div>
-
-        <div class="install-command" id="install-cmd" title="Click to copy">
-          <span class="install-prefix">$</span>
-          <span>npm install @runtypelabs/persona</span>
-          <span class="install-copy">Copy</span>
         </div>
 
         <div class="hero-badges">
@@ -62,22 +56,51 @@
 
 
       <!-- Quick Start -->
-      <section class="card cardFull reveal-el">
+      <section class="card cardFull quick-start-section reveal-el">
         <span class="label">Quick Start</span>
-        <h2 class="card-title kern-tight" style="font-size: 24px;">Three lines to a working chat</h2>
-        <p>Install, configure, and ship. That's it.</p>
-        <div class="code-showcase">
-          <pre><code><span class="code-keyword">import</span> { <span class="code-function">initAgentWidget</span> } <span class="code-keyword">from</span> <span class="code-string">"@runtypelabs/persona"</span>;
+        <h2 class="card-title kern-tight" style="font-size: 24px;">Two steps to a working chat</h2>
+        <p>Install the package, import the styles, and mount the widget on any element.</p>
+        <div class="quick-start-steps">
+          <div class="quick-start-step">
+            <div class="quick-start-step-meta">
+              <span class="quick-start-step-index">01</span>
+              <div class="quick-start-step-copy">
+                <h3 class="quick-start-step-title">Install Persona</h3>
+                <p>Add the widget package to your app.</p>
+              </div>
+            </div>
+            <button
+              type="button"
+              class="install-command quick-start-install"
+              data-copy-text="npm install @runtypelabs/persona"
+              data-copy-default="Copy"
+              data-copy-success="Copied!"
+              aria-label="Copy npm install command"
+            >
+              <span class="install-prefix">$</span>
+              <span>npm install @runtypelabs/persona</span>
+              <span class="install-copy" data-copy-label>Copy</span>
+            </button>
+          </div>
 
-<span class="code-comment">// Mount an AI chat widget on any element</span>
+          <div class="quick-start-step">
+            <div class="quick-start-step-meta">
+              <span class="quick-start-step-index">02</span>
+              <div class="quick-start-step-copy">
+                <h3 class="quick-start-step-title">Mount the widget</h3>
+                <p>Import the stylesheet, initialize Persona, and point it at your SSE endpoint.</p>
+              </div>
+            </div>
+            <div class="code-showcase">
+              <pre><code><span class="code-keyword">import</span> <span class="code-string">"@runtypelabs/persona/widget.css"</span>;
+<span class="code-keyword">import</span> { <span class="code-function">initAgentWidget</span> } <span class="code-keyword">from</span> <span class="code-string">"@runtypelabs/persona"</span>;
+
 <span class="code-function">initAgentWidget</span>({
-  <span class="code-keyword">target</span>: document.<span class="code-function">getElementById</span>(<span class="code-string">"chat"</span>),
-  <span class="code-keyword">config</span>: {
-    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
-    features: { streaming: <span class="code-keyword">true</span> },
-    theme: { primary: <span class="code-string">"#5B2EFF"</span> },
-  },
+  <span class="code-keyword">target</span>: <span class="code-string">"#chat"</span>,
+  <span class="code-keyword">config</span>: { apiUrl: <span class="code-string">"https://your-api.com/chat"</span> },
 });</code></pre>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -152,7 +175,7 @@
           <a href="https://runtype.com" target="_blank" rel="noopener">
             <img src="/runtype-logo.svg" alt="Runtype" style="height: 16px; width: auto; opacity: 0.55;">
           </a>
-          <span class="footer-tagline">Open source AI chat widget</span>
+          <span class="footer-tagline">Where AI products are built</span>
         </div>
         <div class="footer-links">
           <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener">GitHub</a>
@@ -165,7 +188,7 @@
     </main>
   </div>
 
-  <!-- Scroll reveal & install-command copy -->
+  <!-- Scroll reveal & copy buttons -->
   <script>
     document.addEventListener('DOMContentLoaded', function() {
       // Scroll reveal
@@ -188,19 +211,23 @@
         });
       }
 
-      // Install command copy
-      var cmd = document.getElementById('install-cmd');
-      if (cmd) {
-        cmd.addEventListener('click', function() {
-          navigator.clipboard.writeText('npm install @runtypelabs/persona').then(function() {
-            var label = cmd.querySelector('.install-copy');
+      // Copy helper
+      document.querySelectorAll('[data-copy-text]').forEach(function(trigger) {
+        trigger.addEventListener('click', function() {
+          var copyText = trigger.getAttribute('data-copy-text');
+          if (!copyText) return;
+
+          navigator.clipboard.writeText(copyText).then(function() {
+            var label = trigger.querySelector('[data-copy-label]');
+            var defaultText = trigger.getAttribute('data-copy-default') || 'Copy';
+            var successText = trigger.getAttribute('data-copy-success') || 'Copied!';
             if (label) {
-              label.textContent = 'Copied!';
-              setTimeout(function() { label.textContent = 'Copy'; }, 2000);
+              label.textContent = successText;
+              setTimeout(function() { label.textContent = defaultText; }, 2000);
             }
           });
         });
-      }
+      });
     });
   </script>
   <script type="module" src="/src/main.ts"></script>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -4,25 +4,52 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="icon" href="/favicon.ico" />
-  <title>Persona — AI Chat Widget</title>
+  <title>Persona — AI Chat Widget by Runtype</title>
 </head>
 <body>
   <div class="page">
     <main class="shell">
-      <section class="hero cardFull">
-        <h1>Persona</h1>
-        <div class="hero-byline">by <a href="https://runtype.com" target="_blank" rel="noopener"><img src="/runtype-logo.svg" alt="Runtype" class="runtype-logo"></a></div>
-        <p>A drop-in streaming chat widget for your AI assistant. Themeable, pluggable, zero framework dependencies.</p>
+
+      <!-- Hero -->
+      <section class="hero cardFull reveal-el">
+        <span class="label">Open Source Chat Widget</span>
+        <h1 class="kern-tight" style="font-size: 40px; line-height: 1.05;">
+          Add a streaming AI chat<br>to any website, in minutes.
+        </h1>
+        <p>Themeable, pluggable, zero framework dependencies. Style isolation, SSE streaming, agent loops, and tool use — all in one drop-in widget.</p>
+
+        <div class="hero-features">
+          <span class="hero-feature-pill">Style Isolation</span>
+          <span class="hero-feature-pill">SSE Streaming</span>
+          <span class="hero-feature-pill">Agent Loops</span>
+          <span class="hero-feature-pill">Theming</span>
+          <span class="hero-feature-pill">Voice Input</span>
+          <span class="hero-feature-pill">Zero Dependencies</span>
+        </div>
+
+        <div class="install-command" id="install-cmd" title="Click to copy">
+          <span class="install-prefix">$</span>
+          <span>npm install @runtypelabs/persona</span>
+          <span class="install-copy">Copy</span>
+        </div>
+
         <div class="hero-badges">
-          <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=262626&label=npm" alt="npm"></a>
-          <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/runtypelabs/persona?style=flat&color=262626&label=GitHub" alt="GitHub"></a>
+          <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=5B2EFF&label=npm" alt="npm"></a>
+          <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/runtypelabs/persona?style=flat&color=5B2EFF&label=GitHub" alt="GitHub"></a>
           <a href="https://deepwiki.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+        </div>
+
+        <div class="hero-byline">
+          <span>Built by</span>
+          <a href="https://runtype.com" target="_blank" rel="noopener"><img src="/runtype-logo.svg" alt="Runtype" class="runtype-logo"></a>
         </div>
       </section>
 
-      <section class="card cardFull tryit-section">
-        <h2 class="card-title">Try it</h2>
-        <p>This is Persona. Ask it anything — or pick a suggestion below to explore.</p>
+      <!-- Live Demo -->
+      <section class="card cardFull tryit-section reveal-el">
+        <span class="label">Live Demo</span>
+        <h2 class="card-title kern-tight" style="font-size: 24px;">Try it live</h2>
+        <p>Ask Persona anything — or pick a suggestion below to explore.</p>
         <div class="tryit-backdrop">
           <div class="tryit-smoke"></div>
           <div class="tryit-grain"></div>
@@ -33,8 +60,31 @@
         </div>
       </section>
 
-      <section class="card cardFull theme-editor-section">
-        <h2 class="card-title">Theme Editor</h2>
+
+      <!-- Quick Start -->
+      <section class="card cardFull reveal-el">
+        <span class="label">Quick Start</span>
+        <h2 class="card-title kern-tight" style="font-size: 24px;">Three lines to a working chat</h2>
+        <p>Install, configure, and ship. That's it.</p>
+        <div class="code-showcase">
+          <pre><code><span class="code-keyword">import</span> { <span class="code-function">initAgentWidget</span> } <span class="code-keyword">from</span> <span class="code-string">"@runtypelabs/persona"</span>;
+
+<span class="code-comment">// Mount an AI chat widget on any element</span>
+<span class="code-function">initAgentWidget</span>({
+  <span class="code-keyword">target</span>: document.<span class="code-function">getElementById</span>(<span class="code-string">"chat"</span>),
+  <span class="code-keyword">config</span>: {
+    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
+    features: { streaming: <span class="code-keyword">true</span> },
+    theme: { primary: <span class="code-string">"#5B2EFF"</span> },
+  },
+});</code></pre>
+        </div>
+      </section>
+
+      <!-- Theme Editor -->
+      <section class="card cardFull theme-editor-section reveal-el">
+        <span class="label">Customization</span>
+        <h2 class="card-title kern-tight">Theme Editor</h2>
         <p>Customize every color, font, and layout token — then copy the config straight into your project.</p>
         <a class="theme-editor-link" href="/theme.html">
           <div class="theme-backdrop">
@@ -49,17 +99,16 @@
         </a>
       </section>
 
-      <section class="card cardFull">
-        <h2 class="card-title">Featured</h2>
-        <p>See what Persona can do across different use cases.</p>
-        <div class="featured-grid">
-          <a class="example-item" href="/fullscreen-assistant-demo.html">Fullscreen Assistant <small>Full-viewport dark layout with artifacts</small></a>
-          <a class="example-item" href="/bakery.html">Bakery Assistant <small>Full business site with context-aware chat</small></a>
-          <a class="example-item" href="/docked-panel-demo.html">Docked Panel <small>Side-docked assistant layout</small></a>
-        </div>
+      <!-- Demos -->
+      <section class="card cardFull reveal-el">
+        <span class="label">Demos</span>
+        <h2 class="card-title kern-tight">See what Persona can do</h2>
+        <p>Explore different use cases across full-page layouts, embedded contexts, and business scenarios.</p>
+        <div id="demo-carousel-mount"></div>
       </section>
 
-      <details class="advanced-section">
+      <!-- Advanced -->
+      <details class="advanced-section reveal-el">
         <summary class="advanced-toggle">Advanced</summary>
 
         <div class="advanced-content">
@@ -77,6 +126,7 @@
                 <li><a class="example-item" href="/focus-input-demo.html">Focus Input <small>Programmatic input focus and state control</small></a></li>
                 <li><a class="example-item" href="/artifact-demo.html">Artifact Sidebar <small>Resizable split view for rich content</small></a></li>
                 <li><a class="example-item" href="/voice-integration-demo.html">Voice Integration <small>Speech-to-text and text-to-speech input</small></a></li>
+                <li><a class="example-item" href="/event-stream-testing.html">Event Stream Testing <small>Inspector API, window events, inline + launcher</small></a></li>
               </ul>
             </section>
 
@@ -93,77 +143,66 @@
               </ul>
             </section>
           </div>
-
-          <div class="section-grid">
-            <section class="card">
-              <h2 class="card-title">Developer Tools</h2>
-              <p>Test the launcher, load synthetic messages, and explore the programmatic API.</p>
-              <div class="cta-row" style="justify-content: flex-start;">
-                <button id="open-chat" class="primaryButton" type="button">Open Launcher</button>
-                <button id="toggle-chat" class="secondaryButton" type="button">Toggle Launcher</button>
-                <select id="target-widget">
-                  <option value="inline">Inline Widget</option>
-                  <option value="launcher">Launcher Widget</option>
-                </select>
-                <button id="load-messages" class="secondaryButton" type="button">Load 1000 Messages</button>
-              </div>
-              <div class="code-example">
-                <pre><code>const launcherController = initAgentWidget({
-  target: "#launcher-root",
-  config: { /* ... */ }
-});
-
-// Open the widget
-launcherController.open();
-
-// Close the widget
-launcherController.close();
-
-// Toggle the widget
-launcherController.toggle();</code></pre>
-              </div>
-            </section>
-
-            <section class="card">
-              <h2 class="card-title">Event Stream Testing</h2>
-              <p>Test the event stream SDK methods, window events, and instance scoping.</p>
-
-              <h3>Controller Methods</h3>
-              <div class="cta-row" style="justify-content: flex-start;">
-                <select id="event-stream-target">
-                  <option value="inline">Inline Widget</option>
-                  <option value="launcher">Launcher Widget</option>
-                </select>
-                <button id="es-show" class="secondaryButton" type="button">Show Event Stream</button>
-                <button id="es-hide" class="secondaryButton" type="button">Hide Event Stream</button>
-                <button id="es-check" class="secondaryButton" type="button">Check Visibility</button>
-              </div>
-
-              <h3 style="margin-top: 16px;">Window Events</h3>
-              <div class="cta-row" style="justify-content: flex-start;">
-                <button id="es-win-show-all" class="secondaryButton" type="button">Show All (window)</button>
-                <button id="es-win-hide-all" class="secondaryButton" type="button">Hide All (window)</button>
-                <button id="es-win-show-inline" class="secondaryButton" type="button">Show Inline Only</button>
-                <button id="es-win-show-launcher" class="secondaryButton" type="button">Show Launcher Only</button>
-                <button id="es-win-show-wrong" class="secondaryButton" type="button">Show Wrong ID</button>
-              </div>
-
-              <h3 style="margin-top: 16px;">Event Listeners</h3>
-              <div class="cta-row" style="justify-content: flex-start;">
-                <button id="es-listen" class="secondaryButton" type="button">Register Listeners</button>
-              </div>
-
-              <div id="es-log" class="code-example" style="margin-top: 16px; max-height:150px; overflow-y:auto; display:none;">
-                <pre id="es-log-pre"></pre>
-              </div>
-            </section>
-          </div>
         </div>
       </details>
+
+      <!-- Footer -->
+      <footer class="footer">
+        <div class="footer-brand">
+          <a href="https://runtype.com" target="_blank" rel="noopener">
+            <img src="/runtype-logo.svg" alt="Runtype" style="height: 16px; width: auto; opacity: 0.55;">
+          </a>
+          <span class="footer-tagline">Open source AI chat widget</span>
+        </div>
+        <div class="footer-links">
+          <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener">npm</a>
+          <a href="https://runtype.com" target="_blank" rel="noopener">Runtype</a>
+        </div>
+        <p class="footer-copy">&copy; 2025 Travrse, Inc.</p>
+      </footer>
+
     </main>
   </div>
 
-  <div id="launcher-root"></div>
+  <!-- Scroll reveal & install-command copy -->
+  <script>
+    document.addEventListener('DOMContentLoaded', function() {
+      // Scroll reveal
+      if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+        document.querySelectorAll('.reveal-el').forEach(function(el) {
+          el.style.opacity = '1';
+          el.style.transform = 'none';
+        });
+      } else {
+        var observer = new IntersectionObserver(function(entries) {
+          entries.forEach(function(entry) {
+            if (entry.isIntersecting) {
+              entry.target.classList.add('revealed');
+              observer.unobserve(entry.target);
+            }
+          });
+        }, { threshold: 0.15, rootMargin: '0px 0px -40px 0px' });
+        document.querySelectorAll('.reveal-el').forEach(function(el) {
+          observer.observe(el);
+        });
+      }
+
+      // Install command copy
+      var cmd = document.getElementById('install-cmd');
+      if (cmd) {
+        cmd.addEventListener('click', function() {
+          navigator.clipboard.writeText('npm install @runtypelabs/persona').then(function() {
+            var label = cmd.querySelector('.install-copy');
+            if (label) {
+              label.textContent = 'Copied!';
+              setTimeout(function() { label.textContent = 'Copy'; }, 2000);
+            }
+          });
+        });
+      }
+    });
+  </script>
   <script type="module" src="/src/main.ts"></script>
 </body>
 </html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -58,49 +58,206 @@
       <!-- Quick Start -->
       <section class="card cardFull quick-start-section reveal-el">
         <span class="label">Quick Start</span>
-        <h2 class="card-title kern-tight" style="font-size: 24px;">Two steps to a working chat</h2>
-        <p>Install the package, import the styles, and mount the widget on any element.</p>
-        <div class="quick-start-steps">
-          <div class="quick-start-step">
-            <div class="quick-start-step-meta">
-              <span class="quick-start-step-index">01</span>
-              <div class="quick-start-step-copy">
-                <h3 class="quick-start-step-title">Install Persona</h3>
-                <p>Add the widget package to your app.</p>
-              </div>
-            </div>
-            <button
-              type="button"
-              class="install-command quick-start-install"
-              data-copy-text="npm install @runtypelabs/persona"
-              data-copy-default="Copy"
-              data-copy-success="Copied!"
-              aria-label="Copy npm install command"
-            >
-              <span class="install-prefix">$</span>
-              <span>npm install @runtypelabs/persona</span>
-              <span class="install-copy" data-copy-label>Copy</span>
-            </button>
-          </div>
+        <h2 class="card-title kern-tight" style="font-size: 24px;">Choose your integration path</h2>
+        <p>Start with Runtype in minutes, or wire Persona into your own SSE backend.</p>
 
-          <div class="quick-start-step">
-            <div class="quick-start-step-meta">
-              <span class="quick-start-step-index">02</span>
-              <div class="quick-start-step-copy">
-                <h3 class="quick-start-step-title">Mount the widget</h3>
-                <p>Import the stylesheet, initialize Persona, and point it at your SSE endpoint.</p>
+        <div class="quick-start-tabs" role="tablist" aria-label="Quick start paths">
+          <button
+            type="button"
+            class="quick-start-tab"
+            id="quick-start-tab-runtype"
+            role="tab"
+            aria-selected="true"
+            aria-controls="quick-start-panel-runtype"
+            data-quick-start-tab="runtype"
+          >
+            Using Runtype
+          </button>
+          <button
+            type="button"
+            class="quick-start-tab"
+            id="quick-start-tab-sse"
+            role="tab"
+            aria-selected="false"
+            aria-controls="quick-start-panel-sse"
+            data-quick-start-tab="sse"
+            tabindex="-1"
+          >
+            Any SSE Backend
+          </button>
+        </div>
+
+        <div
+          class="quick-start-panel"
+          id="quick-start-panel-runtype"
+          role="tabpanel"
+          aria-labelledby="quick-start-tab-runtype"
+          data-quick-start-panel="runtype"
+        >
+          <div class="quick-start-steps">
+            <div class="quick-start-step">
+              <div class="quick-start-step-meta">
+                <span class="quick-start-step-index">01</span>
+                <div class="quick-start-step-copy">
+                  <h3 class="quick-start-step-title">Install Persona</h3>
+                  <p>Add the widget package to your app.</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="install-command quick-start-install"
+                data-copy-text="npm install @runtypelabs/persona"
+                data-copy-default="Copy"
+                data-copy-success="Copied!"
+                aria-label="Copy npm install command"
+              >
+                <span class="install-prefix">$</span>
+                <span>npm install @runtypelabs/persona</span>
+                <span class="install-copy" data-copy-label>Copy</span>
+              </button>
+            </div>
+
+            <div class="quick-start-step">
+              <div class="quick-start-step-meta">
+                <span class="quick-start-step-index">02</span>
+                <div class="quick-start-step-copy">
+                  <h3 class="quick-start-step-title">Sign up &amp; create an agent</h3>
+                  <p>Run the guided setup to create your account and product, then create an agent.</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="install-command quick-start-install"
+                data-copy-text="npx @runtypelabs/cli@latest init"
+                data-copy-default="Copy"
+                data-copy-success="Copied!"
+                aria-label="Copy Runtype init command"
+              >
+                <span class="install-prefix">$</span>
+                <span>npx @runtypelabs/cli@latest init</span>
+                <span class="install-copy" data-copy-label>Copy</span>
+              </button>
+              <p class="quick-start-step-note">Then create an agent and note the returned ID:</p>
+              <button
+                type="button"
+                class="install-command quick-start-install"
+                data-copy-text="npx @runtypelabs/cli@latest agents create -n &quot;my-agent&quot;"
+                data-copy-default="Copy"
+                data-copy-success="Copied!"
+                aria-label="Copy agent create command"
+              >
+                <span class="install-prefix">$</span>
+                <span>npx @runtypelabs/cli@latest agents create -n "my-agent"</span>
+                <span class="install-copy" data-copy-label>Copy</span>
+              </button>
+            </div>
+
+            <div class="quick-start-step">
+              <div class="quick-start-step-meta">
+                <span class="quick-start-step-index">03</span>
+                <div class="quick-start-step-copy">
+                  <h3 class="quick-start-step-title">Create a client token</h3>
+                  <p>Generate a browser-safe token for the agent you just created.</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="install-command quick-start-install"
+                data-copy-text="npx @runtypelabs/cli@latest client-tokens create -n &quot;my-widget&quot; --agent-ids &lt;agent-id&gt; --environment test"
+                data-copy-default="Copy"
+                data-copy-success="Copied!"
+                aria-label="Copy Runtype client token command"
+              >
+                <span class="install-prefix">$</span>
+                <span>npx @runtypelabs/cli@latest client-tokens create -n "my-widget" --agent-ids &lt;agent-id&gt; --environment test</span>
+                <span class="install-copy" data-copy-label>Copy</span>
+              </button>
+              <p class="quick-start-step-note">Replace <code>&lt;agent-id&gt;</code> with the ID from step 02, then paste the returned token into the config below.</p>
+            </div>
+
+            <div class="quick-start-step">
+              <div class="quick-start-step-meta">
+                <span class="quick-start-step-index">04</span>
+                <div class="quick-start-step-copy">
+                  <h3 class="quick-start-step-title">Mount the widget</h3>
+                  <p>Import the stylesheet and initialize Persona with the client token.</p>
+                </div>
+              </div>
+              <div class="code-showcase">
+                <pre><code><span class="code-keyword">import</span> <span class="code-string">"@runtypelabs/persona/widget.css"</span>;
+<span class="code-keyword">import</span> { <span class="code-function">DEFAULT_WIDGET_CONFIG</span>, <span class="code-function">initAgentWidget</span> } <span class="code-keyword">from</span> <span class="code-string">"@runtypelabs/persona"</span>;
+
+<span class="code-function">initAgentWidget</span>({
+  <span class="code-keyword">target</span>: <span class="code-string">"#chat"</span>,
+  <span class="code-keyword">config</span>: {
+    ...<span class="code-function">DEFAULT_WIDGET_CONFIG</span>,
+    clientToken: <span class="code-string">"ct_test_..."</span>,
+    launcher: {
+      ...<span class="code-function">DEFAULT_WIDGET_CONFIG</span>.launcher,
+      enabled: <span class="code-keyword">false</span>,
+    },
+  },
+});</code></pre>
               </div>
             </div>
-            <div class="code-showcase">
-              <pre><code><span class="code-keyword">import</span> <span class="code-string">"@runtypelabs/persona/widget.css"</span>;
+          </div>
+          <p class="quick-start-footnote">Need server-side flow control instead? Use <code>@runtypelabs/persona-proxy</code> and switch to a proxy-based Runtype setup later.</p>
+        </div>
+
+        <div
+          class="quick-start-panel"
+          id="quick-start-panel-sse"
+          role="tabpanel"
+          aria-labelledby="quick-start-tab-sse"
+          data-quick-start-panel="sse"
+          hidden
+        >
+          <div class="quick-start-intro">
+            <strong>Bring your own backend:</strong> point Persona at any SSE endpoint and adapt the request or event format if needed.
+          </div>
+          <div class="quick-start-steps">
+            <div class="quick-start-step">
+              <div class="quick-start-step-meta">
+                <span class="quick-start-step-index">01</span>
+                <div class="quick-start-step-copy">
+                  <h3 class="quick-start-step-title">Install Persona</h3>
+                  <p>Add the widget package to your app.</p>
+                </div>
+              </div>
+              <button
+                type="button"
+                class="install-command quick-start-install"
+                data-copy-text="npm install @runtypelabs/persona"
+                data-copy-default="Copy"
+                data-copy-success="Copied!"
+                aria-label="Copy npm install command"
+              >
+                <span class="install-prefix">$</span>
+                <span>npm install @runtypelabs/persona</span>
+                <span class="install-copy" data-copy-label>Copy</span>
+              </button>
+            </div>
+
+            <div class="quick-start-step">
+              <div class="quick-start-step-meta">
+                <span class="quick-start-step-index">02</span>
+                <div class="quick-start-step-copy">
+                  <h3 class="quick-start-step-title">Mount the widget</h3>
+                  <p>Import the stylesheet, initialize Persona, and point it at your SSE endpoint.</p>
+                </div>
+              </div>
+              <div class="code-showcase">
+                <pre><code><span class="code-keyword">import</span> <span class="code-string">"@runtypelabs/persona/widget.css"</span>;
 <span class="code-keyword">import</span> { <span class="code-function">initAgentWidget</span> } <span class="code-keyword">from</span> <span class="code-string">"@runtypelabs/persona"</span>;
 
 <span class="code-function">initAgentWidget</span>({
   <span class="code-keyword">target</span>: <span class="code-string">"#chat"</span>,
   <span class="code-keyword">config</span>: { apiUrl: <span class="code-string">"https://your-api.com/chat"</span> },
 });</code></pre>
+              </div>
             </div>
           </div>
+          <p class="quick-start-footnote">If your backend uses a different request or event shape, customize <code>customFetch</code> or <code>parseSSEEvent</code> in the widget config.</p>
         </div>
       </section>
 
@@ -209,6 +366,42 @@
         document.querySelectorAll('.reveal-el').forEach(function(el) {
           observer.observe(el);
         });
+      }
+
+      // Quick start tabs
+      var quickStartTabs = Array.prototype.slice.call(document.querySelectorAll('[data-quick-start-tab]'));
+      var quickStartPanels = Array.prototype.slice.call(document.querySelectorAll('[data-quick-start-panel]'));
+
+      function activateQuickStartTab(name) {
+        quickStartTabs.forEach(function(tab) {
+          var isActive = tab.getAttribute('data-quick-start-tab') === name;
+          tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+          tab.tabIndex = isActive ? 0 : -1;
+        });
+
+        quickStartPanels.forEach(function(panel) {
+          panel.hidden = panel.getAttribute('data-quick-start-panel') !== name;
+        });
+      }
+
+      quickStartTabs.forEach(function(tab, index) {
+        tab.addEventListener('click', function() {
+          activateQuickStartTab(tab.getAttribute('data-quick-start-tab'));
+        });
+
+        tab.addEventListener('keydown', function(event) {
+          if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+          event.preventDefault();
+          var direction = event.key === 'ArrowRight' ? 1 : -1;
+          var nextIndex = (index + direction + quickStartTabs.length) % quickStartTabs.length;
+          var nextTab = quickStartTabs[nextIndex];
+          activateQuickStartTab(nextTab.getAttribute('data-quick-start-tab'));
+          nextTab.focus();
+        });
+      });
+
+      if (quickStartTabs.length && quickStartPanels.length) {
+        activateQuickStartTab('runtype');
       }
 
       // Copy helper

--- a/examples/embedded-app/launcher-demo.html
+++ b/examples/embedded-app/launcher-demo.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="/favicon.ico" />
+  <title>Launcher Demo — Persona</title>
+  <style>
+    * { margin: 0; box-sizing: border-box; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", sans-serif;
+      background: #f8fafc;
+      color: #334155;
+      min-height: 100vh;
+    }
+    .page-content {
+      max-width: 640px;
+      margin: 0 auto;
+      padding: 80px 24px;
+    }
+    .page-content h1 {
+      font-size: 28px;
+      font-weight: 700;
+      color: #0f172a;
+      margin-bottom: 12px;
+    }
+    .page-content p {
+      font-size: 15px;
+      line-height: 1.7;
+      color: #64748b;
+      margin-bottom: 16px;
+    }
+    .page-content .hint {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      font-size: 13px;
+      color: #94a3b8;
+      margin-top: 24px;
+      padding: 8px 14px;
+      border: 1px dashed #e2e8f0;
+      border-radius: 8px;
+    }
+    .hint svg { flex-shrink: 0; }
+  </style>
+</head>
+<body>
+  <div class="page-content">
+    <h1>Your Website</h1>
+    <p>This is a placeholder for your site content. The Persona chat widget launcher appears in the bottom-right corner — ready for your visitors to click and start a conversation.</p>
+    <p>The launcher, panel, and all UI are fully themeable. This is the default out-of-the-box experience with no custom configuration.</p>
+    <div class="hint">
+      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+      Click the chat bubble to open
+    </div>
+  </div>
+  <div id="launcher-root"></div>
+  <script type="module" src="/src/launcher-demo.ts"></script>
+</body>
+</html>

--- a/examples/embedded-app/src/event-stream-testing.ts
+++ b/examples/embedded-app/src/event-stream-testing.ts
@@ -1,0 +1,212 @@
+import "@runtypelabs/persona/widget.css";
+import "./demo-shared.css";
+
+import {
+  createAgentExperience,
+  createLocalStorageAdapter,
+  DEFAULT_WIDGET_CONFIG,
+  initAgentWidget
+} from "@runtypelabs/persona";
+
+const sharedStorage = createLocalStorageAdapter("persona-event-stream-demo-state");
+
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const proxyUrl =
+  import.meta.env.VITE_PROXY_URL ?
+    `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch` :
+    `http://localhost:${proxyPort}/api/chat/dispatch`;
+
+const persistKeyPrefix = "persona-event-stream-demo-";
+
+const baseConfig = {
+  ...DEFAULT_WIDGET_CONFIG,
+  apiUrl: proxyUrl,
+  copy: {
+    ...DEFAULT_WIDGET_CONFIG.copy,
+    welcomeTitle: "Event stream demo",
+    welcomeSubtitle: "Try the controls in the left panel — toggle the event stream inspector on each widget.",
+    inputPlaceholder: "Message is optional for API testing…"
+  },
+  features: {
+    showEventStreamToggle: true
+  },
+  persistState: {
+    keyPrefix: persistKeyPrefix
+  },
+  storageAdapter: sharedStorage
+};
+
+const inlineMount = document.getElementById("es-inline-widget");
+if (!inlineMount) {
+  throw new Error("es-inline-widget mount missing");
+}
+
+const inlineController = createAgentExperience(inlineMount, {
+  ...baseConfig,
+  launcher: {
+    ...DEFAULT_WIDGET_CONFIG.launcher,
+    width: "100%",
+    enabled: false,
+    fullHeight: true
+  }
+});
+
+const launcherController = initAgentWidget({
+  target: "#launcher-root",
+  config: {
+    ...baseConfig,
+    launcher: {
+      ...DEFAULT_WIDGET_CONFIG.launcher,
+      title: "Event stream (launcher)",
+      subtitle: "Use window events with instanceId launcher-root.",
+      iconUrl: "https://dummyimage.com/96x96/111827/ffffff&text=AI",
+      closeButtonColor: "#6b7280",
+      collapsedMaxWidth: "min(380px, calc(100vw - 48px))"
+    }
+  }
+});
+
+const targetSelect = document.getElementById("es-target-widget") as HTMLSelectElement | null;
+const getTarget = () => (targetSelect?.value === "launcher" ? launcherController : inlineController);
+const targetLabel = () => (targetSelect?.value === "launcher" ? "launcher" : "inline");
+
+document.getElementById("es-open-launcher")?.addEventListener("click", () => launcherController.open());
+document.getElementById("es-toggle-launcher")?.addEventListener("click", () => launcherController.toggle());
+
+document.getElementById("es-show")?.addEventListener("click", () => getTarget().showEventStream());
+document.getElementById("es-hide")?.addEventListener("click", () => getTarget().hideEventStream());
+document.getElementById("es-check")?.addEventListener("click", () => {
+  const visible = getTarget().isEventStreamVisible();
+  alert(`${targetLabel()} event stream visible: ${visible}`);
+});
+
+document.getElementById("es-win-show-all")?.addEventListener("click", () => {
+  window.dispatchEvent(new CustomEvent("persona:showEventStream"));
+});
+document.getElementById("es-win-hide-all")?.addEventListener("click", () => {
+  window.dispatchEvent(new CustomEvent("persona:hideEventStream"));
+});
+document.getElementById("es-win-show-inline")?.addEventListener("click", () => {
+  window.dispatchEvent(
+    new CustomEvent("persona:showEventStream", { detail: { instanceId: "es-inline-widget" } })
+  );
+});
+document.getElementById("es-win-show-launcher")?.addEventListener("click", () => {
+  window.dispatchEvent(
+    new CustomEvent("persona:showEventStream", { detail: { instanceId: "launcher-root" } })
+  );
+});
+document.getElementById("es-win-show-wrong")?.addEventListener("click", () => {
+  window.dispatchEvent(new CustomEvent("persona:showEventStream", { detail: { instanceId: "wrong-id" } }));
+  alert('Dispatched persona:showEventStream with instanceId "wrong-id" — nothing should open.');
+});
+
+const esLogEl = document.getElementById("es-log");
+const esLogPre = document.getElementById("es-log-pre");
+document.getElementById("es-listen")?.addEventListener("click", () => {
+  if (esLogEl) esLogEl.style.display = "block";
+  const log = (msg: string) => {
+    if (esLogPre) {
+      esLogPre.textContent += `[${new Date().toLocaleTimeString()}] ${msg}\n`;
+      esLogPre.parentElement!.scrollTop = esLogPre.parentElement!.scrollHeight;
+    }
+    console.log(`[EventStream] ${msg}`);
+  };
+  inlineController.on("eventStream:opened", (e) => log(`inline opened (ts: ${e.timestamp})`));
+  inlineController.on("eventStream:closed", (e) => log(`inline closed (ts: ${e.timestamp})`));
+  launcherController.on("eventStream:opened", (e) => log(`launcher opened (ts: ${e.timestamp})`));
+  launcherController.on("eventStream:closed", (e) => log(`launcher closed (ts: ${e.timestamp})`));
+  log("Listeners registered for inline and launcher");
+});
+
+const loadBtn = document.getElementById("es-load-messages");
+if (loadBtn) {
+  loadBtn.addEventListener("click", () => {
+    const messageCount = 1000;
+    const chunksPerMessage = 5;
+    const isLauncher = targetSelect?.value === "launcher";
+    const target = isLauncher ? launcherController : inlineController;
+    const baseTime = Date.now() - messageCount * 1000;
+
+    if (isLauncher) {
+      launcherController.open();
+    }
+
+    const batch: Array<{ role: "user" | "assistant"; content: string; createdAt: string }> = [];
+
+    for (let msg = 0; msg < messageCount; msg++) {
+      const msgNum = msg + 1;
+      const isUser = msg % 2 === 0;
+      const timestamp = new Date(baseTime + msg * 1000).toISOString();
+
+      if (isUser) {
+        const content = `Test question #${Math.ceil(msgNum / 2)}: What is ${Math.ceil(msgNum / 2) * 7}?`;
+        batch.push({ role: "user", content, createdAt: timestamp });
+      } else {
+        const fullText = `The answer to question #${Math.ceil(msgNum / 2)} is **${Math.ceil(msgNum / 2) * 7}**. Here's some extra text to make the message more realistic and test rendering with longer content.`;
+        batch.push({ role: "assistant", content: fullText, createdAt: timestamp });
+      }
+    }
+
+    target.injectMessageBatch(batch);
+
+    for (let msg = 0; msg < messageCount; msg++) {
+      const msgNum = msg + 1;
+      const isUser = msg % 2 === 0;
+
+      if (isUser) {
+        target.__pushEventStreamEvent({
+          type: "step_delta",
+          payload: { type: "step_delta", text: batch[msg].content, stepType: "prompt" }
+        });
+        target.__pushEventStreamEvent({
+          type: "step_complete",
+          payload: { type: "step_complete", result: { response: batch[msg].content } }
+        });
+      } else {
+        for (let chunk = 0; chunk < chunksPerMessage; chunk++) {
+          const chunkStart = Math.floor((chunk / chunksPerMessage) * batch[msg].content.length);
+          const chunkEnd = Math.floor(((chunk + 1) / chunksPerMessage) * batch[msg].content.length);
+          target.__pushEventStreamEvent({
+            type: "step_delta",
+            payload: {
+              type: "step_delta",
+              text: batch[msg].content.slice(chunkStart, chunkEnd),
+              stepType: "prompt",
+              messageId: `ast_${msg}`
+            }
+          });
+        }
+        target.__pushEventStreamEvent({
+          type: "step_complete",
+          payload: { type: "step_complete", result: { response: batch[msg].content }, messageId: `ast_${msg}` }
+        });
+      }
+
+      if (msg % 20 === 0) {
+        for (const t of ["reason_start", "reason_delta", "reason_complete", "tool_start", "tool_delta", "tool_complete"]) {
+          target.__pushEventStreamEvent({
+            type: t,
+            payload: {
+              type: t,
+              text: `Simulated ${t} for msg #${msgNum}`,
+              toolName: t.startsWith("tool") ? "web_search" : undefined
+            }
+          });
+        }
+      }
+    }
+
+    target.__pushEventStreamEvent({
+      type: "flow_complete",
+      payload: { type: "flow_complete", messageCount }
+    });
+
+    const name = isLauncher ? "launcher" : "inline";
+    console.log(`[Event stream demo] Injected ${messageCount} messages + events into ${name}`);
+    loadBtn.textContent = `Loaded into ${name}!`;
+    setTimeout(() => {
+      loadBtn.textContent = "Load 1000 messages";
+    }, 2000);
+  });
+}

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -511,6 +511,107 @@ code {
 .code-showcase .code-string { color: #8FD400; }
 .code-showcase .code-function { color: #00B8D9; }
 
+.quick-start-section {
+  gap: 18px;
+}
+
+.quick-start-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.quick-start-step {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 18px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: linear-gradient(180deg, rgba(246, 247, 251, 0.86), rgba(255, 255, 255, 0.96));
+}
+
+.quick-start-step-meta {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.quick-start-step-index {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  flex: 0 0 32px;
+  border-radius: 999px;
+  border: 1px solid rgba(91, 46, 255, 0.18);
+  background: rgba(91, 46, 255, 0.08);
+  color: var(--primary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1;
+}
+
+.quick-start-step-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.quick-start-step-title {
+  margin: 0;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+
+.quick-start-step-copy p {
+  margin: 0;
+  font-size: 14px;
+}
+
+.quick-start-install {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 12px;
+  width: 100%;
+  max-width: none;
+  padding: 12px 16px;
+  background: #050507;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  color: #c9c9c9;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 400;
+  text-align: left;
+  box-shadow: none;
+}
+
+.quick-start-install:hover {
+  transform: none;
+  background: #050507;
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.quick-start-install:active {
+  transform: none;
+  box-shadow: none;
+}
+
+.quick-start-install:focus-visible {
+  outline: none;
+  box-shadow:
+    0 0 0 1px rgba(91, 46, 255, 0.35),
+    0 0 0 4px rgba(91, 46, 255, 0.12);
+}
+
+.quick-start-step .code-showcase {
+  padding: 18px 20px;
+}
+
 /* Feature Grid */
 .feature-grid {
   display: grid;
@@ -904,6 +1005,25 @@ code {
   .install-command {
     font-size: 12px;
     padding: 10px 12px;
+  }
+
+  .quick-start-step {
+    padding: 14px;
+  }
+
+  .quick-start-step-meta {
+    gap: 10px;
+  }
+
+  .quick-start-step-index {
+    width: 28px;
+    height: 28px;
+    flex-basis: 28px;
+    font-size: 11px;
+  }
+
+  .quick-start-step .code-showcase {
+    padding: 14px;
   }
 
   .card {

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -301,7 +301,7 @@ code {
  * the header close control. With `width`/`height` 32px and `box-sizing: border-box`,
  * horizontal padding 18+18px leaves no room for the SVG.
  */
-.page button:not([data-persona-root] *),
+.page button:not([data-persona-root] *):not(.quick-start-tab),
 .page select:not([data-persona-root] *),
 .page .btn:not([data-persona-root] *) {
   font-family: var(--font-sans);
@@ -515,6 +515,71 @@ code {
   gap: 18px;
 }
 
+.quick-start-tabs {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  padding: 3px;
+  border-radius: 10px;
+  border: 1px solid var(--border);
+  background: rgba(246, 247, 251, 0.9);
+}
+
+.quick-start-tab {
+  position: relative;
+  min-height: 34px;
+  padding: 6px 16px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: color 0.15s ease, background 0.15s ease, box-shadow 0.15s ease;
+  outline: none;
+}
+
+.quick-start-tab:hover {
+  color: var(--foreground);
+  background: rgba(0, 0, 0, 0.03);
+}
+
+.quick-start-tab[aria-selected='true'] {
+  background: #ffffff;
+  color: var(--foreground);
+  box-shadow:
+    0 1px 3px rgba(0, 0, 0, 0.08),
+    0 0 0 1px rgba(0, 0, 0, 0.04);
+}
+
+.quick-start-tab:focus-visible {
+  box-shadow:
+    0 0 0 2px rgba(91, 46, 255, 0.4),
+    0 0 0 4px rgba(91, 46, 255, 0.12);
+}
+
+.quick-start-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.quick-start-panel[hidden] {
+  display: none;
+}
+
+.quick-start-intro {
+  padding: 14px 16px;
+  border-radius: var(--radius);
+  border: 1px solid rgba(91, 46, 255, 0.12);
+  background: rgba(91, 46, 255, 0.05);
+  color: var(--secondary-text);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
 .quick-start-steps {
   display: flex;
   flex-direction: column;
@@ -570,6 +635,14 @@ code {
 .quick-start-step-copy p {
   margin: 0;
   font-size: 14px;
+}
+
+.quick-start-step-note,
+.quick-start-footnote {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+  line-height: 1.6;
 }
 
 .quick-start-install {
@@ -1009,6 +1082,15 @@ code {
 
   .quick-start-step {
     padding: 14px;
+  }
+
+  .quick-start-tabs {
+    width: 100%;
+    border-radius: 10px;
+  }
+
+  .quick-start-tab {
+    flex: 1;
   }
 
   .quick-start-step-meta {

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -1,18 +1,30 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;1,6..72,400&family=JetBrains+Mono:wght@400;700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Asap+Condensed:wght@400&family=Inter:wght@400;500;600;700&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,600;1,6..72,400&family=JetBrains+Mono:wght@400;700&display=swap');
 
 :root {
   color-scheme: light;
-  --background: #fcfcfa;
-  --foreground: #262626;
-  --primary: #262626;
-  --primary-foreground: #fafafa;
-  --border: #e0e0e0;
-  --muted: #737373;
-  --accent: #f5f5f5;
+
+  /* Runtype marketing palette */
+  --background: #F6F7FB;
+  --foreground: #1A1B20;
+  --primary: #5B2EFF;
+  --primary-hover: #3D1DCC;
+  --primary-foreground: #ffffff;
+  --secondary: #7A5CFF;
+  --border: #E6E8F0;
+  --muted: #6B6E76;
+  --muted-light: #8A8F9C;
+  --secondary-text: #3D3F46;
+  --accent: #EEE9FF;
+  --accent-lime: #8FD400;
+  --accent-cyan: #00B8D9;
 
   --font-sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   --font-serif: 'Newsreader', Georgia, serif;
   --font-mono: 'JetBrains Mono', monospace;
+  --font-label: 'Asap Condensed', sans-serif;
+
+  --ease-smooth: cubic-bezier(0.16, 1, 0.3, 1);
+  --radius: 6px;
 }
 
 *, *::before, *::after {
@@ -30,13 +42,40 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Paper grid background */
 .page {
   position: relative;
   overflow: hidden;
   min-height: 100vh;
 }
 
+.page::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  opacity: 0.45;
+  z-index: 0;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      rgba(20, 20, 20, 0.025) 0px,
+      rgba(20, 20, 20, 0.025) 1px,
+      transparent 1px,
+      transparent 40px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      rgba(20, 20, 20, 0.025) 0px,
+      rgba(20, 20, 20, 0.025) 1px,
+      transparent 1px,
+      transparent 40px
+    );
+}
+
 .shell {
+  position: relative;
+  z-index: 1;
   width: 100%;
   max-width: 980px;
   margin: 0 auto;
@@ -49,7 +88,7 @@ body {
 /* Headers */
 h1, h2, h3 {
   font-family: var(--font-serif);
-  font-weight: 600;
+  font-weight: 400;
   letter-spacing: -0.025em;
   margin-top: 0;
   margin-bottom: 0.5rem;
@@ -73,16 +112,61 @@ code {
   border-radius: 4px;
 }
 
+/* Utilities */
+.kern-tight {
+  letter-spacing: -0.035em;
+}
+
+.label {
+  font-family: var(--font-label);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--primary);
+  display: inline-block;
+}
+
+.label-muted {
+  font-family: var(--font-label);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--muted-light);
+  display: inline-block;
+}
+
+/* Scroll reveal animation */
+.reveal-el {
+  opacity: 0;
+  transform: translateY(20px);
+  transition:
+    opacity 0.7s var(--ease-smooth),
+    transform 0.7s var(--ease-smooth);
+}
+
+.reveal-el.revealed {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal-el {
+    opacity: 1;
+    transform: none;
+    transition: none;
+  }
+}
+
 /* Hero Section */
 .hero {
   display: flex;
   flex-direction: column;
   gap: 12px;
-  padding: 28px 32px;
-  border-radius: 8px;
+  padding: 40px 32px 32px;
+  border-radius: var(--radius);
   background: rgba(255, 255, 255, 0.95);
   border: 1px solid var(--border);
-  box-shadow: 0 12px 32px -12px rgba(0, 0, 0, 0.1);
+  box-shadow: none;
   text-align: center;
   align-items: center;
 }
@@ -93,33 +177,57 @@ code {
   justify-content: center;
   gap: 5px;
   font-family: var(--font-sans);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 400;
-  color: var(--muted);
+  color: var(--muted-light);
   letter-spacing: 0;
-  margin-bottom: 4px;
 }
 
 .runtype-logo {
-  height: 15px;
+  height: 14px;
   width: auto;
-  opacity: 0.55;
+  opacity: 0.5;
   display: block;
   position: relative;
   top: 1px;
+  transition: opacity 0.2s ease;
 }
 
 .hero-byline a:hover .runtype-logo {
   opacity: 1;
 }
 
-.hero h1 { margin: 0 0 -24px; font-size: 36px; }
+.hero h1 {
+  margin: 4px 0 0;
+  font-size: 36px;
+  line-height: 1.05;
+}
 
 .hero p {
-  max-width: 650px;
+  max-width: 520px;
   margin-bottom: 0;
-  font-size: 16px;
+  font-size: 15px;
   color: var(--muted);
+  line-height: 1.6;
+}
+
+.hero-features {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  justify-content: center;
+  margin-top: 4px;
+}
+
+.hero-feature-pill {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted);
+  padding: 4px 10px;
+  border-radius: 100px;
+  border: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.6);
+  white-space: nowrap;
 }
 
 .hero-badges {
@@ -136,6 +244,46 @@ code {
 
 .hero-badges img {
   height: 20px;
+}
+
+/* Install command */
+.install-command {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: #050507;
+  border-radius: var(--radius);
+  padding: 12px 16px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: #c9c9c9;
+  max-width: 420px;
+  width: 100%;
+  cursor: pointer;
+  transition: box-shadow 0.2s ease;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.install-command:hover {
+  box-shadow: 0 0 0 1px rgba(91, 46, 255, 0.3);
+}
+
+.install-prefix {
+  color: var(--accent-cyan);
+  user-select: none;
+}
+
+.install-copy {
+  margin-left: auto;
+  color: var(--muted-light);
+  font-size: 12px;
+  opacity: 0.6;
+  transition: opacity 0.2s ease;
+  user-select: none;
+}
+
+.install-command:hover .install-copy {
+  opacity: 1;
 }
 
 .cta-row {
@@ -159,7 +307,7 @@ code {
   font-family: var(--font-sans);
   font-size: 14px;
   font-weight: 600;
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 10px 18px;
   cursor: pointer;
   transition: all 0.2s ease;
@@ -174,12 +322,18 @@ code {
 .primaryButton {
   background: var(--primary);
   color: var(--primary-foreground);
-  box-shadow: 0 4px 12px -4px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 4px 12px -4px rgba(91, 46, 255, 0.25);
 }
 
 .primaryButton:hover {
+  background: var(--primary-hover);
   transform: translateY(-1px);
-  box-shadow: 0 6px 16px -4px rgba(0, 0, 0, 0.25);
+  box-shadow: 0 6px 16px -4px rgba(91, 46, 255, 0.3);
+}
+
+.primaryButton:active {
+  transform: translateY(1px);
+  box-shadow: 0 1px 4px rgba(91, 46, 255, 0.15);
 }
 
 .secondaryButton,
@@ -192,6 +346,7 @@ code {
 
 .secondaryButton:hover {
   background: var(--accent);
+  border-color: rgba(91, 46, 255, 0.2);
   transform: translateY(-1px);
 }
 
@@ -210,12 +365,13 @@ code {
 .card {
   background: rgba(255, 255, 255, 0.92);
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   padding: 24px;
   display: flex;
   flex-direction: column;
   gap: 16px;
-  box-shadow: var(--shadow-sm, 0 1px 3px rgba(0, 0, 0, 0.06));
+  box-shadow: none;
+  transition: border-color 0.3s ease;
 }
 
 .cardFull {
@@ -243,7 +399,7 @@ code {
   display: flex;
   flex-direction: column;
   padding: 12px 16px;
-  border-radius: 6px;
+  border-radius: var(--radius);
   background: var(--accent);
   border: 1px solid var(--border);
   text-decoration: none;
@@ -296,7 +452,8 @@ code {
 
 .example-item:hover {
   transform: translateY(-1px);
-  box-shadow: 0 4px 12px -8px rgba(0, 0, 0, 0.15);
+  border-color: rgba(91, 46, 255, 0.2);
+  box-shadow: 0 4px 12px -8px rgba(91, 46, 255, 0.15);
 }
 
 .example-item small {
@@ -310,7 +467,7 @@ code {
 /* Code Blocks */
 .code-example {
   background: #141414;
-  border-radius: 6px;
+  border-radius: var(--radius);
   padding: 16px;
   overflow-x: auto;
 }
@@ -327,6 +484,79 @@ code {
   padding: 0;
 }
 
+/* Code Showcase (syntax highlighted) */
+.code-showcase {
+  background: #050507;
+  border-radius: var(--radius);
+  padding: 24px;
+  overflow-x: auto;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.code-showcase pre {
+  margin: 0;
+}
+
+.code-showcase code {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  background: transparent;
+  color: #c9c9c9;
+  padding: 0;
+  line-height: 1.7;
+}
+
+.code-showcase .code-comment { color: #6B6E76; }
+.code-showcase .code-keyword { color: #7A5CFF; }
+.code-showcase .code-string { color: #8FD400; }
+.code-showcase .code-function { color: #00B8D9; }
+
+/* Feature Grid */
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1px;
+  background: var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  border: 1px solid var(--border);
+}
+
+.feature-cell {
+  background: var(--background);
+  padding: 28px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.feature-cell h3 {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  margin: 0;
+  color: var(--foreground);
+  letter-spacing: -0.01em;
+}
+
+.feature-cell p {
+  font-size: 13px;
+  color: var(--muted-light);
+  line-height: 1.6;
+  margin: 0;
+}
+
+.feature-accent {
+  width: 24px;
+  height: 2px;
+  background: var(--primary);
+  margin-bottom: 4px;
+  transition: width 0.3s var(--ease-smooth);
+}
+
+.feature-cell:hover .feature-accent {
+  width: 40px;
+}
+
 /* Featured Grid */
 .featured-grid {
   display: grid;
@@ -337,7 +567,7 @@ code {
 /* Try-it Smoke Background */
 .tryit-backdrop {
   position: relative;
-  border-radius: 16px;
+  border-radius: 12px;
   overflow: hidden;
   padding: 32px;
 }
@@ -405,8 +635,9 @@ code {
 .tryit-widget-frame {
   position: relative;
   z-index: 3;
-  border-radius: 12px;
+  border-radius: 8px;
   background: #ffffff;
+  height: 600px;
   overflow: hidden;
   box-shadow: 0 8px 32px -8px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(255, 255, 255, 0.1);
 }
@@ -419,7 +650,7 @@ code {
 .theme-editor-link {
   display: block;
   text-decoration: none;
-  border-radius: 16px;
+  border-radius: 12px;
   overflow: hidden;
   transition: transform 0.25s ease, box-shadow 0.25s ease;
 }
@@ -431,7 +662,7 @@ code {
 
 .theme-backdrop {
   position: relative;
-  border-radius: 16px;
+  border-radius: 12px;
   overflow: hidden;
   padding: 56px 32px;
 }
@@ -523,6 +754,55 @@ code {
   transform: translateX(4px);
 }
 
+/* Footer */
+.footer {
+  border-top: 1px solid var(--border);
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  text-align: center;
+}
+
+.footer-brand {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+}
+
+.footer-tagline {
+  font-family: var(--font-label);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--muted-light);
+}
+
+.footer-links {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.footer-links a {
+  font-size: 13px;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.footer-links a:hover {
+  color: var(--primary);
+}
+
+.footer-copy {
+  font-size: 12px;
+  color: var(--muted-light);
+  margin: 0;
+}
+
 /* Advanced Collapsible Section */
 .advanced-section {
   width: 100%;
@@ -540,7 +820,7 @@ code {
   color: var(--muted);
   cursor: pointer;
   border: 1px solid var(--border);
-  border-radius: 8px;
+  border-radius: var(--radius);
   background: rgba(255, 255, 255, 0.6);
   transition: all 0.2s ease;
   list-style: none;
@@ -571,7 +851,7 @@ code {
 .advanced-toggle:hover {
   background: rgba(255, 255, 255, 0.92);
   color: var(--foreground);
-  border-color: #ccc;
+  border-color: rgba(91, 46, 255, 0.2);
 }
 
 .advanced-toggle:hover::after {
@@ -599,8 +879,7 @@ code {
 
 /* Inline Embed Target */
 .embedded-target {
-  min-height: 500px;
-  overflow: hidden;
+  height: 550px;
 }
 
 /* Mobile Responsive */
@@ -611,16 +890,20 @@ code {
   }
 
   .hero {
-    padding: 20px 16px;
+    padding: 24px 16px 20px;
   }
 
   .hero h1 {
-    font-size: 28px;
-    margin-bottom: -18px;
+    font-size: 26px;
   }
 
   .hero p {
     font-size: 14px;
+  }
+
+  .install-command {
+    font-size: 12px;
+    padding: 10px 12px;
   }
 
   .card {
@@ -636,13 +919,20 @@ code {
     grid-template-columns: 1fr;
   }
 
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .feature-cell {
+    padding: 20px 16px;
+  }
+
   .embedded-target {
     min-height: 400px;
   }
 
   .theme-backdrop {
     padding: 36px 16px;
-    border-radius: 12px;
   }
 
   .theme-cta-label {
@@ -651,7 +941,6 @@ code {
 
   .tryit-backdrop {
     padding: 16px;
-    border-radius: 12px;
   }
 
   .cta-row {
@@ -669,5 +958,17 @@ code {
 
   .code-example code {
     font-size: 12px;
+  }
+
+  .code-showcase {
+    padding: 16px;
+  }
+
+  .code-showcase code {
+    font-size: 12px;
+  }
+
+  .footer {
+    padding: 24px 16px;
   }
 }

--- a/examples/embedded-app/src/launcher-demo.ts
+++ b/examples/embedded-app/src/launcher-demo.ts
@@ -1,0 +1,16 @@
+import "@runtypelabs/persona/widget.css";
+import { initAgentWidget, DEFAULT_WIDGET_CONFIG } from "@runtypelabs/persona";
+
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const proxyUrl =
+  import.meta.env.VITE_PROXY_URL
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
+    : `http://localhost:${proxyPort}/api/chat/dispatch`;
+
+initAgentWidget({
+  target: "#launcher-root",
+  config: {
+    ...DEFAULT_WIDGET_CONFIG,
+    apiUrl: proxyUrl,
+  },
+});

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -4,10 +4,10 @@ import "./App.css";
 
 import type { DeepPartial, PersonaTheme } from "@runtypelabs/persona";
 import {
-  initAgentWidget,
   createAgentExperience,
   createLocalStorageAdapter,
   markdownPostprocessor,
+  createDemoCarousel,
   DEFAULT_WIDGET_CONFIG
 } from "@runtypelabs/persona";
 
@@ -253,7 +253,7 @@ const homeDemoWelcomeSubtitle =
 const homeDemoInputPlaceholder =
   "Ask about Persona features, theming, integrations…";
 
-/** Same Runtype agent, request options, and welcome copy for inline embed and corner launcher. */
+/** Same Runtype agent, request options, and welcome copy for the inline embed. */
 const homeDemoSharedAssistant = {
   agent: {
     name: "Persona Documentation Assistant",
@@ -304,7 +304,13 @@ const inlineController = createAgentExperience(inlineMount, {
   launcher: {
     ...DEFAULT_WIDGET_CONFIG.launcher,
     width: "100%",
-    enabled: false
+    enabled: false,
+    fullHeight: true,
+  },
+  statusIndicator: {
+    idleText: "Powered by Runtype",
+    idleLink: "https://runtype.com",
+    align: "center",
   },
   features: {
     showEventStreamToggle: true
@@ -319,184 +325,18 @@ const inlineController = createAgentExperience(inlineMount, {
 });
 setupCodeCopyHandler(inlineMount);
 
-const launcherController = initAgentWidget({
-  target: "#launcher-root",
-  config: {
-    ...DEFAULT_WIDGET_CONFIG,
-    apiUrl: proxyUrl,
-    ...homeDemoSharedAssistant,
-    features: {
-      showEventStreamToggle: true
-    },
-    persistState: {
-      keyPrefix: homeDemoPersistKeyPrefix
-    },
-    storageAdapter: sharedWidgetStorage,
-    theme: {
-      components: {
-        launcher: {
-          borderRadius: ".5rem"
-        }
-      }
-    },
-    launcher: {
-      ...DEFAULT_WIDGET_CONFIG.launcher,
-      title: homeDemoWelcomeTitle,
-      subtitle: homeDemoWelcomeSubtitle,
-      iconUrl: "https://dummyimage.com/96x96/111827/ffffff&text=AI",
-      closeButtonColor: "#6b7280",
-      collapsedMaxWidth: "min(380px, calc(100vw - 48px))",
-    },
-    suggestionChips: [...homeDemoSuggestionChips],
-    postprocessMessage: ({ text, streaming }) => codeBlockCopyPostprocessor(text, streaming)
-  }
-});
-setupCodeCopyHandler(document.getElementById("launcher-root")!);
-
 // ---------------------------------------------------------------------------
-// Event Stream Testing
+// Demo Carousel
 // ---------------------------------------------------------------------------
-const esTargetSelect = document.getElementById('event-stream-target') as HTMLSelectElement | null;
-const getEsTarget = () => esTargetSelect?.value === 'launcher' ? launcherController : inlineController;
 
-document.getElementById('es-show')?.addEventListener('click', () => getEsTarget().showEventStream());
-document.getElementById('es-hide')?.addEventListener('click', () => getEsTarget().hideEventStream());
-document.getElementById('es-check')?.addEventListener('click', () => {
-  const visible = getEsTarget().isEventStreamVisible();
-  const name = esTargetSelect?.value ?? 'inline';
-  alert(`${name} event stream visible: ${visible}`);
-});
-
-// Window events
-document.getElementById('es-win-show-all')?.addEventListener('click', () => {
-  window.dispatchEvent(new CustomEvent('persona:showEventStream'));
-});
-document.getElementById('es-win-hide-all')?.addEventListener('click', () => {
-  window.dispatchEvent(new CustomEvent('persona:hideEventStream'));
-});
-document.getElementById('es-win-show-inline')?.addEventListener('click', () => {
-  window.dispatchEvent(new CustomEvent('persona:showEventStream', { detail: { instanceId: 'inline-widget' } }));
-});
-document.getElementById('es-win-show-launcher')?.addEventListener('click', () => {
-  window.dispatchEvent(new CustomEvent('persona:showEventStream', { detail: { instanceId: 'launcher-root' } }));
-});
-document.getElementById('es-win-show-wrong')?.addEventListener('click', () => {
-  window.dispatchEvent(new CustomEvent('persona:showEventStream', { detail: { instanceId: 'wrong-id' } }));
-  alert('Dispatched with instanceId "wrong-id" — nothing should open.');
-});
-
-// Event listeners with log output
-const esLogEl = document.getElementById('es-log');
-const esLogPre = document.getElementById('es-log-pre');
-document.getElementById('es-listen')?.addEventListener('click', () => {
-  if (esLogEl) esLogEl.style.display = 'block';
-  const log = (msg: string) => {
-    if (esLogPre) {
-      esLogPre.textContent += `[${new Date().toLocaleTimeString()}] ${msg}\n`;
-      esLogPre.parentElement!.scrollTop = esLogPre.parentElement!.scrollHeight;
-    }
-    console.log(`[EventStream] ${msg}`);
-  };
-  inlineController.on('eventStream:opened', (e) => log(`inline opened (ts: ${e.timestamp})`));
-  inlineController.on('eventStream:closed', (e) => log(`inline closed (ts: ${e.timestamp})`));
-  launcherController.on('eventStream:opened', (e) => log(`launcher opened (ts: ${e.timestamp})`));
-  launcherController.on('eventStream:closed', (e) => log(`launcher closed (ts: ${e.timestamp})`));
-  log('Listeners registered for both widgets');
-});
-
-// ---------------------------------------------------------------------------
-// Existing controls
-// ---------------------------------------------------------------------------
-const openButton = document.getElementById('open-chat')
-const toggleButton = document.getElementById('toggle-chat')
-const loadMessagesButton = document.getElementById('load-messages')
-const targetWidgetSelect = document.getElementById('target-widget') as HTMLSelectElement | null
-
-if (openButton) {
-  openButton.addEventListener('click', () => launcherController.open())
-}
-if (toggleButton) {
-  toggleButton.addEventListener('click', () => launcherController.toggle())
-}
-if (loadMessagesButton) {
-  loadMessagesButton.addEventListener('click', () => {
-    const messageCount = 1000;
-    const chunksPerMessage = 5;
-    const isLauncher = targetWidgetSelect?.value === 'launcher';
-    const target = isLauncher ? launcherController : inlineController;
-    const baseTime = Date.now() - messageCount * 1000;
-
-    if (isLauncher) {
-      launcherController.open();
-    }
-
-    // Build all messages up front, then inject in a single batch (one sort + one render)
-    const batch: Array<{ role: 'user' | 'assistant'; content: string; createdAt: string }> = [];
-
-    for (let msg = 0; msg < messageCount; msg++) {
-      const msgNum = msg + 1;
-      const isUser = msg % 2 === 0;
-      const timestamp = new Date(baseTime + msg * 1000).toISOString();
-
-      if (isUser) {
-        const content = `Test question #${Math.ceil(msgNum / 2)}: What is ${Math.ceil(msgNum / 2) * 7}?`;
-        batch.push({ role: 'user', content, createdAt: timestamp });
-      } else {
-        const fullText = `The answer to question #${Math.ceil(msgNum / 2)} is **${Math.ceil(msgNum / 2) * 7}**. Here's some extra text to make the message more realistic and test rendering with longer content.`;
-        batch.push({ role: 'assistant', content: fullText, createdAt: timestamp });
-      }
-    }
-
-    // Single batch insert: one sort, one DOM render
-    target.injectMessageBatch(batch);
-
-    // Push SSE events for the event stream inspector
-    for (let msg = 0; msg < messageCount; msg++) {
-      const msgNum = msg + 1;
-      const isUser = msg % 2 === 0;
-
-      if (isUser) {
-        target.__pushEventStreamEvent({
-          type: 'step_delta',
-          payload: { type: 'step_delta', text: batch[msg].content, stepType: 'prompt' }
-        });
-        target.__pushEventStreamEvent({
-          type: 'step_complete',
-          payload: { type: 'step_complete', result: { response: batch[msg].content } }
-        });
-      } else {
-        for (let chunk = 0; chunk < chunksPerMessage; chunk++) {
-          const chunkStart = Math.floor((chunk / chunksPerMessage) * batch[msg].content.length);
-          const chunkEnd = Math.floor(((chunk + 1) / chunksPerMessage) * batch[msg].content.length);
-          target.__pushEventStreamEvent({
-            type: 'step_delta',
-            payload: { type: 'step_delta', text: batch[msg].content.slice(chunkStart, chunkEnd), stepType: 'prompt', messageId: `ast_${msg}` }
-          });
-        }
-        target.__pushEventStreamEvent({
-          type: 'step_complete',
-          payload: { type: 'step_complete', result: { response: batch[msg].content }, messageId: `ast_${msg}` }
-        });
-      }
-
-      if (msg % 20 === 0) {
-        for (const t of ['reason_start', 'reason_delta', 'reason_complete', 'tool_start', 'tool_delta', 'tool_complete']) {
-          target.__pushEventStreamEvent({
-            type: t,
-            payload: { type: t, text: `Simulated ${t} for msg #${msgNum}`, toolName: t.startsWith('tool') ? 'web_search' : undefined }
-          });
-        }
-      }
-    }
-
-    target.__pushEventStreamEvent({
-      type: 'flow_complete',
-      payload: { type: 'flow_complete', messageCount }
-    });
-
-    const targetName = targetWidgetSelect?.value === 'launcher' ? 'launcher' : 'inline';
-    console.log(`[Demo] Batch injected ${messageCount} messages + events into ${targetName} widget`);
-    loadMessagesButton.textContent = `Loaded into ${targetName}!`;
-    setTimeout(() => { loadMessagesButton.textContent = 'Load 1000 Messages'; }, 2000);
+const carouselMount = document.getElementById("demo-carousel-mount");
+if (carouselMount) {
+  createDemoCarousel(carouselMount, {
+    items: [
+      { url: "/fullscreen-assistant-demo.html", title: "Fullscreen Assistant", description: "Full-viewport dark layout with artifacts" },
+      { url: "/bakery.html", title: "Bakery Assistant", description: "Full business site with context-aware chat" },
+      { url: "/docked-panel-demo.html", title: "Docked Panel", description: "Side-docked assistant layout" },
+      { url: "/artifact-demo.html", title: "Artifact Sidebar", description: "Resizable split view for rich content" },
+    ],
   });
 }

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -333,10 +333,10 @@ const carouselMount = document.getElementById("demo-carousel-mount");
 if (carouselMount) {
   createDemoCarousel(carouselMount, {
     items: [
-      { url: "/fullscreen-assistant-demo.html", title: "Fullscreen Assistant", description: "Full-viewport dark layout with artifacts" },
-      { url: "/bakery.html", title: "Bakery Assistant", description: "Full business site with context-aware chat" },
-      { url: "/docked-panel-demo.html", title: "Docked Panel", description: "Side-docked assistant layout" },
-      { url: "/artifact-demo.html", title: "Artifact Sidebar", description: "Resizable split view for rich content" },
+      { url: "/launcher-demo.html", title: "Default Launcher", description: "Out-of-the-box chat widget experience" },
+      { url: "/bakery.html", title: "Site Nav, Checkout", description: "Full business site with context-aware chat" },
+      { url: "/fullscreen-assistant-demo.html", title: "Fullscreen", description: "Full-viewport dark layout with artifacts" },
+      { url: "/docked-panel-demo.html", title: "Docked Assistant", description: "Side-docked assistant layout" },
     ],
   });
 }

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -288,6 +288,7 @@ export default defineConfig({
         'event-stream-testing': path.resolve(__dirname, 'event-stream-testing.html'),
         'artifact-demo': path.resolve(__dirname, 'artifact-demo.html'),
         'fullscreen-assistant-demo': path.resolve(__dirname, 'fullscreen-assistant-demo.html'),
+        'launcher-demo': path.resolve(__dirname, 'launcher-demo.html'),
         'custom-loading-indicator': path.resolve(__dirname, 'custom-loading-indicator.html'),
         'voice-integration-demo': path.resolve(__dirname, 'voice-integration-demo.html'),
         // Standalone (CDN / Copy-Paste) pages

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -285,6 +285,7 @@ export default defineConfig({
         'approval-demo': path.resolve(__dirname, 'approval-demo.html'),
         // Focus input demo
         'focus-input-demo': path.resolve(__dirname, 'focus-input-demo.html'),
+        'event-stream-testing': path.resolve(__dirname, 'event-stream-testing.html'),
         'artifact-demo': path.resolve(__dirname, 'artifact-demo.html'),
         'fullscreen-assistant-demo': path.resolve(__dirname, 'fullscreen-assistant-demo.html'),
         'custom-loading-indicator': path.resolve(__dirname, 'custom-loading-indicator.html'),

--- a/packages/widget/src/components/composer-builder.ts
+++ b/packages/widget/src/components/composer-builder.ts
@@ -480,17 +480,33 @@ export const buildComposer = (context: ComposerBuildContext): ComposerElements =
   actionsRow.append(leftActions, rightActions);
   composerForm.append(actionsRow);
 
+  // Apply status indicator config
+  const statusConfig = config?.statusIndicator ?? {};
+  const alignClass =
+    statusConfig.align === "left" ? "persona-text-left"
+    : statusConfig.align === "center" ? "persona-text-center"
+    : "persona-text-right";
   const statusText = createElement(
     "div",
-    "persona-mt-2 persona-text-right persona-text-xs persona-text-persona-muted"
+    `persona-mt-2 ${alignClass} persona-text-xs persona-text-persona-muted`
   );
   statusText.setAttribute("data-persona-composer-status", "");
 
-  // Apply status indicator config
-  const statusConfig = config?.statusIndicator ?? {};
   const isVisible = statusConfig.visible ?? true;
   statusText.style.display = isVisible ? "" : "none";
-  statusText.textContent = statusConfig.idleText ?? "Online";
+  const idleLabel = statusConfig.idleText ?? "Online";
+  if (statusConfig.idleLink) {
+    const link = createElement("a");
+    link.href = statusConfig.idleLink;
+    link.target = "_blank";
+    link.rel = "noopener noreferrer";
+    link.textContent = idleLabel;
+    link.style.color = "inherit";
+    link.style.textDecoration = "none";
+    statusText.appendChild(link);
+  } else {
+    statusText.textContent = idleLabel;
+  }
 
   footer.append(suggestions, composerForm, statusText);
 

--- a/packages/widget/src/components/demo-carousel.ts
+++ b/packages/widget/src/components/demo-carousel.ts
@@ -1,0 +1,699 @@
+import { createElement } from "../utils/dom";
+import { createIconButton } from "../utils/buttons";
+import { createToggleGroup } from "../utils/buttons";
+import { renderLucideIcon } from "../utils/icons";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DemoCarouselItem {
+  /** URL to load in the iframe (relative or absolute). */
+  url: string;
+  /** Display title shown in the toolbar. */
+  title: string;
+  /** Optional subtitle/description. */
+  description?: string;
+}
+
+export interface DemoCarouselOptions {
+  /** Demo pages to cycle through. */
+  items: DemoCarouselItem[];
+  /** Initial item index. Default: 0. */
+  initialIndex?: number;
+  /** Initial device viewport. Default: 'desktop'. */
+  initialDevice?: "desktop" | "mobile";
+  /** Initial color scheme for the iframe wrapper. Default: 'light'. */
+  initialColorScheme?: "light" | "dark";
+  /** Show zoom +/- controls. Default: true. */
+  showZoomControls?: boolean;
+  /** Show desktop/mobile toggle. Default: true. */
+  showDeviceToggle?: boolean;
+  /** Show light/dark scheme toggle. Default: true. */
+  showColorSchemeToggle?: boolean;
+  /** Called when the active demo changes. */
+  onChange?: (index: number, item: DemoCarouselItem) => void;
+}
+
+export interface DemoCarouselHandle {
+  /** Root element (already appended to the container). */
+  element: HTMLElement;
+  /** Navigate to a demo by index. */
+  goTo(index: number): void;
+  /** Go to the next demo. */
+  next(): void;
+  /** Go to the previous demo. */
+  prev(): void;
+  /** Current demo index. */
+  getIndex(): number;
+  /** Change the device viewport. */
+  setDevice(device: "desktop" | "mobile"): void;
+  /** Change the wrapper color scheme. */
+  setColorScheme(scheme: "light" | "dark"): void;
+  /** Override zoom level (null = auto-fit). */
+  setZoom(zoom: number | null): void;
+  /** Tear down listeners, observer, and DOM. */
+  destroy(): void;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEVICE_DIMENSIONS: Record<string, { w: number; h: number }> = {
+  desktop: { w: 1280, h: 800 },
+  mobile: { w: 390, h: 844 },
+};
+
+const ZOOM_STEP = 0.1;
+const ZOOM_MIN = 0.15;
+const ZOOM_MAX = 1.5;
+const STAGE_PADDING = 24;
+const SHADOW_MARGIN = 40;
+
+// ---------------------------------------------------------------------------
+// Injected CSS (self-contained, prefixed persona-dc-)
+// ---------------------------------------------------------------------------
+
+const CAROUSEL_CSS = /* css */ `
+/* ── Root ── */
+.persona-dc-root {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  color: #111827;
+  line-height: 1.4;
+}
+
+/* ── Toolbar ── */
+.persona-dc-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 8px 12px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-bottom: none;
+  border-radius: 10px 10px 0 0;
+  flex-wrap: wrap;
+}
+.persona-dc-toolbar-lead {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+.persona-dc-toolbar-trail {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.persona-dc-title-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-weight: 600;
+  font-size: 13px;
+  white-space: nowrap;
+  max-width: 240px;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 0.375rem;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: inherit;
+  font-family: inherit;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+.persona-dc-title-btn:hover {
+  background: #f3f4f6;
+  border-color: #e5e7eb;
+}
+.persona-dc-title-btn .persona-dc-title-text {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.persona-dc-title-btn .persona-dc-title-chevron {
+  flex-shrink: 0;
+  transition: transform 0.15s ease;
+}
+.persona-dc-title-btn[aria-expanded="true"] .persona-dc-title-chevron {
+  transform: rotate(180deg);
+}
+
+/* ── Title dropdown ── */
+.persona-dc-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 4px;
+  min-width: 220px;
+  max-width: 320px;
+  background: #fff;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.12), 0 2px 6px rgba(0,0,0,0.06);
+  padding: 4px;
+  z-index: 100;
+  max-height: 300px;
+  overflow-y: auto;
+}
+.persona-dc-root .persona-dc-dropdown button.persona-dc-dropdown-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  justify-content: flex-start;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  background: none;
+  border-radius: 6px;
+  cursor: pointer;
+  text-align: left;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  color: #111827;
+  transition: background-color 0.1s ease;
+}
+.persona-dc-root .persona-dc-dropdown button.persona-dc-dropdown-item:hover {
+  background: #f3f4f6;
+}
+.persona-dc-root .persona-dc-dropdown button.persona-dc-dropdown-item[aria-current="true"] {
+  background: #eff6ff;
+  color: #2563eb;
+}
+.persona-dc-root .persona-dc-dropdown-desc {
+  font-weight: 400;
+  font-size: 12px;
+  color: #6b7280;
+  margin-top: 1px;
+  text-align: left;
+}
+.persona-dc-root .persona-dc-dropdown button.persona-dc-dropdown-item[aria-current="true"] .persona-dc-dropdown-desc {
+  color: #60a5fa;
+}
+.persona-dc-counter {
+  font-size: 12px;
+  color: #6b7280;
+  white-space: nowrap;
+}
+.persona-dc-zoom-controls {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.persona-dc-zoom-level {
+  font-size: 12px;
+  color: #6b7280;
+  min-width: 36px;
+  text-align: center;
+  user-select: none;
+}
+.persona-dc-separator {
+  width: 1px;
+  height: 20px;
+  background: #e5e7eb;
+  flex-shrink: 0;
+}
+
+/* ── Stage ── */
+.persona-dc-stage {
+  height: 550px;
+  min-height: 400px;
+  padding: ${STAGE_PADDING}px;
+  overflow: auto;
+  background: #f0f1f3;
+  background-image: radial-gradient(circle, #e0e1e5 1px, transparent 1px);
+  background-size: 24px 24px;
+  border: 1px solid #e5e7eb;
+  border-radius: 0 0 10px 10px;
+  display: flex;
+}
+
+/* ── Iframe wrapper ── */
+.persona-dc-iframe-wrapper {
+  position: relative;
+  overflow: hidden;
+  background: #fff;
+  border-radius: 10px;
+  box-shadow: 0 16px 64px rgba(0, 0, 0, 0.12), 0 2px 8px rgba(0, 0, 0, 0.06);
+  margin: auto;
+  flex-shrink: 0;
+  transition: border-radius 0.2s ease;
+}
+.persona-dc-iframe-wrapper[data-color-scheme="dark"] {
+  background: #0f172a;
+}
+
+/* ── Iframe ── */
+.persona-dc-iframe {
+  border: none;
+  display: block;
+  background: #fff;
+  transform-origin: top left;
+}
+.persona-dc-iframe-wrapper[data-color-scheme="dark"] .persona-dc-iframe {
+  background: #0f172a;
+}
+
+/* ── Button/toggle base styles (standalone, no widget.css dependency) ── */
+.persona-dc-root .persona-icon-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.25rem;
+  border-radius: 0.375rem;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+  color: #111827;
+  cursor: pointer;
+  line-height: 1;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+}
+.persona-dc-root .persona-icon-btn:hover {
+  background: #f3f4f6;
+}
+.persona-dc-root .persona-icon-btn:focus-visible {
+  outline: 2px solid #3b82f6;
+  outline-offset: 2px;
+}
+.persona-dc-root .persona-icon-btn[aria-pressed="true"] {
+  background: #f3f4f6;
+  border-color: #d1d5db;
+}
+.persona-dc-root .persona-toggle-group {
+  display: inline-flex;
+  gap: 0;
+}
+.persona-dc-root .persona-toggle-group > .persona-icon-btn {
+  border-radius: 0;
+}
+.persona-dc-root .persona-toggle-group > .persona-icon-btn:first-child {
+  border-top-left-radius: 0.375rem;
+  border-bottom-left-radius: 0.375rem;
+}
+.persona-dc-root .persona-toggle-group > .persona-icon-btn:last-child {
+  border-top-right-radius: 0.375rem;
+  border-bottom-right-radius: 0.375rem;
+}
+
+/* ── Responsive ── */
+@media (max-width: 640px) {
+  .persona-dc-toolbar {
+    gap: 8px;
+  }
+  .persona-dc-zoom-controls {
+    display: none;
+  }
+  .persona-dc-stage {
+    height: 400px;
+    min-height: 300px;
+  }
+}
+`;
+
+function injectStyles(): void {
+  if (document.querySelector("style[data-persona-dc-styles]")) return;
+  const style = document.createElement("style");
+  style.setAttribute("data-persona-dc-styles", "");
+  style.textContent = CAROUSEL_CSS;
+  document.head.appendChild(style);
+}
+
+// ---------------------------------------------------------------------------
+// Scale helpers (ported from theme editor)
+// ---------------------------------------------------------------------------
+
+function computeFitScale(
+  stage: HTMLElement,
+  dims: { w: number; h: number },
+): number {
+  const availW = stage.clientWidth - STAGE_PADDING * 2 - SHADOW_MARGIN;
+  const availH = stage.clientHeight - STAGE_PADDING * 2 - SHADOW_MARGIN;
+  if (availW <= 0 || availH <= 0) return 1;
+  return Math.min(availW / dims.w, availH / dims.h, 1);
+}
+
+function applyScale(
+  wrapper: HTMLElement,
+  iframe: HTMLIFrameElement,
+  dims: { w: number; h: number },
+  scale: number,
+  device: string,
+): void {
+  wrapper.style.width = `${dims.w * scale}px`;
+  wrapper.style.height = `${dims.h * scale}px`;
+  wrapper.style.borderRadius =
+    device === "mobile" ? `${32 * scale}px` : "10px";
+
+  iframe.style.width = `${dims.w}px`;
+  iframe.style.height = `${dims.h}px`;
+  iframe.style.transformOrigin = "top left";
+  iframe.style.transform = `scale(${scale})`;
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export function createDemoCarousel(
+  container: HTMLElement,
+  options: DemoCarouselOptions,
+): DemoCarouselHandle {
+  const {
+    items,
+    initialIndex = 0,
+    initialDevice = "desktop",
+    initialColorScheme = "light",
+    showZoomControls = true,
+    showDeviceToggle = true,
+    showColorSchemeToggle = true,
+    onChange,
+  } = options;
+
+  if (items.length === 0) {
+    throw new Error("createDemoCarousel: items array must not be empty");
+  }
+
+  injectStyles();
+
+  // ── State ──
+  let currentIndex = Math.max(0, Math.min(initialIndex, items.length - 1));
+  let currentDevice = initialDevice;
+  let currentScheme = initialColorScheme;
+  let zoomOverride: number | null = null;
+  let lastAutoScale = 1;
+  let destroyed = false;
+
+  // ── DOM ──
+  const root = createElement("div", "persona-dc-root");
+
+  // Toolbar
+  const toolbar = createElement("div", "persona-dc-toolbar");
+  const toolbarLead = createElement("div", "persona-dc-toolbar-lead");
+  const toolbarTrail = createElement("div", "persona-dc-toolbar-trail");
+
+  // Prev / title / next / counter
+  const prevBtn = createIconButton({
+    icon: "chevron-left",
+    label: "Previous demo",
+    size: 14,
+    onClick: () => navigate(-1),
+  });
+
+  // Title button with dropdown
+  const titleWrap = createElement("div");
+  titleWrap.style.position = "relative";
+
+  const titleBtn = createElement("button", "persona-dc-title-btn");
+  titleBtn.type = "button";
+  titleBtn.setAttribute("aria-expanded", "false");
+  titleBtn.setAttribute("aria-haspopup", "listbox");
+  const titleText = createElement("span", "persona-dc-title-text");
+  const titleChevron = createElement("span", "persona-dc-title-chevron");
+  const chevronSvg = renderLucideIcon("chevron-down", 12, "currentColor", 2);
+  if (chevronSvg) titleChevron.appendChild(chevronSvg);
+  titleBtn.append(titleText, titleChevron);
+
+  // Dropdown list
+  const dropdown = createElement("div", "persona-dc-dropdown");
+  dropdown.setAttribute("role", "listbox");
+  dropdown.style.display = "none";
+  let dropdownOpen = false;
+
+  function buildDropdownItems(): void {
+    dropdown.innerHTML = "";
+    for (let i = 0; i < items.length; i++) {
+      const item = items[i];
+      const btn = createElement("button", "persona-dc-dropdown-item");
+      btn.type = "button";
+      btn.setAttribute("role", "option");
+      btn.setAttribute("aria-current", i === currentIndex ? "true" : "false");
+      const titleSpan = createElement("span");
+      titleSpan.textContent = item.title;
+      btn.appendChild(titleSpan);
+      if (item.description) {
+        const desc = createElement("span", "persona-dc-dropdown-desc");
+        desc.textContent = item.description;
+        btn.appendChild(desc);
+      }
+      btn.addEventListener("click", () => {
+        closeDropdown();
+        goTo(i);
+      });
+      dropdown.appendChild(btn);
+    }
+  }
+
+  function toggleDropdown(): void {
+    dropdownOpen = !dropdownOpen;
+    dropdown.style.display = dropdownOpen ? "" : "none";
+    titleBtn.setAttribute("aria-expanded", dropdownOpen ? "true" : "false");
+    if (dropdownOpen) buildDropdownItems();
+  }
+
+  function closeDropdown(): void {
+    if (!dropdownOpen) return;
+    dropdownOpen = false;
+    dropdown.style.display = "none";
+    titleBtn.setAttribute("aria-expanded", "false");
+  }
+
+  titleBtn.addEventListener("click", (e) => {
+    e.stopPropagation();
+    toggleDropdown();
+  });
+
+  // Close on outside click
+  const onDocClick = (): void => closeDropdown();
+  document.addEventListener("click", onDocClick);
+
+  titleWrap.append(titleBtn, dropdown);
+
+  const nextBtn = createIconButton({
+    icon: "chevron-right",
+    label: "Next demo",
+    size: 14,
+    onClick: () => navigate(1),
+  });
+
+  const counterEl = createElement("span", "persona-dc-counter");
+
+  toolbarLead.append(prevBtn, titleWrap, nextBtn, counterEl);
+
+  // Device toggle
+  let deviceToggle: ReturnType<typeof createToggleGroup> | null = null;
+  if (showDeviceToggle) {
+    deviceToggle = createToggleGroup({
+      items: [
+        { id: "desktop", icon: "monitor", label: "Desktop" },
+        { id: "mobile", icon: "smartphone", label: "Mobile" },
+      ],
+      selectedId: currentDevice,
+      onSelect: (id) => {
+        currentDevice = id as "desktop" | "mobile";
+        wrapper.dataset.device = currentDevice;
+        zoomOverride = null;
+        rescale();
+      },
+    });
+    toolbarTrail.appendChild(deviceToggle.element);
+  }
+
+  // Zoom controls
+  let zoomLevelEl: HTMLSpanElement | null = null;
+  if (showZoomControls) {
+    const zoomWrap = createElement("div", "persona-dc-zoom-controls");
+    const zoomOut = createIconButton({
+      icon: "minus",
+      label: "Zoom out",
+      size: 14,
+      onClick: () => {
+        const current = zoomOverride ?? lastAutoScale;
+        zoomOverride = Math.max(ZOOM_MIN, current - ZOOM_STEP);
+        rescale();
+      },
+    });
+    zoomLevelEl = createElement("span", "persona-dc-zoom-level");
+    zoomLevelEl.title = "Reset to 100%";
+    zoomLevelEl.style.cursor = "pointer";
+    zoomLevelEl.addEventListener("click", () => {
+      zoomOverride = 1;
+      rescale();
+    });
+    const zoomIn = createIconButton({
+      icon: "plus",
+      label: "Zoom in",
+      size: 14,
+      onClick: () => {
+        const current = zoomOverride ?? lastAutoScale;
+        zoomOverride = Math.min(ZOOM_MAX, current + ZOOM_STEP);
+        rescale();
+      },
+    });
+    const zoomFit = createIconButton({
+      icon: "maximize",
+      label: "Fit to view",
+      size: 14,
+      onClick: () => {
+        zoomOverride = null;
+        rescale();
+      },
+    });
+    zoomWrap.append(zoomOut, zoomLevelEl, zoomIn, zoomFit);
+    toolbarTrail.appendChild(zoomWrap);
+  }
+
+  // Color scheme toggle
+  if (showColorSchemeToggle) {
+    const sep = createElement("div", "persona-dc-separator");
+    toolbarTrail.appendChild(sep);
+    const schemeToggle = createToggleGroup({
+      items: [
+        { id: "light", icon: "sun", label: "Light" },
+        { id: "dark", icon: "moon", label: "Dark" },
+      ],
+      selectedId: currentScheme,
+      onSelect: (id) => {
+        currentScheme = id as "light" | "dark";
+        wrapper.dataset.colorScheme = currentScheme;
+        applySchemeToIframe();
+      },
+    });
+    toolbarTrail.appendChild(schemeToggle.element);
+  }
+
+  // Open in new tab
+  const sep2 = createElement("div", "persona-dc-separator");
+  toolbarTrail.appendChild(sep2);
+  const openBtn = createIconButton({
+    icon: "external-link",
+    label: "Open in new tab",
+    size: 14,
+    onClick: () => {
+      window.open(items[currentIndex].url, "_blank");
+    },
+  });
+  toolbarTrail.appendChild(openBtn);
+
+  toolbar.append(toolbarLead, toolbarTrail);
+
+  // Stage + iframe
+  const stage = createElement("div", "persona-dc-stage");
+  const wrapper = createElement("div", "persona-dc-iframe-wrapper");
+  wrapper.dataset.device = currentDevice;
+  wrapper.dataset.colorScheme = currentScheme;
+
+  const iframe = createElement("iframe", "persona-dc-iframe");
+  iframe.setAttribute("sandbox", "allow-scripts allow-same-origin");
+  iframe.setAttribute("loading", "lazy");
+  iframe.title = items[currentIndex].title;
+
+  wrapper.appendChild(iframe);
+  stage.appendChild(wrapper);
+  root.append(toolbar, stage);
+  container.appendChild(root);
+
+  // ── Logic ──
+
+  function applySchemeToIframe(): void {
+    try {
+      const body = iframe.contentDocument?.body;
+      if (!body) return;
+      if (currentScheme === "dark") {
+        body.classList.add("theme-dark");
+      } else {
+        body.classList.remove("theme-dark");
+      }
+    } catch {
+      // Cross-origin iframe — silently ignore
+    }
+  }
+
+  // Re-apply scheme after iframe loads new content
+  iframe.addEventListener("load", () => applySchemeToIframe());
+
+  function updateDisplay(): void {
+    const item = items[currentIndex];
+    titleText.textContent = item.title;
+    counterEl.textContent = `${currentIndex + 1} / ${items.length}`;
+    iframe.title = item.title;
+  }
+
+  function navigate(delta: number): void {
+    const next = ((currentIndex + delta) % items.length + items.length) % items.length;
+    goTo(next);
+  }
+
+  function goTo(index: number): void {
+    if (index < 0 || index >= items.length) return;
+    currentIndex = index;
+    iframe.src = items[currentIndex].url;
+    updateDisplay();
+    onChange?.(currentIndex, items[currentIndex]);
+  }
+
+  function rescale(): void {
+    if (destroyed) return;
+    const dims = DEVICE_DIMENSIONS[currentDevice] ?? DEVICE_DIMENSIONS.desktop;
+    lastAutoScale = computeFitScale(stage, dims);
+    const scale = Math.max(
+      ZOOM_MIN,
+      Math.min(ZOOM_MAX, zoomOverride ?? lastAutoScale),
+    );
+    applyScale(wrapper, iframe, dims, scale, currentDevice);
+    if (zoomLevelEl) {
+      zoomLevelEl.textContent = `${Math.round(scale * 100)}%`;
+    }
+  }
+
+  // ResizeObserver
+  const resizeObserver = new ResizeObserver(() => rescale());
+  resizeObserver.observe(stage);
+
+  // Initial render
+  updateDisplay();
+  iframe.src = items[currentIndex].url;
+  // Defer initial scale to next frame so stage has layout dimensions
+  requestAnimationFrame(() => rescale());
+
+  // ── Handle ──
+
+  function destroy(): void {
+    if (destroyed) return;
+    destroyed = true;
+    resizeObserver.disconnect();
+    document.removeEventListener("click", onDocClick);
+    root.remove();
+  }
+
+  return {
+    element: root,
+    goTo,
+    next: () => navigate(1),
+    prev: () => navigate(-1),
+    getIndex: () => currentIndex,
+    setDevice(device: "desktop" | "mobile") {
+      currentDevice = device;
+      wrapper.dataset.device = device;
+      deviceToggle?.setSelected(device);
+      zoomOverride = null;
+      rescale();
+    },
+    setColorScheme(scheme: "light" | "dark") {
+      currentScheme = scheme;
+      wrapper.dataset.colorScheme = scheme;
+    },
+    setZoom(zoom: number | null) {
+      zoomOverride = zoom;
+      rescale();
+    },
+    destroy,
+  };
+}

--- a/packages/widget/src/components/header-builder.ts
+++ b/packages/widget/src/components/header-builder.ts
@@ -92,7 +92,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
     }
   }
 
-  const headerCopy = createElement("div", "persona-flex persona-flex-col");
+  const headerCopy = createElement("div", "persona-flex persona-flex-col persona-flex-1 persona-min-w-0");
   const title = createElement("span", "persona-text-base persona-font-semibold");
   title.style.color = HEADER_THEME_CSS.titleColor;
   title.textContent = config?.launcher?.title ?? "Chat Assistant";

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -194,6 +194,14 @@ export type {
   ComboButtonHandle
 } from "./utils/buttons";
 
+// Demo carousel exports
+export { createDemoCarousel } from "./components/demo-carousel";
+export type {
+  DemoCarouselItem,
+  DemoCarouselOptions,
+  DemoCarouselHandle
+} from "./components/demo-carousel";
+
 // Theme system exports
 export {
   createTheme,

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -884,7 +884,11 @@ export type AgentWidgetClearChatConfig = {
 
 export type AgentWidgetStatusIndicatorConfig = {
   visible?: boolean;
+  /** Text alignment. Default: 'right'. */
+  align?: 'left' | 'center' | 'right';
   idleText?: string;
+  /** URL to open in a new tab when the idle text is clicked. */
+  idleLink?: string;
   connectingText?: string;
   connectedText?: string;
   errorText?: string;

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -604,6 +604,23 @@ export const createAgentExperience = (
     return statusCopy[status];
   };
 
+  /** Update statusText element, rendering a link for idle status when idleLink is configured. */
+  function applyStatusToElement(el: HTMLElement, text: string, statusCfg: typeof statusConfig, status: string): void {
+    if (status === "idle" && statusCfg.idleLink) {
+      el.textContent = "";
+      const link = document.createElement("a");
+      link.href = statusCfg.idleLink;
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = text;
+      link.style.color = "inherit";
+      link.style.textDecoration = "none";
+      el.appendChild(link);
+    } else {
+      el.textContent = text;
+    }
+  }
+
   const { wrapper, panel } = createWrapper(config);
   const panelElements = buildPanel(config, launcherEnabled);
   let {
@@ -2670,14 +2687,14 @@ export const createAgentExperience = (
     },
     onStatusChanged(status) {
       const currentStatusConfig = config.statusIndicator ?? {};
-      const getCurrentStatusText = (status: AgentWidgetSessionStatus): string => {
-        if (status === "idle") return currentStatusConfig.idleText ?? statusCopy.idle;
-        if (status === "connecting") return currentStatusConfig.connectingText ?? statusCopy.connecting;
-        if (status === "connected") return currentStatusConfig.connectedText ?? statusCopy.connected;
-        if (status === "error") return currentStatusConfig.errorText ?? statusCopy.error;
-        return statusCopy[status];
+      const getCurrentStatusText = (s: AgentWidgetSessionStatus): string => {
+        if (s === "idle") return currentStatusConfig.idleText ?? statusCopy.idle;
+        if (s === "connecting") return currentStatusConfig.connectingText ?? statusCopy.connecting;
+        if (s === "connected") return currentStatusConfig.connectedText ?? statusCopy.connected;
+        if (s === "error") return currentStatusConfig.errorText ?? statusCopy.error;
+        return statusCopy[s];
       };
-      statusText.textContent = getCurrentStatusText(status);
+      applyStatusToElement(statusText, getCurrentStatusText(status), currentStatusConfig, status);
     },
     onStreamingChanged(streaming) {
       isStreaming = streaming;
@@ -4815,14 +4832,14 @@ export const createAgentExperience = (
       // Update status text if status is currently set
       if (session) {
         const currentStatus = session.getStatus();
-        const getCurrentStatusText = (status: AgentWidgetSessionStatus): string => {
-          if (status === "idle") return statusIndicatorConfig.idleText ?? statusCopy.idle;
-          if (status === "connecting") return statusIndicatorConfig.connectingText ?? statusCopy.connecting;
-          if (status === "connected") return statusIndicatorConfig.connectedText ?? statusCopy.connected;
-          if (status === "error") return statusIndicatorConfig.errorText ?? statusCopy.error;
-          return statusCopy[status];
+        const getCurrentStatusText = (s: AgentWidgetSessionStatus): string => {
+          if (s === "idle") return statusIndicatorConfig.idleText ?? statusCopy.idle;
+          if (s === "connecting") return statusIndicatorConfig.connectingText ?? statusCopy.connecting;
+          if (s === "connected") return statusIndicatorConfig.connectedText ?? statusCopy.connected;
+          if (s === "error") return statusIndicatorConfig.errorText ?? statusCopy.error;
+          return statusCopy[s];
         };
-        statusText.textContent = getCurrentStatusText(currentStatus);
+        applyStatusToElement(statusText, getCurrentStatusText(currentStatus), statusIndicatorConfig, currentStatus);
       }
     },
     open() {


### PR DESCRIPTION
## Summary

This branch ships a new **exportable demo carousel** for marketing or docs-style previews, extends **status indicator** configuration and fixes **header action alignment**, and **refreshes the embedded-app index** with clearer quick-start / integration flows plus two new demo entry points.

---

## Widget (`@runtypelabs/persona`)

- **`createDemoCarousel()`** — New public API (`packages/widget/src/components/demo-carousel.ts`, re-exported from `index.ts`) for scaled iframe demos with device viewport toggle, zoom, light/dark scheme, carousel navigation (including dropdown), and open-in-new-tab. Self-contained styling for standalone use.
- **`statusIndicator`**
  - **`align`**: `'left' | 'center' | 'right'` for status text alignment (default remains right-aligned behavior as documented in types).
  - **`idleLink`**: When idle, status text becomes a link (new tab, `noopener`/`noreferrer`) pointing at the given URL.
- **Header** — Trailing actions (e.g. event stream toggle, clear, close) stay **flush to the right** instead of bunching after the title (`header-builder` / related layout).
- **`composer-builder`** — Small adjustments in support of the above UX.

**Changeset:** `.changeset/demo-carousel-and-status-indicator.md` (minor bump for `@runtypelabs/persona`).

---

## Examples (`examples/embedded-app`)

- **`index.html` + `index.css`** — Revamped **quick start** with integration-oriented layout and improved styling; copy/code UX improvements.
- **`main.ts`** — Slimmed down; demo-specific behavior moved or reorganized to match the new pages.
- **New pages**
  - **`event-stream-testing.html`** + **`src/event-stream-testing.ts`** — Dedicated event-stream testing surface.
  - **`launcher-demo.html`** + **`src/launcher-demo.ts`** — Launcher-focused demo.
- **`vite.config.ts`** — MPA entries for `event-stream-testing' and `launcher-demo`.
