### PR TITLE
Add optional config.onSSEEvent hook

### DIFF
--- a/.changeset/on-sse-event-handler.md
+++ b/.changeset/on-sse-event-handler.md
@@ -1,0 +1,5 @@
+---
+'@runtypelabs/persona': minor
+---
+
+Add optional `config.onSSEEvent` so hosts can observe every parsed SSE frame (e.g. artifact side effects) without short-circuiting native streaming.

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -2902,6 +2902,15 @@ export type AgentWidgetConfig = {
    */
   parseSSEEvent?: AgentWidgetSSEEventParser;
   /**
+   * Called for every parsed SSE frame (after JSON parse), before native handling.
+   * Use for lightweight side effects (e.g. telemetry). Does not replace native
+   * streaming; pair with {@link parseSSEEvent} only when you need to override text mapping.
+   *
+   * When the event stream inspector is enabled, this runs in the same order as
+   * events are appended to the inspector buffer.
+   */
+  onSSEEvent?: (eventType: string, payload: unknown) => void;
+  /**
    * Layout configuration for customizing widget appearance and structure.
    * Provides control over header, messages, and content slots.
    * 

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -3118,9 +3118,10 @@ export const createAgentExperience = (
     });
   }
 
-  // Wire up event stream buffer to capture SSE events
-  if (eventStreamBuffer) {
+  // Wire up optional SSE tap (host) + event stream buffer to capture SSE events
+  if (eventStreamBuffer || config.onSSEEvent) {
     session.setSSEEventCallback((type: string, payload: unknown) => {
+      config.onSSEEvent?.(type, payload);
       eventStreamBuffer?.push({
         id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         type,
@@ -4187,8 +4188,9 @@ export const createAgentExperience = (
           eventStreamStore = new EventStreamStore(eventStreamDbName);
           eventStreamBuffer = new EventStreamBuffer(eventStreamMaxEvents, eventStreamStore);
           eventStreamStore.open().then(() => eventStreamBuffer?.restore()).catch(() => {});
-          // Register the SSE event callback
+          // Register the SSE event callback (host tap + buffer)
           session.setSSEEventCallback((type: string, payload: unknown) => {
+            config.onSSEEvent?.(type, payload);
             eventStreamBuffer!.push({
               id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
               type,


### PR DESCRIPTION
Allow hosts to observe parsed SSE frames for lightweight side effects without disrupting native streaming.