### PR TITLE
Enhance floating launcher panel width and message part rendering

### DIFF
--- a/.changeset/interleaved-tool-text.md
+++ b/.changeset/interleaved-tool-text.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Render assistant text and tool calls in chronological order instead of lumping all text before tools. The widget now handles `text_start`/`text_end` lifecycle events and `partId` on `step_delta` to split assistant messages at tool boundaries, matching the segmentation the Runtype API already emits.

--- a/.changeset/interleaved-tool-text.md
+++ b/.changeset/interleaved-tool-text.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona": minor
 ---
 
-Render assistant text and tool calls in chronological order instead of lumping all text before tools. The widget now handles `text_start`/`text_end` lifecycle events and `partId` on `step_delta` to split assistant messages at tool boundaries, matching the segmentation the Runtype API already emits.
+Render assistant text and tool calls in chronological order instead of lumping all text before tools. The widget now handles `text_start`/`text_end` lifecycle events and `partId` on `step_delta` to split assistant messages at tool boundaries, matching the segmentation the Runtype API already emits. Split messages use deterministic IDs derived from the base `assistantMessageId` and `partId` (e.g. `ast_abc_text_1`) for feedback traceability, and `flow_complete` no longer overwrites segment content with the full concatenated response.

--- a/.changeset/wider-default-panel.md
+++ b/.changeset/wider-default-panel.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Increase the default floating launcher panel width from 400px to 440px (still `min(..., calc(100vw - 24px))`) so code blocks and structured replies are easier to read, aligned with common chat-widget sizing while leaving room for custom `launcher.width`.

--- a/examples/embedded-app/artifact-demo.html
+++ b/examples/embedded-app/artifact-demo.html
@@ -115,7 +115,7 @@
       <p class="toolbar-label">Launcher base width (<code>launcher.width</code>)</p>
       <div class="toolbar toolbar--launcher" id="toolbar-launcher-width">
         <button type="button" data-launcher-width="min(320px, calc(100vw - 24px))">320px cap</button>
-        <button type="button" data-launcher-width="min(400px, calc(100vw - 24px))">400px cap (default)</button>
+        <button type="button" data-launcher-width="min(440px, calc(100vw - 24px))">440px cap (default)</button>
         <button type="button" data-launcher-width="min(480px, calc(100vw - 24px))">480px cap</button>
       </div>
       <p class="toolbar-label">

