### PR TITLE
Fix tool call bubbles to display the correct tool name in active text templates

### DIFF
--- a/.changeset/fix-data-config-newlines.md
+++ b/.changeset/fix-data-config-newlines.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix JSON parse error when `data-config` attribute contains line breaks in HTML

--- a/.changeset/fix-tool-name-animation.md
+++ b/.changeset/fix-tool-name-animation.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix tool call bubbles showing fallback "tool" instead of the actual tool name in active text templates. When `agent_tool_start` arrived before `tool_start`, the name-less first render was cached and preserved by the animation morph guard. The fingerprint now includes `toolCall.name` so the cache invalidates when the name arrives, and the morph callback allows content updates when text has meaningfully changed.

--- a/.changeset/loading-animations.md
+++ b/.changeset/loading-animations.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add configurable loading animations and text templates for tool call and reasoning bubbles. New `loadingAnimation` display option (`pulse`, `shimmer`, `shimmer-color`, `rainbow`) provides visual feedback during tool execution and reasoning. Text templates (`activeTextTemplate`, `completeTextTemplate`) support `{toolName}` and `{duration}` placeholders with inline formatting syntax (`~dim~`, `*italic*`, `**bold**`). The `renderCollapsedSummary` callback for both tool calls and reasoning now receives `elapsed` and `createElapsedElement()` for custom renderers to display live-updating duration.

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -300,7 +300,7 @@
                 <li><a class="example-item" href="/artifact-demo.html">Artifact Sidebar <small>Resizable split view for rich content</small></a></li>
                 <li><a class="example-item" href="/attachments-demo.html">Attachments <small>File and image attachments in the composer</small></a></li>
                 <li><a class="example-item" href="/voice-integration-demo.html">Voice Integration <small>Speech-to-text and text-to-speech input</small></a></li>
-                <li><a class="example-item" href="/tool-loading-demo.html">Tool Loading Animations <small>Configurable loading indicators for tool calls</small></a></li>
+                <li><a class="example-item" href="/tool-loading-demo.html">Tool &amp; Reasoning Loading Animations <small>Configurable loading indicators for tool calls and reasoning</small></a></li>
                 <li><a class="example-item" href="/event-stream-testing.html">Event Stream Testing <small>Inspector API, window events, inline + launcher</small></a></li>
               </ul>
             </section>

--- a/examples/embedded-app/tool-loading-demo.html
+++ b/examples/embedded-app/tool-loading-demo.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/src/demo-shared.css">
     <link rel="icon" href="/favicon.ico" />
