### PR TITLE
fix: address memory leak in reasonSeqBuffers cleanup

### DIFF
--- a/.changeset/fix-reason-seq-buffer-leak.md
+++ b/.changeset/fix-reason-seq-buffer-leak.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix memory leak where reasonSeqBuffers was not cleaned up when reason_delta completed via done:true without a separate reason_complete event.

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1552,6 +1552,7 @@ export class AgentWidgetClient {
               0,
               (reasoningMessage.reasoning.completedAt ?? Date.now()) - start
             );
+            reasonSeqBuffers.delete(reasoningId);
           }
           reasoningMessage.streaming = reasoningMessage.reasoning.status !== "complete";
           emitMessage(reasoningMessage);


### PR DESCRIPTION
Ensure that reasonSeqBuffers are properly deleted when reason_delta completes with done:true, preventing memory leaks in the widget client.