### PR TITLE
Add programmatic access to widget handle in the installer

### DIFF
--- a/.changeset/programmatic-access-installer.md
+++ b/.changeset/programmatic-access-installer.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add programmatic access to widget handle from the install script via `windowKey`, `onReady` callback, and `persona:ready` custom event. The code generator now supports an optional `windowKey` option for script formats.

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -311,6 +311,8 @@ window.chatController.submitMessage("Test message")
 window.chatController.startVoiceRecognition()
 ```
 
+When using the automatic installer script (`install.global.js`), see [Programmatic access with the installer](#programmatic-access-with-the-installer) for additional approaches including the `onReady` callback and `persona:ready` event.
+
 #### Message Types
 
 The widget uses `AgentWidgetMessage` objects to represent messages in the conversation. You can access these through `postprocessMessage` callbacks or by inspecting the session's message array.
@@ -482,6 +484,20 @@ window.dispatchEvent(new CustomEvent('persona:focusInput', {
 ```
 
 **Instance scoping:** Same as `persona:showEventStream` — use `detail.instanceId` to target a specific widget. Without `instanceId`, all instances receive the event.
+
+#### `persona:ready`
+
+Dispatched on `window` by the automatic installer script (`install.global.js`) after the widget is initialized. The `event.detail` contains the `AgentWidgetInitHandle` (the same object returned by `initAgentWidget()`).
+
+```ts
+window.addEventListener('persona:ready', (e) => {
+  const handle = e.detail;
+  handle.on('message:sent', (msg) => console.log(msg));
+  handle.open();
+});
+```
+
+> **Note:** This event is only dispatched by the automatic installer script. Direct calls to `initAgentWidget()` return the handle synchronously and do not fire this event.
 
 ### Controller Events
 
@@ -1249,6 +1265,13 @@ The easiest way is to use the automatic installer script. It handles loading CSS
 - `target` - CSS selector or element where widget mounts (default: `"body"`)
 - `config` - Widget configuration object (see Configuration reference)
 - `autoInit` - Automatically initialize after loading (default: `true`)
+- `clientToken` - Client token for authentication (alternative to proxy `apiUrl`)
+- `flowId` - Flow ID for client token authentication
+- `apiUrl` - API URL for the chat endpoint (can also be set inside `config`)
+- `previewQueryParam` - Query parameter key that gates widget loading; widget only loads when the parameter is present and truthy
+- `useShadowDom` - Use Shadow DOM for style isolation (default: `false`)
+- `windowKey` - If provided, stores the widget handle on `window[windowKey]` for programmatic access
+- `onReady` - Callback fired with the widget handle after initialization; signature: `(handle) => void`
 
 **Example with version pinning:**
 
@@ -1263,6 +1286,62 @@ The easiest way is to use the automatic installer script. It handles loading CSS
   };
 </script>
 <script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@0.1.0/dist/install.global.js"></script>
