### PR TITLE
feat(attachments): customizable drop overlay, attachments demo, and a…

### DIFF
--- a/.changeset/attachment-drop-upload.md
+++ b/.changeset/attachment-drop-upload.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Add drag-and-drop file upload on the chat panel when attachments are enabled, with a subtle drop-target highlight.

--- a/.changeset/createagentexperience-null-guard.md
+++ b/.changeset/createagentexperience-null-guard.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+`createAgentExperience` now throws a clear error when `mount` is null or undefined instead of failing on property access.

--- a/.changeset/custom-composer-attachments-submit.md
+++ b/.changeset/custom-composer-attachments-submit.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+`renderComposer` `onSubmit` now sends pending attachments (and optional text) the same way as the built-in composer.

--- a/examples/embedded-app/attachments-demo.html
+++ b/examples/embedded-app/attachments-demo.html
@@ -1,0 +1,199 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/src/demo-shared.css">
+  <link rel="icon" href="/favicon.ico" />
+  <title>Attachments Demo</title>
+  <style>
+    #attachments-widget { height: 100%; }
+
+    .config-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.75rem;
+      margin-bottom: 1rem;
+    }
+
+    .config-field label {
+      display: block;
+      font-size: 0.8rem;
+      color: var(--muted);
+      margin-bottom: 0.25rem;
+    }
+
+    .config-field select,
+    .config-field input {
+      width: 100%;
+      padding: 0.4rem 0.5rem;
+      border-radius: var(--radius);
+      border: 1px solid var(--border);
+      background: var(--card);
+      color: var(--foreground);
+      font-family: var(--font-sans);
+      font-size: 0.85rem;
+    }
+  </style>
+</head>
+<body>
+  <a href="/" class="back-link">&larr; Back to examples</a>
+
+  <div class="layout">
+    <!-- Left: Info Panel -->
+    <div class="info-panel">
+      <h1>Attachments Demo</h1>
+      <p>Enable file attachments in the composer. Users can click the attach button or drag &amp; drop files onto the widget.</p>
+
+      <div class="info-section">
+        <h3>How it works</h3>
+        <p>Set <code>attachments.enabled: true</code> in the widget config. Files are converted to base64 content parts and sent alongside the message text. You can constrain allowed types, max file size, and max file count.</p>
+      </div>
+
+      <div class="info-section">
+        <h3>Configuration</h3>
+        <div class="config-grid">
+          <div class="config-field">
+            <label for="cfg-max-files">Max files</label>
+            <select id="cfg-max-files">
+              <option value="1">1</option>
+              <option value="2">2</option>
+              <option value="4" selected>4</option>
+              <option value="6">6</option>
+              <option value="8">8</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-max-size">Max file size</label>
+            <select id="cfg-max-size">
+              <option value="1">1 MB</option>
+              <option value="5">5 MB</option>
+              <option value="10" selected>10 MB</option>
+              <option value="25">25 MB</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-allowed-types">Allowed types</label>
+            <select id="cfg-allowed-types">
+              <option value="images" selected>Images only</option>
+              <option value="images-pdf">Images + PDF</option>
+              <option value="all">All supported</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-icon">Button icon</label>
+            <select id="cfg-icon">
+              <option value="paperclip" selected>paperclip</option>
+              <option value="image-plus">image-plus</option>
+              <option value="upload">upload</option>
+            </select>
+          </div>
+        </div>
+
+        <h3 style="margin: 0.75rem 0 0.5rem; font-size: 0.85rem;">Drop Overlay</h3>
+        <div class="config-grid">
+          <div class="config-field">
+            <label for="cfg-drop-bg">Background</label>
+            <select id="cfg-drop-bg">
+              <option value="" selected>Default (light blue)</option>
+              <option value="rgba(59,130,246,0.15)" data-no-blur>Color only (blue, no blur)</option>
+              <option value="rgba(34,197,94,0.08)">Green tint</option>
+              <option value="rgba(168,85,247,0.08)">Purple tint</option>
+              <option value="rgba(0,0,0,0.06)">Neutral</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-drop-icon">Overlay icon</label>
+            <select id="cfg-drop-icon">
+              <option value="" selected>upload (default)</option>
+              <option value="image-plus">image-plus</option>
+              <option value="file-up">file-up</option>
+              <option value="cloud-upload">cloud-upload</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-drop-stroke">Icon stroke width</label>
+            <select id="cfg-drop-stroke">
+              <option value="" selected>Default (0.5)</option>
+              <option value="1">Thin (1)</option>
+              <option value="2">Medium (2)</option>
+              <option value="2.5">Thick (2.5)</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-drop-label">Label text</label>
+            <input type="text" id="cfg-drop-label" placeholder="e.g. Drop files here" />
+          </div>
+          <div class="config-field">
+            <label for="cfg-drop-border">Border style</label>
+            <select id="cfg-drop-border">
+              <option value="" selected>Default (dashed blue)</option>
+              <option value="2px dashed rgba(34,197,94,0.4)">Dashed green</option>
+              <option value="2px solid rgba(59,130,246,0.3)">Solid blue</option>
+              <option value="none">None</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-drop-blur">Backdrop blur</label>
+            <select id="cfg-drop-blur">
+              <option value="" selected>Default (8px)</option>
+              <option value="0px">None</option>
+              <option value="4px">Subtle (4px)</option>
+              <option value="16px">Heavy (16px)</option>
+            </select>
+          </div>
+          <div class="config-field">
+            <label for="cfg-drop-inset">Inset (margin)</label>
+            <select id="cfg-drop-inset">
+              <option value="" selected>None (0)</option>
+              <option value="4px">4px</option>
+              <option value="8px">8px</option>
+              <option value="12px">12px</option>
+            </select>
+          </div>
+        </div>
+
+        <button class="btn btn-primary" id="apply-config">Apply &amp; Reload Widget</button>
+      </div>
+
+      <div class="info-section">
+        <h3>Try it</h3>
+        <ul style="margin: 0; padding-left: 1.25rem; font-size: 0.85rem; color: var(--muted);">
+          <li>Click the attach button in the composer</li>
+          <li>Drag &amp; drop a file onto the chat</li>
+          <li>Paste an image from your clipboard</li>
+          <li>Attach multiple files, then send a message</li>
+        </ul>
+      </div>
+
+      <div class="code-block">
+        <span class="comment">// Enable attachments with a custom drop overlay</span><br>
+        <span class="keyword">const</span> config = {<br>
+        &nbsp;&nbsp;<span class="prop">attachments</span>: {<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="prop">enabled</span>: <span class="keyword">true</span>,<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="prop">maxFiles</span>: <span class="string">4</span>,<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="prop">maxFileSize</span>: <span class="string">10 * 1024 * 1024</span>,<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;<span class="prop">dropOverlay</span>: {<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="prop">background</span>: <span class="string">'rgba(59,130,246,0.08)'</span>,<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="prop">iconName</span>: <span class="string">'upload'</span>,<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<span class="prop">label</span>: <span class="string">'Drop files here'</span>,<br>
+        &nbsp;&nbsp;&nbsp;&nbsp;}<br>
+        &nbsp;&nbsp;}<br>
+        };
+      </div>
+
+      <h3 style="margin: 0 0 0.5rem; font-size: 0.9rem; color: var(--muted);">Event Log</h3>
+      <div class="event-log" id="log">
+        <div style="color: var(--muted);">Waiting for attachment events…</div>
+      </div>
+    </div>
+
+    <!-- Right: Widget -->
+    <div class="panel widget-container">
+      <div id="attachments-widget"></div>
+    </div>
+  </div>
+
+  <script type="module" src="/src/attachments-demo.ts"></script>
+</body>
+</html>

