### PR TITLE
Enhance widget overlay functionality and artifact dark mode support

### DIFF
--- a/.changeset/fix-artifact-card-dark-mode.md
+++ b/.changeset/fix-artifact-card-dark-mode.md
@@ -1,5 +1,13 @@
 ---
-"@runtypelabs/persona": patch
+"@runtypelabs/persona": minor
 ---
 
-Fix inline artifact card background in dark mode by referencing the correct CSS variable (`--persona-surface` instead of the nonexistent `--persona-bg`)
+Add theme tokens for markdown elements, collapsible widget chrome, and message borders — enabling full dark mode styling via config without CSS overrides.
+
+- Fix inline artifact card background in dark mode (`--persona-surface` instead of nonexistent `--persona-bg`)
+- Add `components.markdown.codeBlock` (background, borderColor, textColor)
+- Add `components.markdown.table` (headerBackground, borderColor)
+- Add `components.markdown.hr` (color)
+- Add `components.markdown.blockquote` (borderColor, background, textColor)
+- Add `components.collapsibleWidget` (container, surface, border) for tool/reasoning/approval bubble chrome
+- Add `components.message.border` for message separator color

--- a/.changeset/fix-artifact-card-dark-mode.md
+++ b/.changeset/fix-artifact-card-dark-mode.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix inline artifact card background in dark mode by referencing the correct CSS variable (`--persona-surface` instead of the nonexistent `--persona-bg`)

--- a/.changeset/fix-scroll-to-bottom-indicator.md
+++ b/.changeset/fix-scroll-to-bottom-indicator.md
@@ -1,0 +1,8 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix scroll-to-bottom indicator appearing when content fits in view and persisting after clearing chat
+
+- Hide indicator when message body has no overflow (scrollHeight <= clientHeight)
+- Reset auto-follow state on clear chat so the indicator dismisses immediately

--- a/.changeset/overlay-stacking-scroll-lock.md
+++ b/.changeset/overlay-stacking-scroll-lock.md
@@ -1,0 +1,14 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Raise default widget z-index from 50/9999 to 100000 across all modes (floating
+panel, launcher button, sidebar, mobile fullscreen, docked mobile fullscreen).
+
+Elevate the host element's stacking context in viewport-covering modes so the
+overlay escapes parent stacking traps.
+
+Lock document scroll when the widget is open in viewport-covering modes (iOS-safe,
+ref-counted, auto-teardown on destroy).
+
+Add overscroll-behavior: contain on the messages body.

