### PR TITLE
feat(stripe): parse errors returned from stripe

### DIFF
--- a/.changeset/stripe-error-messages.md
+++ b/.changeset/stripe-error-messages.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Surface Stripe API error messages when checkout session creation fails, and reject non-integer or non-positive line item prices/quantities before calling Stripe.

--- a/packages/proxy/src/utils/stripe.ts
+++ b/packages/proxy/src/utils/stripe.ts
@@ -23,6 +23,18 @@ export interface CheckoutSessionResponse {
   error?: string;
 }
 
+function parseStripeApiErrorBody(body: string): string | undefined {
+  try {
+    const parsed = JSON.parse(body) as {
+      error?: { message?: string; type?: string };
+    };
+    const msg = parsed?.error?.message;
+    return typeof msg === "string" && msg.length > 0 ? msg : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Creates a Stripe checkout session using the REST API
  * @param options - Checkout session configuration
@@ -47,6 +59,19 @@ export async function createCheckoutSession(
         return {
           success: false,
           error: "Each item must have name (string), price (number in cents), and quantity (number)"
+        };
+      }
+      if (
+        !Number.isFinite(item.price) ||
+        !Number.isInteger(item.price) ||
+        item.price < 1 ||
+        !Number.isInteger(item.quantity) ||
+        item.quantity < 1
+      ) {
+        return {
+          success: false,
+          error:
+            "Each item needs a positive integer price (cents) and quantity (Stripe rejects decimals or zero)",
         };
       }
     }
@@ -91,10 +116,11 @@ export async function createCheckoutSession(
 
     if (!stripeResponse.ok) {
       const errorData = await stripeResponse.text();
+      const stripeMessage = parseStripeApiErrorBody(errorData);
       console.error("Stripe API error:", errorData);
       return {
         success: false,
-        error: "Failed to create checkout session"
+        error: stripeMessage ?? "Failed to create checkout session",
       };
     }
 


### PR DESCRIPTION
Surface Stripe API error messages when checkout session creation fails, and reject non-integer or non-positive line item prices/quantities before calling Stripe.