--- a/examples/embedded-app/autoscroll-stress-test.html
+++ b/examples/embedded-app/autoscroll-stress-test.html
@@ -1,0 +1,738 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/demo-shared.css">
+    <link rel="icon" href="/favicon.ico" />
+    <title>Auto-Scroll Stress Test - Persona</title>
+    <style>
+      body {
+        padding: 1.5rem;
+        max-width: 1200px;
+        margin: 0 auto;
+      }
+      h1 { margin: 0 0 0.25rem 0; }
+      .subtitle { color: var(--muted); margin: 0 0 1.5rem 0; font-size: 0.875rem; }
+
+      .layout {
+        width: 100%;
+      }
+
+      .controls {
+        background: var(--card);
+        border-radius: var(--radius-lg);
+        padding: 1.25rem;
+        box-shadow: var(--shadow-md);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        position: sticky;
+        top: 1.5rem;
+      }
+      .controls h2 {
+        font-size: 0.9375rem;
+        margin: 0;
+        color: var(--foreground);
+      }
+      .controls p {
+        font-size: 0.8125rem;
+        color: var(--muted);
+        margin: 0;
+      }
+      .btn-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+      }
+      .btn-group label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--muted);
+      }
+      button {
+        padding: 0.5rem 0.75rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--card);
+        color: var(--foreground);
+        font-size: 0.8125rem;
+        cursor: pointer;
+        transition: background 0.15s;
+        text-align: left;
+      }
+      button:hover { background: var(--border); }
+      button:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+      button.running {
+        border-color: #f59e0b;
+        background: rgba(245, 158, 11, 0.1);
+      }
+      .status-row {
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        font-size: 0.8125rem;
+      }
+      .status-dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
+      .status-dot.following { background: #22c55e; }
+      .status-dot.paused { background: #ef4444; }
+      .status-dot.idle { background: #94a3b8; }
+      #log {
+        font-size: 0.75rem;
+        font-family: monospace;
+        background: #111;
+        color: #aaa;
+        border-radius: var(--radius-sm);
+        padding: 0.5rem;
+        max-height: 160px;
+        overflow-y: auto;
+        line-height: 1.6;
+      }
+      #log .info { color: #60a5fa; }
+      #log .warn { color: #f59e0b; }
+    </style>
+  </head>
+  <body>
+    <!-- Mount first so it always exists before the module runs (deferred ES modules). -->
+    <div id="autoscroll-launcher-root" aria-hidden="true"></div>
+
+    <h1>Auto-Scroll Stress Test</h1>
+    <p class="subtitle">
+      Uses the floating launcher (bottom-right). The panel opens automatically. Run a scenario and watch the
+      message list — it should stay pinned to the bottom unless you scroll up inside the chat.
+    </p>
+
+    <div class="layout">
+      <div class="controls">
+        <div>
+          <h2>Status</h2>
+          <div class="status-row" id="follow-status">
+            <span class="status-dot following"></span>
+            <span>Auto-follow: active</span>
+          </div>
+        </div>
+
+        <div class="btn-group">
+          <label>Scenarios</label>
+          <button id="btn-rapid">Rapid Messages (20 msgs, 100ms apart)</button>
+          <button id="btn-stream">Simulate Streaming (word-by-word)</button>
+          <button id="btn-conversation">Realistic Conversation</button>
+          <button id="btn-mixed">Mixed Content (markdown, code, lists)</button>
+          <button id="btn-trace">Tool + Reasoning Trace</button>
+          <button id="btn-stress">Stress Test (all at once)</button>
+        </div>
+
+        <div class="btn-group">
+          <label>Utilities</label>
+          <button id="btn-cancel">Cancel Running Scenario</button>
+          <button id="btn-reset">Reset Session</button>
+        </div>
+
+        <div>
+          <h2>Log</h2>
+          <div id="log"></div>
+        </div>
+      </div>
+    </div>
+
+    <script type="module">
+      import "@runtypelabs/persona/widget.css";
+      import "./src/index.css";
+      import { createAgentExperience, DEFAULT_WIDGET_CONFIG } from "@runtypelabs/persona";
+
+      // ── helpers ──────────────────────────────────────────────────
+
+      const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+      let cancelToken = { cancelled: false };
+
+      function freshCancel() {
+        cancelToken.cancelled = true;
+        cancelToken = { cancelled: false };
+        return cancelToken;
+      }
+
+      const logEl = document.getElementById("log");
+      function log(msg, cls = "") {
+        if (!logEl) return;
+        const line = document.createElement("div");
+        if (cls) line.className = cls;
+        line.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+        logEl.appendChild(line);
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+
+      function setAllButtons(disabled) {
+        document.querySelectorAll(".btn-group button").forEach((b) => {
+          if (b.id !== "btn-cancel" && b.id !== "btn-reset") b.disabled = disabled;
+        });
+      }
+
+      let msgCounter = 0;
+      const nextId = (prefix) => `${prefix}-${++msgCounter}`;
+
+      // ── widget init ─────────────────────────────────────────────
+
+      const mount = document.getElementById("autoscroll-launcher-root");
+      if (!mount) {
+        throw new Error('[autoscroll-stress-test] Missing #autoscroll-launcher-root in the DOM.');
+      }
+      const controller = createAgentExperience(mount, {
+        ...DEFAULT_WIDGET_CONFIG,
+        apiUrl: "https://noop.test/chat",
+        launcher: {
+          ...DEFAULT_WIDGET_CONFIG.launcher,
+          enabled: true,
+          autoExpand: true,
+          width: "560px",
+          position: "bottom-right",
+        },
+        suggestionChips: [],
+        persistState: false,
+        features: {
+          ...DEFAULT_WIDGET_CONFIG.features,
+          toolCallDisplay: {
+            collapsedMode: "tool-name",
+            activePreview: true,
+          },
+          reasoningDisplay: {
+            activePreview: true,
+          },
+        },
+        theme: {
+          ...DEFAULT_WIDGET_CONFIG.theme,
+          primary: "#0d9488",
+          accent: "#0d9488",
+          surface: "#ffffff",
+          muted: "#64748b",
+        },
+        copy: {
+          ...DEFAULT_WIDGET_CONFIG.copy,
+          welcomeTitle: "Auto-Scroll Stress Test",
+          welcomeSubtitle: "Run a scenario from the test page, or type here. The transcript should auto-scroll while streaming.",
+        },
+      });
+
+      // ── follow-state monitor ────────────────────────────────────
+
+      const statusEl = document.getElementById("follow-status");
+
+      function findScrollContainer() {
+        return (
+          mount.querySelector("#persona-scroll-container") ??
+          mount.shadowRoot?.querySelector("#persona-scroll-container")
+        );
+      }
+
+      function pollFollowState() {
+        const dot = statusEl.querySelector(".status-dot");
+        const label = statusEl.querySelector("span:last-child");
+        const { open } = controller.getState();
+        if (!open) {
+          dot.className = "status-dot idle";
+          label.textContent = "Panel closed — open the chat to see scroll state";
+          requestAnimationFrame(pollFollowState);
+          return;
+        }
+        const scrollContainer = findScrollContainer();
+        if (!scrollContainer || scrollContainer.clientHeight === 0) {
+          dot.className = "status-dot idle";
+          label.textContent = "Scroll area not ready";
+          requestAnimationFrame(pollFollowState);
+          return;
+        }
+        const atBottom =
+          scrollContainer.scrollHeight - scrollContainer.clientHeight - scrollContainer.scrollTop < 12;
+        if (atBottom) {
+          dot.className = "status-dot following";
+          label.textContent = "Auto-follow: active (at bottom of transcript)";
+        } else {
+          dot.className = "status-dot paused";
+          label.textContent = "Auto-follow: paused (scrolled up in chat)";
+        }
+        requestAnimationFrame(pollFollowState);
+      }
+      requestAnimationFrame(pollFollowState);
+
+      // ── content generators ──────────────────────────────────────
+
+      const SHORT_MESSAGES = [
+        "Got it!", "Working on that now.", "Sure thing.", "Here you go!",
+        "Let me check.", "One moment please.", "Absolutely!", "Done.",
+        "I can help with that.", "Interesting question!",
+      ];
+
+      const LONG_PARAGRAPHS = [
+        "The quick brown fox jumps over the lazy dog. This sentence contains every letter of the English alphabet at least once, making it a pangram. Pangrams are often used to display typefaces and test keyboards.",
+        "Artificial intelligence has made remarkable strides in recent years, transforming industries from healthcare to transportation. Machine learning models can now process natural language, recognize images, generate creative content, and even write code. The implications for society are both exciting and challenging.",
+        "In software engineering, maintaining clean code is not just about aesthetics — it directly impacts a team's velocity, the frequency of production incidents, and how quickly new developers can onboard. Code that is easy to read is easy to reason about, and code that is easy to reason about is easy to change safely.",
+      ];
+
+      const MARKDOWN_BLOCKS = [
+        "## Search Results\n\nHere are the top results:\n\n1. **Product A** — $29.99\n   - In stock, ships tomorrow\n   - Rating: ★★★★☆\n2. **Product B** — $49.99\n   - Limited availability\n   - Rating: ★★★★★\n3. **Product C** — $19.99\n   - Backordered until next week\n   - Rating: ★★★☆☆\n\n> *Prices may vary by region.*",
+
+        "### Steps to Complete\n\n- [x] Initialize the project\n- [x] Set up the database\n- [ ] Build the API endpoints\n- [ ] Write integration tests\n- [ ] Deploy to staging\n\nWe're making good progress! The first two steps are done.",
+
+        "Here's a code example:\n\n```javascript\nfunction fibonacci(n) {\n  if (n <= 1) return n;\n  let a = 0, b = 1;\n  for (let i = 2; i <= n; i++) {\n    [a, b] = [b, a + b];\n  }\n  return b;\n}\n\nconsole.log(fibonacci(10)); // 55\n```\n\nThis iterative approach runs in O(n) time and O(1) space.",
+
+        "| Feature | Free | Pro | Enterprise |\n|---------|------|-----|------------|\n| Users | 5 | 50 | Unlimited |\n| Storage | 1 GB | 100 GB | 1 TB |\n| Support | Community | Email | Dedicated |\n| SSO | No | No | Yes |\n\nI'd recommend the **Pro** plan for your team size.",
+      ];
+
+      const USER_MESSAGES = [
+        "Can you help me find a product?",
+        "What are the pricing options?",
+        "Tell me more about the enterprise plan.",
+        "Can you show me a code example?",
+        "What's the status of my order?",
+        "How do I set up the project?",
+        "Thanks, that's really helpful!",
+        "One more question — do you support SSO?",
+      ];
+
+      function injectReasoningMessage({ id, status = "streaming", chunks = [] }) {
+        controller.injectTestMessage({
+          type: "message",
+          message: {
+            id,
+            role: "assistant",
+            content: "",
+            createdAt: new Date().toISOString(),
+            streaming: status !== "complete",
+            variant: "reasoning",
+            reasoning: {
+              id,
+              status,
+              chunks,
+            },
+          },
+        });
+      }
+
+      function injectToolMessage({ id, name, status = "running", chunks = [], args, result }) {
+        controller.injectTestMessage({
+          type: "message",
+          message: {
+            id,
+            role: "assistant",
+            content: "",
+            createdAt: new Date().toISOString(),
+            streaming: status !== "complete",
+            variant: "tool",
+            toolCall: {
+              id,
+              name,
+              status,
+              chunks,
+              args,
+              result,
+            },
+          },
+        });
+      }
+
+      const STREAMING_TEXT = `Let me walk you through the complete setup process for your new project.
+
+First, you'll need to install the dependencies. Make sure you have Node.js version 20 or higher installed on your system. You can verify this by running \`node --version\` in your terminal.
+
+Next, clone the repository and navigate into the project directory:
+
+\`\`\`bash
+git clone https://github.com/example/project.git
+cd project
+npm install
+\`\`\`
+
+Once the dependencies are installed, you'll need to configure your environment variables. Create a \`.env\` file in the root directory with the following contents:
+
+\`\`\`
+DATABASE_URL=postgresql://localhost:5432/mydb
+API_KEY=your-api-key-here
+NODE_ENV=development
+\`\`\`
+
+Now you can start the development server:
+
+\`\`\`bash
+npm run dev
+\`\`\`
+
+The server will start on port 3000 by default. Open your browser and navigate to **http://localhost:3000** to see the application running.
+
+If you encounter any issues, check the following:
+
+1. Make sure PostgreSQL is running locally
+2. Verify your API key is valid
+3. Check that port 3000 isn't already in use
+4. Review the logs in the terminal for error messages
+
+Let me know if you need any additional help with the setup!`;
+
+      // ── scenarios ───────────────────────────────────────────────
+
+      async function rapidMessages() {
+        const token = freshCancel();
+        log("Starting: Rapid Messages", "info");
+        setAllButtons(true);
+        document.getElementById("btn-rapid").classList.add("running");
+
+        for (let i = 0; i < 20; i++) {
+          if (token.cancelled) break;
+          const isUser = i % 3 === 0;
+          if (isUser) {
+            controller.injectUserMessage({
+              id: nextId("rapid-user"),
+              content: USER_MESSAGES[i % USER_MESSAGES.length],
+            });
+          } else {
+            const long = i % 5 === 0;
+            controller.injectAssistantMessage({
+              id: nextId("rapid-asst"),
+              content: long
+                ? LONG_PARAGRAPHS[i % LONG_PARAGRAPHS.length]
+                : SHORT_MESSAGES[i % SHORT_MESSAGES.length],
+            });
+          }
+          await sleep(100);
+        }
+
+        document.getElementById("btn-rapid").classList.remove("running");
+        setAllButtons(false);
+        log("Done: Rapid Messages");
+      }
+
+      async function simulateStreaming() {
+        const token = freshCancel();
+        log("Starting: Simulate Streaming", "info");
+        setAllButtons(true);
+        document.getElementById("btn-stream").classList.add("running");
+
+        controller.injectUserMessage({
+          id: nextId("stream-user"),
+          content: "Can you walk me through the project setup?",
+        });
+        await sleep(400);
+
+        const msgId = nextId("stream-asst");
+        const words = STREAMING_TEXT.split(/(\s+)/);
+        let accumulated = "";
+
+        for (let i = 0; i < words.length; i++) {
+          if (token.cancelled) break;
+          accumulated += words[i];
+          controller.injectAssistantMessage({
+            id: msgId,
+            content: accumulated,
+            streaming: true,
+          });
+          // Variable delay: shorter for whitespace, longer for punctuation
+          const word = words[i].trim();
+          const delay = !word ? 0 : word.endsWith(".") || word.endsWith(":") ? 60 : 25;
+          if (delay > 0) await sleep(delay);
+        }
+
+        if (!token.cancelled) {
+          controller.injectAssistantMessage({
+            id: msgId,
+            content: accumulated,
+            streaming: false,
+          });
+        }
+
+        document.getElementById("btn-stream").classList.remove("running");
+        setAllButtons(false);
+        log("Done: Simulate Streaming");
+      }
+
+      async function realisticConversation() {
+        const token = freshCancel();
+        log("Starting: Realistic Conversation", "info");
+        setAllButtons(true);
+        document.getElementById("btn-conversation").classList.add("running");
+
+        const exchanges = [
+          { role: "user", content: "Hi! I'm looking for a good laptop for software development." },
+          { role: "assistant", content: "I'd be happy to help you find the right laptop for development! To give you the best recommendations, I have a few questions:\n\n1. **Budget range** — What's your price range?\n2. **Primary use** — What kind of development? (web, mobile, ML/AI, etc.)\n3. **OS preference** — macOS, Windows, or Linux?\n4. **Portability** — Do you need something lightweight for travel?" },
+          { role: "user", content: "Budget is around $2000, mostly web development and some Docker work. I prefer macOS but open to Linux." },
+          { role: "assistant", content: MARKDOWN_BLOCKS[0].replace(/Product/g, "Laptop").replace(/\$\d+\.\d+/g, (m, i) => ["$1,799", "$1,999", "$1,599"][i] || m) },
+          { role: "user", content: "The second one sounds good. What about the specs?" },
+          { role: "assistant", content: "Great choice! Here are the detailed specs:\n\n" + MARKDOWN_BLOCKS[3].replace(/Feature|Free|Pro|Enterprise/g, (m) => ({ Feature: "Spec", Free: "Base", Pro: "Recommended", Enterprise: "Max" }[m] || m)) },
+          { role: "user", content: "Perfect, I'll go with the recommended config. How do I order?" },
+          { role: "assistant", content: "Excellent! I'll set up the order for you. " + LONG_PARAGRAPHS[1] },
+        ];
+
+        for (const msg of exchanges) {
+          if (token.cancelled) break;
+          if (msg.role === "user") {
+            controller.injectUserMessage({ id: nextId("conv-user"), content: msg.content });
+            await sleep(800);
+          } else {
+            // Simulate word-by-word streaming for assistant
+            const msgId = nextId("conv-asst");
+            const words = msg.content.split(/(\s+)/);
+            let acc = "";
+            for (let i = 0; i < words.length; i++) {
+              if (token.cancelled) break;
+              acc += words[i];
+              controller.injectAssistantMessage({ id: msgId, content: acc, streaming: true });
+              if (words[i].trim()) await sleep(15);
+            }
+            if (!token.cancelled) {
+              controller.injectAssistantMessage({ id: msgId, content: acc, streaming: false });
+            }
+            await sleep(500);
+          }
+        }
+
+        document.getElementById("btn-conversation").classList.remove("running");
+        setAllButtons(false);
+        log("Done: Realistic Conversation");
+      }
+
+      async function mixedContent() {
+        const token = freshCancel();
+        log("Starting: Mixed Content", "info");
+        setAllButtons(true);
+        document.getElementById("btn-mixed").classList.add("running");
+
+        for (let i = 0; i < MARKDOWN_BLOCKS.length; i++) {
+          if (token.cancelled) break;
+          controller.injectUserMessage({
+            id: nextId("mix-user"),
+            content: USER_MESSAGES[i % USER_MESSAGES.length],
+          });
+          await sleep(300);
+
+          if (token.cancelled) break;
+          // Stream each markdown block word-by-word
+          const msgId = nextId("mix-asst");
+          const words = MARKDOWN_BLOCKS[i].split(/(\s+)/);
+          let acc = "";
+          for (let j = 0; j < words.length; j++) {
+            if (token.cancelled) break;
+            acc += words[j];
+            controller.injectAssistantMessage({ id: msgId, content: acc, streaming: true });
+            if (words[j].trim()) await sleep(20);
+          }
+          if (!token.cancelled) {
+            controller.injectAssistantMessage({ id: msgId, content: acc, streaming: false });
+          }
+          await sleep(400);
+        }
+
+        document.getElementById("btn-mixed").classList.remove("running");
+        setAllButtons(false);
+        log("Done: Mixed Content");
+      }
+
+      async function toolReasoningTrace() {
+        const token = freshCancel();
+        log("Starting: Tool + Reasoning Trace", "info");
+        setAllButtons(true);
+        document.getElementById("btn-trace").classList.add("running");
+
+        controller.injectUserMessage({
+          id: nextId("trace-user"),
+          content: "Can you analyze the integration docs and summarize the best setup path?",
+        });
+        await sleep(250);
+
+        const reasoningId = nextId("trace-reasoning");
+        const reasoningChunks = [
+          "I should first inspect the official integration docs, then compare installation options, and finally summarize the shortest path for a production-ready setup.",
+          "I also want to note any caveats around styling, proxying, and event stream visibility so the recommendation is practical rather than generic.",
+        ];
+        injectReasoningMessage({
+          id: reasoningId,
+          status: "streaming",
+          chunks: [reasoningChunks[0]],
+        });
+        await sleep(500);
+        if (token.cancelled) return finish();
+
+        injectReasoningMessage({
+          id: reasoningId,
+          status: "complete",
+          chunks: reasoningChunks,
+        });
+        await sleep(250);
+        if (token.cancelled) return finish();
+
+        const toolOneId = nextId("trace-tool");
+        injectToolMessage({
+          id: toolOneId,
+          name: "Fetch integration docs",
+          status: "running",
+          args: { source: "docs", topic: "embed setup" },
+          chunks: ["Loading widget install guide and configuration reference..."],
+        });
+        await sleep(550);
+        if (token.cancelled) return finish();
+
+        injectToolMessage({
+          id: toolOneId,
+          name: "Fetch integration docs",
+          status: "complete",
+          args: { source: "docs", topic: "embed setup" },
+          chunks: [
+            "Loading widget install guide and configuration reference...",
+            "Found inline embed, launcher mode, and proxy examples.",
+          ],
+          result: {
+            recommended: "launcher",
+            notes: ["supports auto-open", "simple setup", "good for testing transcript behavior"],
+          },
+        });
+        await sleep(250);
+        if (token.cancelled) return finish();
+
+        const toolTwoId = nextId("trace-tool");
+        injectToolMessage({
+          id: toolTwoId,
+          name: "Compare demo layouts",
+          status: "running",
+          args: { demos: ["homepage", "event-stream-testing", "autoscroll-stress-test"] },
+          chunks: ["Comparing working examples for panel width, scroll behavior, and launcher configuration..."],
+        });
+        await sleep(500);
+        if (token.cancelled) return finish();
+
+        injectToolMessage({
+          id: toolTwoId,
+          name: "Compare demo layouts",
+          status: "complete",
+          args: { demos: ["homepage", "event-stream-testing", "autoscroll-stress-test"] },
+          chunks: [
+            "Comparing working examples for panel width, scroll behavior, and launcher configuration...",
+            "Launcher mode works best here once the panel width is increased and transcript rows include reasoning/tool variants.",
+          ],
+          result: {
+            launcherWidth: "560px",
+            activePreview: true,
+          },
+        });
+        await sleep(300);
+        if (token.cancelled) return finish();
+
+        controller.injectAssistantMessage({
+          id: nextId("trace-summary"),
+          content:
+            "Best path: use the launcher for this stress test, keep the panel wider, and exercise transcript behavior with explicit **reasoning** and **tool** rows. Expand the new rows above to verify their collapsed summaries, previews, and final content all auto-scroll correctly.",
+        });
+
+        finish();
+
+        function finish() {
+          document.getElementById("btn-trace").classList.remove("running");
+          setAllButtons(false);
+          log("Done: Tool + Reasoning Trace");
+        }
+      }
+
+      async function stressTest() {
+        const token = freshCancel();
+        log("Starting: Stress Test", "warn");
+        setAllButtons(true);
+        document.getElementById("btn-stress").classList.add("running");
+
+        // Phase 1: burst of short messages
+        log("Phase 1/3: Rapid burst");
+        for (let i = 0; i < 10; i++) {
+          if (token.cancelled) break;
+          const isUser = i % 2 === 0;
+          if (isUser) {
+            controller.injectUserMessage({ id: nextId("stress-user"), content: USER_MESSAGES[i % USER_MESSAGES.length] });
+          } else {
+            controller.injectAssistantMessage({ id: nextId("stress-asst"), content: SHORT_MESSAGES[i % SHORT_MESSAGES.length] });
+          }
+          await sleep(50);
+        }
+
+        if (token.cancelled) { finish(); return; }
+
+        // Phase 2: long streaming message while short messages interleave
+        log("Phase 2/3: Streaming + interleaved injections");
+        const streamId = nextId("stress-stream");
+        const words = STREAMING_TEXT.split(/(\s+)/);
+        let acc = "";
+        let interleaveIdx = 0;
+
+        for (let i = 0; i < words.length; i++) {
+          if (token.cancelled) break;
+          acc += words[i];
+          controller.injectAssistantMessage({ id: streamId, content: acc, streaming: true });
+
+          // Every ~40 words, inject a user message (simulates concurrent activity)
+          if (i > 0 && i % 80 === 0) {
+            controller.injectUserMessage({
+              id: nextId("stress-interleave"),
+              content: USER_MESSAGES[interleaveIdx++ % USER_MESSAGES.length],
+            });
+          }
+          if (words[i].trim()) await sleep(15);
+        }
+        if (!token.cancelled) {
+          controller.injectAssistantMessage({ id: streamId, content: acc, streaming: false });
+        }
+
+        if (token.cancelled) { finish(); return; }
+        await sleep(200);
+
+        // Phase 3: rapid markdown blocks
+        log("Phase 3/3: Rapid rich content");
+        for (const block of MARKDOWN_BLOCKS) {
+          if (token.cancelled) break;
+          controller.injectAssistantMessage({ id: nextId("stress-md"), content: block });
+          await sleep(150);
+        }
+
+        finish();
+        function finish() {
+          document.getElementById("btn-stress").classList.remove("running");
+          setAllButtons(false);
+          log("Done: Stress Test");
+        }
+      }
+
+      // ── wire buttons ────────────────────────────────────────────
+
+      document.getElementById("btn-rapid").addEventListener("click", rapidMessages);
+      document.getElementById("btn-stream").addEventListener("click", simulateStreaming);
+      document.getElementById("btn-conversation").addEventListener("click", realisticConversation);
+      document.getElementById("btn-mixed").addEventListener("click", mixedContent);
+      document.getElementById("btn-trace").addEventListener("click", toolReasoningTrace);
+      document.getElementById("btn-stress").addEventListener("click", stressTest);
+
+      document.getElementById("btn-cancel").addEventListener("click", () => {
+        cancelToken.cancelled = true;
+        setAllButtons(false);
+        document.querySelectorAll(".running").forEach((b) => b.classList.remove("running"));
+        log("Cancelled", "warn");
+      });
+
+      document.getElementById("btn-reset").addEventListener("click", () => {
+        cancelToken.cancelled = true;
+        controller.clearChat();
+        msgCounter = 0;
+        setAllButtons(false);
+        document.querySelectorAll(".running").forEach((b) => b.classList.remove("running"));
+        log("Session reset", "info");
+      });
+
+      // Seed the launcher with a deterministic transcript that includes
+      // reasoning + tool rows so the demo is immediately useful on load.
+      controller.clearChat();
+      requestAnimationFrame(() => {
+        toolReasoningTrace();
+      });
+    </script>
+  </body>
+</html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -298,6 +298,7 @@
                 <li><a class="example-item" href="/approval-demo.html">Tool Approval <small>Human-in-the-loop confirmation before tool execution</small></a></li>
                 <li><a class="example-item" href="/focus-input-demo.html">Focus Input <small>Programmatic input focus and state control</small></a></li>
                 <li><a class="example-item" href="/artifact-demo.html">Artifact Sidebar <small>Resizable split view for rich content</small></a></li>
+                <li><a class="example-item" href="/attachments-demo.html">Attachments <small>File and image attachments in the composer</small></a></li>
                 <li><a class="example-item" href="/voice-integration-demo.html">Voice Integration <small>Speech-to-text and text-to-speech input</small></a></li>
                 <li><a class="example-item" href="/event-stream-testing.html">Event Stream Testing <small>Inspector API, window events, inline + launcher</small></a></li>
               </ul>

--- a/examples/embedded-app/src/attachments-demo.ts
+++ b/examples/embedded-app/src/attachments-demo.ts
@@ -1,0 +1,144 @@
+import "@runtypelabs/persona/widget.css";
+import {
+  createAgentExperience,
+  markdownPostprocessor,
+  DEFAULT_WIDGET_CONFIG,
+} from "@runtypelabs/persona";
+import type { AgentWidgetController, AgentWidgetAttachmentsConfig } from "@runtypelabs/persona";
+
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const proxyUrl = import.meta.env.VITE_PROXY_URL
+  ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
+  : `http://localhost:${proxyPort}/api/chat/dispatch`;
+
+const MB = 1024 * 1024;
+
+const ALLOWED_TYPE_PRESETS: Record<string, string[]> = {
+  images: ["image/png", "image/jpeg", "image/gif", "image/webp"],
+  "images-pdf": ["image/png", "image/jpeg", "image/gif", "image/webp", "application/pdf"],
+  all: [
+    "image/png", "image/jpeg", "image/gif", "image/webp",
+    "application/pdf", "text/plain", "text/csv", "text/html",
+    "application/json",
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Log helper
+// ---------------------------------------------------------------------------
+const logEl = document.getElementById("log");
+
+function log(msg: string) {
+  if (!logEl) return;
+  const ts = new Date().toLocaleTimeString("en-US", { hour12: false });
+  const line = document.createElement("div");
+  line.textContent = `[${ts}] ${msg}`;
+  logEl.appendChild(line);
+  logEl.scrollTop = logEl.scrollHeight;
+}
+
+// ---------------------------------------------------------------------------
+// Read config from the UI controls
+// ---------------------------------------------------------------------------
+function readAttachmentsConfig(): AgentWidgetAttachmentsConfig {
+  const maxFiles = Number(
+    (document.getElementById("cfg-max-files") as HTMLSelectElement).value
+  );
+  const maxFileSize =
+    Number((document.getElementById("cfg-max-size") as HTMLSelectElement).value) * MB;
+  const typesKey = (document.getElementById("cfg-allowed-types") as HTMLSelectElement).value;
+  const allowedTypes = ALLOWED_TYPE_PRESETS[typesKey] ?? ALLOWED_TYPE_PRESETS.images;
+  const buttonIconName = (document.getElementById("cfg-icon") as HTMLSelectElement).value;
+
+  const dropBg = (document.getElementById("cfg-drop-bg") as HTMLSelectElement).value;
+  const dropIcon = (document.getElementById("cfg-drop-icon") as HTMLSelectElement).value;
+  const dropLabel = (document.getElementById("cfg-drop-label") as HTMLInputElement).value.trim();
+  const dropBorder = (document.getElementById("cfg-drop-border") as HTMLSelectElement).value;
+  const dropStroke = (document.getElementById("cfg-drop-stroke") as HTMLSelectElement).value;
+  const dropBlur = (document.getElementById("cfg-drop-blur") as HTMLSelectElement).value;
+  const dropInset = (document.getElementById("cfg-drop-inset") as HTMLSelectElement).value;
+
+  const dropOverlay: AgentWidgetAttachmentsConfig["dropOverlay"] = {
+    ...(dropBg ? { background: dropBg } : {}),
+    ...(dropIcon ? { iconName: dropIcon } : {}),
+    ...(dropStroke ? { iconStrokeWidth: Number(dropStroke) } : {}),
+    ...(dropLabel ? { label: dropLabel } : {}),
+    ...(dropBorder ? { border: dropBorder } : {}),
+    ...(dropBlur ? { backdropBlur: dropBlur } : {}),
+    ...(dropInset ? { inset: dropInset } : {}),
+  };
+
+  return {
+    enabled: true,
+    maxFiles,
+    maxFileSize,
+    allowedTypes,
+    buttonIconName,
+    ...(Object.keys(dropOverlay).length > 0 ? { dropOverlay } : {}),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Widget lifecycle
+// ---------------------------------------------------------------------------
+let controller: AgentWidgetController | null = null;
+
+function mountWidget() {
+  const mount = document.getElementById("attachments-widget");
+  if (!mount) throw new Error("Widget mount not found");
+
+  mount.innerHTML = "";
+
+  const attachments = readAttachmentsConfig();
+  log(`Mounted — maxFiles=${attachments.maxFiles}, maxSize=${(attachments.maxFileSize ?? 0) / MB}MB, icon=${attachments.buttonIconName}`);
+
+  controller = createAgentExperience(mount, {
+    ...DEFAULT_WIDGET_CONFIG,
+    apiUrl: proxyUrl,
+    launcher: {
+      ...DEFAULT_WIDGET_CONFIG.launcher,
+      enabled: false,
+      width: "100%",
+    },
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Attachments Demo",
+      welcomeSubtitle: "Attach images or files and send them with your message.",
+      inputPlaceholder: "Type a message or attach a file…",
+    },
+    suggestionChips: [
+      "Describe what you see in the image",
+      "Summarize this document",
+    ],
+    attachments,
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+  });
+
+  (window as unknown as { attachmentsController: typeof controller }).attachmentsController =
+    controller;
+}
+
+mountWidget();
+
+// ---------------------------------------------------------------------------
+// Sync blur dropdown when a "no blur" background preset is picked
+// ---------------------------------------------------------------------------
+const bgSelect = document.getElementById("cfg-drop-bg") as HTMLSelectElement | null;
+const blurSelect = document.getElementById("cfg-drop-blur") as HTMLSelectElement | null;
+bgSelect?.addEventListener("change", () => {
+  const selected = bgSelect.selectedOptions[0];
+  if (selected?.hasAttribute("data-no-blur") && blurSelect) {
+    blurSelect.value = "0px";
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Apply button — destroy and re-create with new config
+// ---------------------------------------------------------------------------
+document.getElementById("apply-config")?.addEventListener("click", () => {
+  if (controller) {
+    controller.destroy();
+    controller = null;
+  }
+  mountWidget();
+});

--- a/examples/embedded-app/src/fullscreen-assistant-demo.ts
+++ b/examples/embedded-app/src/fullscreen-assistant-demo.ts
@@ -186,7 +186,8 @@ const fullscreenAssistantComposerPlugin: AgentWidgetPlugin = {
     const input = document.createElement("textarea");
     input.setAttribute("data-persona-composer-input", "");
     input.rows = 1;
-    input.placeholder = config.copy?.inputPlaceholder ?? "Reply…";
+    input.placeholder =
+      config.copy?.inputPlaceholder ?? "Reply… (drop files on the chat to attach)";
     input.className =
       "persona-w-full persona-resize-none persona-border-none persona-bg-transparent persona-text-sm persona-outline-none persona-px-5";
     input.style.color = COLORS.text;
@@ -283,7 +284,7 @@ const fullscreenAssistantComposerPlugin: AgentWidgetPlugin = {
 
     const trySend = () => {
       const v = input.value.trim();
-      if (v) onSubmit(v);
+      onSubmit(v);
       input.value = "";
     };
 
@@ -481,7 +482,7 @@ const config = mergeWithDefaults({
   launcher: { enabled: false, fullHeight: true },
   copy: {
     showWelcomeCard: false,
-    inputPlaceholder: "Reply…"
+    inputPlaceholder: "Reply… (drop files on the chat to attach)"
   },
   voiceRecognition: { enabled: true },
   messageActions: {

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -286,6 +286,7 @@ export default defineConfig({
         'bakery-goods': path.resolve(__dirname, 'bakery-goods.html'),
         'bakery-services': path.resolve(__dirname, 'bakery-services.html'),
         // Approval demo
+        'attachments-demo': path.resolve(__dirname, 'attachments-demo.html'),
         'approval-demo': path.resolve(__dirname, 'approval-demo.html'),
         // Focus input demo
         'focus-input-demo': path.resolve(__dirname, 'focus-input-demo.html'),
@@ -295,6 +296,7 @@ export default defineConfig({
         'launcher-demo': path.resolve(__dirname, 'launcher-demo.html'),
         'custom-loading-indicator': path.resolve(__dirname, 'custom-loading-indicator.html'),
         'voice-integration-demo': path.resolve(__dirname, 'voice-integration-demo.html'),
+        'autoscroll-stress-test': path.resolve(__dirname, 'autoscroll-stress-test.html'),
         // Standalone (CDN / Copy-Paste) pages
         'standalone/shopify': path.resolve(__dirname, 'standalone/shopify.html'),
         'standalone/example-shop': path.resolve(__dirname, 'standalone/example-shop.html'),

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -93,6 +93,35 @@
   gap: 1.5rem;
 }
 
+[data-persona-root] .persona-widget-container .persona-attachment-drop-overlay {
+  display: none;
+  position: absolute;
+  inset: var(--persona-drop-overlay-inset, 0);
+  z-index: 50;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  pointer-events: none;
+  background: var(--persona-drop-overlay-bg, rgba(59, 130, 246, 0.08));
+  -webkit-backdrop-filter: blur(var(--persona-drop-overlay-blur, 8px));
+  backdrop-filter: blur(var(--persona-drop-overlay-blur, 8px));
+  border: var(--persona-drop-overlay-border, 2px dashed rgba(59, 130, 246, 0.4));
+  border-radius: var(--persona-drop-overlay-radius, inherit);
+  transition: opacity 0.15s ease;
+}
+
+[data-persona-root] .persona-widget-container .persona-attachment-drop-overlay .persona-drop-overlay-label {
+  font-size: var(--persona-drop-overlay-label-size, 0.875rem);
+  color: var(--persona-drop-overlay-label-color, rgba(59, 130, 246, 0.8));
+  font-weight: 500;
+  user-select: none;
+}
+
+[data-persona-root] .persona-widget-container.persona-attachment-drop-active .persona-attachment-drop-overlay {
+  display: flex;
+}
+
 /* Widget CSS Variables - scoped to widget root to avoid polluting global namespace */
 [data-persona-root] {
   --persona-radius-sm: 0.125rem;
@@ -935,6 +964,7 @@
 }
 
 .persona-widget-container {
+  position: relative;
   border-radius: var(--persona-panel-radius, var(--persona-radius-xl, 0.75rem));
 }
 

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -2081,6 +2081,35 @@ export type AgentWidgetAttachmentsConfig = {
    * Callback when a file is rejected (wrong type or too large).
    */
   onFileRejected?: (file: File, reason: 'type' | 'size' | 'count') => void;
+  /**
+   * Customize the drag-and-drop overlay that appears when files are dragged over the widget.
+   */
+  dropOverlay?: {
+    /** Background color/value of the overlay. @default 'rgba(59, 130, 246, 0.08)' */
+    background?: string;
+    /** Backdrop blur applied behind the overlay (CSS value). @default '8px' */
+    backdropBlur?: string;
+    /** Border style shown during drag. @default '2px dashed rgba(59, 130, 246, 0.4)' */
+    border?: string;
+    /** Border radius of the overlay. @default 'inherit' */
+    borderRadius?: string;
+    /** Inset/margin pulling the overlay away from the container edges (CSS value). @default '0' */
+    inset?: string;
+    /** Lucide icon name displayed in the center. @default 'upload' */
+    iconName?: string;
+    /** Icon size (CSS value). @default '48px' */
+    iconSize?: string;
+    /** Icon stroke color. @default 'rgba(59, 130, 246, 0.6)' */
+    iconColor?: string;
+    /** Icon stroke width. @default 0.5 */
+    iconStrokeWidth?: number;
+    /** Optional label text shown below the icon. */
+    label?: string;
+    /** Label font size. @default '0.875rem' */
+    labelSize?: string;
+    /** Label color. @default 'rgba(59, 130, 246, 0.8)' */
+    labelColor?: string;
+  };
 };
 
 /**

--- a/packages/widget/src/ui.attachments-drop.test.ts
+++ b/packages/widget/src/ui.attachments-drop.test.ts
@@ -1,0 +1,188 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentExperience } from "./ui";
+import { AttachmentManager } from "./utils/attachment-manager";
+
+const createMount = () => {
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  return mount;
+};
+
+/** jsdom does not expose `DataTransfer`; real browsers set `dropEffect` on dragover. */
+function createFileDataTransfer(files: File[]): DataTransfer {
+  const list: File[] = [...files];
+  const fileList = list as unknown as FileList;
+  return {
+    dropEffect: "none",
+    effectAllowed: "all",
+    files: fileList,
+    items: {
+      add: () => {},
+      clear: () => {},
+      remove: () => {}
+    } as unknown as DataTransferItemList,
+    types: files.length > 0 ? ["Files"] : [],
+    clearData: () => {},
+    getData: () => "",
+    setData: () => {},
+    setDragImage: () => {}
+  } as unknown as DataTransfer;
+}
+
+function createDragEvent(type: string, dataTransfer: DataTransfer): DragEvent {
+  const ev = new Event(type, { bubbles: true, cancelable: true }) as unknown as DragEvent;
+  Object.defineProperty(ev, "dataTransfer", { value: dataTransfer, enumerable: true });
+  return ev;
+}
+
+describe("createAgentExperience attachment file drop", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (cb: (time: number) => void) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("calls AttachmentManager.handleFiles when files are dropped on the mount", () => {
+    const handleFilesSpy = vi.spyOn(AttachmentManager.prototype, "handleFiles");
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: true, maxFiles: 4 },
+    });
+
+    const file = new File(["x"], "test.png", { type: "image/png" });
+    const dt = createFileDataTransfer([file]);
+
+    // dragover/drop are on mount so the browser default is suppressed everywhere
+    const dragOver = createDragEvent("dragover", dt);
+    mount.dispatchEvent(dragOver);
+    expect(dragOver.defaultPrevented).toBe(true);
+    expect(dt.dropEffect).toBe("copy");
+
+    const drop = createDragEvent("drop", dt);
+    mount.dispatchEvent(drop);
+    expect(drop.defaultPrevented).toBe(true);
+
+    expect(handleFilesSpy).toHaveBeenCalledTimes(1);
+    const passed = handleFilesSpy.mock.calls[0]?.[0] as File[];
+    expect(passed).toHaveLength(1);
+    expect(passed[0]?.name).toBe("test.png");
+
+    handleFilesSpy.mockRestore();
+    controller.destroy();
+  });
+
+  it("shows drop-active highlight on container during dragenter", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: true, maxFiles: 4 },
+    });
+
+    const container = mount.querySelector(".persona-widget-container")!;
+    const file = new File(["x"], "test.png", { type: "image/png" });
+    const dt = createFileDataTransfer([file]);
+
+    container.dispatchEvent(createDragEvent("dragenter", dt));
+    expect(container.classList.contains("persona-attachment-drop-active")).toBe(true);
+
+    container.dispatchEvent(createDragEvent("dragleave", dt));
+    expect(container.classList.contains("persona-attachment-drop-active")).toBe(false);
+
+    controller.destroy();
+  });
+
+  it("renders drop overlay with icon inside container", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: true, maxFiles: 4 },
+    });
+
+    const overlay = mount.querySelector(".persona-attachment-drop-overlay");
+    expect(overlay).not.toBeNull();
+    expect(overlay!.querySelector("svg")).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  it("applies custom dropOverlay config as CSS variables", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: {
+        enabled: true,
+        maxFiles: 4,
+        dropOverlay: {
+          background: "rgba(255, 0, 0, 0.1)",
+          backdropBlur: "12px",
+          border: "2px solid red",
+          inset: "8px",
+          iconName: "image-plus",
+          label: "Drop here",
+        },
+      },
+    });
+
+    const overlay = mount.querySelector<HTMLElement>(".persona-attachment-drop-overlay")!;
+    expect(overlay).not.toBeNull();
+    expect(overlay.style.getPropertyValue("--persona-drop-overlay-bg")).toBe("rgba(255, 0, 0, 0.1)");
+    expect(overlay.style.getPropertyValue("--persona-drop-overlay-blur")).toBe("12px");
+    expect(overlay.style.getPropertyValue("--persona-drop-overlay-border")).toBe("2px solid red");
+    expect(overlay.style.getPropertyValue("--persona-drop-overlay-inset")).toBe("8px");
+
+    const label = overlay.querySelector(".persona-drop-overlay-label");
+    expect(label).not.toBeNull();
+    expect(label!.textContent).toBe("Drop here");
+
+    controller.destroy();
+  });
+
+  it("does not render drop overlay when attachments are disabled", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: false },
+    });
+
+    const overlay = mount.querySelector(".persona-attachment-drop-overlay");
+    expect(overlay).toBeNull();
+
+    controller.destroy();
+  });
+
+  it("does not prevent dragover when attachments are disabled", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: false },
+    });
+
+    const file = new File(["x"], "test.png", { type: "image/png" });
+    const dt = createFileDataTransfer([file]);
+
+    const dragOver = createDragEvent("dragover", dt);
+    mount.dispatchEvent(dragOver);
+    expect(dragOver.defaultPrevented).toBe(false);
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.scroll.test.ts
+++ b/packages/widget/src/ui.scroll.test.ts
@@ -472,6 +472,52 @@ describe("createAgentExperience streaming scroll", () => {
     controller.destroy();
   });
 
