### PR TITLE
feat: partId-based message segmentation for tool interleaving

### DIFF
--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@runtypelabs/persona",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "Themeable, pluggable streaming agent widget for websites, in plain JS with support for voice input and reasoning / tool output.",
   "type": "module",
   "main": "dist/index.cjs",

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -881,7 +881,8 @@ export class AgentWidgetClient {
     onEvent: SSEHandler,
     assistantMessageRef: { current: AgentWidgetMessage | null },
     emitMessage: (msg: AgentWidgetMessage) => void,
-    nextSequence: () => number
+    nextSequence: () => number,
+    partIdState: { current: string | null }
   ): Promise<boolean> {
     if (!this.parseSSEEvent) return false;
 
@@ -889,8 +890,7 @@ export class AgentWidgetClient {
       const result = await this.parseSSEEvent(payload);
       if (result === null) return false; // Event should be ignored
 
-      const ensureAssistant = () => {
-        if (assistantMessageRef.current) return assistantMessageRef.current;
+      const createNewAssistant = (partId?: string): AgentWidgetMessage => {
         const msg: AgentWidgetMessage = {
           id: `assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`,
           role: "assistant",
@@ -898,15 +898,42 @@ export class AgentWidgetClient {
           createdAt: new Date().toISOString(),
           streaming: true,
           variant: "assistant",
-          sequence: nextSequence()
+          sequence: nextSequence(),
+          ...(partId !== undefined && { partId })
         };
         assistantMessageRef.current = msg;
         emitMessage(msg);
         return msg;
       };
 
+      const ensureAssistant = (partId?: string) => {
+        if (assistantMessageRef.current) return assistantMessageRef.current;
+        return createNewAssistant(partId);
+      };
+
       if (result.text !== undefined) {
-        const assistant = ensureAssistant();
+        // partId-based message segmentation: when partId changes, seal current
+        // message and start a new one for chronological tool/text interleaving
+        if (result.partId !== undefined && partIdState.current !== null && result.partId !== partIdState.current) {
+          // Seal the current assistant message
+          if (assistantMessageRef.current) {
+            assistantMessageRef.current.streaming = false;
+            emitMessage(assistantMessageRef.current);
+          }
+          // Create a new assistant message for the new text segment
+          createNewAssistant(result.partId);
+        }
+
+        // Update partId tracking (only when partId is provided — backward compatible)
+        if (result.partId !== undefined) {
+          partIdState.current = result.partId;
+        }
+
+        const assistant = ensureAssistant(result.partId);
+        // Tag the message with partId if present and not already set
+        if (result.partId !== undefined && !assistant.partId) {
+          assistant.partId = result.partId;
+        }
         assistant.content += result.text;
         emitMessage(assistant);
       }
@@ -916,10 +943,12 @@ export class AgentWidgetClient {
           assistantMessageRef.current.streaming = false;
           emitMessage(assistantMessageRef.current);
         }
+        partIdState.current = null;
         onEvent({ type: "status", status: "idle" });
       }
 
       if (result.error) {
+        partIdState.current = null;
         onEvent({
           type: "error",
           error: new Error(result.error)
@@ -987,6 +1016,8 @@ export class AgentWidgetClient {
     let assistantMessage: AgentWidgetMessage | null = null;
     // Reference to track assistant message for custom event handler
     const assistantMessageRef = { current: null as AgentWidgetMessage | null };
+    // Track current partId for message segmentation at tool boundaries
+    const partIdState = { current: null as string | null };
     const reasoningMessages = new Map<string, AgentWidgetMessage>();
     const toolMessages = new Map<string, AgentWidgetMessage>();
     const reasoningContext = {
@@ -1276,10 +1307,11 @@ export class AgentWidgetClient {
             onEvent,
             assistantMessageRef,
             emitMessage,
-            nextSequence
+            nextSequence,
+            partIdState
           );
-          // Update assistantMessage from ref (in case it was created)
-          if (assistantMessageRef.current && !assistantMessage) {
+          // Update assistantMessage from ref (in case it was created or replaced by partId segmentation)
+          if (assistantMessageRef.current && assistantMessageRef.current !== assistantMessage) {
             assistantMessage = assistantMessageRef.current;
           }
           if (handled) continue; // Skip default handling if custom handler processed it

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1247,6 +1247,8 @@ export type AgentWidgetSSEEventResult = {
   done?: boolean;
   /** Error message if an error occurred */
   error?: string;
+  /** Text segment identity — when this changes, a new assistant message bubble is created */
+  partId?: string;
 } | null;
 
 /**
@@ -2843,6 +2845,12 @@ export type AgentWidgetMessage = {
    * }
    */
   llmContent?: string;
+  /**
+   * Text segment identity for chronological ordering.
+   * When present, identifies which text segment this message represents
+   * (e.g., "text_0", "text_1") for messages split at tool boundaries.
+   */
+  partId?: string;
   /**
    * Metadata for messages created during agent loop execution.
    * Contains execution context like iteration number and turn ID.


### PR DESCRIPTION
## Summary
- Adds `partId` field to `AgentWidgetSSEEventResult` and `AgentWidgetMessage` types
- When `partId` changes between text deltas, seals the current assistant message and creates a new one
- Produces chronological interleaving of text and tool call bubbles during agent execution
- Backward compatible: absent `partId` preserves single-message accumulation behavior

## Companion PR
runtypelabs/core — adds `partId`, `seq`, and `text_start`/`text_end` lifecycle events to flow SSE events

## Test plan
- [ ] Build passes (`pnpm build`)
- [ ] Existing chat flows without tools render as before (single message)
- [ ] Agent flows with tools show text segments interspersed with tool call bubbles chronologically
- [ ] Old API (no `partId` in events) still works — single merged message

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes streaming message lifecycle/ordering in `streamResponse` when `parseSSEEvent` is used, which could affect UI sequencing or completion state if `partId` events are inconsistent. Backward compatibility is preserved when `partId` is absent.
> 
> **Overview**
> Enables **partId-based message segmentation** for custom SSE streams so text deltas can be split into multiple assistant bubbles, improving chronological interleaving with tool call messages.
> 
> Adds optional `partId` to `AgentWidgetSSEEventResult` and `AgentWidgetMessage`, tracks current `partId` during streaming, and when it changes, *seals* the current assistant message (`streaming=false`) and starts a new assistant message tagged with the new `partId`. Also resets `partId` tracking on `done`/`error`, and bumps the widget version to `3.5.1`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f14d17babe48e43280dc46995f05dd4e788fe715. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->