-    <title>Tool Loading Animations - Persona</title>
+    <title>Tool &amp; Reasoning Loading Animations - Persona</title>
     <style>
       body {
         padding: 1.5rem;
@@ -163,9 +163,9 @@
   <body>
     <div id="tool-loading-launcher-root" aria-hidden="true"></div>
 
-    <h1>Tool Loading Animations</h1>
+    <h1>Tool &amp; Reasoning Loading Animations</h1>
     <p class="subtitle">
-      Configure animation mode, text templates, and colors, then run tool scenarios to preview. The widget opens automatically (bottom-right).
+      Configure animation mode, text templates, and colors, then run tool or reasoning scenarios to preview. The widget opens automatically (bottom-right).
     </p>
 
     <div class="controls">
@@ -181,16 +181,21 @@
       </div>
 
       <div class="section">
-        <label>Active Text Template</label>
+        <label>Tool Text Templates</label>
         <input type="text" id="active-template" placeholder="e.g. Calling {toolName}..." value="Calling {toolName}... ~{duration}~" />
+        <input type="text" id="complete-template" placeholder="e.g. Finished {toolName} ({duration})" value="Finished {toolName} ~{duration}~" />
         <small style="color:var(--muted);font-size:0.6875rem;margin-top:-0.25rem">
           Placeholders: <code>{toolName}</code> <code>{duration}</code> &nbsp;|&nbsp; Formatting: <code>~dim~</code> <code>*italic*</code> <code>**bold**</code>
         </small>
       </div>
 
       <div class="section">
-        <label>Complete Text Template</label>
-        <input type="text" id="complete-template" placeholder="e.g. Finished {toolName} ({duration})" value="Finished {toolName} ~{duration}~" />
+        <label>Reasoning Text Templates</label>
+        <input type="text" id="reason-active-template" placeholder="e.g. Thinking... ~{duration}~" value="Thinking... ~{duration}~" />
+        <input type="text" id="reason-complete-template" placeholder="e.g. Thought for ~{duration}~" value="Thought for ~{duration}~" />
+        <small style="color:var(--muted);font-size:0.6875rem;margin-top:-0.25rem">
+          Placeholder: <code>{duration}</code> &nbsp;|&nbsp; Formatting: <code>~dim~</code> <code>*italic*</code> <code>**bold**</code>
+        </small>
       </div>
 
       <div class="section">
@@ -219,6 +224,14 @@
           <button id="btn-long">Long Tool (8s) with streaming chunks</button>
           <button id="btn-concurrent">Multiple Concurrent Tools (3 tools)</button>
           <button id="btn-names">Tool Name Variants (short, long, empty)</button>
+        </div>
+      </div>
+
+      <div class="section">
+        <label>Reasoning Scenarios</label>
+        <div class="btn-group">
+          <button id="btn-reason-short">Short Thinking (2s)</button>
+          <button id="btn-reason-long">Long Thinking (6s) with chunks</button>
         </div>
       </div>
 
@@ -275,6 +288,8 @@
         const mode = currentMode;
         const activeTemplate = document.getElementById("active-template").value || undefined;
         const completeTemplate = document.getElementById("complete-template").value || undefined;
+        const reasonActiveTemplate = document.getElementById("reason-active-template").value || undefined;
+        const reasonCompleteTemplate = document.getElementById("reason-complete-template").value || undefined;
         const duration = parseInt(document.getElementById("anim-duration").value, 10);
         const primaryColor = document.getElementById("color-primary").value;
         const secondaryColor = document.getElementById("color-secondary").value;
@@ -293,9 +308,15 @@
           persistState: false,
           features: {
             ...DEFAULT_WIDGET_CONFIG.features,
+            showReasoning: true,
             toolCallDisplay: {
               collapsedMode: "tool-name",
               activePreview: false,
+              expandable: true,
+              loadingAnimation: mode,
+            },
+            reasoningDisplay: {
+              activePreview: true,
               expandable: true,
               loadingAnimation: mode,
             },
@@ -303,6 +324,15 @@
           toolCall: {
             activeTextTemplate: activeTemplate,
             completeTextTemplate: completeTemplate,
+            loadingAnimationDuration: duration,
+            ...(mode === "shimmer-color" ? {
+              loadingAnimationColor: primaryColor,
+              loadingAnimationSecondaryColor: secondaryColor,
+            } : {}),
+          },
+          reasoning: {
+            activeTextTemplate: reasonActiveTemplate,
+            completeTextTemplate: reasonCompleteTemplate,
             loadingAnimationDuration: duration,
             ...(mode === "shimmer-color" ? {
               loadingAnimationColor: primaryColor,
@@ -318,8 +348,8 @@
           },
           copy: {
             ...DEFAULT_WIDGET_CONFIG.copy,
-            welcomeTitle: "Tool Loading Animations",
-            welcomeSubtitle: "Use the controls to change animation settings, then run a scenario.",
+            welcomeTitle: "Tool & Reasoning Loading Animations",
+            welcomeSubtitle: "Use the controls to change animation settings, then run a tool or reasoning scenario.",
           },
         };
       }
@@ -670,6 +700,99 @@
         }
       }
 
