### PR TITLE
Default API URL to production Runtype API

### DIFF
--- a/.changeset/production-api-url.md
+++ b/.changeset/production-api-url.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Change default API URL from localhost to production Runtype API (api.runtype.com)

--- a/packages/widget/src/defaults.ts
+++ b/packages/widget/src/defaults.ts
@@ -7,7 +7,7 @@ import { deepMerge } from "./utils/deep-merge";
  * Single source of truth for all default values
  */
 export const DEFAULT_WIDGET_CONFIG: Partial<AgentWidgetConfig> = {
-  apiUrl: "http://localhost:43111/api/chat/dispatch",
+  apiUrl: "https://api.runtype.com/api/chat/dispatch",
   // Client token mode defaults (optional, only used when clientToken is set)
   clientToken: undefined,
   theme: undefined,


### PR DESCRIPTION
## Summary
- Changes the default `apiUrl` in `DEFAULT_WIDGET_CONFIG` from `http://localhost:43111/api/chat/dispatch` to `https://api.runtype.com/api/chat/dispatch`
- Widget now points to the production API out of the box, removing the need for a local proxy in production/CDN usage

## Test plan
- [ ] Verify widget connects to `api.runtype.com` when no `apiUrl` is provided
- [ ] Verify local dev still works when `apiUrl` is explicitly set to localhost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the widget’s default backend endpoint from localhost to production, which alters out-of-the-box network behavior and could impact existing setups that relied on the prior local default.
> 
> **Overview**
> Updates the widget’s `DEFAULT_WIDGET_CONFIG` to default `apiUrl` to `https://api.runtype.com/api/chat/dispatch` instead of the localhost dispatch URL, so the widget connects to production by default.
> 
> Adds a changeset to publish this as a patch release for `@runtypelabs/persona`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e15fff590fd6046de330ae86a042e6f257389785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->