### PR TITLE
fix(widget): restore artifact pane reopening functionality

### DIFF
--- a/.changeset/fix-artifact-pane-reopen.md
+++ b/.changeset/fix-artifact-pane-reopen.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix clicking an artifact card not reopening the artifact pane after the user dismissed it

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1289,6 +1289,7 @@ export const createAgentExperience = (
     if (openPrevented === true) return;
     event.preventDefault();
     event.stopPropagation();
+    artifactsPaneUserHidden = false;
     session.selectArtifact(artifactId);
     syncArtifactPane();
   });


### PR DESCRIPTION
- Fixed an issue where clicking an artifact card would not reopen the artifact pane after it was dismissed by the user. This change ensures a smoother user experience when interacting with artifact cards.