--- a/examples/embedded-app/src/artifact-demo.ts
+++ b/examples/embedded-app/src/artifact-demo.ts
@@ -4,6 +4,7 @@ import {
   initAgentWidget,
   componentRegistry,
   markdownPostprocessor,
+  DEFAULT_FLOATING_LAUNCHER_WIDTH,
   DEFAULT_WIDGET_CONFIG,
   type AgentWidgetArtifactsLayoutConfig,
   type AgentWidgetConfig,
@@ -85,7 +86,7 @@ const LAUNCHER_DEMO_LAUNCHER_BASE = {
   subtitle: "Floating trigger — artifacts sidebar inside the panel",
   agentIconText: "✨",
   position: "bottom-right" as const,
-  width: "min(400px, calc(100vw - 24px))",
+  width: DEFAULT_FLOATING_LAUNCHER_WIDTH,
   iconUrl: "https://dummyimage.com/96x96/0ea5e9/0c1222&text=A",
 };
 

--- a/examples/embedded-app/standalone/shopify.html
+++ b/examples/embedded-app/standalone/shopify.html
@@ -55,7 +55,7 @@
         subtitle: "Here to help you get answers fast",
         agentIconText: "🛍️",
         position: "bottom-right",
-        width: "min(400px, calc(100vw - 24px))",
+        width: "min(440px, calc(100vw - 24px))",
         autoExpand: false,
         callToActionIconHidden: false,
         agentIconSize: "40px",

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -1715,7 +1715,7 @@ config: {
 | `colorScheme` | `'light' \| 'dark' \| 'auto'` | Color scheme mode. `'auto'` detects from `<html class="dark">` or `prefers-color-scheme`. Default: `'light'`. |
 | `copy` | `{ welcomeTitle?, welcomeSubtitle?, inputPlaceholder?, sendButtonLabel? }` | Customize user-facing text strings. |
 | `autoFocusInput` | `boolean` | Focus the chat input after the panel opens. Skips when voice is active. Default: `false`. |
-| `launcherWidth` | `string` | CSS width for the floating launcher panel (e.g. `'320px'`). Default: `'min(400px, calc(100vw - 24px))'`. |
+| `launcherWidth` | `string` | CSS width for the floating launcher panel (e.g. `'320px'`). Default: `'min(440px, calc(100vw - 24px))'`. |
 
 #### Launcher
 

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -305,8 +305,8 @@ Semantic tokens provide intent-based naming that references palette values.
 
 | Token | Default |
 |-------|---------|
-| `width` | `min(400px, calc(100vw - 24px))` |
-| `maxWidth` | `400px` |
+| `width` | `min(440px, calc(100vw - 24px))` |
+| `maxWidth` | `440px` |
 | `height` | `600px` |
 | `maxHeight` | `calc(100vh - 80px)` |
 | `borderRadius` | `palette.radius.xl` |

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1680,5 +1680,109 @@ describe('AgentWidgetClient - partId Text/Tool Interleaving', () => {
       expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
     }
   });
+
+  it('should give split messages unique IDs even when assistantMessageId is provided', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e({ type: 'step_delta', id: 's1', text: 'Before tool.', partId: 'text_0' });
+          e({ type: 'tool_start', toolId: 'tc_1', name: 'lookup', toolType: 'mcp' });
+          e({ type: 'tool_complete', toolId: 'tc_1', name: 'lookup', result: {}, success: true, executionTime: 50 });
+          e({ type: 'step_delta', id: 's1', text: 'After tool.', partId: 'text_1' });
+          e({ type: 'flow_complete', success: true });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    // Use agent mode so assistantMessageId is forwarded to streamResponse
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    await client.dispatch(
+      {
+        messages: [{ id: 'usr_1', role: 'user', content: 'Go', createdAt: new Date().toISOString() }],
+        assistantMessageId: 'ast_pre_generated_id',
+      },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const assistantTexts = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant)
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+
+    // Should have two distinct messages
+    expect(assistantTexts.length).toBe(2);
+    // First message uses the provided ID
+    expect(assistantTexts[0].id).toBe('ast_pre_generated_id');
+    // Second message composes baseId + partId for traceability
+    expect(assistantTexts[1].id).toBe('ast_pre_generated_id_text_1');
+    // Content is correct per segment
+    expect(assistantTexts[0].content).toBe('Before tool.');
+    expect(assistantTexts[1].content).toBe('After tool.');
+  });
+
+  it('should not overwrite last segment content with full response in flow_complete', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e({ type: 'step_delta', id: 's1', text: 'First part.', partId: 'text_0' });
+          e({ type: 'tool_start', toolId: 'tc_1', name: 'action', toolType: 'mcp' });
+          e({ type: 'tool_complete', toolId: 'tc_1', name: 'action', result: {}, success: true, executionTime: 10 });
+          e({ type: 'step_delta', id: 's1', text: 'Second part.', partId: 'text_1' });
+          // flow_complete with full concatenated response
+          e({ type: 'flow_complete', success: true, result: { response: 'First part.Second part.' } });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Go', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const assistantTexts = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant)
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+
+    expect(assistantTexts.length).toBe(2);
+    // Last segment should keep its own content, NOT the full response
+    expect(assistantTexts[0].content).toBe('First part.');
+    expect(assistantTexts[1].content).toBe('Second part.');
+    // Both should be finalized
+    expect(assistantTexts[0].streaming).toBe(false);
+    expect(assistantTexts[1].streaming).toBe(false);
+  });
 });
 

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1440,3 +1440,245 @@ describe('AgentWidgetClient - Unified Event Names', () => {
   });
 });
 
