### PR TITLE
feat(stripe): add optional Stripe-Context for organization keys in checkout sessions

### DIFF
--- a/.changeset/stripe-org-context.md
+++ b/.changeset/stripe-org-context.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Add optional `Stripe-Context` for checkout session creation (`stripeContext` / `STRIPE_CONTEXT`) and require it when using organization secret keys (`sk_org_…`), per Stripe’s organization key rules.

--- a/examples/cloudflare-workers/.dev.vars.example
+++ b/examples/cloudflare-workers/.dev.vars.example
@@ -13,6 +13,7 @@ RUNTYPE_API_KEY=rt_test_your_api_key_here
 # Optional: Stripe secret key for checkout functionality
 # Required for /api/checkout endpoint and shopping assistant checkout actions
 # STRIPE_SECRET_KEY=sk_test_your_stripe_key_here
+# STRIPE_CONTEXT=acct_xxxxxxxxxxxxx  # Required with sk_org_… organization keys
 
 # Optional: Allowed origins for CORS (comma-separated or "*" for all)
 # ALLOWED_ORIGINS=http://localhost:5173,http://localhost:4173

--- a/examples/cloudflare-workers/README.md
+++ b/examples/cloudflare-workers/README.md
@@ -66,6 +66,7 @@ Edit `.dev.vars` and add your Runtype API key and optionally other configuration
 RUNTYPE_API_KEY=rt_test_your_api_key_here
 RUNTYPE_FLOW_ID=flow_your_flow_id_here  # Optional, for directive flow
 STRIPE_SECRET_KEY=sk_test_your_stripe_key_here  # Optional, for checkout functionality
+STRIPE_CONTEXT=acct_xxxxxxxxxxxxx               # Optional; required with sk_org_… organization keys
 ALLOWED_ORIGINS=*  # Optional, defaults to "*". For production, use: https://yourdomain.com
 ```
 
@@ -73,6 +74,7 @@ ALLOWED_ORIGINS=*  # Optional, defaults to "*". For production, use: https://you
 - `RUNTYPE_API_KEY` (required): Your Runtype API key
 - `RUNTYPE_FLOW_ID` (optional): Reference to an existing Runtype flow for the directive endpoint
 - `STRIPE_SECRET_KEY` (optional): Stripe secret key for checkout functionality
+- `STRIPE_CONTEXT` (optional): Target account (`acct_…`) for organization keys (`sk_org_…`)
 - `ALLOWED_ORIGINS` (optional): CORS allowed origins. Defaults to `*` (all origins). For production, set to your frontend domain(s). Supports comma-separated list: `https://app.com,https://www.app.com`
 
 ### 3. Authenticate with Cloudflare

--- a/examples/cloudflare-workers/src/index.ts
+++ b/examples/cloudflare-workers/src/index.ts
@@ -14,6 +14,8 @@ interface Env {
   FLOW_ID_SHOPPING_ASSISTANT?: string;
   FLOW_ID_SHOPPING_ASSISTANT_METADATA?: string;
   STRIPE_SECRET_KEY?: string;
+  /** Target `acct_…` (or path) when using a Stripe organization secret key (`sk_org_…`). */
+  STRIPE_CONTEXT?: string;
   ALLOWED_ORIGINS?: string;
 }
 
@@ -112,6 +114,7 @@ app.post("/api/checkout", async (c) => {
       items,
       successUrl: `${c.req.header("origin") || "http://localhost:5173"}/action-middleware.html?checkout=success`,
       cancelUrl: `${c.req.header("origin") || "http://localhost:5173"}/action-middleware.html?checkout=cancelled`,
+      stripeContext: c.env.STRIPE_CONTEXT?.trim() || undefined,
     });
 
     return c.json(result, result.success ? 200 : 400);

--- a/examples/vercel-edge/.env.example
+++ b/examples/vercel-edge/.env.example
@@ -15,6 +15,8 @@
 # Optional: Stripe secret key for checkout functionality
 # Required for /api/checkout endpoint and shopping assistant checkout actions
 # STRIPE_SECRET_KEY=sk_test_your_stripe_key_here
+# Organization keys (sk_org_…) also need the Stripe account to bill (see Dashboard → account ID)
+# STRIPE_CONTEXT=acct_xxxxxxxxxxxxx
 
 # Optional: Frontend URL for checkout success/cancel redirects
 # FRONTEND_URL=http://localhost:5173

--- a/examples/vercel-edge/README.md
+++ b/examples/vercel-edge/README.md
@@ -34,6 +34,7 @@ pnpm install
 RUNTYPE_API_KEY=rt_test_xxx
 RUNTYPE_FLOW_ID=flow_xxx  # Optional, for directive-enabled flow
 STRIPE_SECRET_KEY=sk_test_xxx  # Optional, for checkout functionality
