### PR TITLE
feat(stripe): add pinned Stripe API version header for checkout sessions

### DIFF
--- a/.changeset/stripe-api-version-header.md
+++ b/.changeset/stripe-api-version-header.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Send a pinned `Stripe-Version` header on Stripe Checkout Session requests so organization API keys and raw REST calls work reliably (matches Stripe versioning requirements).

--- a/packages/proxy/src/utils/stripe.ts
+++ b/packages/proxy/src/utils/stripe.ts
@@ -3,6 +3,12 @@
  * This approach works on all platforms including Cloudflare Workers, Vercel Edge, etc.
  */
 
+/**
+ * Pinned API version for raw HTTP calls (no SDK). Required for organization API keys and
+ * keeps behavior stable across accounts. See https://docs.stripe.com/api/versioning
+ */
+const STRIPE_API_VERSION = "2026-03-25.dahlia";
+
 export interface CheckoutItem {
   name: string;
   price: number; // Price in cents
@@ -108,8 +114,9 @@ export async function createCheckoutSession(
     const stripeResponse = await fetch("https://api.stripe.com/v1/checkout/sessions", {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${secretKey}`,
+        Authorization: `Bearer ${secretKey}`,
         "Content-Type": "application/x-www-form-urlencoded",
+        "Stripe-Version": STRIPE_API_VERSION,
       },
       body: params,
     });


### PR DESCRIPTION
Send a pinned `Stripe-Version` header on Stripe Checkout Session requests so organization API keys and raw REST calls work reliably (matches Stripe versioning requirements).