+      // ── reasoning scenarios ──────────────────────────────────────
+
+      function injectReasoningMessage({ id, status = "streaming", chunks = [], startedAt, completedAt, durationMs }) {
+        controller.injectTestMessage({
+          type: "message",
+          message: {
+            id,
+            role: "assistant",
+            content: "",
+            createdAt: new Date().toISOString(),
+            streaming: status !== "complete",
+            variant: "reasoning",
+            reasoning: { id, status, chunks, startedAt, completedAt, durationMs },
+          },
+        });
+      }
+
+      async function shortReasoning() {
+        const token = freshCancel();
+        log("Starting: Short Thinking (2s)", "info");
+        setAllScenarioButtons(true);
+        document.getElementById("btn-reason-short").classList.add("running");
+
+        controller.injectUserMessage({ id: nextId("user"), content: "Explain quantum computing" });
+        await sleep(300);
+
+        const rId = nextId("reason");
+        const start = Date.now();
+        injectReasoningMessage({ id: rId, status: "streaming", startedAt: start });
+
+        await sleep(2000);
+        if (token.cancelled) return finish();
+
+        injectReasoningMessage({
+          id: rId, status: "complete",
+          chunks: ["Quantum computing uses qubits that can exist in superposition..."],
+          startedAt: start, completedAt: Date.now(), durationMs: Date.now() - start,
+        });
+
+        finish();
+        function finish() {
+          document.getElementById("btn-reason-short").classList.remove("running");
+          setAllScenarioButtons(false);
+          log("Done: Short Thinking");
+        }
+      }
+
+      async function longReasoning() {
+        const token = freshCancel();
+        log("Starting: Long Thinking (6s)", "info");
+        setAllScenarioButtons(true);
+        document.getElementById("btn-reason-long").classList.add("running");
+
+        controller.injectUserMessage({ id: nextId("user"), content: "Solve this complex optimization problem" });
+        await sleep(300);
+
+        const rId = nextId("reason");
+        const start = Date.now();
+        injectReasoningMessage({ id: rId, status: "streaming", startedAt: start });
+
+        const thoughtChunks = [
+          "Let me break this down step by step...\n",
+          "First, I need to consider the constraints.\n",
+          "The optimal approach uses dynamic programming.\n",
+          "Checking edge cases...\n",
+        ];
+        for (let i = 0; i < thoughtChunks.length; i++) {
+          await sleep(1200);
+          if (token.cancelled) return finish();
+          injectReasoningMessage({
+            id: rId, status: "streaming",
+            chunks: thoughtChunks.slice(0, i + 1),
+            startedAt: start,
+          });
+        }
+
+        await sleep(800);
+        if (token.cancelled) return finish();
+
+        injectReasoningMessage({
+          id: rId, status: "complete",
+          chunks: thoughtChunks,
+          startedAt: start, completedAt: Date.now(), durationMs: Date.now() - start,
+        });
+
+        finish();
+        function finish() {
+          document.getElementById("btn-reason-long").classList.remove("running");
+          setAllScenarioButtons(false);
+          log("Done: Long Thinking");
+        }
+      }
+
       // ── wire buttons ────────────────────────────────────────────
 
       document.getElementById("btn-short").addEventListener("click", shortTool);
@@ -677,6 +800,8 @@
       document.getElementById("btn-long").addEventListener("click", longTool);
       document.getElementById("btn-concurrent").addEventListener("click", concurrentTools);
       document.getElementById("btn-names").addEventListener("click", nameVariants);