+  it("ignores layout-driven scroll events before a scheduled auto-scroll starts", () => {
+    const raf = installRafMock();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      features: {
+        toolCallDisplay: {
+          activePreview: true,
+        },
+      },
+    } as any);
+
+    const scrollContainer = mount.querySelector<HTMLElement>("#persona-scroll-container");
+    expect(scrollContainer).not.toBeNull();
+
+    const metrics = installScrollMetrics(scrollContainer!, {
+      scrollHeight: 960,
+      clientHeight: 400,
+    });
+
+    emitStreamingStatus(controller);
+    emitToolMessage(controller, { id: "tool-1", chunks: ["Loaded tools"] });
+    emitToolMessage(controller, { id: "tool-2", chunks: ["Fetched docs"] });
+    raf.flush();
+
+    expect(metrics.getScrollTop()).toBe(metrics.getBottomScrollTop());
+
+    metrics.setScrollHeight(1035);
+    emitToolMessage(controller, {
+      id: "tool-3",
+      chunks: ["Compared layouts and noted launcher sizing"],
+    });
+
+    // Simulate the browser emitting a scroll event caused by layout/scroll
+    // anchoring before the scheduled auto-scroll rAF has started.
+    metrics.setScrollTop(metrics.getScrollTop() - 2);
+    scrollContainer!.dispatchEvent(new Event("scroll"));
+
+    raf.flush();
+
+    expect(metrics.getScrollTop()).toBe(metrics.getBottomScrollTop());
+
+    controller.destroy();
+  });
+
   it("uses icon-only arrow-down defaults for the transcript affordance", () => {
     const raf = installRafMock();
     const mount = createMount();

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -147,6 +147,19 @@ function getClipboardImageFiles(clipboardData: DataTransfer | null): File[] {
   return imageFiles;
 }
 
+function dataTransferHasFiles(
+  dataTransfer: DataTransfer | null
+): dataTransfer is DataTransfer {
+  if (!dataTransfer) return false;
+  const types = dataTransfer.types;
+  if (!types) return false;
+  // Real browsers return DOMStringList which has .contains(); test polyfills use plain arrays.
+  if (typeof (types as unknown as { contains?: unknown }).contains === "function") {
+    return (types as unknown as DOMStringList).contains("Files");
+  }
+  return Array.from(types).includes("Files");
+}
+
 // ============================================================================
 // PERSIST STATE HELPERS
 // ============================================================================
@@ -389,11 +402,43 @@ const buildPostprocessor = (
   };
 };
 
+function buildDropOverlay(
+  dropCfg?: NonNullable<AgentWidgetConfig["attachments"]>["dropOverlay"]
+): HTMLElement {
+  const overlay = createElement("div", "persona-attachment-drop-overlay");
+  if (dropCfg?.background) overlay.style.setProperty("--persona-drop-overlay-bg", dropCfg.background);
+  if (dropCfg?.backdropBlur !== undefined) overlay.style.setProperty("--persona-drop-overlay-blur", dropCfg.backdropBlur);
+  if (dropCfg?.border) overlay.style.setProperty("--persona-drop-overlay-border", dropCfg.border);
+  if (dropCfg?.borderRadius) overlay.style.setProperty("--persona-drop-overlay-radius", dropCfg.borderRadius);
+  if (dropCfg?.inset) overlay.style.setProperty("--persona-drop-overlay-inset", dropCfg.inset);
+  if (dropCfg?.labelSize) overlay.style.setProperty("--persona-drop-overlay-label-size", dropCfg.labelSize);
+  if (dropCfg?.labelColor) overlay.style.setProperty("--persona-drop-overlay-label-color", dropCfg.labelColor);
+
+  const iconName = dropCfg?.iconName ?? "upload";
+  const iconSize = dropCfg?.iconSize ?? "48px";
+  const iconColor = dropCfg?.iconColor ?? "rgba(59, 130, 246, 0.6)";
+  const iconStrokeWidth = dropCfg?.iconStrokeWidth ?? 0.5;
+  const iconSvg = renderLucideIcon(iconName, iconSize, iconColor, iconStrokeWidth);
+  if (iconSvg) overlay.appendChild(iconSvg);
+
+  if (dropCfg?.label) {
+    const labelEl = createElement("span", "persona-drop-overlay-label");
+    labelEl.textContent = dropCfg.label;
+    overlay.appendChild(labelEl);
+  }
+  return overlay;
+}
+
 export const createAgentExperience = (
   mount: HTMLElement,
   initialConfig?: AgentWidgetConfig,
   runtimeOptions?: { debugTools?: boolean }
 ): Controller => {
+  if (mount == null) {
+    throw new Error(
+      "createAgentExperience: mount must be a non-null HTMLElement (e.g. pass document.getElementById(\"my-root\") after the node exists)."
+    );
+  }
   // Preserve original mount id as data attribute for window event instance scoping
   if (mount.id && !mount.getAttribute("data-persona-instance")) {
     mount.setAttribute("data-persona-instance", mount.id);
@@ -870,8 +915,21 @@ export const createAgentExperience = (
         return composerElements.footer;
       },
       onSubmit: (text: string) => {
-        if (session && !session.isStreaming()) {
-          session.sendMessage(text);
+        if (!session || session.isStreaming()) return;
+        const value = text.trim();
+        const hasAttachments = attachmentManager?.hasAttachments() ?? false;
+        if (!value && !hasAttachments) return;
+        let contentParts: ContentPart[] | undefined;
+        if (hasAttachments) {
+          contentParts = [];
+          contentParts.push(...attachmentManager!.getContentParts());
+          if (value) {
+            contentParts.push(createTextPart(value));
+          }
+        }
+        session.sendMessage(value, { contentParts });
+        if (hasAttachments) {
+          attachmentManager!.clearAttachments();
         }
       },
       streaming: false,
@@ -959,6 +1017,10 @@ export const createAgentExperience = (
       attachmentManager?.handleFileSelect(target.files);
       target.value = "";
     });
+
+    const dropCfg = config.attachments.dropOverlay;
+    const overlay = buildDropOverlay(dropCfg);
+    container.appendChild(overlay);
   }
 
   // Slot system: allow custom content injection into specific regions
@@ -1925,6 +1987,7 @@ export const createAgentExperience = (
   let lastScrollTop = 0;
   let scrollRAF: number | null = null;
   let isAutoScrolling = false;
+  let hasPendingAutoScroll = false;
 
   const USER_SCROLL_THRESHOLD = 1;
   const BOTTOM_THRESHOLD = 8;
@@ -2041,6 +2104,7 @@ export const createAgentExperience = (
       cancelAnimationFrame(scrollRAF);
       scrollRAF = null;
     }
+    hasPendingAutoScroll = false;
     cancelSmoothScroll();
   };
 
@@ -2076,10 +2140,25 @@ export const createAgentExperience = (
 
     if (!force && !isStreaming) return;
 
-    cancelAutoScroll();
+    // Only cancel the pending schedule rAF — keep the ongoing smooth scroll
+    // animation alive so isAutoScrolling stays true.  This prevents scroll
+    // events fired by DOM morphing (between cancel and the next rAF) from
+    // being misinterpreted as user-initiated upward scrolls that would
+    // permanently pause auto-follow during streaming.
+    // smoothScrollToBottom() already calls cancelSmoothScroll() internally
+    // before starting its new animation.
+    if (scrollRAF !== null) {
+      cancelAnimationFrame(scrollRAF);
+      scrollRAF = null;
+    }
 
+    // Treat the render -> next-rAF window as programmatic scrolling too.
+    // This prevents layout/scroll-anchoring scroll events fired before the
+    // actual smooth scroll starts from being misread as user intent.
+    hasPendingAutoScroll = true;
     scrollRAF = requestAnimationFrame(() => {
       scrollRAF = null;
+      hasPendingAutoScroll = false;
       if (!autoFollow.isFollowing()) return;
       smoothScrollToBottom(getScrollableContainer(), force ? 220 : 140);
     });
@@ -3776,7 +3855,7 @@ export const createAgentExperience = (
       lastScrollTop,
       nearBottom: isElementNearBottom(body, BOTTOM_THRESHOLD),
       userScrollThreshold: USER_SCROLL_THRESHOLD,
-      isAutoScrolling,
+      isAutoScrolling: isAutoScrolling || hasPendingAutoScroll,
       pauseOnUpwardScroll: true,
       pauseWhenAwayFromBottom: false,
       resumeRequiresDownwardScroll: true
@@ -3915,12 +3994,94 @@ export const createAgentExperience = (
   textarea?.addEventListener("keydown", handleInputEnter);
   textarea?.addEventListener("paste", handleInputPaste);
 
+  const ATTACHMENT_DROP_ACTIVE_CLASS = "persona-attachment-drop-active";
+  let attachmentFileDragDepth = 0;
+
+  const clearAttachmentDropVisual = () => {
+    attachmentFileDragDepth = 0;
+    container.classList.remove(ATTACHMENT_DROP_ACTIVE_CLASS);
+  };
+
+  const attachmentDropHandlingActive = (): boolean =>
+    config.attachments?.enabled === true && attachmentManager !== null;
+
+  // Visual highlight tracked on `container` (the chat column).
+  const handleAttachmentDragEnterCapture = (e: DragEvent) => {
+    if (!dataTransferHasFiles(e.dataTransfer) || !attachmentDropHandlingActive()) return;
+    attachmentFileDragDepth++;
+    if (attachmentFileDragDepth === 1) {
+      container.classList.add(ATTACHMENT_DROP_ACTIVE_CLASS);
+    }
+  };
+
+  const handleAttachmentDragLeaveCapture = (e: DragEvent) => {
+    if (!dataTransferHasFiles(e.dataTransfer) || !attachmentDropHandlingActive()) return;
+    attachmentFileDragDepth--;
+    if (attachmentFileDragDepth <= 0) {
+      clearAttachmentDropVisual();
+    }
+  };
+
+  // dragover + drop registered on `mount` so the browser default (open file)
+  // is suppressed across the entire widget surface (artifact pane, gaps, etc.).
+  const handleAttachmentDragOverCapture = (e: DragEvent) => {
+    if (!dataTransferHasFiles(e.dataTransfer) || !attachmentDropHandlingActive()) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  };
+
+  const handleAttachmentDropCapture = (e: DragEvent) => {
+    if (!dataTransferHasFiles(e.dataTransfer) || !attachmentDropHandlingActive()) return;
+    e.preventDefault();
+    e.stopPropagation();
+    clearAttachmentDropVisual();
+    const files = Array.from(e.dataTransfer.files ?? []);
+    if (files.length === 0) return;
+    void attachmentManager!.handleFiles(files);
+  };
+
+  const attachmentDropCapture = true;
+  container.addEventListener("dragenter", handleAttachmentDragEnterCapture, attachmentDropCapture);
+  container.addEventListener("dragleave", handleAttachmentDragLeaveCapture, attachmentDropCapture);
+  mount.addEventListener("dragover", handleAttachmentDragOverCapture, attachmentDropCapture);
+  mount.addEventListener("drop", handleAttachmentDropCapture, attachmentDropCapture);
+
+  // Prevent the browser from navigating to/opening a dropped file anywhere on
+  // the page while this widget instance has attachments enabled.  These guards
+  // intentionally skip the `dataTransferHasFiles` check because real OS drags
+  // may expose `dataTransfer.types` as a DOMStringList or restrict access
+  // during certain drag phases.  The cost is minimal: we suppress the native
+  // "open file" default for ALL drag-overs while the widget is alive and
+  // attachments are on — text drags into the textarea still work because
+  // element-level handlers are unaffected (we don't stopPropagation here).
+  const ownerDoc = mount.ownerDocument;
+  const handleDocDragOver = (e: DragEvent) => {
+    if (!attachmentDropHandlingActive()) return;
+    e.preventDefault();
+  };
+  const handleDocDrop = (e: DragEvent) => {
+    if (!attachmentDropHandlingActive()) return;
+    e.preventDefault();
+  };
+  ownerDoc.addEventListener("dragover", handleDocDragOver);
+  ownerDoc.addEventListener("drop", handleDocDrop);
+
   destroyCallbacks.push(() => {
     if (composerForm) {
       composerForm.removeEventListener("submit", handleSubmit);
     }
     textarea?.removeEventListener("keydown", handleInputEnter);
     textarea?.removeEventListener("paste", handleInputPaste);
+  });
+
+  destroyCallbacks.push(() => {
+    container.removeEventListener("dragenter", handleAttachmentDragEnterCapture, attachmentDropCapture);
+    container.removeEventListener("dragleave", handleAttachmentDragLeaveCapture, attachmentDropCapture);
+    mount.removeEventListener("dragover", handleAttachmentDragOverCapture, attachmentDropCapture);
+    mount.removeEventListener("drop", handleAttachmentDropCapture, attachmentDropCapture);
+    ownerDoc.removeEventListener("dragover", handleDocDragOver);
+    ownerDoc.removeEventListener("drop", handleDocDrop);
+    clearAttachmentDropVisual();
   });
 
   destroyCallbacks.push(() => {
@@ -4958,6 +5119,11 @@ export const createAgentExperience = (
               }
             });
           }
+
+          // Create drop overlay if missing
+          if (!container.querySelector(".persona-attachment-drop-overlay")) {
+            container.appendChild(buildDropOverlay(attachmentsConfig.dropOverlay));
+          }
         } else {
           // Show existing attachment button and update config
           attachmentButtonWrapper.style.display = "";
@@ -4987,6 +5153,8 @@ export const createAgentExperience = (
         if (attachmentManager) {
           attachmentManager.clearAttachments();
         }
+        // Remove drop overlay
+        container.querySelector(".persona-attachment-drop-overlay")?.remove();
       }
 
       // Update send button styling


### PR DESCRIPTION
- Add drag-and-drop file upload on the chat panel when attachments are enabled, with a subtle drop-target highlight.
- `createAgentExperience` now throws a clear error when `mount` is null or undefined instead of failing on property access.
- `renderComposer` `onSubmit` now sends pending attachments (and optional text) the same way as the built-in composer.