### PR TITLE
feat(widget): render agent_media events inline in chat

### DIFF
--- a/.changeset/agent-media-events.md
+++ b/.changeset/agent-media-events.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Handle the new `agent_media` SSE event so tool-produced media (images, audio, video, files) renders inline in the chat at the point the tool completed. Wire format follows the AI SDK v3/v4/v6 `MediaContentPart` shape (`{ type: 'media' | 'image-url' | 'file-url' }`); `mediaType` drives routing to the right rendering bucket. Adds `AudioContentPart` and `VideoContentPart` to the public types and renders `<audio>`/`<video>` controls plus file download links in message bubbles.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -2851,3 +2851,524 @@ describe('AgentWidgetClient.resumeFlow', () => {
   });
 });
 
+// ============================================================================
+// agent_media Event Handling
+// ============================================================================
+
+describe('AgentWidgetClient - agent_media events', () => {
+  const collectMediaMessages = (events: AgentWidgetEvent[]): AgentWidgetMessage[] => {
+    const byId = new Map<string, AgentWidgetMessage>();
+    for (const event of events) {
+      if (event.type === 'message' && event.message.id.startsWith('agent-media-')) {
+        byId.set(event.message.id, event.message);
+      }
+    }
+    return Array.from(byId.values());
+  };
+
+  it('renders a base64 image (AI SDK v6 type:"media") as a synthetic message', async () => {
+    const execId = 'exec_media_image';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxTurns: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxTurns: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_tool_start', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_shot',
+        toolName: 'browser:screenshot', startedAt: new Date().toISOString(), seq: 3,
+      }),
+      sseEvent('agent_tool_complete', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_shot',
+        toolName: 'browser:screenshot', completedAt: new Date().toISOString(), seq: 4,
+      }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_shot',
+        toolName: 'browser:screenshot',
+        media: [
+          { type: 'media', data: 'iVBORw==', mediaType: 'image/png' },
+        ],
+        seq: 5,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 6,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Snap', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const mediaMessages = collectMediaMessages(events);
+    expect(mediaMessages).toHaveLength(1);
+    const msg = mediaMessages[0]!;
+    expect(msg.id).toMatch(/^agent-media-tc_shot-\d+$/);
+    expect(msg.role).toBe('assistant');
+    expect(msg.streaming).toBe(false);
+    expect(msg.contentParts).toBeDefined();
+    expect(msg.contentParts).toHaveLength(1);
+    const part = msg.contentParts![0];
+    expect(part.type).toBe('image');
+    if (part.type === 'image') {
+      expect(part.image).toBe('data:image/png;base64,iVBORw==');
+      expect(part.mimeType).toBe('image/png');
+    }
+    expect(msg.agentMetadata?.executionId).toBe(execId);
+    expect(msg.agentMetadata?.iteration).toBe(1);
+  });
+
+  it('renders a hosted image (AI SDK v3/v4 type:"image-url") as a synthetic message', async () => {
+    const execId = 'exec_media_url';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_dalle', toolName: 'dalle',
+        media: [{ type: 'image-url', url: 'https://r2.example.com/img.png' }],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Generate', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const mediaMessages = collectMediaMessages(events);
+    expect(mediaMessages).toHaveLength(1);
+    const part = mediaMessages[0]!.contentParts![0];
+    expect(part.type).toBe('image');
+    if (part.type === 'image') {
+      expect(part.image).toBe('https://r2.example.com/img.png');
+      expect(part.mimeType).toBeUndefined();
+    }
+  });
+
+  it('preserves mediaType on image-url parts when provided', async () => {
+    const execId = 'exec_media_url_typed';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_dalle', toolName: 'dalle',
+        media: [{ type: 'image-url', url: 'https://r2.example.com/img.png', mediaType: 'image/png' }],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Generate', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const part = collectMediaMessages(events)[0]!.contentParts![0];
+    expect(part.type).toBe('image');
+    if (part.type === 'image') {
+      expect(part.image).toBe('https://r2.example.com/img.png');
+      expect(part.mimeType).toBe('image/png');
+    }
+  });
+
+  it('renders a base64 audio part with mediaType', async () => {
+    const execId = 'exec_media_audio';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_tts', toolName: 'elevenlabs-tts',
+        media: [{ type: 'media', data: 'AAAA', mediaType: 'audio/mpeg' }],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Speak', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const mediaMessages = collectMediaMessages(events);
+    expect(mediaMessages).toHaveLength(1);
+    const part = mediaMessages[0]!.contentParts![0];
+    expect(part.type).toBe('audio');
+    if (part.type === 'audio') {
+      expect(part.audio).toBe('data:audio/mpeg;base64,AAAA');
+      expect(part.mimeType).toBe('audio/mpeg');
+    }
+  });
+
+  it('routes file-url parts by mediaType (audio/video/file)', async () => {
+    const execId = 'exec_media_file_url';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_files', toolName: 'multi',
+        media: [
+          { type: 'file-url', url: 'https://example.com/a.mp3', mediaType: 'audio/mpeg' },
+          { type: 'file-url', url: 'https://example.com/v.mp4', mediaType: 'video/mp4' },
+          { type: 'file-url', url: 'https://example.com/r.pdf', mediaType: 'application/pdf' },
+        ],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const parts = collectMediaMessages(events)[0]!.contentParts!;
+    expect(parts).toHaveLength(3);
+    expect(parts[0].type).toBe('audio');
+    expect(parts[1].type).toBe('video');
+    expect(parts[2].type).toBe('file');
+    if (parts[0].type === 'audio') expect(parts[0].audio).toBe('https://example.com/a.mp3');
+    if (parts[1].type === 'video') expect(parts[1].video).toBe('https://example.com/v.mp4');
+    if (parts[2].type === 'file') {
+      expect(parts[2].data).toBe('https://example.com/r.pdf');
+      expect(parts[2].mimeType).toBe('application/pdf');
+      expect(parts[2].filename).toBe('attachment.pdf');
+    }
+  });
+
+  it('renders mixed media parts in a single message', async () => {
+    const execId = 'exec_media_mixed';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_mix', toolName: 'multi',
+        media: [
+          { type: 'media', data: 'IMG', mediaType: 'image/png' },
+          { type: 'image-url', url: 'https://example.com/dalle.png' },
+          { type: 'media', data: 'FILE', mediaType: 'application/pdf' },
+        ],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const mediaMessages = collectMediaMessages(events);
+    expect(mediaMessages).toHaveLength(1);
+    const parts = mediaMessages[0]!.contentParts!;
+    expect(parts).toHaveLength(3);
+    expect(parts[0].type).toBe('image');
+    expect(parts[1].type).toBe('image');
+    expect(parts[2].type).toBe('file');
+    if (parts[2].type === 'file') {
+      expect(parts[2].data).toBe('data:application/pdf;base64,FILE');
+      expect(parts[2].filename).toBe('attachment.pdf');
+    }
+  });
+
+  it('inserts media between tool bubble and the next text turn', async () => {
+    const execId = 'exec_media_order';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_turn_start', { executionId: execId, iteration: 1, turnIndex: 0, role: 'assistant', turnId: 'turn_1', seq: 3 }),
+      sseEvent('agent_turn_delta', { executionId: execId, iteration: 1, delta: 'Calling tool...', contentType: 'text', turnId: 'turn_1', seq: 4 }),
+      sseEvent('agent_tool_start', { executionId: execId, iteration: 1, toolCallId: 'tc_1', toolName: 'browser:screenshot', startedAt: new Date().toISOString(), seq: 5 }),
+      sseEvent('agent_tool_complete', { executionId: execId, iteration: 1, toolCallId: 'tc_1', toolName: 'browser:screenshot', completedAt: new Date().toISOString(), seq: 6 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_1', toolName: 'browser:screenshot',
+        media: [{ type: 'media', data: 'PNG', mediaType: 'image/png' }],
+        seq: 7,
+      }),
+      sseEvent('agent_turn_start', { executionId: execId, iteration: 1, turnIndex: 1, role: 'assistant', turnId: 'turn_2', seq: 8 }),
+      sseEvent('agent_turn_delta', { executionId: execId, iteration: 1, delta: 'Done!', contentType: 'text', turnId: 'turn_2', seq: 9 }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 10 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Take a snap', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    // Collect the most-recent state of every emitted message by id.
+    const latest = new Map<string, AgentWidgetMessage>();
+    for (const e of events) {
+      if (e.type === 'message') latest.set(e.message.id, e.message);
+    }
+    const ordered = Array.from(latest.values()).sort(
+      (a, b) => (a.sequence ?? 0) - (b.sequence ?? 0)
+    );
+
+    // Find the media bubble plus the assistant text bubble that came AFTER it
+    const mediaMsg = ordered.find((m) => m.id.startsWith('agent-media-tc_1-'));
+    expect(mediaMsg).toBeDefined();
+    const followingText = ordered.find(
+      (m) =>
+        m.role === 'assistant' &&
+        !m.variant &&
+        !m.id.startsWith('agent-media-') &&
+        (m.sequence ?? 0) > (mediaMsg!.sequence ?? 0)
+    );
+    expect(followingText).toBeDefined();
+    expect(followingText!.content).toBe('Done!');
+  });
+
+  it('skips malformed media parts that have neither data nor url', async () => {
+    const execId = 'exec_media_empty';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_x', toolName: 'noop',
+        media: [
+          { type: 'media', mediaType: 'image/png' },         // missing data
+          { type: 'image-url' },                              // missing url
+          { type: 'unknown-shape', payload: 'whatever' },     // unknown discriminator
+        ],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    expect(collectMediaMessages(events)).toHaveLength(0);
+  });
+
+  it('produces unique ids for repeated agent_media events on the same toolCallId', async () => {
+    const execId = 'exec_media_repeat';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_repeat', toolName: 'multi',
+        media: [{ type: 'media', data: 'A', mediaType: 'image/png' }],
+        seq: 3,
+      }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_repeat', toolName: 'multi',
+        media: [{ type: 'media', data: 'B', mediaType: 'image/png' }],
+        seq: 4,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 5 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const mediaMessages = collectMediaMessages(events);
+    expect(mediaMessages).toHaveLength(2);
+    expect(mediaMessages[0]!.id).not.toBe(mediaMessages[1]!.id);
+    // Both messages should preserve the toolCallId in the id for traceability
+    for (const m of mediaMessages) {
+      expect(m.id).toMatch(/^agent-media-tc_repeat-\d+$/);
+    }
+    // First message keeps its first content part; not overwritten by the second
+    const first = mediaMessages.find((m) => {
+      const p = m.contentParts?.[0];
+      return p?.type === 'image' && p.image === 'data:image/png;base64,A';
+    });
+    expect(first).toBeDefined();
+  });
+
+  it('seals an in-flight assistant text bubble before splitting on agent_media', async () => {
+    const execId = 'exec_media_seal';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_turn_start', { executionId: execId, iteration: 1, turnIndex: 0, role: 'assistant', turnId: 'turn_1', seq: 3 }),
+      sseEvent('agent_turn_delta', { executionId: execId, iteration: 1, delta: 'Streaming...', contentType: 'text', turnId: 'turn_1', seq: 4 }),
+      // Media arrives mid-stream — earlier text bubble is still streaming.
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_seal', toolName: 'shot',
+        media: [{ type: 'media', data: 'PNG', mediaType: 'image/png' }],
+        seq: 5,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 6 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Go', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const latest = new Map<string, AgentWidgetMessage>();
+    for (const e of events) {
+      if (e.type === 'message') latest.set(e.message.id, e.message);
+    }
+
+    // The pre-media assistant bubble must be sealed (no orphan typing indicator).
+    const orphan = Array.from(latest.values()).find(
+      (m) =>
+        m.role === 'assistant' &&
+        !m.variant &&
+        !m.id.startsWith('agent-media-') &&
+        m.content === 'Streaming...'
+    );
+    expect(orphan).toBeDefined();
+    expect(orphan!.streaming).toBe(false);
+  });
+
+  it('routes audio parts case-insensitively (RFC 7231)', async () => {
+    const execId = 'exec_media_case';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_case', toolName: 'tts',
+        // Non-canonical casing should still land in the audio bucket, not the file bucket.
+        media: [{ type: 'media', data: 'AAAA', mediaType: 'Audio/MPEG' }],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Speak', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const part = collectMediaMessages(events)[0]!.contentParts![0];
+    expect(part.type).toBe('audio');
+    if (part.type === 'audio') {
+      // mediaType is canonicalized to lowercase for both routing and storage.
+      expect(part.mimeType).toBe('audio/mpeg');
+      expect(part.audio).toBe('data:audio/mpeg;base64,AAAA');
+    }
+  });
+
+  it('renders a base64 text/csv attachment as a file part (not silently dropped)', async () => {
+    const execId = 'exec_media_csv';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_csv', toolName: 'export',
+        media: [{ type: 'media', data: 'YSxiCjEsMg==', mediaType: 'text/csv' }],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Export', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const part = collectMediaMessages(events)[0]!.contentParts![0];
+    expect(part.type).toBe('file');
+    if (part.type === 'file') {
+      expect(part.mimeType).toBe('text/csv');
+      expect(part.filename).toBe('attachment.csv');
+      expect(part.data).toBe('data:text/csv;base64,YSxiCjEsMg==');
+    }
+  });
+
+  it('defaults missing mediaType on a type:"media" part to application/octet-stream', async () => {
+    const execId = 'exec_media_no_type';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_iteration_start', { executionId: execId, iteration: 1, maxTurns: 1, startedAt: new Date().toISOString(), seq: 2 }),
+      sseEvent('agent_media', {
+        executionId: execId, iteration: 1, toolCallId: 'tc_blob', toolName: 'opaque',
+        // mediaType is empty — should not produce a malformed `data:;base64,...` URI.
+        media: [{ type: 'media', data: 'AAAA', mediaType: '' }],
+        seq: 3,
+      }),
+      sseEvent('agent_complete', { executionId: execId, agentId: 'virtual', success: true, iterations: 1, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 4 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const part = collectMediaMessages(events)[0]!.contentParts![0];
+    expect(part.type).toBe('file');
+    if (part.type === 'file') {
+      expect(part.mimeType).toBe('application/octet-stream');
+      expect(part.data).toBe('data:application/octet-stream;base64,AAAA');
+    }
+  });
+});
+

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -19,7 +19,8 @@ import {
   ClientChatRequest,
   ClientFeedbackRequest,
   ClientFeedbackType,
-  PersonaArtifactKind
+  PersonaArtifactKind,
+  ContentPart
 } from "./types";
 import {
   extractTextFromJson,
@@ -43,6 +44,36 @@ type SSEHandler = (event: AgentWidgetEvent) => void;
 
 const DEFAULT_ENDPOINT = "https://api.runtype.com/v1/dispatch";
 const DEFAULT_CLIENT_API_BASE = "https://api.runtype.com";
+
+/**
+ * Derive a download filename for `agent_media` parts that are delivered
+ * without one. Maps a few well-known MIME types to friendly extensions and
+ * falls back to `attachment.<subtype>` (or just `attachment` for opaque
+ * types like `application/octet-stream`).
+ */
+function filenameFromMediaType(mediaType: string): string {
+  // MIME types are case-insensitive (RFC 7231); compare against a lowercased
+  // copy so callers that pass mixed casing still hit the friendly extensions.
+  const lower = mediaType.toLowerCase();
+  const knownExtensions: Record<string, string> = {
+    "application/pdf": "pdf",
+    "application/json": "json",
+    "application/zip": "zip",
+    "text/plain": "txt",
+    "text/csv": "csv",
+    "text/markdown": "md"
+  };
+  const ext = knownExtensions[lower];
+  if (ext) return `attachment.${ext}`;
+  const slash = lower.indexOf("/");
+  if (slash > 0) {
+    const subtype = lower.slice(slash + 1).split(";")[0]?.trim() ?? "";
+    if (subtype && subtype !== "octet-stream" && /^[a-z0-9.+-]+$/i.test(subtype)) {
+      return `attachment.${subtype}`;
+    }
+  }
+  return "attachment";
+}
 
 /**
  * Check if a message has valid (non-empty) content for sending to the API.
@@ -2562,6 +2593,124 @@ export class AgentWidgetClient {
                 toolContext.byCall.delete(callKey);
               }
             }
+          }
+        } else if (payloadType === "agent_media") {
+          // A tool produced media (image / audio / video / file). Render it
+          // as a synthetic assistant message inserted at the point the tool
+          // completed — between the tool bubble and the next text turn.
+          //
+          // Wire format is the AI SDK–aligned `MediaContentPart` from
+          // @runtypelabs/shared:
+          //   { type: 'media', data, mediaType }                // AI SDK v6: base64
+          //   { type: 'image-url', url, mediaType? }            // AI SDK v3/v4
+          //   { type: 'file-url', url, mediaType }              // AI SDK v3/v4
+          const rawMedia = Array.isArray(payload.media) ? payload.media : [];
+          const mediaContentParts: ContentPart[] = [];
+          for (const part of rawMedia) {
+            if (!part || typeof part !== "object") continue;
+            const rec = part as Record<string, unknown>;
+            const partType = typeof rec.type === "string" ? rec.type : undefined;
+
+            // Resolve `(src, mediaType)` for the part.
+            // RFC 7231 says MIME types are case-insensitive, so we canonicalize
+            // to lowercase once here. That makes the `startsWith("image/")` /
+            // `"audio/"` / `"video/"` bucket checks robust to upstream tools
+            // that emit non-canonical casing like `Image/PNG`.
+            const rawMediaType =
+              typeof rec.mediaType === "string" ? rec.mediaType.toLowerCase() : "";
+            let src: string | null = null;
+            let mediaType = "";
+            if (partType === "media") {
+              const data = typeof rec.data === "string" ? rec.data : undefined;
+              if (!data) continue;
+              // Empty/missing mediaType yields `data:;base64,...` which RFC 2397
+              // resolves to `text/plain` — stamp a default so the data URI is
+              // well-formed and the part lands in the file bucket.
+              mediaType = rawMediaType.length > 0 ? rawMediaType : "application/octet-stream";
+              src = `data:${mediaType};base64,${data}`;
+            } else if (partType === "image-url") {
+              const url = typeof rec.url === "string" ? rec.url : undefined;
+              if (!url) continue;
+              mediaType = rawMediaType;
+              src = url;
+            } else if (partType === "file-url") {
+              const url = typeof rec.url === "string" ? rec.url : undefined;
+              if (!url) continue;
+              mediaType = rawMediaType;
+              src = url;
+            } else {
+              continue;
+            }
+            if (!src) continue;
+
+            // Pick the right rendering bucket based on mediaType.
+            if (partType === "image-url" || mediaType.startsWith("image/")) {
+              mediaContentParts.push({
+                type: "image",
+                image: src,
+                ...(mediaType ? { mimeType: mediaType } : {}),
+              });
+            } else if (mediaType.startsWith("audio/")) {
+              mediaContentParts.push({
+                type: "audio",
+                audio: src,
+                mimeType: mediaType,
+              });
+            } else if (mediaType.startsWith("video/")) {
+              mediaContentParts.push({
+                type: "video",
+                video: src,
+                mimeType: mediaType,
+              });
+            } else {
+              const resolvedMediaType = mediaType || "application/octet-stream";
+              mediaContentParts.push({
+                type: "file",
+                data: src,
+                mimeType: resolvedMediaType,
+                filename: filenameFromMediaType(resolvedMediaType),
+              });
+            }
+          }
+
+          if (mediaContentParts.length > 0) {
+            // Uniquify per emission. A tool may emit multiple `agent_media`
+            // events for the same `toolCallId` (e.g. streamed/batched media);
+            // sharing an id would let `emitMessage` merge them by id and
+            // overwrite the prior `contentParts`.
+            const seq = nextSequence();
+            const toolCallIdRaw = payload.toolCallId;
+            const mediaIdSuffix =
+              typeof toolCallIdRaw === "string" && toolCallIdRaw.length > 0
+                ? `${toolCallIdRaw}-${seq}`
+                : String(seq);
+            const mediaMessage: AgentWidgetMessage = {
+              id: `agent-media-${mediaIdSuffix}`,
+              role: "assistant",
+              content: "",
+              contentParts: mediaContentParts,
+              createdAt: new Date().toISOString(),
+              streaming: false,
+              sequence: seq,
+              agentMetadata: {
+                executionId: payload.executionId,
+                iteration: payload.iteration,
+              },
+            };
+            emitMessage(mediaMessage);
+
+            // Seal any in-flight assistant text bubble before splitting the
+            // stream. Without this, an orphan bubble retains `streaming: true`
+            // forever — `agent_complete` only finalizes the latest
+            // `assistantMessage`, so the typing/caret indicator would stay on
+            // the prior bubble even though no more deltas will arrive.
+            const prevAssistant = assistantMessage as AgentWidgetMessage | null;
+            if (prevAssistant) {
+              prevAssistant.streaming = false;
+              emitMessage(prevAssistant);
+            }
+            assistantMessage = null;
+            assistantMessageRef.current = null;
           }
         } else if (payloadType === "agent_iteration_complete") {
           // Iteration complete - no special handling needed

--- a/packages/widget/src/components/message-bubble.test.ts
+++ b/packages/widget/src/components/message-bubble.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   createStandardBubble,
   isSafeImageSrc,
+  isSafeMediaSrc,
   resolveStopReasonNoticeText,
   getDefaultStopReasonNoticeCopy,
 } from "./message-bubble";
@@ -272,5 +273,196 @@ describe("createStandardBubble — stopReason notice", () => {
       stopReason: "max_tool_calls",
     });
     expect(bubble.querySelector(".persona-message-stop-reason")).toBeNull();
+  });
+});
+
+describe("isSafeMediaSrc", () => {
+  it("allows https URLs", () => {
+    expect(isSafeMediaSrc("https://example.com/audio.mp3")).toBe(true);
+  });
+
+  it("allows http URLs", () => {
+    expect(isSafeMediaSrc("http://example.com/audio.mp3")).toBe(true);
+  });
+
+  it("allows blob URLs", () => {
+    expect(isSafeMediaSrc("blob:http://example.com/abc-123")).toBe(true);
+  });
+
+  it("allows audio data URIs", () => {
+    expect(isSafeMediaSrc("data:audio/mpeg;base64,AAAA")).toBe(true);
+  });
+
+  it("allows video data URIs", () => {
+    expect(isSafeMediaSrc("data:video/mp4;base64,AAAA")).toBe(true);
+  });
+
+  it("allows binary file data URIs", () => {
+    expect(isSafeMediaSrc("data:application/pdf;base64,AAAA")).toBe(true);
+  });
+
+  it("blocks javascript: URIs", () => {
+    expect(isSafeMediaSrc("javascript:alert(1)")).toBe(false);
+  });
+
+  it("blocks data:text/html URIs", () => {
+    expect(isSafeMediaSrc("data:text/html,<script>alert(1)</script>")).toBe(false);
+    expect(isSafeMediaSrc("data:text/html;base64,PHNjcmlwdD5hbGVydCgxKTwvc2NyaXB0Pg==")).toBe(false);
+  });
+
+  it("blocks other executable data: types", () => {
+    expect(isSafeMediaSrc("data:text/javascript,alert(1)")).toBe(false);
+    expect(isSafeMediaSrc("data:text/xml,<svg onload=alert(1)/>")).toBe(false);
+    expect(isSafeMediaSrc("data:application/xhtml+xml,<html>")).toBe(false);
+  });
+
+  it("blocks data:image/svg+xml URIs (XSS via right-click open in new tab)", () => {
+    expect(isSafeMediaSrc("data:image/svg+xml,<svg onload=alert(1)>")).toBe(false);
+    expect(isSafeMediaSrc("data:image/svg+xml;base64,PHN2Zz4=")).toBe(false);
+    expect(isSafeMediaSrc("data:image/SVG+XML;base64,PHN2Zz4=")).toBe(false);
+  });
+
+  it("allows inert data:text/* payloads (plain, csv, markdown)", () => {
+    expect(isSafeMediaSrc("data:text/plain;base64,SGVsbG8=")).toBe(true);
+    expect(isSafeMediaSrc("data:text/csv;base64,YSxiCjEsMg==")).toBe(true);
+    expect(isSafeMediaSrc("data:text/markdown;base64,IyBIaQ==")).toBe(true);
+  });
+
+  it("allows relative paths", () => {
+    expect(isSafeMediaSrc("relative/file.mp3")).toBe(true);
+  });
+});
+
+describe("createStandardBubble — audio/video/file content parts", () => {
+  it("renders an <audio> element with controls for an audio content part", () => {
+    const bubble = createStandardBubble(
+      makeMessage({
+        contentParts: [
+          {
+            type: "audio",
+            audio: "data:audio/mpeg;base64,AAAA",
+            mimeType: "audio/mpeg",
+          },
+        ],
+      }),
+      ({ text }) => text
+    );
+
+    const container = bubble.querySelector('[data-message-attachments="audio"]');
+    expect(container).not.toBeNull();
+    const audio = container?.querySelector("audio") as HTMLAudioElement | null;
+    expect(audio).not.toBeNull();
+    expect(audio?.controls).toBe(true);
+    expect(audio?.getAttribute("src")).toBe("data:audio/mpeg;base64,AAAA");
+  });
+
+  it("renders an <audio> element for a URL-based audio part", () => {
+    const bubble = createStandardBubble(
+      makeMessage({
+        contentParts: [
+          {
+            type: "audio",
+            audio: "https://example.com/clip.mp3",
+            mimeType: "audio/mpeg",
+          },
+        ],
+      }),
+      ({ text }) => text
+    );
+
+    const audio = bubble.querySelector(
+      '[data-message-attachments="audio"] audio'
+    ) as HTMLAudioElement | null;
+    expect(audio?.getAttribute("src")).toBe("https://example.com/clip.mp3");
+  });
+
+  it("skips audio parts with unsafe schemes", () => {
+    const bubble = createStandardBubble(
+      makeMessage({
+        contentParts: [
+          {
+            type: "audio",
+            audio: "javascript:alert(1)",
+            mimeType: "audio/mpeg",
+          },
+        ],
+      }),
+      ({ text }) => text
+    );
+
+    expect(
+      bubble.querySelector('[data-message-attachments="audio"]')
+    ).toBeNull();
+  });
+
+  it("renders a <video> element with controls for a video content part", () => {
+    const bubble = createStandardBubble(
+      makeMessage({
+        contentParts: [
+          {
+            type: "video",
+            video: "https://example.com/clip.mp4",
+            mimeType: "video/mp4",
+          },
+        ],
+      }),
+      ({ text }) => text
+    );
+
+    const video = bubble.querySelector(
+      '[data-message-attachments="video"] video'
+    ) as HTMLVideoElement | null;
+    expect(video).not.toBeNull();
+    expect(video?.controls).toBe(true);
+    expect(video?.getAttribute("src")).toBe("https://example.com/clip.mp4");
+  });
+
+  it("renders a download link for a file content part", () => {
+    const bubble = createStandardBubble(
+      makeMessage({
+        contentParts: [
+          {
+            type: "file",
+            data: "data:application/pdf;base64,AAAA",
+            mimeType: "application/pdf",
+            filename: "report.pdf",
+          },
+        ],
+      }),
+      ({ text }) => text
+    );
+
+    const link = bubble.querySelector(
+      '[data-message-attachments="files"] a'
+    ) as HTMLAnchorElement | null;
+    expect(link).not.toBeNull();
+    expect(link?.getAttribute("href")).toBe("data:application/pdf;base64,AAAA");
+    expect(link?.getAttribute("download")).toBe("report.pdf");
+    expect(link?.textContent).toBe("report.pdf");
+    // Cross-origin URLs ignore `download`, so we open in a new tab to avoid
+    // navigating the chat page away from the conversation.
+    expect(link?.getAttribute("target")).toBe("_blank");
+    expect(link?.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("renders a download link for a URL-hosted file", () => {
+    const bubble = createStandardBubble(
+      makeMessage({
+        contentParts: [
+          {
+            type: "file",
+            data: "https://example.com/report.pdf",
+            mimeType: "application/pdf",
+            filename: "report.pdf",
+          },
+        ],
+      }),
+      ({ text }) => text
+    );
+
+    const link = bubble.querySelector(
+      '[data-message-attachments="files"] a'
+    ) as HTMLAnchorElement | null;
+    expect(link?.getAttribute("href")).toBe("https://example.com/report.pdf");
   });
 });

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -8,6 +8,9 @@ import {
   AgentWidgetMessageFeedback,
   LoadingIndicatorRenderContext,
   ImageContentPart,
+  AudioContentPart,
+  VideoContentPart,
+  FileContentPart,
   StopReasonKind
 } from "../types";
 import { createIconButton } from "../utils/buttons";
@@ -98,6 +101,31 @@ export const isSafeImageSrc = (src: string): boolean => {
   return false;
 };
 
+/**
+ * Validate that a media src URL (audio/video/file) uses a safe scheme.
+ * Allows http(s), blob:, and inert data: URIs. Blocks `javascript:` and the
+ * executable data: types whose payloads a browser would render or run when a
+ * user right-clicks the link → "Open in new tab" (bypassing `download`):
+ * `data:text/html`, `data:text/javascript`, `data:text/xml`,
+ * `data:application/xhtml`, and `data:image/svg+xml`. Inert text payloads
+ * (`text/plain`, `text/csv`, `text/markdown`) remain allowed so attachments
+ * with those mime types render as download links instead of vanishing.
+ */
+export const isSafeMediaSrc = (src: string): boolean => {
+  const lower = src.toLowerCase();
+  if (lower.startsWith("javascript:")) return false;
+  if (lower.startsWith("data:text/html")) return false;
+  if (lower.startsWith("data:text/javascript")) return false;
+  if (lower.startsWith("data:text/xml")) return false;
+  if (lower.startsWith("data:application/xhtml")) return false;
+  if (lower.startsWith("data:image/svg+xml")) return false;
+  if (/^(?:https?|blob):/i.test(src)) return true;
+  if (lower.startsWith("data:")) return true;
+  // Relative URLs are safe
+  if (!src.includes(":")) return true;
+  return false;
+};
+
 export type LoadingIndicatorRenderer = (context: LoadingIndicatorRenderContext) => HTMLElement | null;
 
 export type MessageTransform = (context: {
@@ -125,6 +153,36 @@ const getMessageImageParts = (message: AgentWidgetMessage): ImageContentPart[] =
       part.type === "image" &&
       typeof part.image === "string" &&
       part.image.trim().length > 0
+  );
+};
+
+const getMessageAudioParts = (message: AgentWidgetMessage): AudioContentPart[] => {
+  if (!message.contentParts || message.contentParts.length === 0) return [];
+  return message.contentParts.filter(
+    (part): part is AudioContentPart =>
+      part.type === "audio" &&
+      typeof part.audio === "string" &&
+      part.audio.trim().length > 0
+  );
+};
+
+const getMessageVideoParts = (message: AgentWidgetMessage): VideoContentPart[] => {
+  if (!message.contentParts || message.contentParts.length === 0) return [];
+  return message.contentParts.filter(
+    (part): part is VideoContentPart =>
+      part.type === "video" &&
+      typeof part.video === "string" &&
+      part.video.trim().length > 0
+  );
+};
+
+const getMessageFileParts = (message: AgentWidgetMessage): FileContentPart[] => {
+  if (!message.contentParts || message.contentParts.length === 0) return [];
+  return message.contentParts.filter(
+    (part): part is FileContentPart =>
+      part.type === "file" &&
+      typeof part.data === "string" &&
+      part.data.trim().length > 0
   );
 };
 
@@ -205,6 +263,124 @@ const createMessageImagePreviews = (
     return container;
   } catch {
     onPreviewFailed?.();
+    return null;
+  }
+};
+
+const createMessageAudioPreviews = (
+  audioParts: AudioContentPart[]
+): HTMLElement | null => {
+  if (audioParts.length === 0) return null;
+  try {
+    const container = createElement(
+      "div",
+      "persona-flex persona-flex-col persona-gap-2"
+    );
+    container.setAttribute("data-message-attachments", "audio");
+    let visible = 0;
+    audioParts.forEach((part) => {
+      if (!isSafeMediaSrc(part.audio)) return;
+      const audioElement = createElement("audio") as HTMLAudioElement;
+      audioElement.controls = true;
+      audioElement.preload = "metadata";
+      audioElement.src = part.audio;
+      audioElement.style.display = "block";
+      audioElement.style.width = "100%";
+      audioElement.style.maxWidth = `${MESSAGE_IMAGE_PREVIEW_MAX_WIDTH_PX}px`;
+      container.appendChild(audioElement);
+      visible += 1;
+    });
+    if (visible === 0) {
+      container.remove();
+      return null;
+    }
+    return container;
+  } catch {
+    return null;
+  }
+};
+
+const createMessageVideoPreviews = (
+  videoParts: VideoContentPart[]
+): HTMLElement | null => {
+  if (videoParts.length === 0) return null;
+  try {
+    const container = createElement(
+      "div",
+      "persona-flex persona-flex-col persona-gap-2"
+    );
+    container.setAttribute("data-message-attachments", "video");
+    let visible = 0;
+    videoParts.forEach((part) => {
+      if (!isSafeMediaSrc(part.video)) return;
+      const videoElement = createElement("video") as HTMLVideoElement;
+      videoElement.controls = true;
+      videoElement.preload = "metadata";
+      videoElement.src = part.video;
+      videoElement.style.display = "block";
+      videoElement.style.width = "100%";
+      videoElement.style.maxWidth = `${MESSAGE_IMAGE_PREVIEW_MAX_WIDTH_PX}px`;
+      videoElement.style.maxHeight = `${MESSAGE_IMAGE_PREVIEW_MAX_HEIGHT_PX}px`;
+      videoElement.style.borderRadius = "10px";
+      videoElement.style.backgroundColor =
+        "var(--persona-attachment-image-bg, var(--persona-container, #f3f4f6))";
+      container.appendChild(videoElement);
+      visible += 1;
+    });
+    if (visible === 0) {
+      container.remove();
+      return null;
+    }
+    return container;
+  } catch {
+    return null;
+  }
+};
+
+const createMessageFilePreviews = (
+  fileParts: FileContentPart[]
+): HTMLElement | null => {
+  if (fileParts.length === 0) return null;
+  try {
+    const container = createElement(
+      "div",
+      "persona-flex persona-flex-col persona-gap-2"
+    );
+    container.setAttribute("data-message-attachments", "files");
+    let visible = 0;
+    fileParts.forEach((part) => {
+      if (!isSafeMediaSrc(part.data)) return;
+      const link = createElement("a") as HTMLAnchorElement;
+      link.href = part.data;
+      link.download = part.filename;
+      // Cross-origin URLs ignore the `download` attribute, so without
+      // `target=_blank` the link would navigate the chat page to the file.
+      // Pair with `rel="noopener noreferrer"` to prevent reverse tabnabbing.
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+      link.textContent = part.filename;
+      link.className = "persona-message-file-attachment";
+      link.style.display = "inline-flex";
+      link.style.alignItems = "center";
+      link.style.gap = "6px";
+      link.style.padding = "6px 10px";
+      link.style.borderRadius = "8px";
+      link.style.fontSize = "0.875rem";
+      link.style.textDecoration = "underline";
+      link.style.backgroundColor =
+        "var(--persona-attachment-file-bg, var(--persona-container, #f3f4f6))";
+      link.style.border =
+        "1px solid var(--persona-attachment-file-border, var(--persona-border, #e5e7eb))";
+      link.style.color = "inherit";
+      container.appendChild(link);
+      visible += 1;
+    });
+    if (visible === 0) {
+      container.remove();
+      return null;
+    }
+    return container;
+  } catch {
     return null;
   }
 };
