### PR TITLE
Add out-of-order sequence reordering for step_delta and reason_delta

### DIFF
--- a/.changeset/fix-stream-seq-reorder.md
+++ b/.changeset/fix-stream-seq-reorder.md
@@ -1,0 +1,7 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix streaming UI freezing when SSE events arrive out of order
+
+`step_delta` and `reason_delta` events can arrive with out-of-order `seq`/`sequenceIndex` values. Previously, text chunks were appended in arrival order, producing garbled content that broke markdown rendering and caused the streaming UI to appear frozen mid-response. Added a sequence-aware reorder buffer that accumulates chunks and rebuilds the full text in correct server-intended order.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,9 +51,23 @@ pnpm release            # Publish to npm
 
 ## Changesets Requirement
 
-All changes that affect published packages must include a changeset. Create one with `pnpm changeset` before committing. Changesets go in `.changeset/` and describe what changed for the changelog.
+All changes that affect published packages **must** include a changeset. This is enforced in CI — PRs without a changeset for affected packages will fail.
 
-Changes to `packages/widget` or `packages/proxy` need a changeset. Changes to `examples/`, `docs/`, CI, or tooling do not.
+Create one by adding a markdown file in `.changeset/` (e.g. `.changeset/my-change-name.md`) with the following format:
+
+```md
+---
+"@runtypelabs/persona": patch
+---
+
+Short description of the change for the changelog.
+```
+
+Use `patch` for bug fixes, `minor` for new features, and `major` for breaking changes. If both packages are affected, list both in the frontmatter.
+
+**Requires a changeset:** Any change to `packages/widget` or `packages/proxy` (source, types, styles, dependencies).
+
+**Does NOT need a changeset:** Changes to `examples/`, `docs/`, CI config, tooling, or `CLAUDE.md`.
 
 ## Architecture
 

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -2025,3 +2025,129 @@ describe('preferFinalStructuredContent', () => {
   });
 });
 
