### PR TITLE
Fix duplicate message bubbles by preventing recreation on step completion

### DIFF
--- a/.changeset/fix-step-complete-duplication.md
+++ b/.changeset/fix-step-complete-duplication.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix duplicate assistant message bubbles when `step_complete` follows `text_end`. The `step_complete` handler now skips recreating a message with the full response when `text_end` has already sealed the streamed content, preventing identical text from rendering twice.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1784,5 +1784,59 @@ describe('AgentWidgetClient - partId Text/Tool Interleaving', () => {
     expect(assistantTexts[0].streaming).toBe(false);
     expect(assistantTexts[1].streaming).toBe(false);
   });
+
+  it('should not duplicate text when step_complete follows text_end', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (eventType: string, data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`event: ${eventType}\ndata: ${JSON.stringify({ type: eventType, ...data })}\n\n`));
+
+          e('flow_start', { flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          // Tools fire first (no text before them)
+          e('tool_start', { toolId: 'tc_1', name: 'test_tool', toolType: 'custom', startedAt: new Date().toISOString() });
+          e('tool_complete', { toolId: 'tc_1', name: 'test_tool', success: true, completedAt: new Date().toISOString(), executionTime: 0 });
+          // Then text segment
+          e('text_start', { partId: 'text_1', messageId: 'msg_s1', seq: 1 });
+          e('step_delta', { id: 's1', text: 'Tool returned a result.', partId: 'text_1', messageId: 'msg_s1', seq: 2 });
+          e('text_end', { partId: 'text_1', messageId: 'msg_s1', seq: 3 });
+          // step_complete with full response (should NOT create a duplicate)
+          e('step_complete', { id: 's1', name: 'Response', stepType: 'prompt', success: true, result: { response: 'Tool returned a result.' }, executionTime: 500 });
+          e('flow_complete', { success: true });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Call tool', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const allMessages = Array.from(messagesById.values());
+    const assistantTexts = allMessages
+      .filter(m => m.role === 'assistant' && !m.variant)
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+    const toolMsgs = allMessages.filter(m => m.variant === 'tool');
+
+    // Exactly ONE text message (not duplicated by step_complete)
+    expect(assistantTexts.length).toBe(1);
+    expect(assistantTexts[0].content).toBe('Tool returned a result.');
+    expect(assistantTexts[0].streaming).toBe(false);
+
+    // Tool message exists
+    expect(toolMsgs.length).toBe(1);
+  });
 });
 

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1757,6 +1757,20 @@ export class AgentWidgetClient {
             // Skip tool-related completions - they're handled by tool_complete
             continue;
           }
+          if (didSplitByPartId) {
+            // text_end already sealed the assistant message(s) — don't recreate
+            // one from step_complete's full response (would cause duplication)
+            if (assistantMessage !== null) {
+              const msg: AgentWidgetMessage = assistantMessage;
+              streamParsers.delete(msg.id);
+              rawContentBuffers.delete(msg.id);
+              if (msg.streaming !== false) {
+                msg.streaming = false;
+                emitMessage(msg);
+              }
+            }
+            continue;
+          }
           const finalContent = payload.result?.response;
           const assistant = ensureAssistantMessage();
           if (finalContent !== undefined && finalContent !== null) {


### PR DESCRIPTION
Fix duplicate assistant message bubbles by preventing recreation of messages when `step_complete` follows `text_end`. Updated tests to ensure correct behavior and validate that only one text message is rendered in this scenario.