+```
+
+#### Programmatic access with the installer
+
+The installer is fully asynchronous (it waits for framework hydration, then loads CSS and JS). To interact with the widget after it initializes, use one of these approaches:
+
+**`onReady` callback** — best when config and access logic live in the same script:
+
+```html
+<script>
+  window.siteAgentConfig = {
+    clientToken: 'YOUR_TOKEN',
+    windowKey: 'myChat',
+    onReady(handle) {
+      handle.on('message:sent', (e) => console.log('sent:', e));
+      handle.on('message:received', (e) => console.log('received:', e));
+    }
+  };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"></script>
+```
+
+**`persona:ready` event** — best for decoupled integration (e.g. tag managers, separate scripts):
+
+```html
+<script>
+  window.addEventListener('persona:ready', (e) => {
+    const handle = e.detail;
+    handle.on('message:sent', (e) => console.log('sent:', e));
+  });
+</script>
+
+<!-- Can be in a different script, tag manager snippet, etc. -->
+<script>
+  window.siteAgentConfig = { clientToken: 'YOUR_TOKEN' };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"></script>
+```
+
+**`windowKey`** — stores the handle on `window[windowKey]` for persistent global access. Combine with `onReady` or `persona:ready` to know when it's available:
+
+```html
+<script>
+  window.siteAgentConfig = {
+    clientToken: 'YOUR_TOKEN',
+    windowKey: 'myChat'
+  };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"></script>
+
+<script>
+  window.addEventListener('persona:ready', () => {
+    // window.myChat is now available and persists until destroy()
+    window.myChat.open();
+  });
+</script>
 ```
 
 #### Method 2: Manual installation

--- a/packages/widget/docs/CODE-GENERATOR.md
+++ b/packages/widget/docs/CODE-GENERATOR.md
@@ -43,6 +43,20 @@ const scriptCode = generateCodeSnippet(config, 'script-manual');
 | `script-manual` | Manual script tag with full control |
 | `script-advanced` | Script tag with DOM context collection and action handling |
 
+## `windowKey` Option
+
+Pass `windowKey` in the options to emit a `windowKey` property in the generated `initAgentWidget()` call, storing the widget handle on `window[windowKey]` for programmatic access:
+
+```typescript
+const code = generateCodeSnippet(config, 'script-installer', { windowKey: 'myChat' });
+```
+
+How it works per format:
+
+- **`script-installer`**: The `data-config` JSON includes `windowKey` alongside a nested `config` object, matching the install script's expected structure.
+- **`script-manual`** and **`script-advanced`**: `windowKey` is added to the `initAgentWidget()` call options.
+- **`esm`**, **`react-component`**, **`react-advanced`**: No effect — these formats return the handle directly as a variable.
+
 ## Custom Hooks
 
 The third parameter accepts options including custom hooks that inject code into the generated snippet. Hooks can be provided as strings or functions (functions are automatically serialized via `.toString()`).
@@ -166,6 +180,7 @@ type CodeGeneratorHooks = {
 type CodeGeneratorOptions = {
   hooks?: CodeGeneratorHooks;
   includeHookComments?: boolean;
+  windowKey?: string; // Emit windowKey in generated initAgentWidget call (script formats only)
 };
 ```
 