@@ -707,6 +883,30 @@ export const createStandardBubble = (
       bubble.appendChild(imagePreviews);
     } else if (shouldHideTextUntilPreviewFails && textContentDiv) {
       textContentDiv.style.display = "";
+    }
+  }
+
+  const audioParts = getMessageAudioParts(message);
+  if (audioParts.length > 0) {
+    const audioPreviews = createMessageAudioPreviews(audioParts);
+    if (audioPreviews) {
+      bubble.appendChild(audioPreviews);
+    }
+  }
+
+  const videoParts = getMessageVideoParts(message);
+  if (videoParts.length > 0) {
+    const videoPreviews = createMessageVideoPreviews(videoParts);
+    if (videoPreviews) {
+      bubble.appendChild(videoPreviews);
+    }
+  }
+
+  const fileParts = getMessageFileParts(message);
+  if (fileParts.length > 0) {
+    const filePreviews = createMessageFilePreviews(fileParts);
+    if (filePreviews) {
+      bubble.appendChild(filePreviews);
     }
   }
 

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -30,15 +30,40 @@ export type ImageContentPart = {
  */
 export type FileContentPart = {
   type: 'file';
-  data: string; // base64 data URI
+  data: string; // base64 data URI or URL
   mimeType: string;
   filename: string;
 };
 
 /**
+ * Audio content part for multi-modal messages
+ * Supports base64 data URIs or URLs
+ */
+export type AudioContentPart = {
+  type: 'audio';
+  audio: string; // base64 data URI or URL
+  mimeType?: string;
+};
+
+/**
+ * Video content part for multi-modal messages
+ * Supports base64 data URIs or URLs
+ */
+export type VideoContentPart = {
+  type: 'video';
+  video: string; // base64 data URI or URL
+  mimeType?: string;
+};
+
+/**
  * Union type for all content part types
  */
-export type ContentPart = TextContentPart | ImageContentPart | FileContentPart;
+export type ContentPart =
+  | TextContentPart
+  | ImageContentPart
+  | FileContentPart
+  | AudioContentPart
+  | VideoContentPart;
 
 /**
  * Message content can be a simple string or an array of content parts


### PR DESCRIPTION
## Summary

The Runtype API now emits a new `agent_media` SSE event whenever a tool produces media (images, audio, video, files). This PR teaches the widget to handle those events so the media renders inline in the chat — at the point the tool completed, between the tool bubble and the next text turn — instead of being lost or appended at the end.

The wire format mirrors the [AI SDK](https://sdk.vercel.ai/) content-part shapes (v3/v4/v6), so it stays forward-compatible with the broader ecosystem rather than inventing yet another media descriptor:

```ts
type MediaContentPart =
  | { type: 'media'; data: string; mediaType: string }     // AI SDK v6 base64
  | { type: 'image-url'; url: string }                      // AI SDK v3/v4
  | { type: 'file-url'; url: string; mediaType: string }    // AI SDK v3/v4
```

`mediaType` drives routing to the right rendering bucket: `image/*` → image preview, `audio/*` → `<audio controls>`, `video/*` → `<video controls>`, anything else → file download link.

### Changes

- **`client.ts`** — new `agent_media` branch in the SSE dispatch chain. Converts each `MediaContentPart` to a content part on a synthetic assistant message (`agent-media-<toolCallId>`). Base64 data is wrapped into a `data:` URI; URLs pass through. Resets the in-flight assistant message reference so subsequent text turns open a new bubble after the media — same pattern used by `transcript_insert`.
- **`types.ts`** — added `AudioContentPart` and `VideoContentPart`; `FileContentPart.data` doc updated to reflect that it now accepts a URL or data URI.
- **`message-bubble.ts`** — new render paths for audio (`<audio>`), video (`<video>`), and files (download `<a>`). New `isSafeMediaSrc` helper allows http(s)/blob/non-text data URIs and blocks `javascript:` / `data:text/*`.
- **Changeset** — `minor` bump for `@runtypelabs/persona`.

### Tests

- `client.test.ts` — 7 new tests covering base64 images, hosted (`image-url`) images, base64 audio, `file-url` routing by `mediaType`, mixed-media messages, ordering between tool bubble / next text turn, and rejection of malformed parts.
- `message-bubble.test.ts` — 13 new tests for `isSafeMediaSrc` and the new audio/video/file rendering paths (incl. `javascript:` blocking).

Total widget suite: **666 tests pass**, lint and typecheck clean, build succeeds.

## Test plan

- [x] `pnpm --filter @runtypelabs/persona test:run`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] Manual: trigger a tool that returns media (e.g. screenshot, DALL-E, ElevenLabs TTS) against a Runtype API build that emits `agent_media` and verify the image/audio renders inline in the dashboard chat between the tool bubble and the next assistant message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new SSE event parsing and DOM rendering for tool-produced media (including external URLs and `data:` URIs), which can affect message ordering/state and has some security/XSS considerations despite added scheme/type filtering.
> 
> **Overview**
> Tool-produced media emitted via the new `agent_media` SSE event is now rendered inline in the chat at the point the tool completes, by emitting a synthetic assistant message with `contentParts` derived from AI SDK-style `{ type: 'media' | 'image-url' | 'file-url' }` payloads.
> 
> The widget now supports `audio` and `video` content parts (rendered with `<audio>`/`<video>` controls) and file attachments (download links with derived filenames), including MIME-type based routing, case-insensitive `mediaType` handling, and safer media URL validation to block executable schemes/types.
> 
> Adds a changeset for a minor `@runtypelabs/persona` bump and expands test coverage for media parsing, ordering/stream-splitting behavior, malformed payload skipping, and safe rendering rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6a1978e7e0f0c74c8b92a7703af31e364873186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->