### PR TITLE
fix: join tool call chunks without newlines

### DIFF
--- a/.changeset/fix-tool-chunk-join.md
+++ b/.changeset/fix-tool-chunk-join.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix tool call activity text rendering each streaming token on its own line

--- a/packages/widget/src/components/tool-bubble.ts
+++ b/packages/widget/src/components/tool-bubble.ts
@@ -215,7 +215,7 @@ export const createToolBubble = (message: AgentWidgetMessage, config?: AgentWidg
     if (toolCallConfig.codeBlockTextColor) {
       logsPre.style.color = toolCallConfig.codeBlockTextColor;
     }
-    logsPre.textContent = tool.chunks.join("\n");
+    logsPre.textContent = tool.chunks.join("");
     logsBlock.append(logsLabel, logsPre);
     content.appendChild(logsBlock);
   }


### PR DESCRIPTION
## Summary

- Tool call "Activity" text was rendering each streaming token on its own line because `chunks.join("\n")` was used in `tool-bubble.ts`
- Changed to `chunks.join("")` to concatenate tokens directly, matching how `reasoning-bubble.ts` already handles chunks

## Before
Each word appeared on its own line in the tool call activity panel.

## After
Streaming tokens flow as continuous text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI rendering change limited to tool-call activity output; low risk aside from slightly altered formatting for any chunks that previously relied on newline separation.
> 
> **Overview**
> Fixes the tool-call **Activity** display in `tool-bubble.ts` by joining streamed `chunks` with `""` instead of `"\n"`, preventing each token from rendering on its own line.
> 
> Adds a patch changeset for `@runtypelabs/persona` documenting the rendering fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60ccdb61a984f9328b8fe02992f6329832a7b45b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->