--- a/packages/widget/src/install.ts
+++ b/packages/widget/src/install.ts
@@ -22,6 +22,10 @@ interface SiteAgentInstallConfig {
   previewQueryParam?: string;
   // Shadow DOM option (defaults to false for better CSS compatibility)
   useShadowDom?: boolean;
+  // Expose the widget handle on window[windowKey] for programmatic access
+  windowKey?: string;
+  // Called when the widget is initialized and ready for interaction
+  onReady?: (handle: any) => void;
 }
 
 declare global {
@@ -273,12 +277,16 @@ declare global {
     }
 
     try {
-      window.AgentWidget.initAgentWidget({
+      const handle = window.AgentWidget.initAgentWidget({
         target,
         config: widgetConfig,
         // Explicitly disable shadow DOM for better CSS compatibility with host page
-        useShadowDom: config.useShadowDom ?? false
+        useShadowDom: config.useShadowDom ?? false,
+        windowKey: config.windowKey
       });
+
+      config.onReady?.(handle);
+      window.dispatchEvent(new CustomEvent("persona:ready", { detail: handle }));
     } catch (error) {
       console.error("Failed to initialize AgentWidget:", error);
     }

--- a/packages/widget/src/runtime/init.test.ts
+++ b/packages/widget/src/runtime/init.test.ts
@@ -85,6 +85,138 @@ function createMockController(config?: { launcher?: { enabled?: boolean; autoExp
   };
 }
 
+describe("initAgentWidget windowKey and ready notifications", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    createAgentExperienceMock.mockReset();
+    createAgentExperienceMock.mockImplementation((_mount, config) => createMockController(config));
+  });
+
+  it("assigns the handle to window[windowKey] when windowKey is provided", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const handle = initAgentWidget({
+      target: "#target",
+      windowKey: "testWidget",
+      config: { launcher: { enabled: false } },
+    });
+
+    expect((window as any).testWidget).toBe(handle);
+
+    handle.destroy();
+    expect((window as any).testWidget).toBeUndefined();
+  });
+
+  it("does not set a window key when windowKey is omitted", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const handle = initAgentWidget({
+      target: "#target",
+      config: { launcher: { enabled: false } },
+    });
+
+    // No arbitrary key should have been set
+    expect((window as any).testWidget2).toBeUndefined();
+    handle.destroy();
+  });
+
+  it("calls onReady after initialization", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const onReady = vi.fn();
+    const handle = initAgentWidget({
+      target: "#target",
+      onReady,
+      config: { launcher: { enabled: false } },
+    });
+
+    expect(onReady).toHaveBeenCalledOnce();
+    handle.destroy();
+  });
+
+  it("the window key handle proxies controller methods", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    initAgentWidget({
+      target: "#target",
+      windowKey: "proxyTest",
+      config: { launcher: { enabled: false } },
+    });
+
+    const proxy = (window as any).proxyTest;
+    expect(proxy).toBeDefined();
+    expect(typeof proxy.open).toBe("function");
+    expect(typeof proxy.close).toBe("function");
+    expect(typeof proxy.on).toBe("function");
+    expect(typeof proxy.destroy).toBe("function");
+    expect(typeof proxy.getState).toBe("function");
+
+    proxy.destroy();
+  });
+});
+
+describe("install script onReady and persona:ready event", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    createAgentExperienceMock.mockReset();
+    createAgentExperienceMock.mockImplementation((_mount, config) => createMockController(config));
+  });
+
+  it("persona:ready event fires with the handle as detail", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const eventPromise = new Promise<any>((resolve) => {
+      window.addEventListener("persona:ready", ((e: CustomEvent) => {
+        resolve(e.detail);
+      }) as EventListener, { once: true });
+    });
+
+    const handle = initAgentWidget({
+      target: "#target",
+      windowKey: "eventTest",
+      config: { launcher: { enabled: false } },
+    });
+
+    // Simulate what install.ts does after initAgentWidget returns
+    window.dispatchEvent(new CustomEvent("persona:ready", { detail: handle }));
+
+    const detail = await eventPromise;
+    expect(detail).toBe(handle);
+    expect(typeof detail.open).toBe("function");
+    expect(typeof detail.on).toBe("function");
+
+    handle.destroy();
+  });
+
+  it("persona:ready event listener set up before init receives the handle", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const received: any[] = [];
+    window.addEventListener("persona:ready", ((e: CustomEvent) => {
+      received.push(e.detail);
+    }) as EventListener, { once: true });
+
+    const handle = initAgentWidget({
+      target: "#target",
+      config: { launcher: { enabled: false } },
+    });
+
+    // Simulate install.ts dispatching the event
+    window.dispatchEvent(new CustomEvent("persona:ready", { detail: handle }));
+
+    expect(received).toHaveLength(1);
+    expect(received[0]).toBe(handle);
+
+    handle.destroy();
+  });
+});
+
 describe("initAgentWidget docked mode", () => {
   beforeEach(() => {
     document.body.innerHTML = "";

--- a/packages/widget/src/runtime/init.test.ts
+++ b/packages/widget/src/runtime/init.test.ts
@@ -171,9 +171,9 @@ describe("install script onReady and persona:ready event", () => {
     document.body.innerHTML = `<div id="target"></div>`;
 
     const eventPromise = new Promise<any>((resolve) => {
-      window.addEventListener("persona:ready", ((e: CustomEvent) => {
-        resolve(e.detail);
-      }) as EventListener, { once: true });
+      window.addEventListener("persona:ready", (e) => {
+        resolve((e as CustomEvent).detail);
+      }, { once: true });
     });
 
     const handle = initAgentWidget({
@@ -198,9 +198,9 @@ describe("install script onReady and persona:ready event", () => {
     document.body.innerHTML = `<div id="target"></div>`;
 
     const received: any[] = [];
-    window.addEventListener("persona:ready", ((e: CustomEvent) => {
-      received.push(e.detail);
-    }) as EventListener, { once: true });
+    window.addEventListener("persona:ready", (e) => {
+      received.push((e as CustomEvent).detail);
+    }, { once: true });
 
     const handle = initAgentWidget({
       target: "#target",

--- a/packages/widget/src/utils/code-generators.test.ts
+++ b/packages/widget/src/utils/code-generators.test.ts
@@ -620,3 +620,60 @@ describe("CDN Version", () => {
     expect(VERSION).toMatch(/^\d+\.\d+\.\d+/);
   });
 });
+
+// =============================================================================
+// windowKey option
+// =============================================================================
+
+describe("windowKey option", () => {
+  it("script-installer with windowKey nests config and includes windowKey in JSON", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-installer", { windowKey: "myWidget" });
+
+    // Parse the data-config JSON from the output
+    const match = code.match(/data-config='([^']*)'/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]);
+
+    expect(parsed.windowKey).toBe("myWidget");
+    expect(parsed.config).toBeDefined();
+    expect(parsed.config.apiUrl).toBe(minimalConfig.apiUrl);
+  });
+
+  it("script-installer without windowKey uses flat config (no nesting)", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-installer");
+
+    const match = code.match(/data-config='([^']*)'/);
+    expect(match).not.toBeNull();
+    const parsed = JSON.parse(match![1]);
+
+    expect(parsed.windowKey).toBeUndefined();
+    expect(parsed.config).toBeUndefined();
+    expect(parsed.apiUrl).toBe(minimalConfig.apiUrl);
+  });
+
+  it("script-manual with windowKey includes windowKey and captures handle", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-manual", { windowKey: "myWidget" });
+
+    expect(code).toContain("var handle = window.AgentWidget.initAgentWidget(");
+    expect(code).toContain("windowKey: 'myWidget'");
+  });
+
+  it("script-manual without windowKey still captures handle but omits windowKey", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-manual");
+
+    expect(code).toContain("var handle = window.AgentWidget.initAgentWidget(");
+    expect(code).not.toContain("windowKey");
+  });
+
+  it("script-advanced with windowKey includes windowKey in initAgentWidget call", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-advanced", { windowKey: "myWidget" });
+
+    expect(code).toContain("windowKey: 'myWidget'");
+  });
+
+  it("script-advanced without windowKey omits windowKey", () => {
+    const code = generateCodeSnippet(minimalConfig, "script-advanced");
+
+    expect(code).not.toContain("windowKey");
+  });
+});

--- a/packages/widget/src/utils/code-generators.ts
+++ b/packages/widget/src/utils/code-generators.ts
@@ -134,6 +134,13 @@ export type CodeGeneratorOptions = {
    * @default true
    */
   includeHookComments?: boolean;
+
+  /**
+   * If provided, emits `windowKey` in the generated `initAgentWidget()` call
+   * so the widget handle is stored on `window[windowKey]`.
+   * Only affects script formats (script-installer, script-manual, script-advanced).
+   */
+  windowKey?: string;
 };
 
 // Internal type for normalized hooks (always strings)
@@ -551,7 +558,7 @@ export function generateCodeSnippet(
   if (format === "esm") {
     return generateESMCode(cleanConfig, normalizedOptions);
   } else if (format === "script-installer") {
-    return generateScriptInstallerCode(cleanConfig);
+    return generateScriptInstallerCode(cleanConfig, normalizedOptions);
   } else if (format === "script-advanced") {
     return generateScriptAdvancedCode(cleanConfig, normalizedOptions);
   } else if (format === "react-component") {
@@ -1346,12 +1353,18 @@ function buildSerializableConfig(config: any): Record<string, any> {
   return serializableConfig;
 }
 
-function generateScriptInstallerCode(config: any): string {
+function generateScriptInstallerCode(config: any, options?: CodeGeneratorOptions): string {
   const serializableConfig = buildSerializableConfig(config);
-  
+
+  // When windowKey is provided, nest the widget config under `config` so the
+  // install script's parsedConfig.config detection picks it up alongside windowKey.
+  const payload = options?.windowKey
+    ? { config: serializableConfig, windowKey: options.windowKey }
+    : serializableConfig;
+
   // Escape single quotes in JSON for HTML attribute
-  const configJson = JSON.stringify(serializableConfig, null, 0).replace(/'/g, "&#39;");
-  
+  const configJson = JSON.stringify(payload, null, 0).replace(/'/g, "&#39;");
+
   return `<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist/install.global.js" data-config='${configJson}'></script>`;
 }
 
@@ -1369,8 +1382,9 @@ function generateScriptManualCode(config: any, options?: CodeGeneratorOptions): 
     "",
     "<!-- Initialize widget -->",
     "<script>",
-    "  window.AgentWidget.initAgentWidget({",
+    "  var handle = window.AgentWidget.initAgentWidget({",
     "    target: 'body',",
+    ...(options?.windowKey ? [`    windowKey: '${options.windowKey}',`] : []),
     "    config: {"
   ];
 
@@ -1723,6 +1737,7 @@ function generateScriptAdvancedCode(config: any, options?: CodeGeneratorOptions)
     "    var handle = agentWidget.initAgentWidget({",
     "      target: 'body',",
     "      useShadowDom: false,",
+    ...(options?.windowKey ? [`      windowKey: '${options.windowKey}',`] : []),
     "      config: widgetConfig",
     "    });",
     "",


### PR DESCRIPTION
- Introduced `windowKey` option to store the widget handle on `window[windowKey]` for programmatic access.
- Added `onReady` callback to execute logic after widget initialization.
- Updated documentation to reflect new features and usage examples for programmatic access.
- Enhanced code generation to support `windowKey` in various script formats.