+STRIPE_CONTEXT=acct_xxx         # Optional; required if STRIPE_SECRET_KEY is an organization key (sk_org_…)
 FRONTEND_URL=http://localhost:5173  # Optional, defaults to http://localhost:5173
 ```
 
@@ -89,6 +90,7 @@ Set these in the Vercel dashboard (Settings → Environment Variables):
 - **RUNTYPE_API_KEY** (required): Your Runtype API key
 - **RUNTYPE_FLOW_ID** (optional): Flow ID for directive-enabled endpoint
 - **STRIPE_SECRET_KEY** (optional): Stripe secret key for checkout functionality
+- **STRIPE_CONTEXT** (optional): Target Stripe account ID (`acct_…`) when using an organization secret key (`sk_org_…`); forwarded as the `Stripe-Context` header ([docs](https://docs.stripe.com/keys#organization-api-keys))
 - **FRONTEND_URL** (optional): Your frontend URL for checkout redirect URLs
 
 ## Deploying to Other Platforms

--- a/examples/vercel-edge/api/index.ts
+++ b/examples/vercel-edge/api/index.ts
@@ -86,6 +86,7 @@ app.post("/api/checkout", async (c) => {
       items,
       successUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/action-middleware.html?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/action-middleware.html?checkout=cancelled`,
+      stripeContext: process.env.STRIPE_CONTEXT?.trim() || undefined,
     });
 
     return c.json(result, result.success ? 200 : 400, {
@@ -129,6 +130,7 @@ app.post("/api/checkout/bakery", async (c) => {
       items,
       successUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/bakery-goods.html?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/bakery-goods.html?checkout=cancelled`,
+      stripeContext: process.env.STRIPE_CONTEXT?.trim() || undefined,
     });
 
     return c.json(result, result.success ? 200 : 400, {

--- a/examples/vercel-edge/src/server.ts
+++ b/examples/vercel-edge/src/server.ts
@@ -116,6 +116,7 @@ app.post("/api/checkout", async (c) => {
       items,
       successUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/action-middleware.html?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/action-middleware.html?checkout=cancelled`,
+      stripeContext: process.env.STRIPE_CONTEXT?.trim() || undefined,
     });
 
     return c.json(result, result.success ? 200 : 400, {
@@ -175,6 +176,7 @@ app.post("/api/checkout/bakery", async (c) => {
       items,
       successUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/bakery-goods.html?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
       cancelUrl: `${process.env.FRONTEND_URL || "http://localhost:5173"}/bakery-goods.html?checkout=cancelled`,
+      stripeContext: process.env.STRIPE_CONTEXT?.trim() || undefined,
     });
 
     return c.json(result, result.success ? 200 : 400, {

--- a/packages/proxy/src/utils/stripe.ts
+++ b/packages/proxy/src/utils/stripe.ts
@@ -20,6 +20,12 @@ export interface CreateCheckoutSessionOptions {
   items: CheckoutItem[];
   successUrl: string;
   cancelUrl: string;
+  /**
+   * Target account for organization API keys (`sk_org_…`), e.g. `acct_1abc…` or
+   * `acct_platform/acct_connected` per Stripe. Required with org keys.
+   * @see https://docs.stripe.com/keys#organization-api-keys
+   */
+  stripeContext?: string;
 }
 
 export interface CheckoutSessionResponse {
@@ -49,9 +55,18 @@ function parseStripeApiErrorBody(body: string): string | undefined {
 export async function createCheckoutSession(
   options: CreateCheckoutSessionOptions
 ): Promise<CheckoutSessionResponse> {
-  const { secretKey, items, successUrl, cancelUrl } = options;
+  const { secretKey, items, successUrl, cancelUrl, stripeContext } = options;
+  const trimmedContext = stripeContext?.trim() || undefined;
 
   try {
+    if (secretKey.startsWith("sk_org") && !trimmedContext) {
+      return {
+        success: false,
+        error:
+          "Organization Stripe keys (sk_org_…) require stripeContext / STRIPE_CONTEXT with the target account (e.g. acct_…). See https://docs.stripe.com/keys#organization-api-keys",
+      };
+    }
+
     // Validate items
     if (!items || !Array.isArray(items) || items.length === 0) {
       return {
@@ -110,14 +125,19 @@ export async function createCheckoutSession(
       params.append(`line_items[${index}][quantity]`, item.quantity.toString());
     });
 
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${secretKey}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+      "Stripe-Version": STRIPE_API_VERSION,
+    };
+    if (trimmedContext) {
+      headers["Stripe-Context"] = trimmedContext;
+    }
+
     // Create Stripe checkout session using REST API
     const stripeResponse = await fetch("https://api.stripe.com/v1/checkout/sessions", {
       method: "POST",
-      headers: {
-        Authorization: `Bearer ${secretKey}`,
-        "Content-Type": "application/x-www-form-urlencoded",
-        "Stripe-Version": STRIPE_API_VERSION,
-      },
+      headers,
       body: params,
     });
 


### PR DESCRIPTION
Add optional `Stripe-Context` for checkout session creation (`stripeContext` / `STRIPE_CONTEXT`) and require it when using organization secret keys (`sk_org_…`), per Stripe’s organization key rules.