+describe('AgentWidgetClient - Out-of-Order Sequence Reordering', () => {
+  it('should reorder step_delta chunks by seq when events arrive out of order', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: any) => {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+          };
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e({ type: 'step_start', id: 's1', name: 'Prompt', stepType: 'prompt', index: 1, totalSteps: 1 });
+          // Send chunks out of order (seq 3 before seq 2)
+          e({ type: 'step_delta', id: 's1', text: 'Hello', partId: 'text_0', seq: 1 });
+          e({ type: 'step_delta', id: 's1', text: ' world', partId: 'text_0', seq: 3 });
+          e({ type: 'step_delta', id: 's1', text: ' beautiful', partId: 'text_0', seq: 2 });
+          e({ type: 'step_delta', id: 's1', text: '!', partId: 'text_0', seq: 4 });
+          e({ type: 'step_complete', id: 's1', name: 'Prompt', success: true });
+          e({ type: 'flow_complete', success: true });
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+
+    await client.dispatch({ messages: [] }, (event) => events.push(event));
+
+    const messageEvents = events.filter(
+      (e): e is AgentWidgetEvent & { type: 'message' } => e.type === 'message'
+    );
+    const finalMessages = messageEvents.filter((e) => !e.message.streaming);
+    expect(finalMessages.length).toBeGreaterThan(0);
+
+    const lastFinal = finalMessages[finalMessages.length - 1];
+    // Content should be in seq order, not arrival order
+    expect(lastFinal.message.content).toBe('Hello beautiful world!');
+  });
+
+  it('should reorder reason_delta chunks by sequenceIndex', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: any) => {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+          };
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e({ type: 'step_start', id: 's1', name: 'Prompt', stepType: 'prompt', index: 1, totalSteps: 1 });
+          e({ type: 'reason_start', reasoningId: 'r1', hidden: false, done: false });
+          // Send reasoning chunks out of order
+          e({ type: 'reason_delta', reasoningId: 'r1', reasoningText: 'I ', hidden: false, done: false, sequenceIndex: 1 });
+          e({ type: 'reason_delta', reasoningId: 'r1', reasoningText: 'about', hidden: false, done: false, sequenceIndex: 3 });
+          e({ type: 'reason_delta', reasoningId: 'r1', reasoningText: 'think ', hidden: false, done: false, sequenceIndex: 2 });
+          e({ type: 'reason_delta', reasoningId: 'r1', reasoningText: ' this.', hidden: false, done: false, sequenceIndex: 4 });
+          e({ type: 'reason_complete', reasoningId: 'r1', hidden: false, done: true });
+          e({ type: 'step_delta', id: 's1', text: 'Result', partId: 'text_0' });
+          e({ type: 'step_complete', id: 's1', name: 'Prompt', success: true });
+          e({ type: 'flow_complete', success: true });
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+
+    await client.dispatch({ messages: [] }, (event) => events.push(event));
+
+    const messageEvents = events.filter(
+      (e): e is AgentWidgetEvent & { type: 'message' } => e.type === 'message'
+    );
+    const reasoningMsgs = messageEvents.filter(
+      (e) => e.message.reasoning && e.message.reasoning.chunks.length > 0
+    );
+    expect(reasoningMsgs.length).toBeGreaterThan(0);
+
+    const lastReasoning = reasoningMsgs[reasoningMsgs.length - 1];
+    // Reasoning chunks should be in sequenceIndex order
+    const fullReasoning = lastReasoning.message.reasoning!.chunks.join('');
+    expect(fullReasoning).toBe('I think about this.');
+  });
+
+  it('should handle step_delta without seq gracefully (no reordering)', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (data: any) => {
+            controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+          };
+          e({ type: 'flow_start', flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e({ type: 'step_start', id: 's1', name: 'Prompt', stepType: 'prompt', index: 1, totalSteps: 1 });
+          // No seq field — should append in arrival order
+          e({ type: 'step_delta', id: 's1', text: 'Hello ' });
+          e({ type: 'step_delta', id: 's1', text: 'world' });
+          e({ type: 'step_delta', id: 's1', text: '!' });
+          e({ type: 'step_complete', id: 's1', name: 'Prompt', success: true });
+          e({ type: 'flow_complete', success: true });
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+
+    await client.dispatch({ messages: [] }, (event) => events.push(event));
+
+    const messageEvents = events.filter(
+      (e): e is AgentWidgetEvent & { type: 'message' } => e.type === 'message'
+    );
+    const finalMessages = messageEvents.filter((e) => !e.message.streaming);
+    expect(finalMessages.length).toBeGreaterThan(0);
+
+    const lastFinal = finalMessages[finalMessages.length - 1];
+    expect(lastFinal.message.content).toBe('Hello world!');
+  });
+});
+

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1295,6 +1295,39 @@ export class AgentWidgetClient {
     const streamParsers = new Map<string, AgentWidgetStreamParser>();
     // Track accumulated raw content for structured formats (JSON, XML, etc.)
     const rawContentBuffers = new Map<string, string>();
+    // Reorder buffer for out-of-order step_delta chunks (keyed by assistant message id)
+    const seqChunkBuffers = new Map<string, Array<{ seq: number; text: string }>>();
+    // Reorder buffer for out-of-order reason_delta chunks (keyed by reasoning id)
+    const reasonSeqBuffers = new Map<string, Array<{ seq: number; text: string }>>();
+
+    /**
+     * Insert a chunk into a sequence-ordered buffer and return
+     * the full accumulated text in correct sequence order.
+     */
+    function insertSeqChunk(
+      bufferMap: Map<string, Array<{ seq: number; text: string }>>,
+      key: string,
+      seq: number,
+      text: string
+    ): string {
+      let buf = bufferMap.get(key);
+      if (!buf) {
+        buf = [];
+        bufferMap.set(key, buf);
+      }
+      // Binary-search insert to keep sorted by seq
+      let lo = 0, hi = buf.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (buf[mid].seq < seq) lo = mid + 1;
+        else hi = mid;
+      }
+      buf.splice(lo, 0, { seq, text });
+      // Join all chunks in seq order
+      let result = "";
+      for (let i = 0; i < buf.length; i++) result += buf[i].text;
+      return result;
+    }
 
     // Only the most-recently sealed segment is reconciled with step_complete's
     // final response. Earlier segments rely on their own async parser microtasks
