### PR TITLE
Implement native handling of flow and dispatch errors in AgentWidgeClient

### DIFF
--- a/.changeset/native-flow-dispatch-errors.md
+++ b/.changeset/native-flow-dispatch-errors.md
@@ -1,0 +1,6 @@
+---
+'@runtypelabs/persona': minor
+'@runtypelabs/persona-proxy': minor
+---
+
+Handle `step_error`, `dispatch_error`, and `flow_error` SSE frames natively: emit `error` events, finalize streaming assistant messages, and transition status to `idle`. Hosts no longer need a custom `parseSSEEvent` callback for these Runtype flow/dispatch error types.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1121,6 +1121,70 @@ describe('AgentWidgetClient - Agent Event Streaming', () => {
     }
   });
 
+  it('should emit error and finalize streaming on step_error', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    global.fetch = createAgentStreamFetch([
+      'data: {"type":"flow_start","flowId":"f1","flowName":"Test","totalSteps":1}\n\n',
+      'data: {"type":"step_delta","id":"s1","name":"Prompt","executionType":"prompt","text":"partial"}\n\n',
+      sseEvent('step_error', { error: 'step blew up', seq: 3 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const errorEvents = events.filter(e => e.type === 'error');
+    expect(errorEvents.length).toBe(1);
+    if (errorEvents[0].type === 'error') {
+      expect(errorEvents[0].error.message).toBe('step blew up');
+    }
+
+    const statusIdle = events.filter(e => e.type === 'status' && e.status === 'idle');
+    expect(statusIdle.length).toBeGreaterThanOrEqual(1);
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const lastAssistant = [...messageEvents]
+      .reverse()
+      .find(e => e.type === 'message' && e.message.role === 'assistant' && !e.message.variant);
+    expect(lastAssistant?.type === 'message' && lastAssistant.message.streaming).toBe(false);
+  });
+
+  it('should emit error and finalize streaming on dispatch_error (message only)', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    global.fetch = createAgentStreamFetch([
+      'data: {"type":"flow_start","flowId":"f1","flowName":"Test","totalSteps":1}\n\n',
+      'data: {"type":"step_delta","id":"s1","name":"Prompt","executionType":"prompt","text":"x"}\n\n',
+      sseEvent('dispatch_error', { message: 'bad config', seq: 2 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const errorEvents = events.filter(e => e.type === 'error');
+    expect(errorEvents.length).toBe(1);
+    if (errorEvents[0].type === 'error') {
+      expect(errorEvents[0].error.message).toBe('bad config');
+    }
+
+    const statusIdle = events.filter(e => e.type === 'status' && e.status === 'idle');
+    expect(statusIdle.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('should handle agent reflection events', async () => {
     const events: AgentWidgetEvent[] = [];
     const execId = 'exec_test_7';

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -2592,14 +2592,43 @@ export class AgentWidgetClient {
           streamParsers.delete(id);
           rawContentBuffers.delete(id);
           seqChunkBuffers.delete(id);
-        } else if (payloadType === "error" && payload.error) {
-          onEvent({
-            type: "error",
-            error:
-              payload.error instanceof Error
-                ? payload.error
-                : new Error(String(payload.error))
-          });
+        } else if (
+          payloadType === "error" ||
+          payloadType === "step_error" ||
+          payloadType === "dispatch_error" ||
+          payloadType === "flow_error"
+        ) {
+          let resolvedError: Error | null = null;
+          if (payload.error instanceof Error) {
+            resolvedError = payload.error;
+          } else if (payloadType === "dispatch_error") {
+            const msg = payload.message ?? payload.error;
+            if (msg != null && msg !== "") {
+              resolvedError = new Error(String(msg));
+            }
+          } else if (
+            payloadType === "step_error" ||
+            payloadType === "flow_error"
+          ) {
+            const e = payload.error;
+            if (typeof e === "string" && e !== "") {
+              resolvedError = new Error(e);
+            } else if (e != null && typeof e === "object" && "message" in e) {
+              resolvedError = new Error(String((e as { message?: unknown }).message ?? e));
+            }
+          } else if (payloadType === "error" && payload.error != null && payload.error !== "") {
+            resolvedError = new Error(String(payload.error));
+          }
+
+          if (resolvedError) {
+            onEvent({ type: "error", error: resolvedError });
+            const finalMsg = assistantMessage as AgentWidgetMessage | null;
+            if (finalMsg && finalMsg.streaming) {
+              finalMsg.streaming = false;
+              emitMessage(finalMsg);
+            }
+            onEvent({ type: "status", status: "idle" });
+          }
         }
       }
     }


### PR DESCRIPTION
- Added support for `step_error`, `dispatch_error`, and `flow_error` SSE frames, emitting `error` events and finalizing streaming assistant messages.
- Updated tests to verify error handling and status transitions to `idle` for these error types, removing the need for custom `parseSSEEvent` callbacks in hosts.