### PR TITLE
chore: add changeset for partId message segmentation

### DIFF
--- a/.changeset/partid-message-segmentation.md
+++ b/.changeset/partid-message-segmentation.md
@@ -1,0 +1,7 @@
+---
+'@runtypelabs/persona': patch
+---
+
+feat: add partId-based message segmentation for tool call interleaving
+
+When `partId` is provided in `parseSSEEvent` results and changes between text deltas, the current assistant message is sealed and a new one is created. This produces chronological interleaving of text and tool call bubbles during agent execution. Backward compatible — absent `partId` preserves single-message behavior.


### PR DESCRIPTION
## Summary
- Adds missing changeset for runtypelabs/persona#136 (patch bump for `@runtypelabs/persona`)
- Required for the changesets-driven publish workflow to pick up the partId segmentation feature

## Test plan
- [ ] Changeset is valid (`pnpm changeset status`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only adds a Changesets entry to trigger a patch release; no runtime code changes, so risk is limited to release/versioning metadata.
> 
> **Overview**
> Adds a new Changesets entry to trigger a **patch** release of `@runtypelabs/persona` documenting the previously implemented *partId-based message segmentation* behavior for interleaving tool-call and text output.
> 
> No product/runtime code changes are included; this PR only affects release metadata for the Changesets-driven publish workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72eca4ec6b9882717d861e7b153b1e3f2979eadd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->