--- a/examples/embedded-app/src/bakery-demo.ts
+++ b/examples/embedded-app/src/bakery-demo.ts
@@ -154,7 +154,7 @@ function createCartBadge(): HTMLElement {
     align-items: center;
     justify-content: center;
     gap: 3px;
-    z-index: 10001;
+    z-index: 100002;
     font-family: Inter, system-ui, sans-serif;
     box-shadow: 0 2px 6px rgba(0,0,0,0.25);
     transform: scale(0);
@@ -444,16 +444,22 @@ function positionCartBadge(): void {
 
     // Use widget controller's isOpen() method for accurate state
     const widgetIsOpen = widgetControllerRef?.isOpen() ?? false;
+    const isMobile = window.innerWidth <= 640;
 
     if (widgetIsOpen) {
-      // Position on top-left of the chat panel container (the white card)
-      const container = launcherRoot?.querySelector('.persona-widget-container');
-      if (container) {
-        const rect = container.getBoundingClientRect();
-        badge.style.top = `${rect.top - 10}px`;
-        badge.style.left = `${rect.left - 10}px`;
-        badge.style.bottom = 'auto';
-        badge.style.right = 'auto';
+      if (isMobile) {
+        // On mobile the widget is fullscreen — pin badge to top-left corner
+        badge.style.inset = '5px auto auto 5px';
+      } else {
+        // Position on top-left of the chat panel container (the white card)
+        const container = launcherRoot?.querySelector('.persona-widget-container');
+        if (container) {
+          const rect = container.getBoundingClientRect();
+          badge.style.top = `${rect.top - 10}px`;
+          badge.style.left = `${rect.left - 10}px`;
+          badge.style.bottom = 'auto';
+          badge.style.right = 'auto';
+        }
       }
     } else {
       // Position on top-left of the launcher button icon

--- a/packages/widget/src/components/artifact-card.ts
+++ b/packages/widget/src/components/artifact-card.ts
@@ -24,7 +24,7 @@ function renderDefaultArtifactCard(
   root.className =
     "persona-flex persona-w-full persona-max-w-full persona-items-center persona-gap-3 persona-rounded-xl persona-px-4 persona-py-3";
   root.style.border = "1px solid var(--persona-border, #e5e7eb)";
-  root.style.backgroundColor = "var(--persona-bg, #ffffff)";
+  root.style.backgroundColor = "var(--persona-surface, #ffffff)";
   root.style.cursor = "pointer";
   root.tabIndex = 0;
   root.setAttribute("role", "button");

--- a/packages/widget/src/components/header-builder.ts
+++ b/packages/widget/src/components/header-builder.ts
@@ -1,6 +1,7 @@
 import { createElement, createElementInDocument } from "../utils/dom";
 import { renderLucideIcon } from "../utils/icons";
 import { AgentWidgetConfig } from "../types";
+import { PORTALED_OVERLAY_Z_INDEX } from "../utils/constants";
 
 /** CSS `color` values; variables are set on `[data-persona-root]` from `theme.components.header`. */
 export const HEADER_THEME_CSS = {
@@ -233,6 +234,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
 
         // Position tooltip above button
         portaledTooltip.style.position = "fixed";
+        portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
         portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
         portaledTooltip.style.top = `${buttonRect.top - 8}px`;
         portaledTooltip.style.transform = "translate(-50%, -100%)";
@@ -389,6 +391,7 @@ export const buildHeader = (context: HeaderBuildContext): HeaderElements => {
 
       // Position tooltip above button
       portaledTooltip.style.position = "fixed";
+      portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
       portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
       portaledTooltip.style.top = `${buttonRect.top - 8}px`;
       portaledTooltip.style.transform = "translate(-50%, -100%)";

--- a/packages/widget/src/components/launcher.ts
+++ b/packages/widget/src/components/launcher.ts
@@ -3,6 +3,7 @@ import { AgentWidgetConfig } from "../types";
 import { positionMap } from "../utils/positioning";
 import { isDockedMountMode } from "../utils/dock";
 import { renderLucideIcon } from "../utils/icons";
+import { DEFAULT_OVERLAY_Z_INDEX } from "../utils/constants";
 
 export interface LauncherButton {
   element: HTMLButtonElement;
@@ -174,12 +175,16 @@ export const createLauncherButton = (
         : positionMap["bottom-right"];
 
     const floatingBase =
-      "persona-fixed persona-flex persona-items-center persona-gap-3 persona-rounded-launcher persona-bg-persona-surface persona-py-2.5 persona-pl-3 persona-pr-3 persona-transition hover:persona-translate-y-[-2px] persona-cursor-pointer persona-z-50";
+      "persona-fixed persona-flex persona-items-center persona-gap-3 persona-rounded-launcher persona-bg-persona-surface persona-py-2.5 persona-pl-3 persona-pr-3 persona-transition hover:persona-translate-y-[-2px] persona-cursor-pointer";
     const dockedBase =
       "persona-relative persona-mt-4 persona-mb-4 persona-mx-auto persona-flex persona-items-center persona-justify-center persona-rounded-launcher persona-bg-persona-surface persona-transition hover:persona-translate-y-[-2px] persona-cursor-pointer";
 
     button.className = dockedMode ? dockedBase : `${floatingBase} ${positionClass}`;
-    
+
+    if (!dockedMode) {
+      button.style.zIndex = String(launcher.zIndex ?? DEFAULT_OVERLAY_Z_INDEX);
+    }
+
     // Apply launcher border and shadow from config (with defaults matching previous Tailwind classes)
     const defaultBorder = "1px solid var(--persona-border, #e5e7eb)";
     const defaultShadow = "var(--persona-shadow, 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1))";

--- a/packages/widget/src/components/panel.ts
+++ b/packages/widget/src/components/panel.ts
@@ -2,6 +2,7 @@ import { createElement } from "../utils/dom";
 import { AgentWidgetConfig } from "../types";
 import { positionMap } from "../utils/positioning";
 import { isDockedMountMode } from "../utils/dock";
+import { DEFAULT_OVERLAY_Z_INDEX } from "../utils/constants";
 import { buildHeader, attachHeaderToContainer, HeaderElements } from "./header-builder";
 import { buildHeaderWithLayout } from "./header-layouts";
 import { buildComposer, ComposerElements } from "./composer-builder";
@@ -58,8 +59,9 @@ export const createWrapper = (config?: AgentWidgetConfig): PanelWrapper => {
 
   const wrapper = createElement(
     "div",
-    `persona-widget-wrapper persona-fixed ${position} persona-z-50 persona-transition`
+    `persona-widget-wrapper persona-fixed ${position} persona-transition`
   );
+  wrapper.style.zIndex = String(config?.launcher?.zIndex ?? DEFAULT_OVERLAY_Z_INDEX);
 
   const panel = createElement(
     "div",

--- a/packages/widget/src/runtime/host-layout.test.ts
+++ b/packages/widget/src/runtime/host-layout.test.ts
@@ -228,7 +228,7 @@ describe("createWidgetHostLayout docked", () => {
       const dockSlot = layout.shell?.querySelector<HTMLElement>('[data-persona-dock-role="panel"]');
       layout.syncWidgetState({ open: true, launcherEnabled: true });
       expect(dockSlot?.style.position).toBe("fixed");
-      expect(dockSlot?.style.zIndex).toBe("9999");
+      expect(dockSlot?.style.zIndex).toBe("100000");
       expect(layout.shell?.dataset.personaDockMobileFullscreen).toBe("true");
 
       layout.destroy();

--- a/packages/widget/src/runtime/host-layout.ts
+++ b/packages/widget/src/runtime/host-layout.ts
@@ -3,6 +3,7 @@ import type {
   AgentWidgetStateSnapshot,
 } from "../types";
 import { isDockedMountMode, resolveDockConfig } from "../utils/dock";
+import { DEFAULT_OVERLAY_Z_INDEX } from "../utils/constants";
 
 export type WidgetHostLayoutMode = "direct" | "docked";
 
@@ -198,7 +199,7 @@ const applyDockStyles = (
     dockSlot.style.minWidth = "0";
     dockSlot.style.minHeight = "0";
     dockSlot.style.overflow = "hidden";
-    dockSlot.style.zIndex = String(config?.launcher?.zIndex ?? 9999);
+    dockSlot.style.zIndex = String(config?.launcher?.zIndex ?? DEFAULT_OVERLAY_Z_INDEX);
     dockSlot.style.transform = "none";
     dockSlot.style.transition = "none";
     dockSlot.style.pointerEvents = "auto";

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -834,6 +834,10 @@
   overflow-y: auto;
 }
 
+.persona-widget-body {
+  overscroll-behavior: contain;
+}
+
 .persona-overflow-hidden {
   overflow: hidden;
 }

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -813,11 +813,16 @@ export type AgentWidgetLauncherConfig = {
    */
   mobileBreakpoint?: number;
   /**
-   * CSS z-index applied to the widget wrapper when it is in a positioned mode
-   * (floating panel, mobile fullscreen, or sidebar). Increase this value if
-   * other elements on the host page appear on top of the widget.
+   * CSS z-index applied to the widget wrapper and launcher button in all
+   * positioned modes (floating panel, mobile fullscreen, sidebar, docked
+   * mobile fullscreen). Increase this value if other elements on the host
+   * page appear on top of the widget.
    *
-   * @default 9999 in overlay modes (mobile fullscreen / sidebar); 50 for the regular floating panel
+   * In viewport-covering modes (sidebar, mobile fullscreen), the widget
+   * also elevates the host element's stacking context and locks
+   * document scroll to prevent background scrolling.
+   *
+   * @default 100000
    */
   zIndex?: number;
   callToActionIconText?: string;

--- a/packages/widget/src/types/theme.ts
+++ b/packages/widget/src/types/theme.ts
@@ -233,6 +233,18 @@ export interface MessageTokens {
     /** Assistant bubble box-shadow (token ref or raw CSS, e.g. `none`). */
     shadow?: string;
   };
+  /** Border color between messages in the thread. */
+  border?: TokenReference<'color'>;
+}
+
+/** Collapsible widget chrome (tool bubbles, reasoning bubbles, approval bubbles). */
+export interface CollapsibleWidgetTokens {
+  /** Background for content areas. */
+  container?: TokenReference<'color'>;
+  /** Background for code blocks inside collapsible sections. */
+  surface?: TokenReference<'color'>;
+  /** Border color for collapsible sections. */
+  border?: TokenReference<'color'>;
 }
 
 export interface MarkdownTokens {
@@ -261,6 +273,27 @@ export interface MarkdownTokens {
       fontSize?: string;
       fontWeight?: string;
     };
+  };
+  /** Fenced code block styling. */
+  codeBlock?: {
+    background?: TokenReference<'color'>;
+    borderColor?: TokenReference<'color'>;
+    textColor?: TokenReference<'color'>;
+  };
+  /** Table styling. */
+  table?: {
+    headerBackground?: TokenReference<'color'>;
+    borderColor?: TokenReference<'color'>;
+  };
+  /** Horizontal rule styling. */
+  hr?: {
+    color?: TokenReference<'color'>;
+  };
+  /** Blockquote styling. */
+  blockquote?: {
+    borderColor?: TokenReference<'color'>;
+    background?: TokenReference<'color'>;
+    textColor?: TokenReference<'color'>;
   };
 }
 
@@ -438,6 +471,8 @@ export interface ComponentTokens {
     tab?: ArtifactTabTokens;
     pane?: ArtifactPaneTokens;
   };
+  /** Collapsible widget chrome (tool/reasoning/approval bubbles). */
+  collapsibleWidget?: CollapsibleWidgetTokens;
 }
 
 export interface PaletteExtras {

--- a/packages/widget/src/ui.overlay-z-index.test.ts
+++ b/packages/widget/src/ui.overlay-z-index.test.ts
@@ -39,7 +39,7 @@ describe("createAgentExperience overlay z-index", () => {
     const wrapper = mount.firstElementChild as HTMLElement | null;
 
     expect(wrapper).not.toBeNull();
-    expect(wrapper?.style.zIndex).toBe("9999");
+    expect(wrapper?.style.zIndex).toBe("100000");
 
     controller.destroy();
   });
@@ -55,7 +55,39 @@ describe("createAgentExperience overlay z-index", () => {
     const wrapper = mount.firstElementChild as HTMLElement | null;
 
     expect(wrapper).not.toBeNull();
-    expect(wrapper?.style.zIndex).toBe("9999");
+    expect(wrapper?.style.zIndex).toBe("100000");
+
+    controller.destroy();
+  });
+
+  it("defaults floating panel wrapper to the overlay z-index", () => {
+    setInnerWidth(1024);
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+    });
+
+    const wrapper = mount.firstElementChild as HTMLElement | null;
+
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.style.zIndex).toBe("100000");
+
+    controller.destroy();
+  });
+
+  it("respects a custom zIndex", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: {
+        sidebarMode: true,
+        zIndex: 42,
+      },
+    });
+
+    const wrapper = mount.firstElementChild as HTMLElement | null;
+    expect(wrapper?.style.zIndex).toBe("42");
 
     controller.destroy();
   });

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2044,7 +2044,8 @@ export const createAgentExperience = (
       container.appendChild(scrollToBottomButton);
     }
     updateScrollToBottomButtonOffset();
-    scrollToBottomButton.style.display = autoFollow.isFollowing() ? "none" : "";
+    const hasOverflow = getScrollBottomOffset(body) > 0;
+    scrollToBottomButton.style.display = (autoFollow.isFollowing() || !hasOverflow) ? "none" : "";
   };
 
   const pauseAutoScroll = () => {
@@ -3745,6 +3746,7 @@ export const createAgentExperience = (
       // Clear messages in session (this will trigger onMessagesChanged which re-renders)
       session.clearMessages();
       messageCache.clear();
+      resumeAutoScroll();
 
       // Always clear the default localStorage key
       try {
@@ -5070,6 +5072,7 @@ export const createAgentExperience = (
       artifactsPaneUserHidden = false;
       session.clearMessages();
       messageCache.clear();
+      resumeAutoScroll();
 
       // Always clear the default localStorage key
       try {

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -40,7 +40,9 @@ import {
   resolveFollowStateFromScroll,
   resolveFollowStateFromWheel
 } from "./utils/auto-follow";
-import { statusCopy } from "./utils/constants";
+import { statusCopy, DEFAULT_OVERLAY_Z_INDEX, PORTALED_OVERLAY_Z_INDEX } from "./utils/constants";
+import { syncOverlayHostStacking } from "./utils/overlay-host-stacking";
+import { acquireScrollLock } from "./utils/scroll-lock";
 import { isDockedMountMode, resolveDockConfig } from "./utils/dock";
 import { createLauncherButton } from "./components/launcher";
 import { createWrapper, buildPanel, buildHeader, buildComposer, attachHeaderToContainer } from "./components/panel";
@@ -1546,7 +1548,7 @@ export const createAgentExperience = (
     // Determine panel styling based on mode, with theme overrides
     const position = config.launcher?.position ?? 'bottom-left';
     const isLeftSidebar = position === 'bottom-left' || position === 'top-left';
-    const overlayZIndex = config.launcher?.zIndex ?? 9999;
+    const overlayZIndex = config.launcher?.zIndex ?? DEFAULT_OVERLAY_Z_INDEX;
 
     // Default values based on mode
     let defaultPanelBorder = (sidebarMode || shouldGoFullscreen) ? 'none' : '1px solid var(--persona-border)';
@@ -1819,9 +1821,8 @@ export const createAgentExperience = (
     if (!isInlineEmbed && !dockedMode) {
       const maxHeightStyles = 'max-height: -moz-available !important; max-height: stretch !important;';
       const paddingStyles = sidebarMode ? '' : 'padding-top: 1.25em !important;';
-      // Override z-index only when explicitly configured; otherwise the persona-z-50 class applies
-      const zIndexStyles = !sidebarMode && config.launcher?.zIndex != null
-        ? `z-index: ${config.launcher.zIndex} !important;`
+      const zIndexStyles = !sidebarMode
+        ? `z-index: ${config.launcher?.zIndex ?? DEFAULT_OVERLAY_Z_INDEX} !important;`
         : '';
       wrapper.style.cssText += maxHeightStyles + paddingStyles + zIndexStyles;
     }
@@ -1833,6 +1834,16 @@ export const createAgentExperience = (
   applyArtifactPaneAppearance(mount, config);
 
   const destroyCallbacks: Array<() => void> = [];
+
+  let teardownHostStacking: (() => void) | null = null;
+  let releaseScrollLock: (() => void) | null = null;
+
+  destroyCallbacks.push(() => {
+    teardownHostStacking?.();
+    teardownHostStacking = null;
+    releaseScrollLock?.();
+    releaseScrollLock = null;
+  });
 
   if (artifactPanelResizeObs) {
     destroyCallbacks.push(() => {
@@ -2620,12 +2631,46 @@ export const createAgentExperience = (
     const prevOpen = open;
     open = nextOpen;
     updateOpenState();
-    
+
+    // Sync host stacking and scroll lock for viewport-covering modes
+    const isViewportCovering = (() => {
+      const sm = config.launcher?.sidebarMode ?? false;
+      const ow = mount.ownerDocument.defaultView ?? window;
+      const mf = config.launcher?.mobileFullscreen ?? true;
+      const mb = config.launcher?.mobileBreakpoint ?? 640;
+      const isMobile = ow.innerWidth <= mb;
+      const dockedMF = isDockedMountMode(config) && mf && isMobile;
+      return sm || (mf && isMobile && launcherEnabled) || dockedMF;
+    })();
+
+    if (open && isViewportCovering) {
+      if (!teardownHostStacking) {
+        const root = mount.getRootNode();
+        const hostEl = root instanceof ShadowRoot
+          ? (root.host as HTMLElement)
+          : mount.closest<HTMLElement>(".persona-host");
+        if (hostEl) {
+          teardownHostStacking = syncOverlayHostStacking(
+            hostEl,
+            config.launcher?.zIndex ?? DEFAULT_OVERLAY_Z_INDEX
+          );
+        }
+      }
+      if (!releaseScrollLock) {
+        releaseScrollLock = acquireScrollLock(mount.ownerDocument);
+      }
+    } else if (!open) {
+      teardownHostStacking?.();
+      teardownHostStacking = null;
+      releaseScrollLock?.();
+      releaseScrollLock = null;
+    }
+
     if (open) {
       recalcPanelHeight();
       scheduleAutoScroll(true);
     }
-    
+
     // Emit widget state events
     const stateEvent: AgentWidgetStateEvent = {
       open,
@@ -3572,6 +3617,35 @@ export const createAgentExperience = (
       // overwrites updateOpenState()'s display:none when docked+closed. Re-sync after every recalc.
       updateScrollToBottomButtonOffset();
       updateOpenState();
+
+      // Sync scroll lock and host stacking when viewport mode changes (e.g. orientation change)
+      if (open && launcherEnabled) {
+        const ow = mount.ownerDocument.defaultView ?? window;
+        const isMobile = ow.innerWidth <= (config.launcher?.mobileBreakpoint ?? 640);
+        const sm = config.launcher?.sidebarMode ?? false;
+        const mf = config.launcher?.mobileFullscreen ?? true;
+        const dockedMF = isDockedMountMode(config) && mf && isMobile;
+        const isVC = sm || (mf && isMobile && launcherEnabled) || dockedMF;
+
+        if (isVC && !releaseScrollLock) {
+          const root = mount.getRootNode();
+          const hostEl = root instanceof ShadowRoot
+            ? (root.host as HTMLElement)
+            : mount.closest<HTMLElement>(".persona-host");
+          if (hostEl && !teardownHostStacking) {
+            teardownHostStacking = syncOverlayHostStacking(
+              hostEl,
+              config.launcher?.zIndex ?? DEFAULT_OVERLAY_Z_INDEX
+            );
+          }
+          releaseScrollLock = acquireScrollLock(mount.ownerDocument);
+        } else if (!isVC) {
+          teardownHostStacking?.();
+          teardownHostStacking = null;
+          releaseScrollLock?.();
+          releaseScrollLock = null;
+        }
+      }
     }
   };
 
@@ -4250,6 +4324,7 @@ export const createAgentExperience = (
 
               // Position tooltip above button
               portaledTooltip.style.position = "fixed";
+              portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
               portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
               portaledTooltip.style.top = `${buttonRect.top - 8}px`;
               portaledTooltip.style.transform = "translate(-50%, -100%)";
@@ -4464,6 +4539,7 @@ export const createAgentExperience = (
 
                 // Position tooltip above button
                 portaledTooltip.style.position = "fixed";
+                portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
                 portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
                 portaledTooltip.style.top = `${buttonRect.top - 8}px`;
                 portaledTooltip.style.transform = "translate(-50%, -100%)";

--- a/packages/widget/src/utils/constants.ts
+++ b/packages/widget/src/utils/constants.ts
@@ -7,6 +7,19 @@ export const statusCopy: Record<AgentWidgetSessionStatus, string> = {
   error: "Offline"
 };
 
+/**
+ * Default z-index for widget overlays. Used for the floating panel, launcher
+ * button, sidebar, mobile fullscreen, and docked mobile fullscreen modes.
+ * Integrators can override via `launcher.zIndex`.
+ */
+export const DEFAULT_OVERLAY_Z_INDEX = 100000;
+
+/**
+ * Z-index for elements portaled to document.body (tooltips, dropdowns).
+ * Must be above the widget overlay so portaled UI is not clipped.
+ */
+export const PORTALED_OVERLAY_Z_INDEX = DEFAULT_OVERLAY_Z_INDEX + 1;
+
 
 
 

--- a/packages/widget/src/utils/dropdown.ts
+++ b/packages/widget/src/utils/dropdown.ts
@@ -1,5 +1,6 @@
 import { createElement } from "./dom";
 import { renderLucideIcon } from "./icons";
+import { PORTALED_OVERLAY_Z_INDEX } from "./constants";
 
 export interface DropdownMenuItem {
   id: string;
@@ -73,7 +74,7 @@ export function createDropdownMenu(options: CreateDropdownOptions): DropdownMenu
   if (portal) {
     // Fixed positioning — menu is portaled outside the anchor's overflow context
     menu.style.position = "fixed";
-    menu.style.zIndex = "10000";
+    menu.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
   } else {
     // Absolute positioning — menu lives inside the anchor
     menu.style.position = "absolute";

--- a/packages/widget/src/utils/overlay-host-stacking.test.ts
+++ b/packages/widget/src/utils/overlay-host-stacking.test.ts
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { syncOverlayHostStacking } from "./overlay-host-stacking";
+
+describe("syncOverlayHostStacking", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  it("sets position relative on a static element and restores on teardown", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const teardown = syncOverlayHostStacking(host);
+    expect(host.style.position).toBe("relative");
+    expect(host.style.zIndex).toBe("100000");
+    expect(host.style.isolation).toBe("isolate");
+
+    teardown();
+    expect(host.style.position).toBe("");
+    expect(host.style.zIndex).toBe("");
+    expect(host.style.isolation).toBe("");
+  });
+
+  it("preserves existing positioned value", () => {
+    const host = document.createElement("div");
+    host.style.position = "absolute";
+    document.body.appendChild(host);
+
+    const teardown = syncOverlayHostStacking(host);
+    expect(host.style.position).toBe("absolute");
+    expect(host.style.zIndex).toBe("100000");
+
+    teardown();
+    expect(host.style.position).toBe("absolute");
+    expect(host.style.zIndex).toBe("");
+  });
+
+  it("accepts custom z-index", () => {
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+
+    const teardown = syncOverlayHostStacking(host, 42);
+    expect(host.style.zIndex).toBe("42");
+
+    teardown();
+  });
+
+  it("restores previous inline z-index on teardown", () => {
+    const host = document.createElement("div");
+    host.style.zIndex = "5";
+    document.body.appendChild(host);
+
+    const teardown = syncOverlayHostStacking(host);
+    expect(host.style.zIndex).toBe("100000");
+
+    teardown();
+    expect(host.style.zIndex).toBe("5");
+  });
+});

--- a/packages/widget/src/utils/overlay-host-stacking.ts
+++ b/packages/widget/src/utils/overlay-host-stacking.ts
@@ -1,0 +1,38 @@
+import { DEFAULT_OVERLAY_Z_INDEX } from "./constants";
+
+/**
+ * Elevates the light-DOM host element's stacking context so viewport-covering
+ * overlays (sidebar, fullscreen) can escape parent stacking traps.
+ *
+ * - If the host has `position: static`, sets it to `relative` (required for
+ *   `z-index` to take effect).
+ * - Applies `z-index` matching the overlay default.
+ * - Applies `isolation: isolate` to create a predictable stacking context.
+ *
+ * @returns A teardown function that restores only the properties that were changed.
+ */
+export function syncOverlayHostStacking(
+  host: HTMLElement,
+  zIndex: number = DEFAULT_OVERLAY_Z_INDEX
+): () => void {
+  const originalPosition = host.style.position;
+  const originalZIndex = host.style.zIndex;
+  const originalIsolation = host.style.isolation;
+
+  const computed = getComputedStyle(host);
+  const positionWasSet = computed.position === "static" || computed.position === "";
+  if (positionWasSet) {
+    host.style.position = "relative";
+  }
+
+  host.style.zIndex = String(zIndex);
+  host.style.isolation = "isolate";
+
+  return () => {
+    if (positionWasSet) {
+      host.style.position = originalPosition;
+    }
+    host.style.zIndex = originalZIndex;
+    host.style.isolation = originalIsolation;
+  };
+}

--- a/packages/widget/src/utils/scroll-lock.test.ts
+++ b/packages/widget/src/utils/scroll-lock.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { acquireScrollLock } from "./scroll-lock";
+
+describe("acquireScrollLock", () => {
+  beforeEach(() => {
+    document.body.style.overflow = "";
+    document.body.style.position = "";
+    document.body.style.top = "";
+    document.body.style.width = "";
+  });
+
+  afterEach(() => {
+    document.body.style.overflow = "";
+    document.body.style.position = "";
+    document.body.style.top = "";
+    document.body.style.width = "";
+  });
+
+  it("sets overflow hidden and position fixed on body", () => {
+    const release = acquireScrollLock();
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.position).toBe("fixed");
+    expect(document.body.style.width).toBe("100%");
+
+    release();
+    expect(document.body.style.overflow).toBe("");
+    expect(document.body.style.position).toBe("");
+    expect(document.body.style.width).toBe("");
+  });
+
+  it("is ref-counted: first release does not unlock when second acquire is active", () => {
+    const release1 = acquireScrollLock();
+    const release2 = acquireScrollLock();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    release1();
+    expect(document.body.style.overflow).toBe("hidden");
+
+    release2();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("release is idempotent", () => {
+    const release = acquireScrollLock();
+    release();
+    release();
+    expect(document.body.style.overflow).toBe("");
+  });
+
+  it("restores original body styles on release", () => {
+    document.body.style.overflow = "scroll";
+    document.body.style.position = "relative";
+
+    const release = acquireScrollLock();
+    expect(document.body.style.overflow).toBe("hidden");
+    expect(document.body.style.position).toBe("fixed");
+
+    release();
+    expect(document.body.style.overflow).toBe("scroll");
+    expect(document.body.style.position).toBe("relative");
+  });
+});

--- a/packages/widget/src/utils/scroll-lock.ts
+++ b/packages/widget/src/utils/scroll-lock.ts
@@ -1,0 +1,62 @@
+interface ScrollLockState {
+  originalOverflow: string;
+  originalPosition: string;
+  originalTop: string;
+  originalWidth: string;
+  scrollY: number;
+}
+
+let lockCount = 0;
+let savedState: ScrollLockState | null = null;
+
+/**
+ * Acquire a document-level scroll lock. The page body becomes non-scrollable
+ * via `overflow: hidden` with an iOS-safe `position: fixed` pattern that
+ * preserves the visual scroll position.
+ *
+ * Ref-counted: multiple callers can acquire; the lock is only released when
+ * all callers have released. Each release call is idempotent.
+ *
+ * @returns A release function. Call it exactly once per acquisition.
+ */
+export function acquireScrollLock(doc: Document = document): () => void {
+  lockCount++;
+
+  if (lockCount === 1) {
+    const body = doc.body;
+    const win = doc.defaultView ?? window;
+    const scrollY = win.scrollY || doc.documentElement.scrollTop;
+
+    savedState = {
+      originalOverflow: body.style.overflow,
+      originalPosition: body.style.position,
+      originalTop: body.style.top,
+      originalWidth: body.style.width,
+      scrollY,
+    };
+
+    body.style.overflow = "hidden";
+    body.style.position = "fixed";
+    body.style.top = `-${scrollY}px`;
+    body.style.width = "100%";
+  }
+
+  let released = false;
+
+  return () => {
+    if (released) return;
+    released = true;
+    lockCount = Math.max(0, lockCount - 1);
+
+    if (lockCount === 0 && savedState) {
+      const body = doc.body;
+      const win = doc.defaultView ?? window;
+      body.style.overflow = savedState.originalOverflow;
+      body.style.position = savedState.originalPosition;
+      body.style.top = savedState.originalTop;
+      body.style.width = savedState.originalWidth;
+      win.scrollTo(0, savedState.scrollY);
+      savedState = null;
+    }
+  };
+}

--- a/packages/widget/src/utils/tokens.ts
+++ b/packages/widget/src/utils/tokens.ts
@@ -312,6 +312,7 @@ export const DEFAULT_COMPONENTS: ComponentTokens = {
       border: 'palette.colors.gray.200',
       shadow: 'palette.shadows.sm',
     },
+    border: 'semantic.colors.border',
   },
   toolBubble: {
     shadow: 'palette.shadows.sm',
@@ -334,6 +335,28 @@ export const DEFAULT_COMPONENTS: ComponentTokens = {
     prose: {
       fontFamily: 'inherit',
     },
+    codeBlock: {
+      background: 'semantic.colors.container',
+      borderColor: 'semantic.colors.border',
+      textColor: 'inherit',
+    },
+    table: {
+      headerBackground: 'semantic.colors.container',
+      borderColor: 'semantic.colors.border',
+    },
+    hr: {
+      color: 'semantic.colors.divider',
+    },
+    blockquote: {
+      borderColor: 'palette.colors.gray.900',
+      background: 'transparent',
+      textColor: 'palette.colors.gray.500',
+    },
+  },
+  collapsibleWidget: {
+    container: 'palette.colors.gray.50',
+    surface: 'semantic.colors.surface',
+    border: 'semantic.colors.border',
   },
   voice: {
     recording: {
@@ -822,6 +845,46 @@ export function themeToCssVariables(theme: PersonaTheme): Record<string, string>
   if (mdProseFont && mdProseFont !== 'inherit') {
     cssVars['--persona-md-prose-font-family'] = mdProseFont;
   }
+
+  // Markdown code block
+  cssVars['--persona-md-code-block-bg'] =
+    cssVars['--persona-components-markdown-codeBlock-background'] ?? cssVars['--persona-container'];
+  cssVars['--persona-md-code-block-border-color'] =
+    cssVars['--persona-components-markdown-codeBlock-borderColor'] ?? cssVars['--persona-border'];
+  cssVars['--persona-md-code-block-text-color'] =
+    cssVars['--persona-components-markdown-codeBlock-textColor'] ?? 'inherit';
+
+  // Markdown table
+  cssVars['--persona-md-table-header-bg'] =
+    cssVars['--persona-components-markdown-table-headerBackground'] ?? cssVars['--persona-container'];
+  cssVars['--persona-md-table-border-color'] =
+    cssVars['--persona-components-markdown-table-borderColor'] ?? cssVars['--persona-border'];
+
+  // Markdown HR
+  cssVars['--persona-md-hr-color'] =
+    cssVars['--persona-components-markdown-hr-color'] ?? cssVars['--persona-divider'];
+
+  // Markdown blockquote
+  cssVars['--persona-md-blockquote-border-color'] =
+    cssVars['--persona-components-markdown-blockquote-borderColor'] ??
+    cssVars['--persona-palette-colors-gray-900'];
+  cssVars['--persona-md-blockquote-bg'] =
+    cssVars['--persona-components-markdown-blockquote-background'] ?? 'transparent';
+  cssVars['--persona-md-blockquote-text-color'] =
+    cssVars['--persona-components-markdown-blockquote-textColor'] ??
+    cssVars['--persona-palette-colors-gray-500'];
+
+  // Collapsible widget chrome (tool/reasoning/approval bubbles)
+  cssVars['--cw-container'] =
+    cssVars['--persona-components-collapsibleWidget-container'] ?? cssVars['--persona-surface'];
+  cssVars['--cw-surface'] =
+    cssVars['--persona-components-collapsibleWidget-surface'] ?? cssVars['--persona-surface'];
+  cssVars['--cw-border'] =
+    cssVars['--persona-components-collapsibleWidget-border'] ?? cssVars['--persona-border'];
+
+  // Message border
+  cssVars['--persona-message-border'] =
+    cssVars['--persona-components-message-border'] ?? cssVars['--persona-border'];
 
   // Icon button tokens
   const components = theme.components;


### PR DESCRIPTION
- Raise z-index of widget and handle page scroll when in mobile breakpoint to improve UX 
- Add theme tokens for markdown elements, collapsible widget chrome, and message borders to enable full dark mode styling via config without CSS overrides
- Fix scroll-to-bottom indicator appearing when content fits in view and persisting after clearing chat