+      document.getElementById("btn-reason-short").addEventListener("click", shortReasoning);
+      document.getElementById("btn-reason-long").addEventListener("click", longReasoning);
 
       document.getElementById("btn-apply").addEventListener("click", () => {
         createWidget();
@@ -687,8 +812,10 @@
         currentMode = "none";
         modeSelector.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
         modeSelector.querySelector('[data-mode="none"]').classList.add("active");
-        document.getElementById("active-template").value = "Calling {toolName}...";
-        document.getElementById("complete-template").value = "Finished {toolName} ({duration})";
+        document.getElementById("active-template").value = "Calling {toolName}... ~{duration}~";
+        document.getElementById("complete-template").value = "Finished {toolName} ~{duration}~";
+        document.getElementById("reason-active-template").value = "Thinking... ~{duration}~";
+        document.getElementById("reason-complete-template").value = "Thought for ~{duration}~";
         durationSlider.value = "2000";
         durationLabel.textContent = "2000ms";
         document.getElementById("color-primary").value = "#0d9488";

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -665,6 +665,39 @@ Templates support **inline formatting markers**: `~dim text~`, `*italic text*`, 
 | `renderCollapsedPreview` | Override collapsed preview content for active tool rows |
 | `renderGroupedSummary` | Override grouped tool container summary |
 
+## Reasoning Display (`config.reasoning.*`)
+
+### Display Features (`config.features.reasoningDisplay.*`)
+| Property | Default | Description |
+|----------|---------|-------------|
+| `activePreview` | `false` | Show a lightweight preview block on active collapsed reasoning rows |
+| `activeMinHeight` | — | CSS min-height for active collapsed rows (e.g. `"100px"`) |
+| `previewMaxLines` | `3` | Maximum preview lines for collapsed active reasoning rows |
+| `expandable` | `true` | Allow expand/collapse toggle; `false` shows summary only |
+| `loadingAnimation` | `"none"` | Animation mode: `"none"` \| `"pulse"` \| `"shimmer"` \| `"shimmer-color"` \| `"rainbow"` |
+
+### Text Templates
+| Property | Default | Description |
+|----------|---------|-------------|
+| `activeTextTemplate` | — | Header text while reasoning is active. Placeholder: `{duration}` (live-updating) |
+| `completeTextTemplate` | — | Header text when reasoning is complete. Placeholder: `{duration}` |
+
+Templates support **inline formatting markers**: `~dim text~`, `*italic text*`, `**bold text**`. Same syntax as tool call templates.
+
+**Example:** `"Thinking... ~{duration}~"` renders the duration in a muted/dim style.
+
+| Property (`config.reasoning.*`) | Default | Description |
+|----------|---------|-------------|
+| `loadingAnimationDuration` | `2000` | Cycle duration in ms |
+| `loadingAnimationColor` | `currentColor` | Primary color for `shimmer-color` mode |
+| `loadingAnimationSecondaryColor` | `#3b82f6` | Secondary color for `shimmer-color` mode |
+
+### Custom Rendering Hooks
+| Property | Description |
+|----------|-------------|
+| `renderCollapsedSummary` | Override collapsed summary. Context includes `elapsed` (static string) and `createElapsedElement()` (returns a live-updating `<span>`) |
+| `renderCollapsedPreview` | Override collapsed preview content for active reasoning rows |
+
 ## Message Actions (`config.messageActions.*`)
 
 ### Basic Options

--- a/packages/widget/src/components/reasoning-bubble.ts
+++ b/packages/widget/src/components/reasoning-bubble.ts
@@ -1,6 +1,6 @@
 import { createElement } from "../utils/dom";
 import { AgentWidgetConfig, AgentWidgetMessage } from "../types";
-import { describeReasonStatus } from "../utils/formatting";
+import { describeReasonStatus, computeReasoningElapsed, parseFormattedTemplate } from "../utils/formatting";
 import { renderLucideIcon } from "../utils/icons";
 
 // Expansion state per widget instance
@@ -112,13 +112,27 @@ export const createReasoningBubble = (message: AgentWidgetMessage, config?: Agen
   const headerContent = createElement("div", "persona-flex persona-flex-col persona-text-left");
   const title = createElement("span", "persona-text-xs persona-text-persona-primary");
   const defaultSummary = "Thinking...";
-  const customSummary = config?.reasoning?.renderCollapsedSummary?.({
+  const reasoningConfig = config?.reasoning ?? {};
+
+  // Elapsed helpers — defined early so they're available to renderCollapsedSummary
+  const startedAt = String(reasoning.startedAt ?? Date.now());
+
+  const createElapsedSpan = (): HTMLElement => {
+    const span = createElement("span", "");
+    span.setAttribute("data-tool-elapsed", startedAt);
+    span.textContent = computeReasoningElapsed(reasoning);
+    return span;
+  };
+
+  const customSummary = reasoningConfig.renderCollapsedSummary?.({
     message,
     reasoning,
     defaultSummary,
     previewText,
     isActive,
     config: config ?? {},
+    elapsed: computeReasoningElapsed(reasoning),
+    createElapsedElement: createElapsedSpan,
   });
   if (typeof customSummary === "string" && customSummary.trim()) {
     title.textContent = customSummary;
@@ -130,14 +144,134 @@ export const createReasoningBubble = (message: AgentWidgetMessage, config?: Agen
     headerContent.appendChild(title);
   }
 
+  // Status span — used in the legacy (no-template) path
   const status = createElement("span", "persona-text-xs persona-text-persona-primary");
   status.textContent = describeReasonStatus(reasoning);
   headerContent.appendChild(status);
 
-  if (reasoning.status === "complete") {
-    title.style.display = "none";
-  } else {
+  // Template and animation support
+  const loadingAnimation = reasoningDisplayConfig.loadingAnimation ?? "none";
+  const activeTemplate = reasoningConfig.activeTextTemplate;
+  const completeTemplate = reasoningConfig.completeTextTemplate;
+  const currentTemplate = isActive ? activeTemplate : completeTemplate;
+  const skipCustomElement = customSummary instanceof HTMLElement;
+
+  // Helper: append text as individual animated character spans
+  const appendCharSpans = (container: HTMLElement, text: string, startIndex: number): number => {
+    let idx = startIndex;
+    for (const char of text) {
+      const span = createElement("span", "persona-tool-char");
+      span.style.setProperty("--char-index", String(idx));
+      span.textContent = char === " " ? "\u00A0" : char;
+      container.appendChild(span);
+      idx++;
+    }
+    return idx;
+  };
+
+  /**
+   * Renders a template into the title element, handling:
+   * - Inline formatting markers: **bold**, *italic*, ~dim~
+   * - {duration} as a live-updating elapsed span (active) or static text (complete)
+   * - Character-by-character animation wrapping when `animated` is true
+   */
+  const renderFormattedTitle = (template: string, animated: boolean) => {
+    title.textContent = "";
+    const segments = parseFormattedTemplate(template, "");
+    let charIndex = 0;
+
+    for (const seg of segments) {
+      const parent = seg.styles.length > 0
+        ? (() => {
+            const w = createElement("span", seg.styles.map(s => `persona-tool-text-${s}`).join(" "));
+            title.appendChild(w);
+            return w;
+          })()
+        : title;
+
+      if (seg.isDuration && isActive) {
+        parent.appendChild(createElapsedSpan());
+      } else {
+        const text = seg.isDuration ? computeReasoningElapsed(reasoning) : seg.text;
+        if (animated) {
+          charIndex = appendCharSpans(parent, text, charIndex);
+        } else {
+          parent.appendChild(document.createTextNode(text));
+        }
+      }
+    }
+  };
+
+  // Apply template + animation, or fall back to legacy title/status approach
+  if (!skipCustomElement && currentTemplate) {
+    // Template mode: unified title replaces separate title/status spans
+    status.style.display = "none";
     title.style.display = "";
+
+    if (isActive && loadingAnimation !== "none") {
+      const animDuration = reasoningConfig.loadingAnimationDuration ?? 2000;
+      title.setAttribute("data-preserve-animation", "true");
+
+      if (loadingAnimation === "pulse") {
+        title.classList.add("persona-tool-loading-pulse");
+        title.style.setProperty("--persona-tool-anim-duration", `${animDuration}ms`);
+        renderFormattedTitle(currentTemplate, false);
+      } else {
+        title.classList.add(`persona-tool-loading-${loadingAnimation}`);
+        title.style.setProperty("--persona-tool-anim-duration", `${animDuration}ms`);
+
+        if (loadingAnimation === "shimmer-color") {
+          if (reasoningConfig.loadingAnimationColor) {
+            title.style.setProperty("--persona-tool-anim-color", reasoningConfig.loadingAnimationColor);
+          }
+          if (reasoningConfig.loadingAnimationSecondaryColor) {
+            title.style.setProperty("--persona-tool-anim-secondary-color", reasoningConfig.loadingAnimationSecondaryColor);
+          }
+        }
+
+        renderFormattedTitle(currentTemplate, true);
+      }
+    } else {
+      renderFormattedTitle(currentTemplate, false);
+    }
+  } else if (!skipCustomElement && isActive && loadingAnimation !== "none") {
+    // Animation without template: animate the default "Thinking..." text
+    title.style.display = "";
+    const animDuration = reasoningConfig.loadingAnimationDuration ?? 2000;
+    title.setAttribute("data-preserve-animation", "true");
+
+    if (loadingAnimation === "pulse") {
+      title.classList.add("persona-tool-loading-pulse");
+      title.style.setProperty("--persona-tool-anim-duration", `${animDuration}ms`);
+    } else {
+      title.classList.add(`persona-tool-loading-${loadingAnimation}`);
+      title.style.setProperty("--persona-tool-anim-duration", `${animDuration}ms`);
+
+      if (loadingAnimation === "shimmer-color") {
+        if (reasoningConfig.loadingAnimationColor) {
+          title.style.setProperty("--persona-tool-anim-color", reasoningConfig.loadingAnimationColor);
+        }
+        if (reasoningConfig.loadingAnimationSecondaryColor) {
+          title.style.setProperty("--persona-tool-anim-secondary-color", reasoningConfig.loadingAnimationSecondaryColor);
+        }
+      }
+
+      const text = title.textContent || defaultSummary;
+      title.textContent = "";
+      appendCharSpans(title, text, 0);
+    }
+
+    // Legacy: hide title on complete, show status
+    if (reasoning.status === "complete") {
+      title.style.display = "none";
+    }
+  } else if (!skipCustomElement) {
+    // Legacy path: no template, no animation
+    if (reasoning.status === "complete") {
+      title.style.display = "none";
+    } else {
+      title.style.display = "";
+    }
   }
 
   let toggleIcon: HTMLElement | null = null;

--- a/packages/widget/src/defaults.ts
+++ b/packages/widget/src/defaults.ts
@@ -129,6 +129,7 @@ export const DEFAULT_WIDGET_CONFIG: Partial<AgentWidgetConfig> = {
       activePreview: false,
       previewMaxLines: 3,
       expandable: true,
+      loadingAnimation: "none",
     },
   },
   suggestionChips: [

--- a/packages/widget/src/install.ts
+++ b/packages/widget/src/install.ts
@@ -55,7 +55,10 @@ declare global {
     const configJson = script.getAttribute('data-config');
     if (configJson) {
       try {
-        const parsedConfig = JSON.parse(configJson);
+        // HTML attributes preserve literal newlines/tabs which are invalid
+        // control characters inside JSON string literals — strip them.
+        const normalizedJson = configJson.replace(/[\r\n]+\s*/g, '');
+        const parsedConfig = JSON.parse(normalizedJson);
         // If it has nested 'config' property, use it; otherwise treat as widget config
         if (parsedConfig.config) {
           // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/widget/src/theme-reference.ts
+++ b/packages/widget/src/theme-reference.ts
@@ -218,9 +218,12 @@ export const THEME_TOKEN_DOCS = {
         'shadow, backgroundColor, borderColor, borderWidth, borderRadius, headerBackgroundColor, headerTextColor, headerPaddingX, headerPaddingY, contentBackgroundColor, contentTextColor, contentPaddingX, contentPaddingY, codeBlockBackgroundColor, codeBlockBorderColor, codeBlockTextColor, toggleTextColor, labelTextColor, activeTextTemplate, completeTextTemplate, loadingAnimationColor, loadingAnimationSecondaryColor, loadingAnimationDuration, renderCollapsedSummary, renderCollapsedPreview, renderGroupedSummary.',
     },
     reasoning: {
-      description: 'Reasoning/thinking row rendering hooks.',
+      description:
+        'Reasoning/thinking row rendering hooks, text templates, and loading animations. ' +
+        'Text templates support {duration} placeholder and inline formatting (~dim~, *italic*, **bold**). ' +
+        'renderCollapsedSummary receives elapsed (static string) and createElapsedElement() (live-updating span) in its context.',
       properties:
-        'renderCollapsedSummary, renderCollapsedPreview.',
+        'renderCollapsedSummary, renderCollapsedPreview, activeTextTemplate, completeTextTemplate, loadingAnimationColor, loadingAnimationSecondaryColor, loadingAnimationDuration.',
     },
     approval: {
       description:
@@ -285,7 +288,7 @@ export const THEME_TOKEN_DOCS = {
     features: {
       description: 'Feature flags.',
       properties:
-        'showReasoning (AI thinking steps), showToolCalls (tool invocations), toolCallDisplay (collapsedMode, activePreview, activeMinHeight, previewMaxLines, grouped, expandable, loadingAnimation), reasoningDisplay (activePreview, activeMinHeight, previewMaxLines, expandable), artifacts (sidebar config).',
+        'showReasoning (AI thinking steps), showToolCalls (tool invocations), toolCallDisplay (collapsedMode, activePreview, activeMinHeight, previewMaxLines, grouped, expandable, loadingAnimation), reasoningDisplay (activePreview, activeMinHeight, previewMaxLines, expandable, loadingAnimation), artifacts (sidebar config).',
     },
   },
 }

--- a/packages/widget/src/tool-call-display-defaults.test.ts
+++ b/packages/widget/src/tool-call-display-defaults.test.ts
@@ -19,6 +19,7 @@ describe("tool call display defaults", () => {
       activePreview: false,
       previewMaxLines: 3,
       expandable: true,
+      loadingAnimation: "none",
     });
   });
 });

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -656,6 +656,17 @@ export type AgentWidgetReasoningDisplayFeature = {
    * @default true
    */
   expandable?: boolean;
+  /**
+   * Animation mode applied to the reasoning header text while reasoning is active.
+   * Reuses the same modes as tool call animations.
+   * - "none" — static text, no animation
+   * - "pulse" — opacity pulse on the entire header text
+   * - "shimmer" — monochrome opacity sweep per character
+   * - "shimmer-color" — color gradient sweep per character
+   * - "rainbow" — rainbow color cycle per character
+   * @default "none"
+   */
+  loadingAnimation?: AgentWidgetToolCallLoadingAnimation;
 };
 
 export type AgentWidgetFeatureFlags = {
@@ -1390,6 +1401,14 @@ export type AgentWidgetReasoningConfig = {
     previewText: string;
     isActive: boolean;
     config: AgentWidgetConfig;
+    /** Static elapsed time snapshot, e.g. "2.6s". */
+    elapsed: string;
+    /**
+     * Returns a `<span>` whose text content is automatically updated every
+     * 100ms by the widget's global timer. Place it anywhere in your returned
+     * HTMLElement to get a live-ticking duration display.
+     */
+    createElapsedElement: () => HTMLElement;
   }) => HTMLElement | string | null;
   /**
    * Override the lightweight collapsed preview content shown for active reasoning rows.
@@ -1402,6 +1421,45 @@ export type AgentWidgetReasoningConfig = {
     isActive: boolean;
     config: AgentWidgetConfig;
   }) => HTMLElement | string | null;
+  /**
+   * Template string for the header text while reasoning is active (streaming).
+   *
+   * **Placeholders:** `{duration}` (live-updating elapsed time).
+   *
+   * **Inline formatting:** `~dim~`, `*italic*`, `**bold**` — parsed at render time.
+   *
+   * When not set, falls back to the default "Thinking..." text.
+   * @example "Thinking... ~{duration}~"
+   */
+  activeTextTemplate?: string;
+  /**
+   * Template string for the header text when reasoning is complete.
+   *
+   * **Placeholders:** `{duration}` (final elapsed time).
+   *
+   * **Inline formatting:** `~dim~`, `*italic*`, `**bold**` — same syntax as `activeTextTemplate`.
+   *
+   * When not set, falls back to the default "Thought for X seconds" text.
+   * @example "Thought for ~{duration}~"
+   */
+  completeTextTemplate?: string;
+  /**
+   * Primary color for shimmer-color animation mode.
+   * Defaults to the current text color.
+   */
+  loadingAnimationColor?: string;
+  /**
+   * Secondary/end color for shimmer-color animation mode.
+   * Creates a gradient sweep between `loadingAnimationColor` and this color.
+   * @default "#3b82f6"
+   */
+  loadingAnimationSecondaryColor?: string;
+  /**
+   * Duration of one full animation cycle in milliseconds.
+   * Applies to pulse, shimmer, shimmer-color, and rainbow modes.
+   * @default 2000
+   */
+  loadingAnimationDuration?: number;
 };
 
 export type AgentWidgetSuggestionChipsConfig = {

--- a/packages/widget/src/utils/formatting.test.ts
+++ b/packages/widget/src/utils/formatting.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { createJsonStreamParser, parseFormattedTemplate } from "./formatting";
+import { createJsonStreamParser, parseFormattedTemplate, computeReasoningElapsed } from "./formatting";
 
 describe("JSON Stream Parser", () => {
   it("should extract text field incrementally as JSON streams in", () => {
@@ -242,5 +242,29 @@ describe("parseFormattedTemplate", () => {
     expect(segments).toEqual([
       { text: "  ", styles: [] },
     ]);
+  });
+});
+
+describe("computeReasoningElapsed", () => {
+  it("uses durationMs when provided", () => {
+    const result = computeReasoningElapsed({
+      id: "r1", status: "complete", chunks: [], durationMs: 2600,
+    });
+    expect(result).toBe("2.6s");
+  });
+
+  it("computes from startedAt/completedAt when durationMs is undefined", () => {
+    const result = computeReasoningElapsed({
+      id: "r2", status: "complete", chunks: [],
+      startedAt: 1000, completedAt: 16000,
+    });
+    expect(result).toBe("15s");
+  });
+
+  it("returns <0.1s for very short durations", () => {
+    const result = computeReasoningElapsed({
+      id: "r3", status: "complete", chunks: [], durationMs: 50,
+    });
+    expect(result).toBe("<0.1s");
   });
 });

--- a/packages/widget/src/utils/formatting.ts
+++ b/packages/widget/src/utils/formatting.ts
@@ -116,6 +116,21 @@ export const computeToolElapsed = (tool: AgentWidgetToolCall): string => {
 };
 
 /**
+ * Computes the current elapsed time string for a reasoning block.
+ */
+export const computeReasoningElapsed = (reasoning: AgentWidgetReasoning): string => {
+  const durationMs =
+    reasoning.durationMs !== undefined
+      ? reasoning.durationMs
+      : Math.max(
+          0,
+          (reasoning.completedAt ?? Date.now()) -
+            (reasoning.startedAt ?? reasoning.completedAt ?? Date.now())
+        );
+  return formatElapsedMs(durationMs);
+};
+
+/**
  * Resolves a text template with tool call placeholders.
  * Supported placeholders: {toolName}, {duration}
  * Returns the fallback if template is undefined.

--- a/packages/widget/src/utils/message-fingerprint.test.ts
+++ b/packages/widget/src/utils/message-fingerprint.test.ts
@@ -90,6 +90,18 @@ describe("computeMessageFingerprint", () => {
     expect(fp1).not.toBe(fp2);
   });
 
+  it("changes when toolCall name changes", () => {
+    const fp1 = computeMessageFingerprint(
+      makeMessage({ toolCall: { status: "running" } }),
+      0
+    );
+    const fp2 = computeMessageFingerprint(
+      makeMessage({ toolCall: { status: "running", name: "UCP Search Catalog" } }),
+      0
+    );
+    expect(fp1).not.toBe(fp2);
+  });
+
   it("changes when toolCall chunks change", () => {
     const fp1 = computeMessageFingerprint(
       makeMessage({ toolCall: { status: "running", chunks: ["Loaded tools"] } }),

--- a/packages/widget/src/utils/message-fingerprint.ts
+++ b/packages/widget/src/utils/message-fingerprint.ts
@@ -53,6 +53,7 @@ export function computeMessageFingerprint(
     message.llmContent?.length ?? 0,
     message.approval?.status ?? "",
     message.toolCall?.status ?? "",
+    message.toolCall?.name ?? "",
     message.toolCall?.chunks?.length ?? 0,
     message.toolCall?.chunks?.[message.toolCall.chunks.length - 1]?.slice(-32) ?? "",
     typeof message.toolCall?.args === "string"

--- a/packages/widget/src/utils/morph.test.ts
+++ b/packages/widget/src/utils/morph.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from "vitest";
+import { morphMessages } from "./morph";
+
+function makeContainer(html: string): HTMLElement {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  return div;
+}
+
+function makeNewContent(html: string): HTMLElement {
+  const div = document.createElement("div");
+  div.innerHTML = html;
+  return div;
+}
+
+describe("morphMessages", () => {
+  describe("data-preserve-animation", () => {
+    it("preserves animated element when old and new both have data-preserve-animation with same text", () => {
+      const container = makeContainer(
+        '<span data-preserve-animation="true">Calling tool... 0.1s</span>'
+      );
+      const oldSpan = container.querySelector("span")!;
+
+      morphMessages(
+        container,
+        makeNewContent(
+          '<span data-preserve-animation="true">Calling tool... 0.1s</span>'
+        )
+      );
+
+      expect(container.querySelector("span")).toBe(oldSpan);
+    });
+
+    it("allows morph when new node drops data-preserve-animation (tool completed)", () => {
+      const container = makeContainer(
+        '<span data-preserve-animation="true">Calling tool... 0.5s</span>'
+      );
+
+      morphMessages(
+        container,
+        makeNewContent("<span>Finished tool 0.5s</span>")
+      );
+
+      expect(container.querySelector("span")!.textContent).toBe(
+        "Finished tool 0.5s"
+      );
+      expect(
+        container.querySelector("span")!.hasAttribute("data-preserve-animation")
+      ).toBe(false);
+    });
+
+    it("allows morph when text content changes despite both having data-preserve-animation", () => {
+      const container = makeContainer(
+        '<span data-preserve-animation="true">Calling tool... 0.1s</span>'
+      );
+
+      morphMessages(
+        container,
+        makeNewContent(
+          '<span data-preserve-animation="true">Calling UCP Search Catalog... 0.2s</span>'
+        )
+      );
+
+      expect(container.querySelector("span")!.textContent).toBe(
+        "Calling UCP Search Catalog... 0.2s"
+      );
+    });
+
+    it("does not preserve when preserveTypingAnimation is false", () => {
+      const container = makeContainer(
+        '<span data-preserve-animation="true">Old text</span>'
+      );
+
+      morphMessages(
+        container,
+        makeNewContent(
+          '<span data-preserve-animation="true">New text</span>'
+        ),
+        { preserveTypingAnimation: false }
+      );
+
+      expect(container.querySelector("span")!.textContent).toBe("New text");
+    });
+  });
+});

--- a/packages/widget/src/utils/morph.ts
+++ b/packages/widget/src/utils/morph.ts
@@ -35,6 +35,14 @@ export const morphMessages = (
             if (newNode instanceof HTMLElement && !newNode.hasAttribute("data-preserve-animation")) {
               return;
             }
+            // Allow morph when content has meaningfully changed (e.g. tool name arrived)
+            if (newNode instanceof HTMLElement && newNode.hasAttribute("data-preserve-animation")) {
+              const oldText = oldNode.textContent ?? "";
+              const newText = newNode.textContent ?? "";
+              if (oldText !== newText) {
+                return;
+              }
+            }
             return false;
           }
         }


### PR DESCRIPTION
Updated the fingerprint computation to include `toolCall.name`, ensuring cache invalidation when the name is available. Added tests for fingerprint changes based on tool call name updates and enhanced morphing behavior to allow content updates when text meaningfully changes.