@@ -1498,7 +1531,16 @@ export class AgentWidgetClient {
             payload.delta ??
             "";
           if (chunk && payload.hidden !== true) {
-            reasoningMessage.reasoning.chunks.push(String(chunk));
+            const reasonSeq = typeof payload.sequenceIndex === 'number' ? payload.sequenceIndex : undefined;
+            if (reasonSeq !== undefined) {
+              // Use reorder buffer so out-of-order chunks are assembled correctly
+              const ordered = insertSeqChunk(reasonSeqBuffers, reasoningId, reasonSeq, String(chunk));
+              // Rebuild the chunks array from the ordered concatenation.
+              // We store a single joined string to avoid duplicated / mis-ordered entries.
+              reasoningMessage.reasoning.chunks = [ordered];
+            } else {
+              reasoningMessage.reasoning.chunks.push(String(chunk));
+            }
           }
           reasoningMessage.reasoning.status = payload.done ? "complete" : "streaming";
           if (payload.done) {
@@ -1530,6 +1572,7 @@ export class AgentWidgetClient {
               (reasoningMessage.reasoning.completedAt ?? Date.now()) - start
             );
             reasoningMessage.streaming = false;
+            reasonSeqBuffers.delete(reasoningId);
             emitMessage(reasoningMessage);
           }
           const stepKey = getStepKey(payload);
@@ -1711,9 +1754,19 @@ export class AgentWidgetClient {
           // Support various field names: text, delta, content, chunk (Runtype uses 'chunk')
           const chunk = payload.text ?? payload.delta ?? payload.content ?? payload.chunk ?? "";
           if (chunk) {
-            // Accumulate raw content for structured format parsing
-            const rawBuffer = rawContentBuffers.get(assistant.id) ?? "";
-            const accumulatedRaw = rawBuffer + chunk;
+            // Check if the event carries a sequence number for reordering
+            const chunkSeq = typeof payload.seq === 'number' ? payload.seq : undefined;
+
+            // Accumulate raw content for structured format parsing.
+            // When seq is present, use the reorder buffer so out-of-order
+            // chunks are assembled in the correct server-intended order.
+            let accumulatedRaw: string;
+            if (chunkSeq !== undefined) {
+              accumulatedRaw = insertSeqChunk(seqChunkBuffers, assistant.id, chunkSeq, chunk);
+            } else {
+              const rawBuffer = rawContentBuffers.get(assistant.id) ?? "";
+              accumulatedRaw = rawBuffer + chunk;
+            }
             // Store raw content for action parsing, but NEVER set assistant.content to raw JSON
             assistant.rawContent = accumulatedRaw;
             
@@ -1736,7 +1789,13 @@ export class AgentWidgetClient {
             
             // If plain text parser, just append the chunk directly
             if (isPlainTextParser) {
-              assistant.content += chunk;
+              // When seq-ordered, rebuild from the reorder buffer;
+              // otherwise fall back to simple append.
+              if (chunkSeq !== undefined) {
+                assistant.content = accumulatedRaw;
+              } else {
+                assistant.content += chunk;
+              }
               // Clear any raw buffer/parser since we're in plain text mode
               rawContentBuffers.delete(assistant.id);
               streamParsers.delete(assistant.id);
@@ -1761,17 +1820,28 @@ export class AgentWidgetClient {
                   emitMessage(assistant);
                 } else if (!looksLikeJson && !accumulatedRaw.trim().startsWith('<')) {
                   // Not a structured format - show as plain text
-                  assistant.content += chunk;
-                  rawContentBuffers.delete(assistant.id);
-                  streamParsers.delete(assistant.id);
-                  assistant.rawContent = undefined;
-                  emitMessage(assistant);
+                  const currentAssistant = assistantMessage;
+                  if (currentAssistant && currentAssistant.id === assistant.id) {
+                    if (chunkSeq !== undefined) {
+                      currentAssistant.content = accumulatedRaw;
+                    } else {
+                      currentAssistant.content += chunk;
+                    }
+                    rawContentBuffers.delete(currentAssistant.id);
+                    streamParsers.delete(currentAssistant.id);
+                    currentAssistant.rawContent = undefined;
+                    emitMessage(currentAssistant);
+                  }
                 }
                 // Otherwise wait for more chunks (incomplete structured format)
                 // Don't emit message if parser hasn't extracted text yet
               }).catch(() => {
                 // On error, treat as plain text
-                assistant.content += chunk;
+                if (chunkSeq !== undefined) {
+                  assistant.content = accumulatedRaw;
+                } else {
+                  assistant.content += chunk;
+                }
                 rawContentBuffers.delete(assistant.id);
                 streamParsers.delete(assistant.id);
                 assistant.rawContent = undefined;
@@ -1789,7 +1859,11 @@ export class AgentWidgetClient {
                 emitMessage(assistant);
               } else if (!looksLikeJson && !accumulatedRaw.trim().startsWith('<')) {
                 // Not a structured format - show as plain text
-                assistant.content += chunk;
+                if (chunkSeq !== undefined) {
+                  assistant.content = accumulatedRaw;
+                } else {
+                  assistant.content += chunk;
+                }
                 // Clear any raw buffer/parser if we were in structured format mode
                 rawContentBuffers.delete(assistant.id);
                 streamParsers.delete(assistant.id);
@@ -1835,11 +1909,16 @@ export class AgentWidgetClient {
                       // Extract text from result (could be string or object)
                       const text = typeof result === 'string' ? result : result?.text ?? null;
                       if (text !== null) {
-                        assistant.content = text;
-                        assistant.streaming = false;
-                        streamParsers.delete(assistant.id);
-                        rawContentBuffers.delete(assistant.id);
-                        emitMessage(assistant);
+                        const currentAssistant = assistantMessage;
+                        if (currentAssistant && currentAssistant.id === assistant.id) {
+                          currentAssistant.content = text;
+                          currentAssistant.streaming = false;
+                          // Clean up
+                          streamParsers.delete(currentAssistant.id);
+                          rawContentBuffers.delete(currentAssistant.id);
+                          seqChunkBuffers.delete(currentAssistant.id);
+                          emitMessage(currentAssistant);
+                        }
                       }
                     });
                   } else {
@@ -1869,6 +1948,7 @@ export class AgentWidgetClient {
                   streamParsers.delete(assistant.id);
                 }
                 rawContentBuffers.delete(assistant.id);
+                seqChunkBuffers.delete(assistant.id);
                 assistant.streaming = false;
                 emitMessage(assistant);
               }
@@ -1889,6 +1969,7 @@ export class AgentWidgetClient {
               const msg: AgentWidgetMessage = assistantMessage;
               streamParsers.delete(msg.id);
               rawContentBuffers.delete(msg.id);
+              seqChunkBuffers.delete(msg.id);
               if (msg.streaming !== false) {
                 msg.streaming = false;
                 emitMessage(msg);
@@ -1946,23 +2027,34 @@ export class AgentWidgetClient {
                       const text = typeof result === 'string' ? result : result?.text ?? null;
                       
                       if (text !== null && text.trim() !== "") {
-                        assistant.content = text;
-                        assistant.streaming = false;
-                        streamParsers.delete(assistant.id);
-                        rawContentBuffers.delete(assistant.id);
-                        emitMessage(assistant);
+                        const currentAssistant = assistantMessage;
+                        if (currentAssistant && currentAssistant.id === assistant.id) {
+                          currentAssistant.content = text;
+                          currentAssistant.streaming = false;
+                          // Clean up
+                          streamParsers.delete(currentAssistant.id);
+                          rawContentBuffers.delete(currentAssistant.id);
+                          seqChunkBuffers.delete(currentAssistant.id);
+                          emitMessage(currentAssistant);
+                        }
                       } else {
                         // No extracted text - check if we should show raw content
                         const finalExtractedText = parser.getExtractedText();
-                        if (finalExtractedText !== null && finalExtractedText.trim() !== "") {
-                          assistant.content = finalExtractedText;
-                        } else if (!rawContentBuffers.has(assistant.id)) {
-                          assistant.content = ensureStringContent(finalContent);
+                        const currentAssistant = assistantMessage;
+                        if (currentAssistant && currentAssistant.id === assistant.id) {
+                          if (finalExtractedText !== null && finalExtractedText.trim() !== "") {
+                            currentAssistant.content = finalExtractedText;
+                          } else if (!rawContentBuffers.has(currentAssistant.id)) {
+                            // Only show raw content if we never had any extracted text
+                            currentAssistant.content = ensureStringContent(finalContent);
+                          }
+                          currentAssistant.streaming = false;
+                          // Clean up
+                          streamParsers.delete(currentAssistant.id);
+                          rawContentBuffers.delete(currentAssistant.id);
+                          seqChunkBuffers.delete(currentAssistant.id);
+                          emitMessage(currentAssistant);
                         }
-                        assistant.streaming = false;
-                        streamParsers.delete(assistant.id);
-                        rawContentBuffers.delete(assistant.id);
-                        emitMessage(assistant);
                       }
                     });
                   } else {
@@ -2008,6 +2100,7 @@ export class AgentWidgetClient {
               }
               streamParsers.delete(assistant.id);
               rawContentBuffers.delete(assistant.id);
+              seqChunkBuffers.delete(assistant.id);
               assistant.streaming = false;
               emitMessage(assistant);
             }
@@ -2015,6 +2108,7 @@ export class AgentWidgetClient {
             // No final content, just mark as complete and clean up
             streamParsers.delete(assistant.id);
             rawContentBuffers.delete(assistant.id);
+            seqChunkBuffers.delete(assistant.id);
             assistant.streaming = false;
             emitMessage(assistant);
           }
@@ -2027,6 +2121,7 @@ export class AgentWidgetClient {
               const msg: AgentWidgetMessage = assistantMessage;
               streamParsers.delete(msg.id);
               rawContentBuffers.delete(msg.id);
+              seqChunkBuffers.delete(msg.id);
               if (msg.streaming !== false) {
                 msg.streaming = false;
                 emitMessage(msg);
@@ -2068,7 +2163,8 @@ export class AgentWidgetClient {
             // Clean up parser and buffer
             streamParsers.delete(assistant.id);
             rawContentBuffers.delete(assistant.id);
-            
+            seqChunkBuffers.delete(assistant.id);
+
             // Only emit if something actually changed to avoid flicker
             const contentChanged = displayContent !== assistant.content;
             const streamingChanged = assistant.streaming !== false;
@@ -2090,6 +2186,7 @@ export class AgentWidgetClient {
               const msg: AgentWidgetMessage = assistantMessage;
               streamParsers.delete(msg.id);
               rawContentBuffers.delete(msg.id);
+              seqChunkBuffers.delete(msg.id);
               
               // Only emit if streaming state changed
               if (msg.streaming !== false) {
@@ -2493,6 +2590,7 @@ export class AgentWidgetClient {
           assistantMessageRef.current = null;
           streamParsers.delete(id);
           rawContentBuffers.delete(id);
+          seqChunkBuffers.delete(id);
         } else if (payloadType === "error" && payload.error) {
           onEvent({
             type: "error",


### PR DESCRIPTION
## Summary
This PR adds support for reordering out-of-order `step_delta` and `reason_delta` chunks based on sequence numbers (`seq` and `sequenceIndex` fields respectively). When chunks arrive out of order from the server, they are now buffered and reassembled in the correct sequence order before being displayed to the user.

## Key Changes
- **Sequence reordering buffers**: Added two new Maps (`seqChunkBuffers` and `reasonSeqBuffers`) to track out-of-order chunks keyed by message/reasoning ID
- **Binary-search insertion**: Implemented `insertSeqChunk()` helper function that performs binary-search insertion to maintain chunks in sequence order and returns the correctly ordered concatenated text
- **step_delta handling**: Modified `step_delta` event processing to check for `seq` field; when present, chunks are inserted into the reorder buffer instead of appended directly
- **reason_delta handling**: Modified `reason_delta` event processing to check for `sequenceIndex` field; when present, chunks are reordered and stored as a single joined string in the reasoning chunks array
- **Graceful fallback**: When `seq`/`sequenceIndex` fields are absent, chunks are processed in arrival order (backward compatible)
- **Cleanup**: Added proper cleanup of reorder buffers when messages complete or are cleaned up

## Implementation Details
- The reorder buffer uses binary search to maintain sorted order by sequence number, ensuring O(n log n) insertion complexity
- For reasoning chunks, the entire chunks array is replaced with a single joined string to avoid duplication when reordering
- For step_delta content, the reordered text is used for both raw content parsing and final display
- All existing cleanup paths now also delete from the sequence reorder buffers to prevent memory leaks
- Three comprehensive test cases validate: out-of-order step_delta, out-of-order reason_delta, and graceful handling of chunks without sequence numbers

https://claude.ai/code/session_01KUek1BhHA4W1kfmXVbX1zY

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core SSE streaming assembly for both assistant text and reasoning; bugs here could affect message content integrity or streaming completion across multiple event paths.
> 
> **Overview**
> Fixes streaming responses that arrive with out-of-order `seq`/`sequenceIndex` by buffering and reassembling `step_delta` (assistant text) and `reason_delta` (reasoning) chunks in order before updating message content.
> 
> Adds a small sequence reorder buffer (`insertSeqChunk`) with cleanup on completion paths, plus new client tests covering out-of-order text, out-of-order reasoning, and the no-sequence fallback; includes a patch changeset and clarifies changeset requirements in `CLAUDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54bf1463c8bfbfa842f7cf5a4130c985603f88fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->