+// ============================================================================
+// Text/Tool Interleaving via partId Segmentation
+// ============================================================================
+
+describe('AgentWidgetClient - partId Text/Tool Interleaving', () => {
+  it('should split assistant messages at tool boundaries using partId on step_delta', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e({ type: 'step_start', id: 's1', name: 'Prompt', stepType: 'prompt', index: 0, totalSteps: 1 });
+          // First text segment
+          e({ type: 'step_delta', id: 's1', text: 'Let me search', partId: 'text_0', messageId: 'msg_s1' });
+          e({ type: 'step_delta', id: 's1', text: ' for that!', partId: 'text_0', messageId: 'msg_s1' });
+          // Tool call
+          e({ type: 'tool_start', toolId: 'tc_1', name: 'search', toolType: 'mcp', startedAt: new Date().toISOString() });
+          e({ type: 'tool_complete', toolId: 'tc_1', name: 'search', result: { found: true }, success: true, completedAt: new Date().toISOString(), executionTime: 200 });
+          // Second text segment (different partId)
+          e({ type: 'step_delta', id: 's1', text: 'Found it! Here', partId: 'text_1', messageId: 'msg_s1' });
+          e({ type: 'step_delta', id: 's1', text: ' are the results.', partId: 'text_1', messageId: 'msg_s1' });
+          e({ type: 'flow_complete', success: true });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Search', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const allMessages = Array.from(messagesById.values());
+    const assistantTexts = allMessages
+      .filter(m => m.role === 'assistant' && !m.variant)
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+    const toolMsgs = allMessages.filter(m => m.variant === 'tool');
+
+    // Should have TWO assistant text messages (split at tool boundary)
+    expect(assistantTexts.length).toBe(2);
+    expect(assistantTexts[0].content).toBe('Let me search for that!');
+    expect(assistantTexts[1].content).toBe('Found it! Here are the results.');
+
+    // First should be sealed (not streaming)
+    expect(assistantTexts[0].streaming).toBe(false);
+
+    // Tool message should exist
+    expect(toolMsgs.length).toBe(1);
+    expect(toolMsgs[0].toolCall?.name).toBe('search');
+
+    // Ordering: first text seq < tool seq < second text seq
+    const seq0 = assistantTexts[0].sequence ?? 0;
+    const seqTool = toolMsgs[0].sequence ?? 0;
+    const seq1 = assistantTexts[1].sequence ?? 0;
+    expect(seq0).toBeLessThan(seqTool);
+    expect(seqTool).toBeLessThan(seq1);
+  });
+
+  it('should split assistant messages using text_start/text_end lifecycle events', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (eventType: string, data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`event: ${eventType}\ndata: ${JSON.stringify({ type: eventType, ...data })}\n\n`));
+
+          e('flow_start', { flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e('text_start', { partId: 'text_0', messageId: 'msg_s1', seq: 1 });
+          e('step_delta', { id: 's1', text: 'Preamble text.', partId: 'text_0', messageId: 'msg_s1', seq: 2 });
+          e('text_end', { partId: 'text_0', messageId: 'msg_s1', seq: 3 });
+          e('tool_start', { toolId: 'tc_1', name: 'get_weather', toolType: 'builtin', startedAt: new Date().toISOString() });
+          e('tool_complete', { toolId: 'tc_1', name: 'get_weather', result: { temp: 72 }, success: true, completedAt: new Date().toISOString(), executionTime: 100 });
+          e('text_start', { partId: 'text_1', messageId: 'msg_s1', seq: 6 });
+          e('step_delta', { id: 's1', text: 'The weather is 72F.', partId: 'text_1', messageId: 'msg_s1', seq: 7 });
+          e('text_end', { partId: 'text_1', messageId: 'msg_s1', seq: 8 });
+          e('flow_complete', { success: true });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Weather?', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const allMessages = Array.from(messagesById.values());
+    const assistantTexts = allMessages
+      .filter(m => m.role === 'assistant' && !m.variant)
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+    const toolMsgs = allMessages.filter(m => m.variant === 'tool');
+
+    expect(assistantTexts.length).toBe(2);
+    expect(assistantTexts[0].content).toBe('Preamble text.');
+    expect(assistantTexts[0].streaming).toBe(false);
+    expect(assistantTexts[1].content).toBe('The weather is 72F.');
+
+    expect(toolMsgs.length).toBe(1);
+
+    const seq0 = assistantTexts[0].sequence ?? 0;
+    const seqTool = toolMsgs[0].sequence ?? 0;
+    const seq1 = assistantTexts[1].sequence ?? 0;
+    expect(seq0).toBeLessThan(seqTool);
+    expect(seqTool).toBeLessThan(seq1);
+  });
+
+  it('should not split when partId is absent (backward compatible)', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e({ type: 'step_delta', id: 's1', text: 'Hello ' });
+          e({ type: 'step_delta', id: 's1', text: 'world' });
+          e({ type: 'flow_complete', success: true });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const assistantTexts = Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant);
+
+    // Should still be a single message (no partId = no splitting)
+    expect(assistantTexts.length).toBe(1);
+    expect(assistantTexts[0].content).toContain('Hello ');
+    expect(assistantTexts[0].content).toContain('world');
+  });
+
+  it('should handle multiple tool calls with proper text interleaving', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          // text_0: preamble
+          e({ type: 'step_delta', id: 's1', text: 'Searching...', partId: 'text_0' });
+          // tool 1
+          e({ type: 'tool_start', toolId: 'tc_1', name: 'search', toolType: 'mcp' });
+          e({ type: 'tool_complete', toolId: 'tc_1', name: 'search', result: { id: 27 }, success: true, executionTime: 100 });
+          // text_1: between tools
+          e({ type: 'step_delta', id: 's1', text: 'Adding to cart...', partId: 'text_1' });
+          // tool 2
+          e({ type: 'tool_start', toolId: 'tc_2', name: 'add_to_cart', toolType: 'mcp' });
+          e({ type: 'tool_complete', toolId: 'tc_2', name: 'add_to_cart', result: { success: true }, success: true, executionTime: 50 });
+          // text_2: final
+          e({ type: 'step_delta', id: 's1', text: 'Done! Item added.', partId: 'text_2' });
+          e({ type: 'flow_complete', success: true });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Add item', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const allMessages = Array.from(messagesById.values());
+    const assistantTexts = allMessages
+      .filter(m => m.role === 'assistant' && !m.variant)
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+    const toolMsgs = allMessages
+      .filter(m => m.variant === 'tool')
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+
+    // 3 text segments, 2 tool calls
+    expect(assistantTexts.length).toBe(3);
+    expect(toolMsgs.length).toBe(2);
+
+    expect(assistantTexts[0].content).toBe('Searching...');
+    expect(assistantTexts[1].content).toBe('Adding to cart...');
+    expect(assistantTexts[2].content).toBe('Done! Item added.');
+
+    // Verify chronological ordering: text0 < tool1 < text1 < tool2 < text2
+    const seqs = [
+      assistantTexts[0].sequence ?? 0,
+      toolMsgs[0].sequence ?? 0,
+      assistantTexts[1].sequence ?? 0,
+      toolMsgs[1].sequence ?? 0,
+      assistantTexts[2].sequence ?? 0,
+    ];
+    for (let i = 1; i < seqs.length; i++) {
+      expect(seqs[i]).toBeGreaterThan(seqs[i - 1]);
+    }
+  });
+});
+

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1507,6 +1507,29 @@ export class AgentWidgetClient {
           if (callKey) {
             toolContext.byCall.delete(callKey);
           }
+        } else if (payloadType === "text_start") {
+          // Lifecycle event: a new text segment is beginning (emitted at tool boundaries)
+          const incomingPartId = payload.partId;
+          if (incomingPartId !== undefined && partIdState.current !== null && incomingPartId !== partIdState.current) {
+            const prev = assistantMessage as AgentWidgetMessage | null;
+            if (prev) {
+              prev.streaming = false;
+              emitMessage(prev);
+              assistantMessage = null;
+            }
+          }
+          if (incomingPartId !== undefined) {
+            partIdState.current = incomingPartId;
+          }
+        } else if (payloadType === "text_end") {
+          // Lifecycle event: current text segment ended (tool call about to start)
+          // Seal the current assistant message so the next segment gets a new one
+          const prev = assistantMessage as AgentWidgetMessage | null;
+          if (prev) {
+            prev.streaming = false;
+            emitMessage(prev);
+            assistantMessage = null;
+          }
         } else if (payloadType === "step_chunk" || payloadType === "step_delta") {
           // Only process chunks for prompt steps, not tool/context steps
           const stepType = (payload as any).stepType;
@@ -1515,7 +1538,26 @@ export class AgentWidgetClient {
             // Skip tool-related chunks - they're handled by tool_start/tool_complete
             continue;
           }
+
+          // partId-based segmentation: when partId changes, seal current message
+          // and start a new one so text and tools render in chronological order
+          const incomingPartId = payload.partId;
+          if (incomingPartId !== undefined && partIdState.current !== null && incomingPartId !== partIdState.current) {
+            const prev = assistantMessage as AgentWidgetMessage | null;
+            if (prev) {
+              prev.streaming = false;
+              emitMessage(prev);
+              assistantMessage = null;
+            }
+          }
+          if (incomingPartId !== undefined) {
+            partIdState.current = incomingPartId;
+          }
+
           const assistant = ensureAssistantMessage();
+          if (incomingPartId !== undefined && !assistant.partId) {
+            assistant.partId = incomingPartId;
+          }
           // Support various field names: text, delta, content, chunk (Runtype uses 'chunk')
           const chunk = payload.text ?? payload.delta ?? payload.content ?? payload.chunk ?? "";
           if (chunk) {

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1018,6 +1018,7 @@ export class AgentWidgetClient {
     const assistantMessageRef = { current: null as AgentWidgetMessage | null };
     // Track current partId for message segmentation at tool boundaries
     const partIdState = { current: null as string | null };
+    let didSplitByPartId = false;
     const reasoningMessages = new Map<string, AgentWidgetMessage>();
     const toolMessages = new Map<string, AgentWidgetMessage>();
     const reasoningContext = {
@@ -1060,11 +1061,22 @@ export class AgentWidgetClient {
           payload.step_id
       );
 
+    const baseAssistantId = assistantMessageId;
+    let assistantIdConsumed = false;
+
     const ensureAssistantMessage = () => {
       if (assistantMessage) return assistantMessage;
+      let id: string;
+      if (!assistantIdConsumed && baseAssistantId) {
+        id = baseAssistantId;
+        assistantIdConsumed = true;
+      } else if (baseAssistantId && partIdState.current) {
+        id = `${baseAssistantId}_${partIdState.current}`;
+      } else {
+        id = `assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+      }
       assistantMessage = {
-        // Use pre-generated ID if provided, otherwise generate one
-        id: assistantMessageId ?? `assistant-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+        id,
         role: "assistant",
         content: "",
         createdAt: new Date().toISOString(),
@@ -1516,6 +1528,7 @@ export class AgentWidgetClient {
               prev.streaming = false;
               emitMessage(prev);
               assistantMessage = null;
+              didSplitByPartId = true;
             }
           }
           if (incomingPartId !== undefined) {
@@ -1529,6 +1542,7 @@ export class AgentWidgetClient {
             prev.streaming = false;
             emitMessage(prev);
             assistantMessage = null;
+            didSplitByPartId = true;
           }
         } else if (payloadType === "step_chunk" || payloadType === "step_delta") {
           // Only process chunks for prompt steps, not tool/context steps
@@ -1548,6 +1562,7 @@ export class AgentWidgetClient {
               prev.streaming = false;
               emitMessage(prev);
               assistantMessage = null;
+              didSplitByPartId = true;
             }
           }
           if (incomingPartId !== undefined) {
@@ -1864,7 +1879,19 @@ export class AgentWidgetClient {
           }
         } else if (payloadType === "flow_complete") {
           const finalContent = payload.result?.response;
-          if (finalContent !== undefined && finalContent !== null) {
+          if (didSplitByPartId) {
+            // Content was split into multiple assistant messages — the full response
+            // in flow_complete would overwrite the last segment. Just finalize streaming.
+            if (assistantMessage !== null) {
+              const msg: AgentWidgetMessage = assistantMessage;
+              streamParsers.delete(msg.id);
+              rawContentBuffers.delete(msg.id);
+              if (msg.streaming !== false) {
+                msg.streaming = false;
+                emitMessage(msg);
+              }
+            }
+          } else if (finalContent !== undefined && finalContent !== null) {
             const assistant = ensureAssistantMessage();
             // Check if we have raw content buffer that needs final processing
             const rawBuffer = rawContentBuffers.get(assistant.id);

--- a/packages/widget/src/components/panel.ts
+++ b/packages/widget/src/components/panel.ts
@@ -1,4 +1,5 @@
 import { createElement } from "../utils/dom";
+import { DEFAULT_FLOATING_LAUNCHER_WIDTH } from "../defaults";
 import { AgentWidgetConfig } from "../types";
 import { positionMap } from "../utils/positioning";
 import { isDockedMountMode } from "../utils/dock";
@@ -68,7 +69,7 @@ export const createWrapper = (config?: AgentWidgetConfig): PanelWrapper => {
     "persona-widget-panel persona-relative persona-min-h-[320px]"
   );
   const launcherWidth = config?.launcher?.width ?? config?.launcherWidth;
-  const width = launcherWidth ?? "min(400px, calc(100vw - 24px))";
+  const width = launcherWidth ?? DEFAULT_FLOATING_LAUNCHER_WIDTH;
   panel.style.width = width;
   panel.style.maxWidth = width;
 

--- a/packages/widget/src/defaults.ts
+++ b/packages/widget/src/defaults.ts
@@ -3,6 +3,16 @@ import type { DeepPartial, PersonaTheme } from "./types/theme";
 import { deepMerge } from "./utils/deep-merge";
 
 /**
+ * Default width for the floating launcher panel (when not overridden).
+ * Benchmarks: many chat products use ~300–400px; 400px is a frequent “standard” default.
+ * We use 440px to better fit code/JSON and structured replies while staying responsive via `min(..., 100vw)`.
+ */
+export const DEFAULT_FLOATING_LAUNCHER_WIDTH = "min(440px, calc(100vw - 24px))";
+
+/** Max width cap paired with {@link DEFAULT_FLOATING_LAUNCHER_WIDTH} for theme defaults. */
+export const DEFAULT_FLOATING_LAUNCHER_MAX_WIDTH = "440px";
+
+/**
  * Default widget configuration
  * Single source of truth for all default values
  */
@@ -26,7 +36,7 @@ export const DEFAULT_WIDGET_CONFIG: Partial<AgentWidgetConfig> = {
     agentIconName: "bot",
     headerIconName: "bot",
     position: "bottom-right",
-    width: "min(400px, calc(100vw - 24px))",
+    width: DEFAULT_FLOATING_LAUNCHER_WIDTH,
     heightOffset: 0,
     autoExpand: false,
     callToActionIconHidden: false,

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -274,6 +274,8 @@ export {
 // Default configuration exports
 export {
   DEFAULT_WIDGET_CONFIG,
+  DEFAULT_FLOATING_LAUNCHER_MAX_WIDTH,
+  DEFAULT_FLOATING_LAUNCHER_WIDTH,
   mergeWithDefaults
 } from "./defaults";
 export {

--- a/packages/widget/src/presets.ts
+++ b/packages/widget/src/presets.ts
@@ -1,5 +1,6 @@
 import type { AgentWidgetConfig } from "./types";
 import type { DeepPartial, PersonaTheme } from "./types/theme";
+import { DEFAULT_FLOATING_LAUNCHER_WIDTH } from "./defaults";
 
 /**
  * A named preset containing partial widget configuration.
@@ -65,7 +66,7 @@ export const PRESET_SHOP: WidgetPreset = {
       subtitle: "Here to help you find what you need",
       agentIconText: "🛍️",
       position: "bottom-right",
-      width: "min(400px, calc(100vw - 24px))",
+      width: DEFAULT_FLOATING_LAUNCHER_WIDTH,
     },
     copy: {
       welcomeTitle: "Welcome to our shop!",

--- a/packages/widget/src/theme-editor/sections.ts
+++ b/packages/widget/src/theme-editor/sections.ts
@@ -1,6 +1,10 @@
 /** Declarative section/field definitions for the theme editor (pure data — no DOM, no render logic) */
 
 import type { SectionDef, TabDef, SubGroupDef, FieldDef } from './types';
+import {
+  DEFAULT_FLOATING_LAUNCHER_MAX_WIDTH,
+  DEFAULT_FLOATING_LAUNCHER_WIDTH,
+} from '../defaults';
 import { COLOR_FAMILIES } from './color-utils';
 import {
   ROLE_SURFACES,
@@ -273,8 +277,8 @@ const panelLayoutSectionDef: SectionDef = {
   title: 'Panel',
   collapsed: false,
   fields: [
-    { id: 'panel-width', label: 'Width', type: 'text', path: 'theme.components.panel.width', defaultValue: 'min(400px, calc(100vw - 24px))' },
-    { id: 'panel-max-width', label: 'Max Width', type: 'text', path: 'theme.components.panel.maxWidth', defaultValue: '400px' },
+    { id: 'panel-width', label: 'Width', type: 'text', path: 'theme.components.panel.width', defaultValue: DEFAULT_FLOATING_LAUNCHER_WIDTH },
+    { id: 'panel-max-width', label: 'Max Width', type: 'text', path: 'theme.components.panel.maxWidth', defaultValue: DEFAULT_FLOATING_LAUNCHER_MAX_WIDTH },
     { id: 'panel-height', label: 'Height', type: 'text', path: 'theme.components.panel.height', defaultValue: '600px' },
     { id: 'panel-max-height', label: 'Max Height', type: 'text', path: 'theme.components.panel.maxHeight', defaultValue: 'calc(100vh - 80px)' },
     { id: 'panel-border-radius', label: 'Border Radius', type: 'select', path: 'theme.components.panel.borderRadius', defaultValue: 'palette.radius.xl', options: [
@@ -590,7 +594,7 @@ const launcherBasicsSectionDef: SectionDef = {
     { id: 'launch-enabled', label: 'Enabled', type: 'toggle', path: 'launcher.enabled', defaultValue: true },
     { id: 'launch-mount-mode', label: 'Mount Mode', type: 'select', path: 'launcher.mountMode', defaultValue: 'floating', options: [{ value: 'floating', label: 'Floating' }, { value: 'docked', label: 'Docked' }] },
     { id: 'launch-position', label: 'Position', type: 'select', path: 'launcher.position', defaultValue: 'bottom-right', options: [{ value: 'bottom-right', label: 'Bottom Right' }, { value: 'bottom-left', label: 'Bottom Left' }, { value: 'top-right', label: 'Top Right' }, { value: 'top-left', label: 'Top Left' }] },
-    { id: 'launch-width', label: 'Width', type: 'text', path: 'launcher.width', defaultValue: 'min(400px, calc(100vw - 24px))' },
+    { id: 'launch-width', label: 'Width', type: 'text', path: 'launcher.width', defaultValue: DEFAULT_FLOATING_LAUNCHER_WIDTH },
     { id: 'launch-auto-expand', label: 'Auto Expand', type: 'toggle', path: 'launcher.autoExpand', defaultValue: false },
     { id: 'launch-title', label: 'Title', type: 'text', path: 'launcher.title', defaultValue: 'Chat Assistant' },
     { id: 'launch-subtitle', label: 'Subtitle', type: 'text', path: 'launcher.subtitle', defaultValue: 'Here to help you get answers fast' },

--- a/packages/widget/src/theme-reference.ts
+++ b/packages/widget/src/theme-reference.ts
@@ -115,7 +115,7 @@ export const THEME_TOKEN_DOCS = {
       panel: {
         description: 'Chat panel container.',
         properties:
-          'width, maxWidth (400px), height (600px), maxHeight, borderRadius, shadow.',
+          'width, maxWidth (440px), height (600px), maxHeight, borderRadius, shadow.',
       },
       header: {
         description: 'Chat panel header.',

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -69,7 +69,7 @@ import {
 import { readFlexGapPx, resolveArtifactPaneWidthPx } from "./utils/artifact-resize";
 import { enhanceWithForms } from "./components/forms";
 import { pluginRegistry } from "./plugins/registry";
-import { mergeWithDefaults } from "./defaults";
+import { mergeWithDefaults, DEFAULT_FLOATING_LAUNCHER_WIDTH } from "./defaults";
 import { createEventBus } from "./utils/events";
 import {
   createActionManager,
@@ -1508,7 +1508,7 @@ export const createAgentExperience = (
       if (mobileFullscreen && ownerWindow.innerWidth <= mobileBreakpoint) return;
       if (!shouldExpandLauncherForArtifacts(config, launcherEnabled)) return;
 
-      const base = config.launcher?.width ?? config.launcherWidth ?? "min(400px, calc(100vw - 24px))";
+      const base = config.launcher?.width ?? config.launcherWidth ?? DEFAULT_FLOATING_LAUNCHER_WIDTH;
       const expanded =
         config.features?.artifacts?.layout?.expandedPanelWidth ??
         "min(720px, calc(100vw - 24px))";
@@ -1659,7 +1659,7 @@ export const createAgentExperience = (
 
     // Re-apply panel width/maxWidth from initial setup
     const launcherWidth = config?.launcher?.width ?? config?.launcherWidth;
-    const width = launcherWidth ?? "min(400px, calc(100vw - 24px))";
+    const width = launcherWidth ?? DEFAULT_FLOATING_LAUNCHER_WIDTH;
     if (!sidebarMode && !dockedMode) {
       if (isInlineEmbed && fullHeight) {
         panel.style.width = "100%";
@@ -3609,7 +3609,7 @@ export const createAgentExperience = (
       // In sidebar/fullHeight mode, don't override the width - it's handled by applyFullHeightStyles
       if (!sidebarMode && !dockedMode) {
         const launcherWidth = config?.launcher?.width ?? config?.launcherWidth;
-        const width = launcherWidth ?? "min(400px, calc(100vw - 24px))";
+        const width = launcherWidth ?? DEFAULT_FLOATING_LAUNCHER_WIDTH;
         panel.style.width = width;
         panel.style.maxWidth = width;
       }

--- a/packages/widget/src/utils/tokens.ts
+++ b/packages/widget/src/utils/tokens.ts
@@ -8,6 +8,10 @@ import type {
   ComponentTokens,
   SemanticTokens,
 } from '../types/theme';
+import {
+  DEFAULT_FLOATING_LAUNCHER_MAX_WIDTH,
+  DEFAULT_FLOATING_LAUNCHER_WIDTH,
+} from '../defaults';
 
 export const DEFAULT_PALETTE = {
   colors: {
@@ -277,8 +281,8 @@ export const DEFAULT_COMPONENTS: ComponentTokens = {
     shadow: 'palette.shadows.lg',
   },
   panel: {
-    width: 'min(400px, calc(100vw - 24px))',
-    maxWidth: '400px',
+    width: DEFAULT_FLOATING_LAUNCHER_WIDTH,
+    maxWidth: DEFAULT_FLOATING_LAUNCHER_MAX_WIDTH,
     height: '600px',
     maxHeight: 'calc(100vh - 80px)',
     borderRadius: 'palette.radius.xl',


### PR DESCRIPTION
- Render assistant text and tool calls in chronological order instead of lumping all text before tools. The widget now handles `text_start`/`text_end` lifecycle events and `partId` on `step_delta` to split assistant messages at tool boundaries, matching the segmentation the Runtype API already emits. Split messages use deterministic IDs derived from the base `assistantMessageId` and `partId` (e.g. `ast_abc_text_1`) for feedback traceability, and `flow_complete` no longer overwrites segment content with the full concatenated response.
- Increase the default floating launcher panel width from 400px to 440px (still `min(..., calc(100vw - 24px))`) so code blocks and structured replies are easier to read, aligned with common chat-widget sizing while leaving room for custom `launcher.width`.