### PR TITLE
Introduce interactive question UI and plugin support

### DIFF
--- a/.changeset/ask-user-question-and-widget-updates.md
+++ b/.changeset/ask-user-question-and-widget-updates.md
@@ -1,0 +1,17 @@
+---
+"@runtypelabs/persona": minor
+"@runtypelabs/persona-proxy": minor
+---
+
+**`@runtypelabs/persona`**
+
+- **Human-in-the-loop (`ask_user_question`).** Support Runtype `step_await` (LOCAL tool pause), `client.resumeFlow()`, and `session.resolveAskUserQuestion()`. Synthesize tool messages with `agentMetadata.awaitingLocalTool`, render the answer UI, and resume via `POST` with `toolOutputs` (with `sendMessage` fallback for agents that do not use LOCAL tools). Idempotent `resolveAskUserQuestion` for rapid double-clicks.
+- **Built-in answer UI.** Interactive sheet (stacked rows by default, optional `layout: "pills"`), optional free-text, progressive hydration from streaming tool args, feature flags under `features.askUserQuestion`, and `renderAskUserQuestion` / `parseAskUserQuestionPayload` for custom renderers. Plugins that delegate to the default should return `null` when `message.agentMetadata.askUserQuestionAnswered === true` so the widget owns the answered transcript.
+- **Grouped questions.** Up to 8 questions per call, paginated stepper, `Record<questionText, string | string[]>` result shape, persistence of in-progress state across refresh, labels `nextLabel` / `backLabel` / `submitAllLabel` / `skipLabel`, and optional `groupedAutoAdvance: false`. UX aligned with common AskUserQuestion-style patterns: row layout, skip/back/submit, Q→A pair messages in the transcript, keyboard shortcuts 1–9, compact header, and optional “Other” input behavior per layout.
+- **Fixes.** Composer overlay width and z-index; sheet lifecycle (answered flag, `awaitingLocalTool` gating, prune stale DOM); remove redundant “awaiting” stub when the sheet is the primary UI. Scroll-to-bottom control no longer covers the answer sheet.
+- **Artifacts.** Persist artifact list and selection in `storageAdapter`; `initialArtifacts` / `initialSelectedArtifactId`, `hydrateArtifacts()`, and controller helpers for custom chrome; completed-only persistence for artifacts. Backward compatible with older stored state.
+- **Theming.** `components.introCard` tokens and CSS variables for the welcome / intro card.
+
+**`@runtypelabs/persona-proxy`**
+
+- **`POST` resume route** (default under the chat path) forwarding `{ executionId, toolOutputs, streamResponse }` to the upstream `/resume` endpoint for LOCAL tool completion. Pre-configured `RuntypeFlowConfig` examples in this package can declare `ask_user_question` and other `runtimeTools` the same way as any custom flow.

--- a/.planning/interleaved-tool-text-hydration.md
+++ b/.planning/interleaved-tool-text-hydration.md
@@ -1,0 +1,115 @@
+# Interleaved Tool/Text — Hydration on Reload
+
+## Problem
+
+During **live streaming**, the widget now splits assistant messages at tool boundaries
+using `partId`, rendering preamble → tool → follow-up in order. But on **page reload**,
+the conversation is loaded from the server record which stores a single assistant message
+with concatenated text + a flat `toolInvocations` array. The interleaved ordering is lost.
+
+---
+
+## Option 1: Store segmented messages server-side
+
+Store each text segment and tool invocation as separate entries in the conversation
+record, preserving the interleaved order.
+
+### Server changes (`/v1/client/chat` in `client.ts`)
+
+- Instead of accumulating `assistantResponse += textContent` into one string,
+  track an ordered `parts` array:
+  ```
+  parts: [
+    { type: "text", id: "ast_abc", partId: "text_0", content: "Let me search..." },
+    { type: "tool", toolCallId: "tc_1", toolName: "search", args: {...}, result: {...} },
+    { type: "text", id: "ast_abc_text_1", partId: "text_1", content: "Found it!..." },
+  ]
+  ```
+- Store `parts` on the assistant message in `updateConversationMessages()`
+- Keep `content` as the full concatenated text for backward compatibility / search
+
+### Widget changes (Persona)
+
+- On hydration, if a message has `parts`, render each part as its own bubble
+  (text segments as assistant messages, tool parts as tool bubbles)
+- Fall back to current behavior (single bubble + `toolInvocations`) when `parts` is absent
+
+### Pros
+- Clean data model — aligns with Anthropic content blocks / AI SDK parts
+- Widget hydration is straightforward: iterate `parts` in order
+- Full fidelity on reload — identical to live streaming experience
+- `toolInvocations` can eventually be deprecated in favor of `parts`
+
+### Cons
+- **Breaking storage schema change** — existing conversation records don't have `parts`
+- Requires migration strategy or dual-write (keep both `content`/`toolInvocations` AND `parts`)
+- More data stored per message (though tool results are already stored in `toolInvocations`)
+- Server needs to track `text_start`/`text_end`/`partId` events during streaming
+  (currently it only tracks `step_delta` text and `tool_start`/`tool_complete`)
+
+### Estimated scope
+- **Server**: ~50-80 lines in `client.ts` stream handler + schema addition
+- **Widget**: ~30-50 lines in session hydration / message loading
+- **Shared types**: Add `MessagePart` type to `@runtypelabs/shared`
+- **Migration**: None required if `parts` is optional and hydration falls back gracefully
+
+---
+
+## Option 2: Store segment markers alongside the existing message
+
+Keep the single `content` string + `toolInvocations` array, but add a `segments`
+metadata field that describes how to re-split the content on hydration.
+
+### Server changes
+
+- Track text segment boundaries during streaming:
+  ```
+  segments: [
+    { type: "text", partId: "text_0", offset: 0, length: 22 },
+    { type: "tool", toolCallId: "tc_1" },
+    { type: "text", partId: "text_1", offset: 22, length: 32 },
+  ]
+  ```
+- Store `segments` on the assistant message alongside `content` and `toolInvocations`
+
+### Widget changes
+
+- On hydration, if `segments` is present, use offsets to slice `content` into
+  separate text bubbles and interleave with tool bubbles from `toolInvocations`
+- Fall back to current behavior when `segments` is absent
+
+### Pros
+- Smaller change — additive field, no schema migration
+- `content` remains the full text (backward compatible for search, export, etc.)
+- Doesn't duplicate tool data (tools are still in `toolInvocations`)
+
+### Cons
+- **Fragile** — offset-based slicing breaks if content is modified (e.g. post-processing,
+  sanitization, or if the server trims/normalizes whitespace)
+- More complex hydration logic (offset math vs. iterating typed parts)
+- Two sources of truth for tool ordering (`segments` order vs. `toolInvocations` array order)
+- Still coupled to the `toolInvocations` format which may be deprecated
+
+### Estimated scope
+- **Server**: ~30-40 lines to track segment offsets during streaming
+- **Widget**: ~40-60 lines for offset-based re-splitting (more complex than Option 1)
+- **Shared types**: Add `SegmentMarker` type
+
+---
+
+## Recommendation
+
+**Option 1** is the better long-term choice. It's cleaner, more robust, and aligns with
+industry conventions (Anthropic content blocks, AI SDK parts, OpenAI output items).
+The `parts` field is additive — existing records without it hydrate with current behavior,
+so no migration is needed.
+
+Option 2 is a patch that creates technical debt (offset fragility, dual ordering) without
+meaningfully reducing scope.
+
+### Suggested implementation order
+
+1. **Ship the current widget change** (live streaming interleaving) — already done
+2. **Add `parts` to the server storage** in a follow-up PR
+3. **Add `parts`-based hydration** to the widget
+4. **Deprecate `toolInvocations`** on the message type once `parts` is fully adopted

--- a/.runtype/marathons/playbooks/design-refresh.yaml
+++ b/.runtype/marathons/playbooks/design-refresh.yaml
@@ -1,0 +1,153 @@
+# Design System Normalization Playbook
+# Researches an existing app's current design standards, creates a unified
+# design-system migration plan, then processes exactly one target file per run.
+#
+# Copy to .runtype/marathons/playbooks/design-refresh.yaml to use:
+# npx @runtypelabs/cli@latest marathon "Design refresh" \
+#   --playbook design-refresh \
+#   --goal "Normalize all the advanced examples in the embedded-app under a single design system. Only modify the examples that are linked to under the advanced accordian. Do not touch the widget package." \
+#   --tool-context hot-tail
+
+name: design-refresh
+description: Normalize an existing app under a single design system through research, planning, and one-file-per-run migrations
+
+rules: |
+  This playbook is for an EXISTING app in the current workspace. Do NOT create a
+  new app, demo, sandbox, or isolated component library unless the user explicitly
+  asks for one.
+
+  The goal is to discover the app's current design standards, define the target
+  design system, and then migrate the codebase incrementally until the app is
+  normalized under that system.
+
+  You must maintain exactly two state files at the workspace root:
+    - conversion-memory.md
+    - todo.md
+
+  At the start of EVERY run, read both files if they exist before deciding what to
+  do next. If they do not exist yet, create them in the earliest appropriate run.
+
+  conversion-memory.md is the rolling journal for the marathon. It should capture:
+    - the current understanding of the app's design standards
+    - the target design-system decisions
+    - a brief log of each completed run
+    - risks, open questions, and notable discoveries
+
+  todo.md is the execution queue. It should contain:
+    - the ordered list of files or file groups to normalize
+    - the status of each item (pending, active, done, blocked)
+    - the next recommended target for the following run
+
+  During execution, each run must edit EXACTLY ONE product/source file. The only
+  additional files that may be edited in that same run are:
+    - conversion-memory.md
+    - todo.md
+
+  A single run may read multiple supporting files for context, but it may only
+  change one actual app file before stopping.
+
+  Every edited app file should be moved toward the shared design system by
+  normalizing tokens, spacing, typography, colors, states, component usage,
+  naming, and layout patterns where relevant.
+
+  Before ending any run that changes a product/source file:
+    - update conversion-memory.md with a concise summary of the work completed
+    - update todo.md to mark the file done and point to the next target
+    - note any follow-up dependencies that future runs must consider
+
+milestones:
+  - name: research
+    description: Audit the existing app and identify the design standards already in use
+    model: gpt-5-mini
+    instructions: |
+      Read the goal and inspect the current app as it exists today.
+
+      Research the design standards already present across the app. Look for:
+        - shared UI primitives and design-system packages
+        - color usage, typography, spacing, radii, borders, shadows, and iconography
+        - layout shells, page structure, form patterns, table/list patterns, and navigation
+        - interaction states, accessibility patterns, responsive behavior, and inconsistencies
+        - one-off styling that should eventually be normalized
+
+      Read enough representative files to understand the real state of the app,
+      not just one component.
+
+      Create or overwrite conversion-memory.md with:
+        - Current Standards
+        - Inconsistencies / Drift
+        - Candidate Design-System Rules
+        - Risks / Open Questions
+
+      If todo.md does not exist yet, create a stub with a placeholder section for
+      the migration backlog that will be filled in during the planning milestone.
+    completionCriteria:
+      type: evidence
+      minReadFiles: 5
+
+  - name: planning
+    description: Turn the research into a concrete normalization plan and ordered migration queue
+    model: claude-sonnet-4-5
+    instructions: |
+      Start by reading conversion-memory.md and todo.md.
+
+      Synthesize the research into a single target design system for this app.
+      Define the normalization strategy, including:
+        - the preferred token sources and component primitives
+        - styling rules that should become the standard
+        - anti-patterns that should be removed over time
+        - the migration order, prioritizing foundational files first
+
+      Then fully populate todo.md with an ordered file-by-file migration queue.
+      Each item should be small enough that one run can complete it. If a file is
+      too large, split it into clearly named sub-tasks, but the default unit should
+      still be a single file per run.
+
+      Update conversion-memory.md with:
+        - Target Design System
+        - Migration Strategy
+        - Prioritization Notes
+        - Initial Ordered Queue
+
+      End this run with a clear next file selected in todo.md.
+    completionCriteria:
+      type: sessions
+      minSessions: 1
+
+  - name: execute
+    description: Migrate the app one file per run until the queue is complete
+    model: claude-sonnet-4-5
+    instructions: |
+      At the very beginning of the run, read conversion-memory.md and todo.md.
+      Use them as the source of truth for what has already been done and what
+      should happen next.
+
+      Select the highest-priority pending item from todo.md and work on exactly
+      one product/source file in this run.
+
+      For the chosen file:
+        - read the file itself
+        - read any immediately relevant supporting files needed for safe edits
+        - update the file to align with the target design system
+        - keep the change scoped; do not branch into other product files
+
+      The goal of each execution run is to finish one meaningful normalization
+      step, not to partially touch many files.
+
+      After the file change:
+        - append a dated run summary to conversion-memory.md
+        - record what standards were applied and any blockers discovered
+        - update todo.md statuses
+        - nominate the next file for the next run
+
+      If validation is practical, run the smallest relevant check for the file you
+      changed and record the result in conversion-memory.md.
+
+      If there are still pending items after this run, stop after updating the two
+      state files so the next run can continue from there.
+
+      Only emit TASK_COMPLETE when todo.md shows that all migration items are done
+      or intentionally cancelled and conversion-memory.md contains a final summary
+      of the completed normalization effort.
+    completionCriteria:
+      type: never
+    canAcceptCompletion: true

--- a/examples/embedded-app/ask-user-question-demo.html
+++ b/examples/embedded-app/ask-user-question-demo.html
@@ -1,0 +1,601 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/demo-shared.css">
+    <link rel="icon" href="/favicon.ico" />
+    <title>Ask User Question - Persona</title>
+    <style>
+      body {
+        padding: 1.5rem;
+        max-width: 1400px;
+        margin: 0 auto;
+      }
+      h1 { margin: 0 0 0.25rem 0; }
+      .subtitle { color: var(--muted); margin: 0 0 1.5rem 0; font-size: 0.875rem; }
+
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+        gap: 1.5rem;
+        align-items: start;
+      }
+
+      .controls {
+        background: var(--card);
+        border-radius: var(--radius-lg);
+        padding: 1.25rem;
+        box-shadow: var(--shadow-md);
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        align-self: start;
+      }
+      .controls h2 {
+        font-size: 0.9375rem;
+        margin: 0;
+        color: var(--foreground);
+      }
+      .section { display: flex; flex-direction: column; gap: 0.5rem; }
+      .section label {
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--muted);
+      }
+
+      .mode-group {
+        display: flex;
+        gap: 0.375rem;
+        flex-wrap: wrap;
+      }
+      .mode-btn {
+        padding: 0.375rem 0.75rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--card);
+        color: var(--foreground);
+        font-size: 0.8125rem;
+        cursor: pointer;
+        transition: background 0.15s, border-color 0.15s;
+      }
+      .mode-btn:hover { background: var(--border); }
+      .mode-btn.active {
+        border-color: #7c3aed;
+        background: rgba(124, 58, 237, 0.1);
+        color: #7c3aed;
+        font-weight: 600;
+      }
+      .hint {
+        margin: 0.25rem 0 0 0;
+        font-size: 0.75rem;
+        line-height: 1.4;
+        color: var(--muted);
+      }
+
+      .btn-group { display: flex; flex-direction: column; gap: 0.5rem; }
+      .btn-group button {
+        padding: 0.5rem 0.75rem;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--border);
+        background: var(--card);
+        color: var(--foreground);
+        font-size: 0.8125rem;
+        cursor: pointer;
+        text-align: left;
+      }
+      .btn-group button:hover { background: var(--border); }
+
+      .btn-row { display: flex; gap: 0.5rem; }
+      .btn-row button { flex: 1; }
+
+      #log {
+        font-size: 0.75rem;
+        font-family: monospace;
+        background: #111;
+        color: #aaa;
+        border-radius: var(--radius-sm);
+        padding: 0.5rem;
+        max-height: 160px;
+        overflow-y: auto;
+        line-height: 1.6;
+      }
+      #log .answered { color: #34d399; }
+      #log .dismissed { color: #f87171; }
+      #log .info { color: #60a5fa; }
+
+      /* Right column — bare container so the widget sits directly on the
+         page background. The widget brings its own surface, header, and
+         shadow, so wrapping it in another card was redundant chrome. */
+      .widget-shell {
+        height: 680px;
+      }
+      #widget-mount {
+        height: 100%;
+        width: 100%;
+      }
+
+      /* Mobile-only summary bar — hidden on desktop. */
+      .controls-summary { display: none; }
+      .controls-close { display: none; }
+      .controls-backdrop { display: none; }
+
+      @media (max-width: 768px) {
+        body { padding: 0.75rem; }
+        .subtitle { margin-bottom: 1rem; }
+
+        .layout {
+          grid-template-columns: 1fr;
+          gap: 0.75rem;
+        }
+
+        /* Compact summary bar visible above the widget on mobile. */
+        .controls-summary {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          flex-wrap: wrap;
+          padding: 0.6rem 0.75rem;
+          background: var(--card);
+          border: 1px solid var(--border);
+          border-radius: var(--radius-lg);
+          box-shadow: var(--shadow-md);
+        }
+        .summary-chip {
+          font-size: 0.7rem;
+          font-weight: 600;
+          letter-spacing: 0.03em;
+          color: var(--muted);
+          background: transparent;
+          padding: 0.25rem 0.55rem;
+          border: 1px solid var(--border);
+          border-radius: 999px;
+          white-space: nowrap;
+        }
+        .summary-edit {
+          margin-left: auto;
+          padding: 0.4rem 0.85rem;
+          font-size: 0.8125rem;
+          font-weight: 600;
+          border-radius: var(--radius-sm);
+          border: 1px solid #7c3aed;
+          background: #7c3aed;
+          color: #fafafa;
+          cursor: pointer;
+        }
+        .summary-edit:hover { filter: brightness(0.95); }
+
+        /* Controls become a left-side drawer over the widget. */
+        .controls {
+          position: fixed;
+          top: 0;
+          left: 0;
+          bottom: 0;
+          width: min(420px, 92vw);
+          margin: 0;
+          border-radius: 0;
+          box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+          padding: 1rem 1rem 1.25rem;
+          overflow-y: auto;
+          transform: translateX(-100%);
+          transition: transform 240ms ease;
+          z-index: 50;
+        }
+        body.controls-open .controls { transform: translateX(0); }
+
+        .controls-close {
+          display: inline-flex;
+          align-self: flex-end;
+          width: 2rem;
+          height: 2rem;
+          align-items: center;
+          justify-content: center;
+          border: none;
+          background: transparent;
+          color: var(--foreground);
+          font-size: 1.4rem;
+          line-height: 1;
+          border-radius: 999px;
+          cursor: pointer;
+        }
+        .controls-close:hover { background: var(--border); }
+
+        .controls-backdrop {
+          display: block;
+          position: fixed;
+          inset: 0;
+          background: rgba(0, 0, 0, 0.4);
+          opacity: 0;
+          pointer-events: none;
+          transition: opacity 200ms ease;
+          z-index: 40;
+        }
+        body.controls-open .controls-backdrop {
+          opacity: 1;
+          pointer-events: auto;
+        }
+
+        /* Let the widget fill the remaining viewport on mobile. */
+        .widget-shell {
+          height: calc(100dvh - 8rem);
+          min-height: 420px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Ask User Question</h1>
+    <p class="subtitle">
+      The <code>ask_user_question</code> local-tool sheet — built-in stacked layout vs. the horizontal-pill layout shipped as a plugin example. Pick a preset and click Trigger to inject a simulated tool call.
+    </p>
+
+    <div class="controls-summary">
+      <span class="summary-chip" data-summary="variant">Variant: Built-in</span>
+      <span class="summary-chip" data-summary="autoadvance">Auto-advance: On</span>
+      <button class="summary-edit" type="button" id="btn-controls-toggle">
+        Edit settings
+      </button>
+    </div>
+    <div class="controls-backdrop" id="controls-backdrop"></div>
+
+    <div class="layout">
+      <div class="controls">
+        <button class="controls-close" type="button" id="btn-controls-close" aria-label="Close settings">×</button>
+        <div class="section">
+          <label>Variant</label>
+          <div class="mode-group" id="variant-selector">
+            <button class="mode-btn active" data-variant="builtin">Built-in (stacked)</button>
+            <button class="mode-btn" data-variant="plugin">Plugin (horizontal pills)</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <label>Auto-advance (grouped)</label>
+          <div class="mode-group" id="autoadvance-selector">
+            <button class="mode-btn active" data-autoadvance="on">On</button>
+            <button class="mode-btn" data-autoadvance="off">Off</button>
+          </div>
+          <p class="hint">
+            When on, picking a single-select pill or pressing Send on free-text
+            jumps to the next question automatically. The final page always waits
+            for an explicit "Submit all" click. Multi-select pages always require Next.
+          </p>
+        </div>
+
+        <div class="section">
+          <label>Question Presets</label>
+          <div class="btn-group" id="preset-group">
+            <button data-preset="single5">Single-select (5 short options)</button>
+            <button data-preset="longLabels">Single-select (long labels)</button>
+            <button data-preset="multi">Multi-select</button>
+            <button data-preset="freeText">Free-text only</button>
+            <button data-preset="grouped3">Grouped (3 mixed)</button>
+            <button data-preset="grouped5">Grouped (5 short)</button>
+            <button data-preset="grouped8">Grouped (8 — cap)</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <label>Actions</label>
+          <div class="btn-row">
+            <button id="btn-reset">Reset transcript</button>
+          </div>
+        </div>
+
+        <div class="section">
+          <label>Events</label>
+          <div id="log"></div>
+        </div>
+      </div>
+
+      <div class="widget-shell">
+        <div id="widget-mount"></div>
+      </div>
+    </div>
+
+    <script type="module">
+      import "@runtypelabs/persona/widget.css";
+      import "./src/index.css";
+      import { createAgentExperience } from "@runtypelabs/persona";
+      import { horizontalPillsAskPlugin } from "./src/plugins/ask-horizontal-pills-plugin.js";
+
+      const mount = document.getElementById("widget-mount");
+      const logEl = document.getElementById("log");
+      const log = (msg, cls = "info") => {
+        const line = document.createElement("div");
+        line.className = cls;
+        line.textContent = `[${new Date().toLocaleTimeString()}] ${msg}`;
+        logEl.appendChild(line);
+        logEl.scrollTop = logEl.scrollHeight;
+      };
+
+      let variant = "builtin";
+      let autoAdvance = true;
+      let controller = null;
+
+      const PRESETS = {
+        single5: {
+          questions: [{
+            question: "Which tone best fits your brand voice on the homepage?",
+            options: [
+              { label: "Trust-first" },
+              { label: "Story-driven" },
+              { label: "Catalog-forward" },
+              { label: "Promotional" },
+              { label: "Editorial" },
+            ],
+            allowFreeText: true,
+          }],
+        },
+        longLabels: {
+          questions: [{
+            question: "Who is the primary audience for this homepage?",
+            options: [
+              { label: "Direct-to-consumer brands under $1M ARR" },
+              { label: "Mid-market retailers with wholesale channels" },
+              { label: "Enterprise catalog publishers" },
+              { label: "Hobbyist / bootstrapped operators" },
+            ],
+            allowFreeText: false,
+          }],
+        },
+        multi: {
+          questions: [{
+            question: "Which sections should the homepage include?",
+            options: [
+              { label: "Hero" },
+              { label: "Best sellers" },
+              { label: "Testimonials" },
+              { label: "Newsletter signup" },
+              { label: "Brand story" },
+            ],
+            multiSelect: true,
+            allowFreeText: false,
+          }],
+        },
+        freeText: {
+          questions: [{
+            question: "Describe the primary call-to-action in one sentence.",
+            options: [],
+            allowFreeText: true,
+          }],
+        },
+        grouped3: {
+          questions: [
+            {
+              question: "Which tone fits your brand voice?",
+              header: "Tone",
+              options: [
+                { label: "Trust-first" },
+                { label: "Story-driven" },
+                { label: "Catalog-forward" },
+                { label: "Promotional" },
+              ],
+              allowFreeText: true,
+            },
+            {
+              question: "Which sections should the homepage include?",
+              header: "Sections",
+              options: [
+                { label: "Hero" },
+                { label: "Best sellers" },
+                { label: "Testimonials" },
+                { label: "Newsletter signup" },
+              ],
+              multiSelect: true,
+              allowFreeText: false,
+            },
+            {
+              question: "Describe the primary CTA in one sentence.",
+              header: "CTA",
+              options: [],
+              allowFreeText: true,
+            },
+          ],
+        },
+        grouped5: {
+          questions: [
+            {
+              question: "Which industry is your store in?",
+              header: "Industry",
+              options: [
+                { label: "Apparel" },
+                { label: "Beauty" },
+                { label: "Home goods" },
+                { label: "Food & beverage" },
+              ],
+            },
+            {
+              question: "What's your average order value?",
+              header: "AOV",
+              options: [
+                { label: "Under $50" },
+                { label: "$50–$150" },
+                { label: "$150–$500" },
+                { label: "$500+" },
+              ],
+            },
+            {
+              question: "Who's your primary audience?",
+              header: "Audience",
+              options: [
+                { label: "Gen Z" },
+                { label: "Millennials" },
+                { label: "Gen X" },
+                { label: "Boomers" },
+              ],
+            },
+            {
+              question: "What's your primary growth channel?",
+              header: "Channel",
+              options: [
+                { label: "Paid social" },
+                { label: "SEO" },
+                { label: "Influencer" },
+                { label: "Email" },
+              ],
+            },
+            {
+              question: "Which goal matters most this quarter?",
+              header: "Goal",
+              options: [
+                { label: "More traffic" },
+                { label: "Higher conversion" },
+                { label: "Bigger AOV" },
+                { label: "Repeat purchase" },
+              ],
+            },
+          ],
+        },
+        grouped8: {
+          questions: Array.from({ length: 8 }, (_, i) => ({
+            question: `Step ${i + 1} — pick an option`,
+            header: `Step ${i + 1}`,
+            options: [
+              { label: `${i + 1}-A` },
+              { label: `${i + 1}-B` },
+              { label: `${i + 1}-C` },
+            ],
+          })),
+        },
+      };
+
+      function createWidget() {
+        if (controller) controller.destroy();
+        mount.innerHTML = "";
+        const plugins = variant === "plugin" ? [horizontalPillsAskPlugin] : [];
+        controller = createAgentExperience(mount, {
+          apiUrl: "https://noop.test/chat",
+          launcher: { enabled: false },
+          persistState: false,
+          plugins,
+          features: {
+            askUserQuestion: { groupedAutoAdvance: autoAdvance },
+          },
+          copy: {
+            welcomeTitle: "Ask User Question Demo",
+            welcomeSubtitle: "Trigger a preset question from the left panel.",
+          },
+        });
+        log(`Widget initialized — variant: ${variant}, autoAdvance: ${autoAdvance}`, "info");
+      }
+
+      let askCounter = 0;
+      function triggerQuestion(key) {
+        const args = PRESETS[key];
+        if (!args || !controller) return;
+        const id = `demo-ask-${++askCounter}`;
+        controller.injectTestMessage({
+          type: "message",
+          message: {
+            id,
+            role: "assistant",
+            content: "",
+            createdAt: new Date().toISOString(),
+            streaming: false,
+            variant: "tool",
+            toolCall: {
+              id,
+              name: "ask_user_question",
+              status: "complete",
+              args,
+              chunks: [],
+            },
+            agentMetadata: {
+              executionId: "demo-exec",
+              awaitingLocalTool: true,
+            },
+          },
+        });
+        log(`Injected preset: ${key} (toolCallId=${id})`, "info");
+      }
+
+      // Mobile drawer + summary chip handling. The drawer is css-driven via
+      // `body.controls-open`; this just toggles that class and keeps the
+      // summary chips in sync with the live state.
+      const mobileQuery = window.matchMedia("(max-width: 768px)");
+      const summaryChips = {
+        variant: document.querySelector('[data-summary="variant"]'),
+        autoadvance: document.querySelector('[data-summary="autoadvance"]'),
+      };
+      const variantLabel = (v) => (v === "plugin" ? "Plugin (pills)" : "Built-in");
+      const updateSummary = () => {
+        if (summaryChips.variant) summaryChips.variant.textContent = `Variant: ${variantLabel(variant)}`;
+        if (summaryChips.autoadvance) summaryChips.autoadvance.textContent = `Auto-advance: ${autoAdvance ? "On" : "Off"}`;
+      };
+      const openDrawer = () => document.body.classList.add("controls-open");
+      const closeDrawer = () => document.body.classList.remove("controls-open");
+      document.getElementById("btn-controls-toggle").addEventListener("click", openDrawer);
+      document.getElementById("btn-controls-close").addEventListener("click", closeDrawer);
+      document.getElementById("controls-backdrop").addEventListener("click", closeDrawer);
+      document.addEventListener("keydown", (e) => {
+        if (e.key === "Escape") closeDrawer();
+      });
+      // If the user resizes back to desktop while the drawer is open, drop
+      // the body class so reopening on desktop doesn't start in drawer state.
+      mobileQuery.addEventListener("change", (e) => {
+        if (!e.matches) closeDrawer();
+      });
+
+      // Variant selector
+      const variantSelector = document.getElementById("variant-selector");
+      variantSelector.addEventListener("click", (e) => {
+        const btn = e.target.closest(".mode-btn");
+        if (!btn) return;
+        variantSelector.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        variant = btn.dataset.variant;
+        updateSummary();
+        createWidget();
+      });
+
+      // Auto-advance toggle
+      const autoAdvanceSelector = document.getElementById("autoadvance-selector");
+      autoAdvanceSelector.addEventListener("click", (e) => {
+        const btn = e.target.closest(".mode-btn");
+        if (!btn) return;
+        autoAdvanceSelector.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        autoAdvance = btn.dataset.autoadvance === "on";
+        updateSummary();
+        createWidget();
+      });
+
+      // Preset buttons. On mobile, auto-close the drawer right after a preset
+      // is picked so the widget is immediately visible underneath.
+      document.getElementById("preset-group").addEventListener("click", (e) => {
+        const btn = e.target.closest("button[data-preset]");
+        if (!btn) return;
+        triggerQuestion(btn.dataset.preset);
+        if (mobileQuery.matches) closeDrawer();
+      });
+
+      // Reset
+      document.getElementById("btn-reset").addEventListener("click", () => {
+        createWidget();
+        logEl.innerHTML = "";
+        log("Reset", "info");
+      });
+
+      // Listen for widget DOM events
+      window.addEventListener("persona:askUserQuestion:answered", (e) => {
+        const { answer, answers, toolUseId } = e.detail ?? {};
+        if (answers && typeof answers === "object" && Object.keys(answers).length > 1) {
+          log(`answered → ${JSON.stringify(answers)} (toolUseId=${toolUseId})`, "answered");
+        } else {
+          log(`answered → "${answer}" (toolUseId=${toolUseId})`, "answered");
+        }
+      });
+      window.addEventListener("persona:askUserQuestion:dismissed", (e) => {
+        const { toolCallId } = e.detail ?? {};
+        log(`dismissed (toolCallId=${toolCallId})`, "dismissed");
+      });
+
+      // Initial mount
+      updateSummary();
+      createWidget();
+    </script>
+  </body>
+</html>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -301,6 +301,7 @@
                 <li><a class="example-item" href="/voice-integration-demo.html">Voice Integration <small>Speech-to-text and text-to-speech input</small></a></li>
                 <li><a class="example-item" href="/tool-loading-demo.html">Tool &amp; Reasoning Loading Animations <small>Configurable loading indicators for tool calls and reasoning</small></a></li>
                 <li><a class="example-item" href="/stream-animations-demo.html">Stream Animations <small>Reveal effects for streaming assistant text: typewriter, word fade, letter rise, glyph cycle, wipe, pop bubble, thinking</small></a></li>
+                <li><a class="example-item" href="/ask-user-question-demo.html">Ask User Question <small>Built-in stacked answers vs. a custom horizontal-pills plugin</small></a></li>
                 <li><a class="example-item" href="/event-stream-testing.html">Event Stream Testing <small>Inspector API, window events, inline + launcher</small></a></li>
               </ul>
             </section>

--- a/examples/embedded-app/package.json
+++ b/examples/embedded-app/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@runtypelabs/persona": "workspace:^",
+    "handlebars": "^4.7.8",
     "idiomorph": "^0.7.4",
     "partial-json": "^0.1.7"
   },

--- a/examples/embedded-app/src/plugins/ask-horizontal-pills-plugin.js
+++ b/examples/embedded-app/src/plugins/ask-horizontal-pills-plugin.js
@@ -1,0 +1,527 @@
+// Example plugin: renders the `ask_user_question` answer sheet as a horizontal
+// wrap of pill buttons with an optional free-text pill that expands into an
+// inline input + Send button.
+//
+// Demonstrates the `renderAskUserQuestion` plugin hook. Register via:
+//   plugins: [horizontalPillsAskPlugin]
+//
+// Supports grouped (multi-question) payloads with an internal stepper: shows
+// "Question N of M", auto-advances on single-select pick, and submits a
+// structured `{ [questionText]: answer }` payload on the final page —
+// matching the schema the agent receives back. Set the payload's `multiSelect`
+// per-question to allow multi-pick (Next button replaces auto-advance).
+//
+// Once the user answers, the widget suppresses the original tool message
+// entirely from the transcript and injects assistant/user bubble pairs
+// (one per question + one per answer; skipped questions become an italic
+// `*Skipped*` user bubble) so the transcript reads as a normal conversation.
+// Plugins do NOT render the answered state — only the interactive sheet.
+//
+// Copy this file into your own app; it has zero dependencies beyond the
+// widget plugin contract.
+
+const STYLE_ID = "ask-pill-plugin-style";
+
+const ensureStyle = () => {
+  if (document.getElementById(STYLE_ID)) return;
+  const style = document.createElement("style");
+  style.id = STYLE_ID;
+  style.textContent = `
+    .ask-pill-sheet {
+      background: var(--persona-surface, #ffffff);
+      border: 1px solid var(--persona-border, #e5e7eb);
+      border-radius: 1rem;
+      padding: 0.85rem 1rem;
+      margin: 0.5rem 0;
+      box-shadow: 0 8px 20px -10px rgba(0, 0, 0, 0.1);
+      width: 100%;
+      max-width: 100%;
+      box-sizing: border-box;
+    }
+    .ask-pill-header {
+      display: flex;
+      align-items: flex-start;
+      gap: 0.5rem;
+      margin-bottom: 0.6rem;
+    }
+    .ask-pill-question {
+      flex: 1;
+      font-size: 0.95rem;
+      color: var(--persona-text, #1f2937);
+    }
+    .ask-pill-stepper {
+      align-self: center;
+      font-size: 0.7rem;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+      color: var(--persona-muted, #6b7280);
+      padding: 0.15rem 0.5rem;
+      border-radius: 999px;
+      background: var(--persona-container, #f3f4f6);
+      white-space: nowrap;
+    }
+    .ask-pill-close {
+      width: 1.6rem;
+      height: 1.6rem;
+      border: none;
+      background: transparent;
+      color: var(--persona-muted, #6b7280);
+      cursor: pointer;
+      border-radius: 0.4rem;
+      font-size: 1rem;
+      line-height: 1;
+      padding: 0;
+    }
+    .ask-pill-close:hover { background: var(--persona-container, #f3f4f6); }
+    .ask-pill-list {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+    }
+    .ask-pill-option, .ask-pill-free-btn {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.5rem 0.95rem;
+      border-radius: 999px;
+      border: 1px solid var(--persona-border, #e5e7eb);
+      background: transparent;
+      color: var(--persona-text, #1f2937);
+      font-size: 0.85rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+    }
+    .ask-pill-option:hover, .ask-pill-free-btn:hover {
+      border-color: var(--persona-text, #1f2937);
+      background: var(--persona-container, #f3f4f6);
+    }
+    .ask-pill-option:active, .ask-pill-free-btn:active { transform: translateY(1px); }
+    .ask-pill-option[aria-pressed="true"] {
+      background: var(--persona-accent, #7c3aed);
+      border-color: var(--persona-accent, #7c3aed);
+      color: #fafafa;
+    }
+    .ask-pill-free-btn { border-style: dashed; }
+    .ask-pill-free-row {
+      display: none;
+      gap: 0.5rem;
+      margin-top: 0.6rem;
+    }
+    .ask-pill-free-row[data-open="true"] { display: flex; }
+    .ask-pill-input {
+      flex: 1;
+      padding: 0.5rem 0.8rem;
+      border: 1px solid var(--persona-border, #e5e7eb);
+      border-radius: 0.55rem;
+      font-size: 0.88rem;
+      background: var(--persona-surface, #ffffff);
+      color: var(--persona-text, #1f2937);
+    }
+    .ask-pill-input:focus {
+      outline: 2px solid var(--persona-accent, #7c3aed);
+      outline-offset: 1px;
+    }
+    .ask-pill-send {
+      padding: 0.5rem 1rem;
+      border: none;
+      border-radius: 0.55rem;
+      background: var(--persona-accent, #7c3aed);
+      color: #fafafa;
+      font-size: 0.85rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .ask-pill-send:disabled { opacity: 0.4; cursor: not-allowed; }
+    .ask-pill-footer {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 0.7rem;
+      align-items: center;
+      justify-content: flex-end;
+    }
+    .ask-pill-footer .ask-pill-stepper {
+      margin-left: auto;
+    }
+    .ask-pill-nav {
+      padding: 0.45rem 0.9rem;
+      border: 1px solid var(--persona-border, #e5e7eb);
+      border-radius: 0.55rem;
+      background: transparent;
+      color: var(--persona-text, #1f2937);
+      font-size: 0.82rem;
+      font-weight: 500;
+      cursor: pointer;
+    }
+    .ask-pill-nav:hover { background: var(--persona-container, #f3f4f6); }
+    .ask-pill-nav:disabled { opacity: 0.4; cursor: not-allowed; }
+    .ask-pill-nav.ask-pill-nav-primary {
+      background: var(--persona-accent, #7c3aed);
+      border-color: var(--persona-accent, #7c3aed);
+      color: #fafafa;
+    }
+    .ask-pill-nav.ask-pill-nav-primary:hover {
+      background: var(--persona-accent, #7c3aed);
+      filter: brightness(0.95);
+    }
+  `;
+  document.head.appendChild(style);
+};
+
+// IMPORTANT — event-delegation pattern.
+//
+// The widget re-renders messages by morphing DOM via idiomorph. To stay
+// robust, this plugin attaches a SINGLE delegated click/keydown handler at
+// the root element and dispatches by `data-action` attribute. All cross-
+// render state lives in `data-*` attributes on the root (current question
+// index, accumulated answers JSON), not in closure refs — so re-renders
+// reading from `e.currentTarget` see the live state.
+//
+// Plugin authors writing their own `renderAskUserQuestion` should follow the
+// same pattern: one delegated listener at the root, identify targets via
+// `data-*` attributes on children, persist state on the root element.
+
+const ATTR_CURRENT = "data-ask-current-index";
+const ATTR_COUNT = "data-ask-question-count";
+const ATTR_ANSWERS = "data-ask-answers";
+
+const readAnswers = (root) => {
+  try {
+    return JSON.parse(root.getAttribute(ATTR_ANSWERS) || "{}");
+  } catch {
+    return {};
+  }
+};
+
+const writeAnswers = (root, answers) => {
+  root.setAttribute(ATTR_ANSWERS, JSON.stringify(answers));
+};
+
+const getCurrentPrompt = (questions, root) => {
+  const idx = Number(root.getAttribute(ATTR_CURRENT) || 0);
+  return { idx, prompt: questions[idx] };
+};
+
+const renderBody = (root, questions) => {
+  const total = questions.length;
+  const { idx, prompt } = getCurrentPrompt(questions, root);
+  if (!prompt) return;
+  const answers = readAnswers(root);
+  const currentAnswer = answers[prompt.question];
+  const isMulti = prompt.multiSelect === true;
+  const allowFreeText = prompt.allowFreeText !== false;
+
+  const header = document.createElement("div");
+  header.className = "ask-pill-header";
+
+  const q = document.createElement("div");
+  q.className = "ask-pill-question";
+  q.textContent = prompt.question ?? "";
+  header.appendChild(q);
+
+  const close = document.createElement("button");
+  close.type = "button";
+  close.className = "ask-pill-close";
+  close.setAttribute("aria-label", "Dismiss");
+  close.setAttribute("data-action", "dismiss");
+  close.textContent = "×";
+  header.appendChild(close);
+
+  const list = document.createElement("div");
+  list.className = "ask-pill-list";
+
+  const options = Array.isArray(prompt.options) ? prompt.options : [];
+  options.forEach((option) => {
+    if (!option || typeof option.label !== "string") return;
+    const btn = document.createElement("button");
+    btn.type = "button";
+    btn.className = "ask-pill-option";
+    btn.textContent = option.label;
+    btn.setAttribute("data-action", "pick");
+    btn.setAttribute("data-label", option.label);
+    if (option.description) btn.title = option.description;
+
+    const isSelected = isMulti
+      ? Array.isArray(currentAnswer) && currentAnswer.includes(option.label)
+      : currentAnswer === option.label;
+    if (isSelected) btn.setAttribute("aria-pressed", "true");
+
+    list.appendChild(btn);
+  });
+
+  if (allowFreeText) {
+    const freeBtn = document.createElement("button");
+    freeBtn.type = "button";
+    freeBtn.className = "ask-pill-free-btn";
+    freeBtn.textContent = "Other…";
+    freeBtn.setAttribute("data-action", "open-free");
+    list.appendChild(freeBtn);
+  }
+
+  let freeRow = null;
+  if (allowFreeText) {
+    freeRow = document.createElement("div");
+    freeRow.className = "ask-pill-free-row";
+
+    const input = document.createElement("input");
+    input.type = "text";
+    input.className = "ask-pill-input";
+    input.placeholder = prompt.freeTextPlaceholder ?? "Type your answer…";
+    input.setAttribute("data-role", "free-input");
+
+    const send = document.createElement("button");
+    send.type = "button";
+    send.className = "ask-pill-send";
+    send.textContent = "Send";
+    send.disabled = true;
+    send.setAttribute("data-action", "submit-free");
+
+    freeRow.append(input, send);
+  }
+
+  // Footer with Back / Next / Submit-all. Shown when grouped, when the
+  // current page is multi-select, or when auto-advance is disabled (so the
+  // user has an explicit Next button on every grouped page).
+  let footer = null;
+  const isLast = idx === total - 1;
+  const autoAdvance = root.getAttribute("data-ask-auto-advance") !== "false";
+  const showFooter = total > 1 || isMulti;
+  if (showFooter) {
+    footer = document.createElement("div");
+    footer.className = "ask-pill-footer";
+
+    if (idx > 0) {
+      const back = document.createElement("button");
+      back.type = "button";
+      back.className = "ask-pill-nav";
+      back.textContent = "Back";
+      back.setAttribute("data-action", "back");
+      footer.appendChild(back);
+    }
+
+    // Show an advance button when:
+    //   - this page is multi-select (pick toggles, doesn't advance), or
+    //   - this is the last page (always needs explicit Submit-all), or
+    //   - auto-advance is disabled (every grouped page needs a Next).
+    const needsAdvanceButton = isMulti || isLast || (!autoAdvance && total > 1);
+    if (needsAdvanceButton) {
+      const next = document.createElement("button");
+      next.type = "button";
+      next.className = "ask-pill-nav ask-pill-nav-primary";
+      next.textContent = isLast ? "Submit all" : "Next";
+      next.setAttribute("data-action", isLast ? "submit-all" : "next");
+      const hasAnswer = isMulti
+        ? Array.isArray(currentAnswer) && currentAnswer.length > 0
+        : currentAnswer != null && currentAnswer !== "";
+      // For the last page in single-Q mode (total === 1), the user picks a
+      // pill which auto-resolves — Submit-all only matters when grouped.
+      if (total > 1 || isMulti) next.disabled = !hasAnswer;
+      footer.appendChild(next);
+    }
+
+    if (total > 1) {
+      const stepper = document.createElement("span");
+      stepper.className = "ask-pill-stepper";
+      stepper.textContent = `Question ${idx + 1} of ${total}`;
+      footer.appendChild(stepper);
+    }
+  }
+
+  const children = [header, list];
+  if (freeRow) children.push(freeRow);
+  if (footer) children.push(footer);
+  root.replaceChildren(...children);
+};
+
+const buildStructuredAnswer = (questions, answers) => {
+  const out = {};
+  questions.forEach((p) => {
+    if (!p?.question) return;
+    const v = answers[p.question];
+    if (v == null) return;
+    out[p.question] = v;
+  });
+  return out;
+};
+
+export const horizontalPillsAskPlugin = {
+  id: "example-horizontal-pills",
+
+  renderAskUserQuestion: ({ message, payload, complete, resolve, dismiss, config }) => {
+    ensureStyle();
+
+    // Answered state is handled entirely by the widget — the original tool
+    // message is suppressed from transcript and Q→A pair bubbles are injected
+    // in its place. Plugins only render the interactive sheet.
+    if (message?.agentMetadata?.askUserQuestionAnswered === true) {
+      return null;
+    }
+
+    const questions = Array.isArray(payload?.questions) ? payload.questions : [];
+    if (questions.length === 0 || !complete) return null;
+
+    // Respect the same `groupedAutoAdvance` config flag the built-in renderer
+    // uses. Default true: a single-select pick on an intermediate page jumps
+    // forward immediately. When false, every grouped page needs an explicit
+    // Next click so the user can review their choice before moving on.
+    const autoAdvance = config?.features?.askUserQuestion?.groupedAutoAdvance !== false;
+
+    const root = document.createElement("div");
+    root.className = "ask-pill-sheet";
+    root.setAttribute("role", "group");
+    root.setAttribute("aria-label", "Suggested answers");
+    root.setAttribute(ATTR_CURRENT, "0");
+    root.setAttribute(ATTR_COUNT, String(questions.length));
+    root.setAttribute(ATTR_ANSWERS, "{}");
+    root.setAttribute("data-ask-auto-advance", autoAdvance ? "true" : "false");
+
+    renderBody(root, questions);
+
+    // Single delegated listener — survives morph passes. Always read state
+    // from `e.currentTarget` (the live root) rather than captured refs.
+    root.addEventListener("click", (e) => {
+      const liveRoot = e.currentTarget;
+      const target = e.target instanceof Element ? e.target.closest("[data-action]") : null;
+      if (!target) return;
+      const action = target.getAttribute("data-action");
+
+      const idx = Number(liveRoot.getAttribute(ATTR_CURRENT) || 0);
+      const total = Number(liveRoot.getAttribute(ATTR_COUNT) || 1);
+      const prompt = questions[idx];
+      if (!prompt) return;
+      const isMulti = prompt.multiSelect === true;
+
+      if (action === "dismiss") {
+        dismiss();
+        return;
+      }
+
+      if (action === "pick") {
+        const label = target.getAttribute("data-label");
+        if (!label) return;
+        const answers = readAnswers(liveRoot);
+        if (isMulti) {
+          const current = Array.isArray(answers[prompt.question]) ? answers[prompt.question] : [];
+          const next = current.includes(label)
+            ? current.filter((v) => v !== label)
+            : [...current, label];
+          answers[prompt.question] = next;
+          writeAnswers(liveRoot, answers);
+          renderBody(liveRoot, questions);
+          return;
+        }
+        // Single-select. Single-question payloads resolve as a plain string
+        // (matching the simple case the agent expects). Grouped payloads
+        // accumulate, then submit a structured object on the last page.
+        if (total === 1) {
+          resolve(label);
+          return;
+        }
+        answers[prompt.question] = label;
+        writeAnswers(liveRoot, answers);
+        // Auto-advance only when (a) the flag is on, and (b) we're not on
+        // the final page (which always requires explicit Submit-all so the
+        // user can review every answer before committing).
+        if (autoAdvance && idx < total - 1) {
+          liveRoot.setAttribute(ATTR_CURRENT, String(idx + 1));
+        }
+        renderBody(liveRoot, questions);
+        return;
+      }
+
+      if (action === "open-free") {
+        const row = liveRoot.querySelector(".ask-pill-free-row");
+        if (row) row.setAttribute("data-open", "true");
+        target.style.display = "none";
+        const liveInput = liveRoot.querySelector('[data-role="free-input"]');
+        setTimeout(() => liveInput?.focus(), 0);
+        return;
+      }
+
+      if (action === "submit-free") {
+        const liveInput = liveRoot.querySelector('[data-role="free-input"]');
+        const value = liveInput?.value.trim() ?? "";
+        if (!value) return;
+        if (total === 1) {
+          resolve(value);
+          return;
+        }
+        const answers = readAnswers(liveRoot);
+        answers[prompt.question] = value;
+        writeAnswers(liveRoot, answers);
+        if (idx < total - 1) {
+          liveRoot.setAttribute(ATTR_CURRENT, String(idx + 1));
+          renderBody(liveRoot, questions);
+        } else {
+          resolve(buildStructuredAnswer(questions, answers));
+        }
+        return;
+      }
+
+      if (action === "next") {
+        if (idx < total - 1) {
+          liveRoot.setAttribute(ATTR_CURRENT, String(idx + 1));
+          renderBody(liveRoot, questions);
+        }
+        return;
+      }
+
+      if (action === "back") {
+        if (idx > 0) {
+          liveRoot.setAttribute(ATTR_CURRENT, String(idx - 1));
+          renderBody(liveRoot, questions);
+        }
+        return;
+      }
+
+      if (action === "submit-all") {
+        const answers = readAnswers(liveRoot);
+        if (total === 1) {
+          // Edge case: shouldn't happen since single-Q resolves on pick, but
+          // guard anyway.
+          const v = answers[prompt.question];
+          if (v != null) resolve(typeof v === "string" ? v : v);
+          return;
+        }
+        resolve(buildStructuredAnswer(questions, answers));
+        return;
+      }
+    });
+
+    root.addEventListener("input", (e) => {
+      if (!(e.target instanceof HTMLInputElement)) return;
+      if (e.target.getAttribute("data-role") !== "free-input") return;
+      const liveSend = e.currentTarget.querySelector('[data-action="submit-free"]');
+      if (liveSend) liveSend.disabled = e.target.value.trim().length === 0;
+    });
+
+    root.addEventListener("keydown", (e) => {
+      if (e.key !== "Enter") return;
+      if (!(e.target instanceof HTMLInputElement)) return;
+      if (e.target.getAttribute("data-role") !== "free-input") return;
+      e.preventDefault();
+      const liveRoot = e.currentTarget;
+      const value = e.target.value.trim();
+      if (!value) return;
+      const idx = Number(liveRoot.getAttribute(ATTR_CURRENT) || 0);
+      const total = Number(liveRoot.getAttribute(ATTR_COUNT) || 1);
+      const prompt = questions[idx];
+      if (!prompt) return;
+      if (total === 1) {
+        resolve(value);
+        return;
+      }
+      const answers = readAnswers(liveRoot);
+      answers[prompt.question] = value;
+      writeAnswers(liveRoot, answers);
+      if (idx < total - 1) {
+        liveRoot.setAttribute(ATTR_CURRENT, String(idx + 1));
+        renderBody(liveRoot, questions);
+      } else {
+        resolve(buildStructuredAnswer(questions, answers));
+      }
+    });
+
+    return root;
+  },
+};

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -300,6 +300,7 @@ export default defineConfig({
         'custom-loading-indicator': path.resolve(__dirname, 'custom-loading-indicator.html'),
         'tool-loading-demo': path.resolve(__dirname, 'tool-loading-demo.html'),
         'stream-animations-demo': path.resolve(__dirname, 'stream-animations-demo.html'),
+        'ask-user-question-demo': path.resolve(__dirname, 'ask-user-question-demo.html'),
         'voice-integration-demo': path.resolve(__dirname, 'voice-integration-demo.html'),
         'autoscroll-stress-test': path.resolve(__dirname, 'autoscroll-stress-test.html'),
         // Standalone (CDN / Copy-Paste) pages

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -327,6 +327,67 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
     });
   });
 
+  // Resume endpoint — forwards client-executed (LOCAL) tool results back to
+  // the Runtype upstream so a paused flow execution can continue. Mounted as
+  // a child of the dispatch path so the widget can derive its URL by
+  // appending "/resume" to whatever `apiUrl` it was configured with.
+  app.post(`${path}/resume`, async (c) => {
+    const apiKey = options.apiKey ?? getRuntimeEnv()?.RUNTYPE_API_KEY;
+    if (!apiKey) {
+      return c.json(
+        { error: "Missing API key. Set RUNTYPE_API_KEY." },
+        401
+      );
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await c.req.json();
+    } catch (error) {
+      return c.json(
+        { error: "Invalid JSON body", details: error },
+        400
+      );
+    }
+
+    const isDevelopment = isDevelopmentRuntime();
+    const upstreamResumeUrl = `${upstream.replace(/\/+$/, '')}/resume`;
+
+    if (isDevelopment) {
+      console.log("\n=== Runtype Proxy Resume ===");
+      console.log("URL:", upstreamResumeUrl);
+      console.log(
+        "executionId:",
+        typeof body.executionId === "string" ? body.executionId : "(missing)"
+      );
+      console.log(
+        "toolOutputs keys:",
+        body.toolOutputs && typeof body.toolOutputs === "object"
+          ? Object.keys(body.toolOutputs)
+          : "(none)"
+      );
+      console.log("=== End Runtype Proxy Resume ===\n");
+    }
+
+    const response = await fetch(upstreamResumeUrl, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json"
+      },
+      body: JSON.stringify(body)
+    });
+
+    return new Response(response.body, {
+      status: response.status,
+      headers: {
+        "Content-Type":
+          response.headers.get("content-type") ?? "application/json",
+        "Cache-Control": "no-store"
+      }
+    });
+  });
+
   return app;
 };
 

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -939,6 +939,148 @@ Indicators are resolved in this order:
 2. **Config function** (`loadingIndicator.render` / `loadingIndicator.renderIdle`)
 3. **Default** (3-dot bouncing animation for loading, `null` for idle)
 
+### Ask User Question
+
+The `ask_user_question` feature turns a LOCAL agent tool into an interactive prompt with tappable option pills. When the agent calls the `ask_user_question` tool, the server pauses execution and emits a `step_await` event; the widget renders an answer-pill sheet over the composer; the user picks / types / dismisses; the widget POSTs the answer to `/v1/dispatch/resume` and the paused execution continues with a structured `tool_result`.
+
+This is the recommended pattern for human-in-the-loop clarifying questions. The agent-side setup (declare `ask_user_question` as a `runtimeTools` LOCAL tool and instruct the model to call it) lives in your `RuntypeFlowConfig` in the proxy — pair it with a `POST` handler that forwards to the upstream `/resume` endpoint (see `@runtypelabs/persona-proxy` and your deployment’s `resume` route).
+
+#### Configuration
+
+```ts
+features: {
+  askUserQuestion: {
+    enabled: true,             // default: true. When false, the tool falls through to the normal tool-bubble path.
+    dismissible: true,         // default: true. Shows a × close button on the sheet.
+    slideInMs: 180,            // slide-in animation duration.
+    freeTextLabel: 'Other…',
+    freeTextPlaceholder: 'Type your answer…',
+    submitLabel: 'Send',
+    styles: {
+      sheetBackground: '#ffffff',
+      sheetBorder: '#e5e7eb',
+      sheetShadow: '0 12px 28px -10px rgba(0,0,0,0.15)',
+      pillBackground: 'transparent',
+      pillBackgroundSelected: '#0f0f0f',
+      pillTextColor: '#1f2937',
+      pillTextColorSelected: '#fafafa',
+      pillBorderRadius: '999px',
+      customInputBackground: '#ffffff'
+    }
+  }
+}
+```
+
+The composer-overlay sheet is the only question UI — no transcript stub is rendered. After the user picks, the picked answer appears as a normal user bubble so the transcript reads naturally.
+
+#### DOM events
+
+The widget dispatches two events on the mount element so the host page can react without touching the plugin API:
+
+| Event | Detail |
+|---|---|
+| `persona:askUserQuestion:answered` | `{ toolUseId, answer, values, isFreeText, source }` where `source` is `'pick' \| 'multi' \| 'free-text'` |
+| `persona:askUserQuestion:dismissed` | `{ toolUseId }` |
+
+```ts
+mount.addEventListener('persona:askUserQuestion:answered', (event) => {
+  const { answer, source } = event.detail;
+  console.log('User picked', answer, 'via', source);
+});
+```
+
+#### Custom UI via the `renderAskUserQuestion` plugin hook
+
+For full control over the question UI — a modal, a sidebar form, a command palette, whatever — register a plugin with `renderAskUserQuestion`. Returning a non-null `HTMLElement` renders inline in the transcript and suppresses the built-in overlay sheet. Returning `null` falls through to the default sheet.
+
+```ts
+import type { AgentWidgetPlugin } from '@runtypelabs/persona';
+
+const customAskPlugin: AgentWidgetPlugin = {
+  id: 'custom-ask',
+  renderAskUserQuestion: ({ payload, complete, resolve, dismiss }) => {
+    const prompt = payload?.questions?.[0];
+    if (!prompt) return null; // streaming — wait for more data, or show a skeleton
+
+    const root = document.createElement('div');
+    root.className = 'my-question-card';
+
+    const q = document.createElement('p');
+    q.textContent = prompt.question ?? '';
+    root.appendChild(q);
+
+    (prompt.options ?? []).forEach((option) => {
+      const btn = document.createElement('button');
+      btn.textContent = option.label;
+      btn.addEventListener('click', () => resolve(option.label));
+      root.appendChild(btn);
+    });
+
+    if (prompt.allowFreeText !== false) {
+      const input = document.createElement('input');
+      input.placeholder = 'Other…';
+      input.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' && input.value.trim()) resolve(input.value.trim());
+      });
+      root.appendChild(input);
+    }
+
+    const close = document.createElement('button');
+    close.textContent = '×';
+    close.addEventListener('click', () => dismiss());
+    root.appendChild(close);
+
+    return root;
+  }
+};
+
+initAgentWidget({
+  target: '#app',
+  config: {
+    plugins: [customAskPlugin]
+  }
+});
+```
+
+#### Type Definitions
+
+```ts
+type AskUserQuestionOption = {
+  label: string;
+  description?: string;
+};
+
+type AskUserQuestionPrompt = {
+  question: string;
+  header?: string;           // short chip label, ≤12 chars
+  options: AskUserQuestionOption[];
+  multiSelect?: boolean;     // allow multiple picks with a Submit button
+  allowFreeText?: boolean;   // show an "Other…" free-text pill
+};
+
+type AskUserQuestionPayload = {
+  questions: AskUserQuestionPrompt[];
+};
+
+// Plugin hook signature
+renderAskUserQuestion?: (context: {
+  message: AgentWidgetMessage;
+  payload: Partial<AskUserQuestionPayload> | null;  // may be partial mid-stream
+  complete: boolean;                                // true once tool-call args fully stream
+  resolve: (answer: string) => void;                // posts /resume with structured toolOutput
+  dismiss: () => void;                              // sends "(dismissed)" sentinel
+  config: AgentWidgetConfig;
+}) => HTMLElement | null;
+```
+
+For plugins that want to re-parse a tool message outside the hook context, the widget also exports a `parseAskUserQuestionPayload(message)` helper that returns `{ payload, complete }` using the same partial-JSON logic the built-in sheet uses.
+
+#### Priority chain
+
+1. **Plugin hook** (`renderAskUserQuestion` returning a non-null element) — fully owns the UI; built-in overlay is suppressed.
+2. **Built-in overlay sheet** — when the feature is enabled and no plugin handles it.
+3. **Generic tool bubble** — when `features.askUserQuestion.enabled` is `false`, the tool call renders through the normal `renderToolCall` path.
+
 ### Dropdown Menu
 
 A reusable dropdown menu utility for building custom menus in plugins, custom components, or host-page UI that matches the widget's theme.

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -362,6 +362,19 @@ Semantic tokens provide intent-based naming that references palette values.
 | `image.background` | `palette.colors.gray.100` |
 | `image.border` | `palette.colors.gray.200` |
 
+### Intro Card (`components.introCard.*`)
+
+The welcome panel rendered above the message list when no messages exist.
+Set `copy.showWelcomeCard: false` to hide it entirely, or use
+`layout.slots["body-top"]` to replace it with a custom element.
+
+| Token | Default Reference |
+|-------|-------------------|
+| `background` | `semantic.colors.surface` |
+| `borderRadius` | `palette.radius.2xl` |
+| `padding` | `semantic.spacing.lg` |
+| `shadow` | `"0 5px 15px rgba(15, 23, 42, 0.08)"` *(matches the legacy `persona-shadow-sm` look)* |
+
 ### Scroll To Bottom (`components.scrollToBottom.*`)
 
 | Token | Default Reference |
@@ -470,6 +483,15 @@ Common tokens have short aliases for easier use in custom CSS:
 ```css
 --persona-attachment-image-bg
 --persona-attachment-image-border
+```
+
+### Intro Card Aliases
+
+```css
+--persona-intro-card-bg
+--persona-intro-card-radius
+--persona-intro-card-padding
+--persona-intro-card-shadow
 ```
 
 ---

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -2717,3 +2717,137 @@ describe('AgentWidgetClient - stopReason propagation', () => {
   });
 });
 
+// ============================================================================
+// step_await (LOCAL tool pause) + resumeFlow
+// ============================================================================
+
+describe('AgentWidgetClient — step_await parsing', () => {
+  const buildStepAwaitStream = (payload: Record<string, unknown>): ReadableStream<Uint8Array> => {
+    const encoder = new TextEncoder();
+    const body = `event: step_await\ndata: ${JSON.stringify({ type: 'step_await', ...payload })}\n\n`;
+    return new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(body));
+        controller.close();
+      },
+    });
+  };
+
+  it('emits a complete tool message with awaitingLocalTool=true for local_tool_required', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      body: buildStepAwaitStream({
+        awaitReason: 'local_tool_required',
+        id: 'step-1',
+        name: 'Test Step',
+        stepType: 'prompt',
+        index: 0,
+        toolId: 'runtime_ask_user_question_123',
+        toolName: 'ask_user_question',
+        executionId: 'exec_abc',
+        parameters: {
+          questions: [{ question: 'Who?', options: [{ label: 'A' }, { label: 'B' }] }],
+        },
+      }),
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const toolMsg = events
+      .filter((e) => e.type === 'message')
+      .map((e) => (e as { message: AgentWidgetMessage }).message)
+      .find((m) => m.variant === 'tool' && m.toolCall?.name === 'ask_user_question');
+
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg!.toolCall!.id).toBe('runtime_ask_user_question_123');
+    expect(toolMsg!.toolCall!.status).toBe('complete');
+    expect(toolMsg!.toolCall!.args).toMatchObject({
+      questions: [{ question: 'Who?', options: [{ label: 'A' }, { label: 'B' }] }],
+    });
+    expect(toolMsg!.agentMetadata?.executionId).toBe('exec_abc');
+    expect(toolMsg!.agentMetadata?.awaitingLocalTool).toBe(true);
+  });
+
+  it('ignores step_await events whose awaitReason is not local_tool_required', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      body: buildStepAwaitStream({
+        awaitReason: 'approval_required',
+        toolId: 't1',
+        toolName: 'some_tool',
+        executionId: 'exec_abc',
+        parameters: {},
+      }),
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const toolMsg = events
+      .filter((e) => e.type === 'message')
+      .map((e) => (e as { message: AgentWidgetMessage }).message)
+      .find((m) => m.agentMetadata?.awaitingLocalTool);
+    expect(toolMsg).toBeUndefined();
+  });
+});
+
+describe('AgentWidgetClient.resumeFlow', () => {
+  it('POSTs to ${apiUrl}/resume with the expected body shape', async () => {
+    let capturedUrl: string | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+    let capturedHeaders: Record<string, string> | undefined;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(init.body as string);
+      capturedHeaders = init.headers as Record<string, string>;
+      return { ok: true, body: null };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'https://api.runtype.com/v1/dispatch' });
+    await client.resumeFlow('exec_xyz', { ["ask_user_question"]: 'Hobbyists' });
+
+    expect(capturedUrl).toBe('https://api.runtype.com/v1/dispatch/resume');
+    expect(capturedBody).toEqual({
+      executionId: 'exec_xyz',
+      toolOutputs: { ["ask_user_question"]: 'Hobbyists' },
+      streamResponse: true,
+    });
+    expect(capturedHeaders!['Content-Type']).toBe('application/json');
+  });
+
+  it('honors a custom streamResponse option', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string);
+      return { ok: true, body: null };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:43111/api/chat/dispatch' });
+    await client.resumeFlow('exec_abc', { t: 'ok' }, { streamResponse: false });
+
+    expect(capturedBody!.streamResponse).toBe(false);
+  });
+
+  it('derives the URL correctly for proxy-style dispatch paths', async () => {
+    let capturedUrl: string | undefined;
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      return { ok: true, body: null };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:43111/api/chat/dispatch' });
+    await client.resumeFlow('exec_abc', {});
+
+    expect(capturedUrl).toBe('http://localhost:43111/api/chat/dispatch/resume');
+  });
+});
+

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -775,6 +775,49 @@ export class AgentWidgetClient {
     });
   }
 
+  /**
+   * Resume a paused flow execution by supplying outputs for LOCAL
+   * (client-executed) tools. Used by the built-in `ask_user_question`
+   * answer-pill sheet, but generic enough for any LOCAL tool.
+   *
+   * Posts to the upstream `/resume` endpoint (the dispatch URL with
+   * `/dispatch` replaced by `/resume` — works for both direct-to-Runtype
+   * and the persona proxy) and returns the raw Response so the caller can
+   * pipe its SSE body through `connectStream()`.
+   *
+   * @param executionId - The paused execution id carried on `step_await`.
+   * @param toolOutputs - Map keyed by tool name → the tool's result value.
+   */
+  public async resumeFlow(
+    executionId: string,
+    toolOutputs: Record<string, unknown>,
+    options?: { streamResponse?: boolean }
+  ): Promise<Response> {
+    const trimmed = this.config.apiUrl?.replace(/\/+$/, '') || DEFAULT_CLIENT_API_BASE;
+    // Runtype mounts POST /resume as a child route of /v1/dispatch, so the
+    // final URL is always `${apiUrl}/resume`. Proxies should follow the
+    // same shape (`/api/chat/dispatch/resume`) to keep the widget agnostic.
+    const url = `${trimmed}/resume`;
+
+    let headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      ...this.headers
+    };
+    if (this.getHeaders) {
+      Object.assign(headers, await this.getHeaders());
+    }
+
+    return fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        executionId,
+        toolOutputs,
+        streamResponse: options?.streamResponse ?? true,
+      }),
+    });
+  }
+
   private async buildAgentPayload(
     messages: AgentWidgetMessage[]
   ): Promise<AgentWidgetAgentRequestPayload> {
@@ -1722,6 +1765,34 @@ export class AgentWidgetClient {
           if (callKey) {
             toolContext.byCall.delete(callKey);
           }
+        } else if (payloadType === "step_await" && payload.awaitReason === "local_tool_required" && payload.toolName) {
+          // LOCAL tool pause. Runtype's prompt step throws LocalToolRequiredError
+          // when the model calls a tool with `toolType: "local"`. The server
+          // emits step_await with the tool name, params, and execution id; the
+          // execution pauses until the client POSTs /resume with toolOutputs.
+          //
+          // Upsert a fully-populated tool-variant message so the existing
+          // ask_user_question bubble + sheet paths fire. Mark the message with
+          // `awaitingLocalTool: true` so the UI knows to resolve via
+          // resumeFlow rather than the legacy sendMessage fallback.
+          const toolId = (payload.toolId as string) ?? `local-${nextSequence()}`;
+          const toolMessage = ensureToolMessage(toolId);
+          const tool = toolMessage.toolCall ?? { id: toolId, status: "pending" as const };
+          tool.name = payload.toolName as string;
+          tool.args = payload.parameters;
+          tool.status = "complete";
+          tool.chunks = tool.chunks ?? [];
+          tool.startedAt =
+            tool.startedAt ?? resolveTimestamp(payload.startedAt ?? payload.timestamp);
+          tool.completedAt = tool.completedAt ?? tool.startedAt;
+          toolMessage.toolCall = tool;
+          toolMessage.streaming = false;
+          toolMessage.agentMetadata = {
+            ...toolMessage.agentMetadata,
+            executionId: (payload.executionId as string) ?? toolMessage.agentMetadata?.executionId,
+            awaitingLocalTool: true,
+          };
+          emitMessage(toolMessage);
         } else if (payloadType === "text_start") {
           // Lifecycle event: a new text segment is beginning (emitted at tool boundaries).
           // When toolContext is present this fired inside a nested flow — it must not

--- a/packages/widget/src/components/ask-user-question-bubble.test.ts
+++ b/packages/widget/src/components/ask-user-question-bubble.test.ts
@@ -1,0 +1,583 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from "vitest";
+import {
+  ASK_USER_QUESTION_MAX,
+  ASK_USER_QUESTION_TOOL_NAME,
+  __resetTruncateWarn,
+  buildStructuredAnswers,
+  createAskUserQuestionBubble,
+  ensureAskUserQuestionSheet,
+  getCurrentIndex,
+  getQuestionCount,
+  getSelectedLabels,
+  isAskUserQuestionMessage,
+  isGroupedSheet,
+  navigateToPage,
+  readAnswersFromSheet,
+  removeAskUserQuestionSheet,
+  setCurrentAnswer,
+} from "./ask-user-question-bubble";
+import type {
+  AgentWidgetConfig,
+  AgentWidgetMessage,
+  AskUserQuestionPrompt,
+} from "../types";
+
+const makeMessage = (overrides: Partial<AgentWidgetMessage> = {}): AgentWidgetMessage => ({
+  id: "msg-1",
+  role: "assistant",
+  content: "",
+  createdAt: new Date().toISOString(),
+  variant: "tool",
+  streaming: false,
+  toolCall: {
+    id: "tool-1",
+    name: ASK_USER_QUESTION_TOOL_NAME,
+    status: "complete",
+    args: {
+      questions: [
+        {
+          question: "Who shops on your site?",
+          options: [
+            { label: "Hobbyists" },
+            { label: "Professionals" },
+            { label: "Gift-seekers" },
+          ],
+          multiSelect: false,
+          allowFreeText: true,
+        },
+      ],
+    },
+    chunks: [],
+  },
+  ...overrides,
+});
+
+const makeOverlay = () => {
+  const overlay = document.createElement("div");
+  overlay.setAttribute("data-persona-composer-overlay", "");
+  document.body.innerHTML = "";
+  document.body.appendChild(overlay);
+  return overlay;
+};
+
+describe("isAskUserQuestionMessage", () => {
+  it("is true for a tool-variant message whose toolCall.name is ask_user_question", () => {
+    expect(isAskUserQuestionMessage(makeMessage())).toBe(true);
+  });
+
+  it("is false for other tool calls", () => {
+    const other = makeMessage({
+      toolCall: {
+        id: "t2",
+        name: "search_products",
+        status: "complete",
+        chunks: [],
+      },
+    });
+    expect(isAskUserQuestionMessage(other)).toBe(false);
+  });
+
+  it("is false for non-tool variants", () => {
+    const notTool = makeMessage({ variant: undefined, toolCall: undefined });
+    expect(isAskUserQuestionMessage(notTool)).toBe(false);
+  });
+});
+
+describe("createAskUserQuestionBubble", () => {
+  it("renders a compact transcript stub carrying the message id", () => {
+    const bubble = createAskUserQuestionBubble(makeMessage());
+    expect(bubble.getAttribute("data-message-id")).toBe("msg-1");
+    expect(bubble.getAttribute("data-bubble-type")).toBe("ask-user-question");
+    expect(bubble.textContent).toContain("Awaiting");
+  });
+});
+
+describe("ensureAskUserQuestionSheet", () => {
+  it("mounts a sheet in the overlay with real pills when args are complete", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]');
+    expect(sheet).not.toBeNull();
+    const pills = sheet!.querySelectorAll('[data-ask-user-action="pick"]');
+    expect(pills.length).toBe(3);
+    // Default rows layout — label is in `.persona-ask-row-label`, alongside
+    // a number-badge affordance. Read the dedicated label slot.
+    const firstLabel = pills[0].querySelector(".persona-ask-row-label");
+    expect(firstLabel?.textContent).toBe("Hobbyists");
+    // Free-text affordance present by default — rows mode embeds the input
+    // inside the Other row via `focus-free-text` (digit shortcut + click chrome).
+    const custom = sheet!.querySelector('[data-ask-user-action="focus-free-text"]');
+    expect(custom).not.toBeNull();
+  });
+
+  it("renders skeleton pills while streaming (status=running, no parsable chunks)", () => {
+    const overlay = makeOverlay();
+    const streaming = makeMessage({
+      toolCall: {
+        id: "tool-streaming",
+        name: ASK_USER_QUESTION_TOOL_NAME,
+        status: "running",
+        chunks: ['{"ques'],
+      },
+    });
+    ensureAskUserQuestionSheet(streaming, {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-streaming"]');
+    expect(sheet).not.toBeNull();
+    const skeletons = sheet!.querySelectorAll(".persona-ask-pill-skeleton");
+    expect(skeletons.length).toBeGreaterThan(0);
+    const realPills = sheet!.querySelectorAll('[data-ask-user-action="pick"]');
+    expect(realPills.length).toBe(0);
+  });
+
+  it("hydrates skeleton pills into real pills when streaming chunks become parsable", () => {
+    const overlay = makeOverlay();
+    const msg = makeMessage({
+      toolCall: {
+        id: "tool-hyd",
+        name: ASK_USER_QUESTION_TOOL_NAME,
+        status: "running",
+        chunks: ['{"questions":[{"question":"X","options":['],
+      },
+    });
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+
+    // Simulate more chunks arriving — options now parseable
+    msg.toolCall!.chunks = ['{"questions":[{"question":"X","options":[{"label":"A"},{"label":"B"}'];
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-hyd"]')!;
+    const pills = sheet.querySelectorAll('[data-ask-user-action="pick"]');
+    expect(pills.length).toBe(2);
+    expect(pills[0].querySelector(".persona-ask-row-label")?.textContent).toBe("A");
+    expect(pills[1].querySelector(".persona-ask-row-label")?.textContent).toBe("B");
+  });
+
+  it("is idempotent — re-invoking does not duplicate sheets", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    const sheets = overlay.querySelectorAll('[data-persona-ask-sheet-for]');
+    expect(sheets.length).toBe(1);
+  });
+
+  it("respects enabled: false — sheet is not mounted", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(
+      makeMessage(),
+      { features: { askUserQuestion: { enabled: false } } } as AgentWidgetConfig,
+      overlay
+    );
+    expect(overlay.querySelector('[data-persona-ask-sheet-for]')).toBeNull();
+  });
+
+  it("omits the free-text pill when allowFreeText is false", () => {
+    const overlay = makeOverlay();
+    const msg = makeMessage();
+    (msg.toolCall!.args as any).questions[0].allowFreeText = false;
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    expect(sheet.querySelector('[data-ask-user-action="open-free-text"]')).toBeNull();
+  });
+
+  it("renders a multi-select submit row when multiSelect is true", () => {
+    const overlay = makeOverlay();
+    const msg = makeMessage();
+    (msg.toolCall!.args as any).questions[0].multiSelect = true;
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    expect(sheet.querySelector('[data-ask-user-action="submit-multi"]')).not.toBeNull();
+    expect(sheet.getAttribute("data-multi-select")).toBe("true");
+  });
+
+  it("does not render a dismiss button — Skip in the nav row is the canonical escape", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    expect(sheet.querySelector('[data-ask-user-action="dismiss"]')).toBeNull();
+    expect(sheet.querySelector(".persona-ask-sheet-close")).toBeNull();
+  });
+});
+
+describe("getSelectedLabels", () => {
+  it("collects labels from pills with aria-pressed=true", () => {
+    const overlay = makeOverlay();
+    const msg = makeMessage();
+    (msg.toolCall!.args as any).questions[0].multiSelect = true;
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    const pills = sheet.querySelectorAll<HTMLElement>('[data-ask-user-action="pick"]');
+    pills[0].setAttribute("aria-pressed", "true");
+    pills[2].setAttribute("aria-pressed", "true");
+    expect(getSelectedLabels(sheet as HTMLElement)).toEqual(["Hobbyists", "Gift-seekers"]);
+  });
+});
+
+describe("removeAskUserQuestionSheet", () => {
+  it("removes the sheet for a specific tool-call id after the slide-out delay", async () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    expect(overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')).not.toBeNull();
+    removeAskUserQuestionSheet(overlay, "tool-1");
+    // The implementation defers removal with setTimeout — flush it.
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect(overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')).toBeNull();
+  });
+});
+
+// ============================================================================
+// Grouped (paginated) multi-question payloads
+// ============================================================================
+
+const makeGroupedMessage = (
+  questions: Partial<AskUserQuestionPrompt>[],
+  agentMetadata?: AgentWidgetMessage["agentMetadata"]
+): AgentWidgetMessage =>
+  makeMessage({
+    toolCall: {
+      id: "tool-grouped",
+      name: ASK_USER_QUESTION_TOOL_NAME,
+      status: "complete",
+      args: { questions },
+      chunks: [],
+    },
+    agentMetadata,
+  });
+
+const sheetFor = (overlay: Element, toolCallId: string): HTMLElement =>
+  overlay.querySelector<HTMLElement>(`[data-persona-ask-sheet-for="${toolCallId}"]`)!;
+
+describe("grouped questions — stepper UI", () => {
+  it("renders 'Question 1 of N' chip and Back/Next nav row when N > 1", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      { question: "Q1?", options: [{ label: "A" }, { label: "B" }] },
+      { question: "Q2?", options: [{ label: "C" }, { label: "D" }] },
+      { question: "Q3?", options: [{ label: "E" }, { label: "F" }] },
+    ]);
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+
+    expect(isGroupedSheet(sheet)).toBe(true);
+    expect(getQuestionCount(sheet)).toBe(3);
+    expect(getCurrentIndex(sheet)).toBe(0);
+
+    const stepInline = sheet.querySelector('[data-ask-step-inline="true"]');
+    expect(stepInline?.textContent).toBe("1/3");
+
+    expect(sheet.querySelector('[data-ask-user-action="back"]')).not.toBeNull();
+    expect(sheet.querySelector('[data-ask-user-action="next"]')).not.toBeNull();
+    expect(sheet.querySelector('[data-ask-user-action="submit-all"]')).toBeNull();
+  });
+
+  it("leaves the inline stepper empty in single-Q mode (no grouped UI)", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-1");
+
+    expect(isGroupedSheet(sheet)).toBe(false);
+    const stepInline = sheet.querySelector('[data-ask-step-inline="true"]');
+    expect(stepInline?.textContent).toBe("");
+    expect(sheet.querySelector('[data-ask-nav-row="true"]')).toBeNull();
+  });
+
+  it("Next is disabled until current page has an answer; enabled after pick", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      { question: "Q1?", options: [{ label: "A" }, { label: "B" }] },
+      { question: "Q2?", options: [{ label: "C" }, { label: "D" }] },
+    ]);
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+    const next = sheet.querySelector<HTMLButtonElement>('[data-ask-user-action="next"]')!;
+    expect(next.disabled).toBe(true);
+
+    setCurrentAnswer(sheet, "A");
+    expect(next.disabled).toBe(false);
+    const pillA = sheet.querySelector<HTMLElement>('[data-option-label="A"]');
+    expect(pillA?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("navigateToPage(1) shows page 2 and Back becomes enabled; Submit-all on final page", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      { question: "Q1?", options: [{ label: "A" }] },
+      { question: "Q2?", options: [{ label: "B" }] },
+    ]);
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+    setCurrentAnswer(sheet, "A");
+    navigateToPage(sheet, msg, undefined, 1);
+
+    const back = sheet.querySelector<HTMLButtonElement>('[data-ask-user-action="back"]')!;
+    expect(back.disabled).toBe(false);
+    const submitAll = sheet.querySelector('[data-ask-user-action="submit-all"]');
+    expect(submitAll).not.toBeNull();
+    expect(sheet.querySelector('[data-ask-user-action="next"]')).toBeNull();
+
+    const stepInline = sheet.querySelector('[data-ask-step-inline="true"]');
+    expect(stepInline?.textContent).toBe("2/2");
+  });
+
+  it("Back from page 2 → page 1 preserves the prior answer's selected pill state", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      { question: "Q1?", options: [{ label: "A" }, { label: "B" }] },
+      { question: "Q2?", options: [{ label: "C" }, { label: "D" }] },
+    ]);
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+
+    setCurrentAnswer(sheet, "A");
+    navigateToPage(sheet, msg, undefined, 1);
+    setCurrentAnswer(sheet, "C");
+    navigateToPage(sheet, msg, undefined, 0);
+
+    const pillA = sheet.querySelector<HTMLElement>('[data-option-label="A"]');
+    expect(pillA?.getAttribute("aria-pressed")).toBe("true");
+    expect(getCurrentIndex(sheet)).toBe(0);
+  });
+
+  it("multi-select page stores an array; pill toggles preserve other selections", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      {
+        question: "Pick many",
+        options: [{ label: "X" }, { label: "Y" }, { label: "Z" }],
+        multiSelect: true,
+        allowFreeText: false,
+      },
+      { question: "Q2?", options: [{ label: "A" }] },
+    ]);
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+
+    setCurrentAnswer(sheet, ["X", "Z"]);
+    const stored = readAnswersFromSheet(sheet)[0];
+    expect(stored).toEqual(["X", "Z"]);
+    const pillX = sheet.querySelector<HTMLElement>('[data-option-label="X"]');
+    const pillY = sheet.querySelector<HTMLElement>('[data-option-label="Y"]');
+    const pillZ = sheet.querySelector<HTMLElement>('[data-option-label="Z"]');
+    expect(pillX?.getAttribute("aria-pressed")).toBe("true");
+    expect(pillY?.getAttribute("aria-pressed")).toBe("false");
+    expect(pillZ?.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("buildStructuredAnswers keys answers by question text", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      { question: "Tone?", options: [{ label: "Bold" }] },
+      { question: "Length?", options: [{ label: "Short" }, { label: "Long" }] },
+    ]);
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+
+    setCurrentAnswer(sheet, "Bold");
+    navigateToPage(sheet, msg, undefined, 1);
+    setCurrentAnswer(sheet, "Short");
+
+    expect(buildStructuredAnswers(sheet, msg)).toEqual({
+      "Tone?": "Bold",
+      "Length?": "Short",
+    });
+  });
+
+  it("hydrates from agentMetadata — restores index and prior answers on a fresh mount", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage(
+      [
+        { question: "Q1?", options: [{ label: "A" }, { label: "B" }] },
+        { question: "Q2?", options: [{ label: "C" }, { label: "D" }] },
+        { question: "Q3?", options: [{ label: "E" }, { label: "F" }] },
+      ],
+      {
+        askUserQuestionAnswers: { "Q1?": "B", "Q2?": "D" },
+        askUserQuestionIndex: 1,
+      }
+    );
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+
+    expect(getCurrentIndex(sheet)).toBe(1);
+    const pillD = sheet.querySelector<HTMLElement>('[data-option-label="D"]');
+    expect(pillD?.getAttribute("aria-pressed")).toBe("true");
+    expect(buildStructuredAnswers(sheet, msg)).toEqual({ "Q1?": "B", "Q2?": "D" });
+  });
+
+  it("renders all 8 questions when at the cap, and warns + truncates at 9", () => {
+    __resetTruncateWarn();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const overlay = makeOverlay();
+    const eight: Partial<AskUserQuestionPrompt>[] = Array.from({ length: 8 }, (_, i) => ({
+      question: `Q${i + 1}?`,
+      options: [{ label: `${i + 1}-A` }],
+    }));
+    ensureAskUserQuestionSheet(makeGroupedMessage(eight), {} as AgentWidgetConfig, overlay);
+    let sheet = sheetFor(overlay, "tool-grouped");
+    expect(getQuestionCount(sheet)).toBe(ASK_USER_QUESTION_MAX);
+    expect(warn).not.toHaveBeenCalled();
+
+    overlay.innerHTML = "";
+    const nine = [...eight, { question: "overflow", options: [{ label: "X" }] }];
+    ensureAskUserQuestionSheet(makeGroupedMessage(nine), {} as AgentWidgetConfig, overlay);
+    sheet = sheetFor(overlay, "tool-grouped");
+    expect(getQuestionCount(sheet)).toBe(ASK_USER_QUESTION_MAX);
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]?.[0]).toContain("truncating to");
+
+    warn.mockRestore();
+  });
+});
+
+describe("rows layout (default)", () => {
+  it("renders option rows with description visible inline (not in title attr)", () => {
+    const overlay = makeOverlay();
+    const msg = makeMessage({
+      toolCall: {
+        id: "tool-rows-desc",
+        name: ASK_USER_QUESTION_TOOL_NAME,
+        status: "complete",
+        args: {
+          questions: [
+            {
+              question: "Pick one",
+              options: [
+                { label: "Discord", description: "Real Discord invite to link" },
+                { label: "Slack", description: "Public Slack community" },
+              ],
+              multiSelect: false,
+              allowFreeText: false,
+            },
+          ],
+        },
+        chunks: [],
+      },
+    });
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-rows-desc"]')!;
+    expect(sheet.getAttribute("data-ask-layout")).toBe("rows");
+    const firstRow = sheet.querySelector<HTMLElement>('[data-ask-user-action="pick"]')!;
+    expect(firstRow.querySelector(".persona-ask-row-label")?.textContent).toBe("Discord");
+    expect(firstRow.querySelector(".persona-ask-row-description")?.textContent).toBe(
+      "Real Discord invite to link"
+    );
+    // No title-attr fallback in rows layout — description is inline.
+    expect(firstRow.getAttribute("title")).toBeNull();
+  });
+
+  it("shows numeric badges 1..N on single-select rows", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    const rows = sheet.querySelectorAll<HTMLElement>('[data-ask-user-action="pick"]');
+    expect(rows[0].querySelector(".persona-ask-row-badge")?.textContent).toBe("1");
+    expect(rows[1].querySelector(".persona-ask-row-badge")?.textContent).toBe("2");
+    expect(rows[2].querySelector(".persona-ask-row-badge")?.textContent).toBe("3");
+    // Multi-select check should NOT be present on single-select rows.
+    expect(rows[0].querySelector(".persona-ask-row-check")).toBeNull();
+  });
+
+  it("shows checkbox affordance instead of badge on multi-select rows", () => {
+    const overlay = makeOverlay();
+    const multi = makeMessage({
+      toolCall: {
+        id: "tool-multi",
+        name: ASK_USER_QUESTION_TOOL_NAME,
+        status: "complete",
+        args: {
+          questions: [
+            {
+              question: "Pick any",
+              options: [{ label: "A" }, { label: "B" }],
+              multiSelect: true,
+              allowFreeText: false,
+            },
+          ],
+        },
+        chunks: [],
+      },
+    });
+    ensureAskUserQuestionSheet(multi, {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-multi"]')!;
+    const rows = sheet.querySelectorAll<HTMLElement>('[data-ask-user-action="pick"]');
+    expect(rows[0].querySelector(".persona-ask-row-check")).not.toBeNull();
+    expect(rows[0].querySelector(".persona-ask-row-badge")).toBeNull();
+  });
+
+  it("embeds the free-text input INSIDE the Other row (rows mode) — no separate row, no Send button", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    // No standalone free-text row in rows mode — input lives inside the Other row.
+    expect(sheet.querySelector('[data-ask-free-text-row="true"]')).toBeNull();
+    const otherRow = sheet.querySelector<HTMLElement>('[data-ask-other-row="true"]')!;
+    expect(otherRow).not.toBeNull();
+    expect(otherRow.classList.contains("persona-ask-row--other")).toBe(true);
+    expect(otherRow.querySelector('[data-ask-free-text-input="true"]')).not.toBeNull();
+    expect(otherRow.querySelector('[data-ask-user-action="submit-free-text"]')).toBeNull();
+    // Other row carries the focus-free-text action (digit shortcut + click chrome).
+    expect(otherRow.getAttribute("data-ask-user-action")).toBe("focus-free-text");
+    // Number badge for the Other row (N+1 — 3 real options + Other = 4).
+    const badge = otherRow.querySelector<HTMLElement>(".persona-ask-row-badge");
+    expect(badge?.textContent).toBe("4");
+  });
+
+  it("respects layout: 'pills' opt-out — no row affordances, free-text starts hidden, Send button still rendered", () => {
+    const overlay = makeOverlay();
+    const config = {
+      features: { askUserQuestion: { layout: "pills" } },
+    } as unknown as AgentWidgetConfig;
+    ensureAskUserQuestionSheet(makeMessage(), config, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    expect(sheet.getAttribute("data-ask-layout")).toBe("pills");
+    const firstPill = sheet.querySelector<HTMLElement>('[data-ask-user-action="pick"]')!;
+    expect(firstPill.querySelector(".persona-ask-row-label")).toBeNull();
+    expect(firstPill.querySelector(".persona-ask-row-badge")).toBeNull();
+    expect(firstPill.textContent).toBe("Hobbyists");
+    const freeRow = sheet.querySelector<HTMLElement>('[data-ask-free-text-row="true"]')!;
+    expect(freeRow.classList.contains("persona-hidden")).toBe(true);
+    // Pills mode keeps the Send button to commit the expand-on-click input.
+    expect(freeRow.querySelector('[data-ask-user-action="submit-free-text"]')).not.toBeNull();
+  });
+});
+
+describe("Skip button", () => {
+  it("renders a Skip button alongside Next in the grouped nav row", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      { question: "Q1", options: [{ label: "A" }] },
+      { question: "Q2", options: [{ label: "B" }] },
+    ]);
+    ensureAskUserQuestionSheet(msg, {} as AgentWidgetConfig, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+    const skip = sheet.querySelector<HTMLButtonElement>('[data-ask-user-action="skip"]');
+    expect(skip).not.toBeNull();
+    expect(skip!.disabled).toBe(false);
+    expect(skip!.textContent).toBe("Skip");
+  });
+
+  it("uses the configured skipLabel override", () => {
+    const overlay = makeOverlay();
+    const msg = makeGroupedMessage([
+      { question: "Q1", options: [{ label: "A" }] },
+      { question: "Q2", options: [{ label: "B" }] },
+    ]);
+    const config = {
+      features: { askUserQuestion: { skipLabel: "Pass" } },
+    } as unknown as AgentWidgetConfig;
+    ensureAskUserQuestionSheet(msg, config, overlay);
+    const sheet = sheetFor(overlay, "tool-grouped");
+    const skip = sheet.querySelector<HTMLButtonElement>('[data-ask-user-action="skip"]')!;
+    expect(skip.textContent).toBe("Pass");
+  });
+
+  it("does not render a Skip button in single-question (non-grouped) mode", () => {
+    const overlay = makeOverlay();
+    ensureAskUserQuestionSheet(makeMessage(), {} as AgentWidgetConfig, overlay);
+    const sheet = overlay.querySelector('[data-persona-ask-sheet-for="tool-1"]')!;
+    expect(sheet.querySelector('[data-ask-user-action="skip"]')).toBeNull();
+  });
+});

--- a/packages/widget/src/components/ask-user-question-bubble.ts
+++ b/packages/widget/src/components/ask-user-question-bubble.ts
@@ -1,0 +1,924 @@
+import { parse as parsePartialJson, ARR, OBJ, STR } from "partial-json";
+import { createElement } from "../utils/dom";
+import {
+  AgentWidgetAskUserQuestionFeature,
+  AgentWidgetConfig,
+  AgentWidgetMessage,
+  AskUserQuestionOption,
+  AskUserQuestionPayload,
+  AskUserQuestionPrompt,
+} from "../types";
+
+export const ASK_USER_QUESTION_TOOL_NAME = "ask_user_question";
+export const ASK_USER_QUESTION_MAX = 8;
+
+const SHEET_SENTINEL = "data-persona-ask-sheet-for";
+const DEFAULT_FREE_TEXT_LABEL_ROWS = "Other";
+const DEFAULT_FREE_TEXT_LABEL_PILLS = "Other…";
+const DEFAULT_FREE_TEXT_PLACEHOLDER = "Type your own answer here";
+const DEFAULT_SUBMIT_LABEL = "Send";
+const DEFAULT_NEXT_LABEL = "Next";
+const DEFAULT_BACK_LABEL = "Back";
+const DEFAULT_SUBMIT_ALL_LABEL = "Submit all";
+const DEFAULT_SKIP_LABEL = "Skip";
+const DEFAULT_SKELETON_PILLS = 3;
+
+export const ATTR_CURRENT_INDEX = "data-ask-current-index";
+export const ATTR_QUESTION_COUNT = "data-ask-question-count";
+export const ATTR_ANSWERS = "data-ask-answers";
+export const ATTR_GROUPED = "data-ask-grouped";
+export const ATTR_LAYOUT = "data-ask-layout";
+
+export type AskUserQuestionLayout = "rows" | "pills";
+
+export const resolveLayout = (
+  feature: AgentWidgetAskUserQuestionFeature
+): AskUserQuestionLayout => (feature.layout === "pills" ? "pills" : "rows");
+
+export const getLayout = (sheet: HTMLElement): AskUserQuestionLayout =>
+  sheet.getAttribute(ATTR_LAYOUT) === "pills" ? "pills" : "rows";
+
+let truncateWarned = false;
+
+/**
+ * Escape a tool-call id for safe use inside a CSS attribute selector.
+ * `CSS.escape` would work but isn't available in all test environments (jsdom).
+ */
+const escapeAttrValue = (value: string): string => value.replace(/["\\]/g, "\\$&");
+
+export const isAskUserQuestionMessage = (message: AgentWidgetMessage): boolean => {
+  return (
+    message.variant === "tool" &&
+    !!message.toolCall &&
+    message.toolCall.name === ASK_USER_QUESTION_TOOL_NAME
+  );
+};
+
+const resolveFeature = (config?: AgentWidgetConfig): AgentWidgetAskUserQuestionFeature => {
+  return config?.features?.askUserQuestion ?? {};
+};
+
+/**
+ * Parse an `ask_user_question` tool-variant message into a partial payload.
+ * Safe to call mid-stream — will walk the tool call's `chunks` via
+ * `partial-json` and return `{ payload: null, complete: false }` when there
+ * isn't enough data yet. `complete` flips to `true` once the tool call
+ * reports status `"complete"`.
+ *
+ * Exported for plugin authors implementing `renderAskUserQuestion`.
+ */
+export const parseAskUserQuestionPayload = (
+  message: AgentWidgetMessage
+): { payload: Partial<AskUserQuestionPayload> | null; complete: boolean } => {
+  const toolCall = message.toolCall;
+  if (!toolCall) return { payload: null, complete: false };
+
+  const complete = toolCall.status === "complete";
+
+  if (toolCall.args && typeof toolCall.args === "object") {
+    return { payload: toolCall.args as Partial<AskUserQuestionPayload>, complete };
+  }
+
+  const chunks = toolCall.chunks;
+  if (!chunks || chunks.length === 0) return { payload: null, complete };
+
+  try {
+    const text = chunks.join("");
+    const parsed = parsePartialJson(text, STR | OBJ | ARR);
+    if (parsed && typeof parsed === "object") {
+      return { payload: parsed as Partial<AskUserQuestionPayload>, complete };
+    }
+  } catch {
+    // malformed; fall through
+  }
+  return { payload: null, complete };
+};
+
+/**
+ * Return the questions array (capped to {@link ASK_USER_QUESTION_MAX}). Logs a
+ * single one-shot warning if a payload exceeds the cap.
+ */
+export const promptsFromPayload = (
+  payload: Partial<AskUserQuestionPayload> | null
+): Partial<AskUserQuestionPrompt>[] => {
+  const all = Array.isArray(payload?.questions) ? (payload!.questions as Partial<AskUserQuestionPrompt>[]) : [];
+  if (all.length > ASK_USER_QUESTION_MAX && !truncateWarned) {
+    truncateWarned = true;
+    if (typeof console !== "undefined") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[AgentWidget] ask_user_question received ${all.length} questions; truncating to ${ASK_USER_QUESTION_MAX}.`
+      );
+    }
+  }
+  return all.slice(0, ASK_USER_QUESTION_MAX);
+};
+
+/**
+ * Kept for plugin authors who only want to render the first question.
+ * @deprecated Plugins should iterate `payload.questions` themselves; the
+ * built-in renderer now paginates multi-question payloads.
+ */
+const firstPrompt = (
+  payload: Partial<AskUserQuestionPayload> | null
+): Partial<AskUserQuestionPrompt> | null => {
+  return promptsFromPayload(payload)[0] ?? null;
+};
+
+const promptAt = (
+  payload: Partial<AskUserQuestionPayload> | null,
+  index: number
+): Partial<AskUserQuestionPrompt> | null => {
+  return promptsFromPayload(payload)[index] ?? null;
+};
+
+const applyStyleVars = (
+  root: HTMLElement,
+  feature: AgentWidgetAskUserQuestionFeature
+): void => {
+  const s = feature.styles;
+  if (!s) return;
+  if (s.sheetBackground) root.style.setProperty("--persona-ask-sheet-bg", s.sheetBackground);
+  if (s.sheetBorder) root.style.setProperty("--persona-ask-sheet-border", s.sheetBorder);
+  if (s.sheetShadow) root.style.setProperty("--persona-ask-sheet-shadow", s.sheetShadow);
+  if (s.pillBackground) root.style.setProperty("--persona-ask-pill-bg", s.pillBackground);
+  if (s.pillBackgroundSelected)
+    root.style.setProperty("--persona-ask-pill-bg-selected", s.pillBackgroundSelected);
+  if (s.pillTextColor) root.style.setProperty("--persona-ask-pill-fg", s.pillTextColor);
+  if (s.pillTextColorSelected)
+    root.style.setProperty("--persona-ask-pill-fg-selected", s.pillTextColorSelected);
+  if (s.pillBorderRadius) root.style.setProperty("--persona-ask-pill-radius", s.pillBorderRadius);
+  if (s.customInputBackground)
+    root.style.setProperty("--persona-ask-input-bg", s.customInputBackground);
+};
+
+const buildAffordance = (
+  layout: AskUserQuestionLayout,
+  multiSelect: boolean,
+  index: number
+): HTMLElement | null => {
+  if (layout !== "rows") return null;
+  const wrap = createElement("span", "persona-ask-row-affordance");
+  wrap.setAttribute("aria-hidden", "true");
+  if (multiSelect) {
+    const check = createElement("span", "persona-ask-row-check");
+    wrap.appendChild(check);
+  } else {
+    const badge = createElement("span", "persona-ask-row-badge");
+    badge.textContent = String(index + 1);
+    wrap.appendChild(badge);
+  }
+  return wrap;
+};
+
+const buildPill = (
+  option: AskUserQuestionOption,
+  index: number,
+  layout: AskUserQuestionLayout,
+  multiSelect: boolean
+): HTMLButtonElement => {
+  const cls =
+    layout === "rows"
+      ? "persona-ask-pill persona-ask-row persona-pointer-events-auto"
+      : "persona-ask-pill persona-pointer-events-auto";
+  const btn = createElement("button", cls) as HTMLButtonElement;
+  btn.type = "button";
+  btn.setAttribute("role", multiSelect ? "checkbox" : "button");
+  btn.setAttribute("aria-pressed", "false");
+  btn.setAttribute("data-ask-user-action", "pick");
+  btn.setAttribute("data-option-index", String(index));
+  btn.setAttribute("data-option-label", option.label);
+
+  if (layout === "rows") {
+    const content = createElement("span", "persona-ask-row-content");
+    const label = createElement("span", "persona-ask-row-label");
+    label.textContent = option.label;
+    content.appendChild(label);
+    if (option.description) {
+      const desc = createElement("span", "persona-ask-row-description");
+      desc.textContent = option.description;
+      content.appendChild(desc);
+    }
+    btn.appendChild(content);
+    const aff = buildAffordance(layout, multiSelect, index);
+    if (aff) btn.appendChild(aff);
+  } else {
+    btn.textContent = option.label;
+    if (option.description) btn.title = option.description;
+  }
+  return btn;
+};
+
+const buildSkeletonPill = (layout: AskUserQuestionLayout): HTMLElement => {
+  const cls =
+    layout === "rows"
+      ? "persona-ask-pill persona-ask-row persona-ask-pill-skeleton persona-pointer-events-none"
+      : "persona-ask-pill persona-ask-pill-skeleton persona-pointer-events-none";
+  const el = createElement("span", cls);
+  el.setAttribute("aria-hidden", "true");
+  return el;
+};
+
+/**
+ * Build the interactive pill list + optional free-text pill for a given prompt.
+ */
+const buildPillList = (
+  prompt: Partial<AskUserQuestionPrompt> | null,
+  feature: AgentWidgetAskUserQuestionFeature,
+  complete: boolean,
+  layout: AskUserQuestionLayout
+): HTMLElement => {
+  const baseClass =
+    layout === "rows"
+      ? "persona-ask-pills persona-ask-pills--rows persona-flex persona-flex-col persona-gap-2"
+      : "persona-ask-pills persona-flex persona-flex-wrap persona-gap-2";
+  const list = createElement("div", baseClass);
+  list.setAttribute("role", "group");
+  list.setAttribute("data-ask-pill-list", "true");
+
+  const multiSelect = !!prompt?.multiSelect;
+  const realOptions = Array.isArray(prompt?.options) ? (prompt!.options as AskUserQuestionOption[]) : [];
+  const cleanOptions = realOptions.filter((o) => o && typeof o.label === "string" && o.label.length > 0);
+
+  if (cleanOptions.length === 0 && !complete) {
+    for (let i = 0; i < DEFAULT_SKELETON_PILLS; i++) {
+      list.appendChild(buildSkeletonPill(layout));
+    }
+    return list;
+  }
+
+  cleanOptions.forEach((option, index) => {
+    list.appendChild(buildPill(option, index, layout, multiSelect));
+  });
+
+  // Free-text affordance:
+  //   - Rows layout: a composite row that visually matches the option rows
+  //     and HAS the input inside it (no separate row below). Number badge
+  //     `N+1` on the right; pressing it focuses the input via the
+  //     `focus-free-text` action.
+  //   - Pills layout (legacy): a dashed pill button that expands a separate
+  //     input row on click (handled by `buildFreeTextRow`).
+  const allowFreeText = prompt?.allowFreeText !== false;
+  if (allowFreeText) {
+    const defaultLabel =
+      layout === "rows" ? DEFAULT_FREE_TEXT_LABEL_ROWS : DEFAULT_FREE_TEXT_LABEL_PILLS;
+    if (layout === "rows") {
+      const otherRow = createElement(
+        "div",
+        "persona-ask-pill persona-ask-row persona-ask-row--other persona-ask-pill-custom persona-pointer-events-auto"
+      );
+      otherRow.setAttribute("data-ask-user-action", "focus-free-text");
+      otherRow.setAttribute("data-option-index", String(cleanOptions.length));
+      otherRow.setAttribute("data-ask-other-row", "true");
+
+      const content = createElement("span", "persona-ask-row-content");
+      const input = document.createElement("input");
+      input.type = "text";
+      input.className = "persona-ask-row-input persona-flex-1 persona-pointer-events-auto";
+      input.placeholder = feature.freeTextPlaceholder ?? DEFAULT_FREE_TEXT_PLACEHOLDER;
+      input.setAttribute("data-ask-free-text-input", "true");
+      input.setAttribute(
+        "aria-label",
+        feature.freeTextLabel ?? defaultLabel
+      );
+      content.appendChild(input);
+      otherRow.appendChild(content);
+
+      const aff = buildAffordance(layout, multiSelect, cleanOptions.length);
+      if (aff) otherRow.appendChild(aff);
+      list.appendChild(otherRow);
+    } else {
+      const freeBtn = createElement(
+        "button",
+        "persona-ask-pill persona-ask-pill-custom persona-pointer-events-auto"
+      ) as HTMLButtonElement;
+      freeBtn.type = "button";
+      freeBtn.setAttribute("data-ask-user-action", "open-free-text");
+      freeBtn.textContent = feature.freeTextLabel ?? defaultLabel;
+      list.appendChild(freeBtn);
+    }
+  }
+
+  return list;
+};
+
+const buildFreeTextRow = (
+  feature: AgentWidgetAskUserQuestionFeature,
+  layout: AskUserQuestionLayout
+): HTMLElement => {
+  const cls =
+    layout === "rows"
+      ? "persona-ask-free-text persona-ask-free-text--rows persona-flex persona-gap-2 persona-mt-2"
+      : "persona-ask-free-text persona-hidden persona-flex persona-gap-2 persona-mt-2";
+  const row = createElement("div", cls);
+  row.setAttribute("data-ask-free-text-row", "true");
+
+  const input = document.createElement("input");
+  input.type = "text";
+  input.className =
+    "persona-ask-free-text-input persona-flex-1 persona-pointer-events-auto";
+  input.placeholder = feature.freeTextPlaceholder ?? DEFAULT_FREE_TEXT_PLACEHOLDER;
+  input.setAttribute("data-ask-free-text-input", "true");
+
+  row.appendChild(input);
+
+  // Pills (legacy) layout keeps the explicit Send button so the expand-on-click
+  // affordance has a commit target. Rows layout drops it: the input commits via
+  // Enter, or via the grouped Next/Submit-all flush path.
+  if (layout !== "rows") {
+    const submit = createElement(
+      "button",
+      "persona-ask-free-text-submit persona-pointer-events-auto"
+    ) as HTMLButtonElement;
+    submit.type = "button";
+    submit.textContent = feature.submitLabel ?? DEFAULT_SUBMIT_LABEL;
+    submit.setAttribute("data-ask-user-action", "submit-free-text");
+    row.appendChild(submit);
+  }
+
+  return row;
+};
+
+const buildMultiSelectActions = (
+  feature: AgentWidgetAskUserQuestionFeature
+): HTMLElement => {
+  const row = createElement(
+    "div",
+    "persona-ask-multi-actions persona-flex persona-justify-end persona-mt-2"
+  );
+  row.setAttribute("data-ask-multi-actions", "true");
+
+  const submit = createElement(
+    "button",
+    "persona-ask-multi-submit persona-pointer-events-auto"
+  ) as HTMLButtonElement;
+  submit.type = "button";
+  submit.textContent = feature.submitLabel ?? DEFAULT_SUBMIT_LABEL;
+  submit.setAttribute("data-ask-user-action", "submit-multi");
+  submit.disabled = true;
+
+  row.appendChild(submit);
+  return row;
+};
+
+const buildNavRow = (
+  index: number,
+  count: number,
+  feature: AgentWidgetAskUserQuestionFeature
+): HTMLElement => {
+  const row = createElement(
+    "div",
+    "persona-ask-nav persona-flex persona-justify-between persona-items-center persona-gap-2 persona-mt-2"
+  );
+  row.setAttribute("data-ask-nav-row", "true");
+
+  const back = createElement(
+    "button",
+    "persona-ask-nav-back persona-pointer-events-auto"
+  ) as HTMLButtonElement;
+  back.type = "button";
+  back.textContent = feature.backLabel ?? DEFAULT_BACK_LABEL;
+  back.setAttribute("data-ask-user-action", "back");
+  back.disabled = index === 0;
+  row.appendChild(back);
+
+  const rightGroup = createElement(
+    "div",
+    "persona-ask-nav-right persona-flex persona-items-center persona-gap-2"
+  );
+
+  const skip = createElement(
+    "button",
+    "persona-ask-nav-skip persona-pointer-events-auto"
+  ) as HTMLButtonElement;
+  skip.type = "button";
+  skip.textContent = feature.skipLabel ?? DEFAULT_SKIP_LABEL;
+  skip.setAttribute("data-ask-user-action", "skip");
+  rightGroup.appendChild(skip);
+
+  const next = createElement(
+    "button",
+    "persona-ask-nav-next persona-pointer-events-auto"
+  ) as HTMLButtonElement;
+  next.type = "button";
+  const isFinal = index === count - 1;
+  next.textContent = isFinal
+    ? feature.submitAllLabel ?? DEFAULT_SUBMIT_ALL_LABEL
+    : feature.nextLabel ?? DEFAULT_NEXT_LABEL;
+  next.setAttribute("data-ask-user-action", isFinal ? "submit-all" : "next");
+  next.disabled = true; // updated by syncNavState
+  rightGroup.appendChild(next);
+
+  row.appendChild(rightGroup);
+
+  return row;
+};
+
+/**
+ * Read the answers map stored on the sheet element.
+ */
+export const readAnswersFromSheet = (
+  sheet: HTMLElement
+): Record<number, string | string[]> => {
+  const raw = sheet.getAttribute(ATTR_ANSWERS);
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? (parsed as Record<number, string | string[]>) : {};
+  } catch {
+    return {};
+  }
+};
+
+/**
+ * Write the answers map back to the sheet element.
+ */
+export const writeAnswersToSheet = (
+  sheet: HTMLElement,
+  answers: Record<number, string | string[]>
+): void => {
+  sheet.setAttribute(ATTR_ANSWERS, JSON.stringify(answers));
+};
+
+export const getCurrentIndex = (sheet: HTMLElement): number => {
+  const raw = Number(sheet.getAttribute(ATTR_CURRENT_INDEX) ?? "0");
+  return Number.isFinite(raw) ? Math.max(0, Math.floor(raw)) : 0;
+};
+
+export const setCurrentIndex = (sheet: HTMLElement, index: number): void => {
+  sheet.setAttribute(ATTR_CURRENT_INDEX, String(Math.max(0, Math.floor(index))));
+};
+
+export const getQuestionCount = (sheet: HTMLElement): number => {
+  const raw = Number(sheet.getAttribute(ATTR_QUESTION_COUNT) ?? "1");
+  return Number.isFinite(raw) ? Math.max(1, Math.floor(raw)) : 1;
+};
+
+export const isGroupedSheet = (sheet: HTMLElement): boolean => {
+  return sheet.getAttribute(ATTR_GROUPED) === "true";
+};
+
+const restoreAnswersFromMessage = (
+  message: AgentWidgetMessage,
+  prompts: Partial<AskUserQuestionPrompt>[]
+): Record<number, string | string[]> => {
+  const stored = message.agentMetadata?.askUserQuestionAnswers;
+  if (!stored || typeof stored !== "object") return {};
+  const result: Record<number, string | string[]> = {};
+  prompts.forEach((p, i) => {
+    const q = typeof p?.question === "string" ? p.question : "";
+    if (q && Object.prototype.hasOwnProperty.call(stored, q)) {
+      const v = stored[q];
+      if (typeof v === "string" || Array.isArray(v)) {
+        result[i] = v;
+      }
+    }
+  });
+  return result;
+};
+
+const restoreIndexFromMessage = (
+  message: AgentWidgetMessage,
+  count: number
+): number => {
+  const stored = message.agentMetadata?.askUserQuestionIndex;
+  if (typeof stored !== "number" || !Number.isFinite(stored)) return 0;
+  return Math.max(0, Math.min(count - 1, Math.floor(stored)));
+};
+
+/**
+ * Keyed-by-question-text view of the current answers on a sheet. Used both for
+ * persistence to message metadata and for the final tool-result payload sent
+ * back to the agent.
+ */
+export const buildStructuredAnswers = (
+  sheet: HTMLElement,
+  message: AgentWidgetMessage
+): Record<string, string | string[]> => {
+  const { payload } = parseAskUserQuestionPayload(message);
+  const prompts = promptsFromPayload(payload);
+  const indexed = readAnswersFromSheet(sheet);
+  const result: Record<string, string | string[]> = {};
+  const seen = new Set<string>();
+  prompts.forEach((p, i) => {
+    const q = typeof p?.question === "string" ? p.question : "";
+    if (!q) return;
+    if (seen.has(q) && typeof console !== "undefined") {
+      // eslint-disable-next-line no-console
+      console.warn(`[AgentWidget] ask_user_question has duplicate question text "${q}"; later answer wins.`);
+    }
+    seen.add(q);
+    if (Object.prototype.hasOwnProperty.call(indexed, i)) {
+      result[q] = indexed[i];
+    }
+  });
+  return result;
+};
+
+/**
+ * Apply the selected/unselected visual state to pills on the current page,
+ * based on the answer stored for `currentIndex`.
+ */
+const applySelectionState = (sheet: HTMLElement): void => {
+  const answers = readAnswersFromSheet(sheet);
+  const currentIndex = getCurrentIndex(sheet);
+  const stored = answers[currentIndex];
+  const selected = new Set<string>();
+  if (typeof stored === "string") selected.add(stored);
+  else if (Array.isArray(stored)) stored.forEach((s) => selected.add(s));
+
+  const pills = sheet.querySelectorAll<HTMLButtonElement>('[data-ask-user-action="pick"][data-option-label]');
+  pills.forEach((pill) => {
+    const label = pill.getAttribute("data-option-label") ?? "";
+    const on = selected.has(label);
+    pill.setAttribute("aria-pressed", on ? "true" : "false");
+    pill.classList.toggle("persona-ask-pill-selected", on);
+  });
+
+  // Also pre-fill the free-text input if the saved answer doesn't match any pill.
+  const realPillLabels = new Set(
+    Array.from(pills).map((p) => p.getAttribute("data-option-label") ?? "")
+  );
+  // In rows mode the input lives inside the Other row of the pill list; in
+  // pills mode it lives in a separate (potentially hidden) free-text row.
+  // Querying the input directly covers both layouts.
+  const freeInput = sheet.querySelector<HTMLInputElement>('[data-ask-free-text-input="true"]');
+  if (freeInput) {
+    if (typeof stored === "string" && stored.length > 0 && !realPillLabels.has(stored)) {
+      freeInput.value = stored;
+      const freeRow = freeInput.closest<HTMLElement>('[data-ask-free-text-row="true"]');
+      freeRow?.classList.remove("persona-hidden");
+    } else {
+      freeInput.value = "";
+    }
+  }
+};
+
+/**
+ * Update the Next/Submit-all enabled state based on whether the current
+ * question has a non-empty answer stored.
+ */
+const syncNavState = (sheet: HTMLElement): void => {
+  if (!isGroupedSheet(sheet)) return;
+  const answers = readAnswersFromSheet(sheet);
+  const currentIndex = getCurrentIndex(sheet);
+  const v = answers[currentIndex];
+  const hasAnswer =
+    (typeof v === "string" && v.length > 0) || (Array.isArray(v) && v.length > 0);
+  const next = sheet.querySelector<HTMLButtonElement>(
+    '[data-ask-user-action="next"], [data-ask-user-action="submit-all"]'
+  );
+  if (next) next.disabled = !hasAnswer;
+
+  // Multi-select submit (1-question mode) — keep existing behavior.
+  const multi = sheet.querySelector<HTMLButtonElement>('[data-ask-user-action="submit-multi"]');
+  if (multi) {
+    const labels = Array.from(
+      sheet.querySelectorAll<HTMLElement>('[aria-pressed="true"][data-option-label]')
+    );
+    multi.disabled = labels.length === 0;
+  }
+};
+
+/**
+ * Replace the page-scoped body of the sheet (question text, pills, free-text
+ * row, multi-select actions) with content for `currentIndex`. Called both on
+ * initial mount and after every Back/Next navigation. Preserves the stepper
+ * row, the dismiss button, and the nav row at the bottom.
+ */
+const renderCurrentPage = (
+  sheet: HTMLElement,
+  message: AgentWidgetMessage,
+  config: AgentWidgetConfig | undefined
+): void => {
+  const feature = resolveFeature(config);
+  const layout = getLayout(sheet);
+  const { payload, complete } = parseAskUserQuestionPayload(message);
+  const grouped = isGroupedSheet(sheet);
+  const index = getCurrentIndex(sheet);
+  const count = getQuestionCount(sheet);
+  const prompt = grouped ? promptAt(payload, index) : firstPrompt(payload);
+  const multiSelect = !!prompt?.multiSelect;
+
+  // Inline stepper "{index+1}/{count}" lives in the header next to the
+  // question text. Empty in single-Q mode.
+  const stepInline = sheet.querySelector<HTMLElement>('[data-ask-step-inline="true"]');
+  if (stepInline) {
+    stepInline.textContent = grouped ? `${index + 1}/${count}` : "";
+  }
+  // Sweep any legacy stepper row from earlier renders.
+  const oldStepper = sheet.querySelector<HTMLElement>('[data-ask-stepper="true"]');
+  if (oldStepper) oldStepper.remove();
+
+  // Question text
+  const qText = sheet.querySelector<HTMLElement>('[data-ask-question="true"]');
+  if (qText) {
+    const text = typeof prompt?.question === "string" ? prompt.question : "";
+    qText.textContent = text;
+    qText.classList.toggle("persona-ask-question-skeleton", !text && !complete);
+  }
+
+  // Pills list
+  const pillList = sheet.querySelector<HTMLElement>('[data-ask-pill-list="true"]');
+  if (pillList) {
+    const fresh = buildPillList(prompt, feature, complete, layout);
+    pillList.replaceWith(fresh);
+  }
+
+  // Free-text row — re-build to clear stale input value across pages.
+  // Only present in pills (legacy) mode; in rows mode the input lives inside
+  // the Other row of the pill list, which is rebuilt above.
+  if (layout !== "rows") {
+    const oldFree = sheet.querySelector<HTMLElement>('[data-ask-free-text-row="true"]');
+    if (oldFree) oldFree.replaceWith(buildFreeTextRow(feature, layout));
+  }
+
+  // Multi-select action row — only relevant in 1-question mode.
+  const oldMulti = sheet.querySelector<HTMLElement>('[data-ask-multi-actions="true"]');
+  if (!grouped && multiSelect && !oldMulti) {
+    sheet.appendChild(buildMultiSelectActions(feature));
+  } else if ((!multiSelect || grouped) && oldMulti) {
+    oldMulti.remove();
+  }
+  sheet.setAttribute("data-multi-select", multiSelect ? "true" : "false");
+
+  // Nav row stays last; only present in grouped mode.
+  const oldNav = sheet.querySelector<HTMLElement>('[data-ask-nav-row="true"]');
+  if (grouped) {
+    const fresh = buildNavRow(index, count, feature);
+    if (oldNav) oldNav.replaceWith(fresh);
+    else sheet.appendChild(fresh);
+  } else if (oldNav) {
+    oldNav.remove();
+  }
+
+  applySelectionState(sheet);
+  syncNavState(sheet);
+};
+
+const buildSheet = (
+  message: AgentWidgetMessage,
+  config: AgentWidgetConfig | undefined,
+  payload: Partial<AskUserQuestionPayload> | null
+): HTMLElement => {
+  const feature = resolveFeature(config);
+  const layout = resolveLayout(feature);
+  const toolCallId = message.toolCall!.id;
+  const prompts = promptsFromPayload(payload);
+  const count = Math.max(1, prompts.length);
+  const grouped = count > 1;
+
+  const initialAnswers = restoreAnswersFromMessage(message, prompts);
+  const initialIndex = grouped ? restoreIndexFromMessage(message, count) : 0;
+
+  const sheet = createElement(
+    "div",
+    [
+      "persona-ask-sheet",
+      `persona-ask-sheet--${layout}`,
+      "persona-pointer-events-auto",
+      "persona-ask-sheet-enter",
+    ].join(" ")
+  );
+  sheet.setAttribute(SHEET_SENTINEL, toolCallId);
+  sheet.setAttribute("data-tool-call-id", toolCallId);
+  sheet.setAttribute("data-message-id", message.id);
+  sheet.setAttribute(ATTR_QUESTION_COUNT, String(count));
+  sheet.setAttribute(ATTR_CURRENT_INDEX, String(initialIndex));
+  sheet.setAttribute(ATTR_GROUPED, grouped ? "true" : "false");
+  sheet.setAttribute(ATTR_LAYOUT, layout);
+  writeAnswersToSheet(sheet, initialAnswers);
+  sheet.setAttribute("role", "group");
+  sheet.setAttribute("aria-label", "Suggested answers");
+
+  if (feature.slideInMs !== undefined) {
+    sheet.style.setProperty("--persona-ask-sheet-duration", `${feature.slideInMs}ms`);
+  }
+  applyStyleVars(sheet, feature);
+
+  // Header: question text (flex-1) + compact "N/M" stepper indicator on the
+  // right (grouped only). Skip in the nav row is the canonical escape hatch
+  // — plugins that want a different escape model render their own UX.
+  const header = createElement(
+    "div",
+    "persona-ask-sheet-header persona-flex persona-items-center persona-gap-3"
+  );
+
+  const qText = createElement("div", "persona-ask-sheet-question persona-flex-1");
+  qText.setAttribute("data-ask-question", "true");
+  qText.textContent = "";
+  header.appendChild(qText);
+
+  // Inline stepper indicator. Empty for single-Q; populated by
+  // renderCurrentPage to "{index+1}/{count}" in grouped mode.
+  const stepInline = createElement(
+    "span",
+    "persona-ask-sheet-step-inline"
+  );
+  stepInline.setAttribute("data-ask-step-inline", "true");
+  stepInline.textContent = "";
+  header.appendChild(stepInline);
+
+  sheet.appendChild(header);
+
+  // Skeleton placeholders — these get replaced wholesale by renderCurrentPage.
+  const skeletonClass =
+    layout === "rows"
+      ? "persona-ask-pills persona-ask-pills--rows persona-flex persona-flex-col persona-gap-2"
+      : "persona-ask-pills persona-flex persona-flex-wrap persona-gap-2";
+  const list = createElement("div", skeletonClass);
+  list.setAttribute("data-ask-pill-list", "true");
+  list.setAttribute("role", "group");
+  sheet.appendChild(list);
+
+  // Pills (legacy) layout uses a separate, hidden free-text row that expands
+  // on click. Rows layout embeds the input inside the Other row of the pill
+  // list, so the standalone row is unnecessary.
+  if (layout !== "rows") {
+    sheet.appendChild(buildFreeTextRow(feature, layout));
+  }
+
+  // Render the actual current page (stepper, pills, multi-actions, nav).
+  renderCurrentPage(sheet, message, config);
+
+  // Remove the enter class next frame so the slide-in transition runs.
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => sheet.classList.remove("persona-ask-sheet-enter"));
+  });
+
+  return sheet;
+};
+
+const syncSheetFromMessage = (
+  sheet: HTMLElement,
+  message: AgentWidgetMessage,
+  config: AgentWidgetConfig | undefined
+): void => {
+  // If the payload's question count grew (rare mid-stream), update the cached count.
+  const { payload } = parseAskUserQuestionPayload(message);
+  const newCount = Math.max(1, promptsFromPayload(payload).length);
+  if (newCount > getQuestionCount(sheet)) {
+    sheet.setAttribute(ATTR_QUESTION_COUNT, String(newCount));
+    if (newCount > 1 && !isGroupedSheet(sheet)) {
+      sheet.setAttribute(ATTR_GROUPED, "true");
+    }
+  }
+  renderCurrentPage(sheet, message, config);
+};
+
+/**
+ * Create the small in-transcript stub for an `ask_user_question` tool call.
+ * The stub is passive — the interactive sheet is mounted separately into
+ * the composer overlay via `ensureAskUserQuestionSheet`.
+ */
+export const createAskUserQuestionBubble = (
+  message: AgentWidgetMessage,
+  config?: AgentWidgetConfig
+): HTMLElement => {
+  const bubble = createElement(
+    "div",
+    "persona-ask-stub persona-inline-flex persona-items-center persona-gap-2"
+  );
+  bubble.id = `bubble-${message.id}`;
+  bubble.setAttribute("data-message-id", message.id);
+  bubble.setAttribute("data-bubble-type", "ask-user-question");
+
+  const feature = resolveFeature(config);
+  applyStyleVars(bubble, feature);
+
+  const text = createElement("span", "persona-ask-stub-label");
+  const { complete } = parseAskUserQuestionPayload(message);
+  text.textContent = complete ? "Awaiting your response…" : "Preparing options…";
+  bubble.appendChild(text);
+
+  return bubble;
+};
+
+/**
+ * Mount or update the interactive answer-pill sheet for a given message.
+ * Idempotent — if a sheet already exists for the tool-call id, it is hydrated
+ * in-place instead of remounted, so streaming updates don't flicker.
+ */
+export const ensureAskUserQuestionSheet = (
+  message: AgentWidgetMessage,
+  config: AgentWidgetConfig | undefined,
+  overlay: HTMLElement | null | undefined
+): void => {
+  if (!overlay) return;
+  if (!isAskUserQuestionMessage(message)) return;
+
+  const feature = resolveFeature(config);
+  if (feature.enabled === false) return;
+
+  const toolCallId = message.toolCall!.id;
+
+  // Only keep the latest sheet in the overlay — clear any stale siblings.
+  const siblings = overlay.querySelectorAll<HTMLElement>(`[${SHEET_SENTINEL}]`);
+  siblings.forEach((el) => {
+    if (el.getAttribute(SHEET_SENTINEL) !== toolCallId) {
+      el.remove();
+    }
+  });
+
+  const existing = overlay.querySelector<HTMLElement>(
+    `[${SHEET_SENTINEL}="${escapeAttrValue(toolCallId)}"]`
+  );
+  if (existing) {
+    syncSheetFromMessage(existing, message, config);
+    return;
+  }
+
+  const { payload } = parseAskUserQuestionPayload(message);
+  const sheet = buildSheet(message, config, payload);
+  overlay.appendChild(sheet);
+};
+
+/**
+ * Remove the sheet for a specific tool-call id, or all sheets if omitted.
+ * Runs a slide-out transition before removing.
+ */
+export const removeAskUserQuestionSheet = (
+  overlay: HTMLElement | null | undefined,
+  toolCallId?: string
+): void => {
+  if (!overlay) return;
+
+  const selector = toolCallId
+    ? `[${SHEET_SENTINEL}="${escapeAttrValue(toolCallId)}"]`
+    : `[${SHEET_SENTINEL}]`;
+  const sheets = overlay.querySelectorAll<HTMLElement>(selector);
+
+  sheets.forEach((sheet) => {
+    sheet.classList.add("persona-ask-sheet-leave");
+    const duration = Number.parseInt(
+      getComputedStyle(sheet).getPropertyValue("--persona-ask-sheet-duration") || "180",
+      10
+    );
+    const remove = () => sheet.remove();
+    setTimeout(remove, Number.isFinite(duration) ? duration : 180);
+  });
+};
+
+/**
+ * Read the currently-selected option labels from a multi-select sheet.
+ */
+export const getSelectedLabels = (sheet: HTMLElement): string[] => {
+  return Array.from(
+    sheet.querySelectorAll<HTMLElement>('[aria-pressed="true"][data-option-label]')
+  )
+    .map((el) => el.getAttribute("data-option-label"))
+    .filter((label): label is string => typeof label === "string" && label.length > 0);
+};
+
+/**
+ * Update the answer for the current page and refresh visual state. Used by
+ * the ui.ts event handlers in grouped mode.
+ */
+export const setCurrentAnswer = (
+  sheet: HTMLElement,
+  answer: string | string[]
+): void => {
+  const answers = readAnswersFromSheet(sheet);
+  const idx = getCurrentIndex(sheet);
+  if (typeof answer === "string" && answer.length === 0) {
+    delete answers[idx];
+  } else if (Array.isArray(answer) && answer.length === 0) {
+    delete answers[idx];
+  } else {
+    answers[idx] = answer;
+  }
+  writeAnswersToSheet(sheet, answers);
+  applySelectionState(sheet);
+  syncNavState(sheet);
+};
+
+/**
+ * Navigate to a page by index and re-render the current page contents.
+ */
+export const navigateToPage = (
+  sheet: HTMLElement,
+  message: AgentWidgetMessage,
+  config: AgentWidgetConfig | undefined,
+  index: number
+): void => {
+  const count = getQuestionCount(sheet);
+  const clamped = Math.max(0, Math.min(count - 1, index));
+  setCurrentIndex(sheet, clamped);
+  renderCurrentPage(sheet, message, config);
+};
+
+/**
+ * Re-export of the post-render nav-state sync, for ui.ts to call after pill
+ * toggles in grouped multi-select mode.
+ */
+export const refreshNavState = (sheet: HTMLElement): void => {
+  syncNavState(sheet);
+};
+
+/**
+ * Test seam — reset the one-shot truncation warning so each test can assert
+ * the warn fires exactly once.
+ */
+export const __resetTruncateWarn = (): void => {
+  truncateWarned = false;
+};

--- a/packages/widget/src/components/messages.ts
+++ b/packages/widget/src/components/messages.ts
@@ -4,6 +4,11 @@ import { MessageTransform, MessageActionCallbacks } from "./message-bubble";
 import { createStandardBubble } from "./message-bubble";
 import { createReasoningBubble } from "./reasoning-bubble";
 import { createToolBubble } from "./tool-bubble";
+import {
+  ensureAskUserQuestionSheet,
+  isAskUserQuestionMessage,
+  removeAskUserQuestionSheet,
+} from "./ask-user-question-bubble";
 
 export const renderMessages = (
   container: HTMLElement,
@@ -12,16 +17,29 @@ export const renderMessages = (
   showReasoning: boolean,
   showToolCalls: boolean,
   config?: AgentWidgetConfig,
-  actionCallbacks?: MessageActionCallbacks
+  actionCallbacks?: MessageActionCallbacks,
+  composerOverlay?: HTMLElement | null
 ) => {
   container.innerHTML = "";
   const fragment = createFragment();
+
+  // Track which ask_user_question tool-call ids are currently in the message
+  // list, so we can prune stale sheets from the overlay afterward.
+  const liveAskToolIds = new Set<string>();
 
   messages.forEach((message) => {
     let bubble: HTMLElement;
     if (message.variant === "reasoning" && message.reasoning) {
       if (!showReasoning) return;
       bubble = createReasoningBubble(message, config);
+    } else if (isAskUserQuestionMessage(message)) {
+      // No transcript bubble — the overlay sheet is the only question UI.
+      if (config?.features?.askUserQuestion?.enabled === false) return;
+      if (!message.agentMetadata?.askUserQuestionAnswered) {
+        if (message.toolCall?.id) liveAskToolIds.add(message.toolCall.id);
+        ensureAskUserQuestionSheet(message, config, composerOverlay ?? null);
+      }
+      return;
     } else if (message.variant === "tool" && message.toolCall) {
       if (!showToolCalls) return;
       bubble = createToolBubble(message, config);
@@ -45,6 +63,20 @@ export const renderMessages = (
 
   container.appendChild(fragment);
   container.scrollTop = container.scrollHeight;
+
+  // Clean up any orphaned ask_user_question sheets whose source message is no
+  // longer in the list (e.g. after clearChat or a message splice).
+  if (composerOverlay) {
+    const sheets = composerOverlay.querySelectorAll<HTMLElement>(
+      '[data-persona-ask-sheet-for]'
+    );
+    sheets.forEach((sheet) => {
+      const id = sheet.getAttribute('data-persona-ask-sheet-for');
+      if (id && !liveAskToolIds.has(id)) {
+        removeAskUserQuestionSheet(composerOverlay, id);
+      }
+    });
+  }
 };
 
 

--- a/packages/widget/src/components/panel.ts
+++ b/packages/widget/src/components/panel.ts
@@ -81,6 +81,12 @@ export interface PanelElements {
   container: HTMLElement;
   body: HTMLElement;
   messagesWrapper: HTMLElement;
+  /**
+   * Absolute-positioned slot above the composer footer. Interactive sheets
+   * (e.g. the answer-pill sheet for the ask_user_question tool) mount here
+   * so they slide in without reflowing the chat transcript.
+   */
+  composerOverlay: HTMLElement;
   suggestions: HTMLElement;
   textarea: HTMLTextAreaElement;
   sendButton: HTMLButtonElement;
@@ -138,10 +144,17 @@ export const buildPanel = (config?: AgentWidgetConfig, showClose = true): PanelE
   body.id = "persona-scroll-container";
   body.setAttribute("data-persona-theme-zone", "messages");
   
-  const introCardClasses = isDockedMountMode(config)
-    ? "persona-rounded-2xl persona-bg-persona-surface persona-p-6"
-    : "persona-rounded-2xl persona-bg-persona-surface persona-p-6 persona-shadow-sm";
-  const introCard = createElement("div", introCardClasses);
+  const introCard = createElement(
+    "div",
+    "persona-rounded-2xl persona-bg-persona-surface persona-p-6"
+  );
+  // Box-shadow flows through the themable `components.introCard.shadow` token
+  // (--persona-intro-card-shadow). Docked mode keeps a flat look by default;
+  // floating mode falls back to the legacy `persona-shadow-sm` value when no
+  // token is set.
+  introCard.style.boxShadow = isDockedMountMode(config)
+    ? "none"
+    : "var(--persona-intro-card-shadow, 0 5px 15px rgba(15, 23, 42, 0.08))";
   const introTitle = createElement(
     "h2",
     "persona-text-lg persona-font-semibold persona-text-persona-primary"
@@ -193,6 +206,26 @@ export const buildPanel = (config?: AgentWidgetConfig, showClose = true): PanelE
   
   container.append(body);
   
+  // Composer overlay slot: sits between body and footer, absolutely positioned
+  // above the composer so sheets (e.g. the ask_user_question answer-pill sheet)
+  // can slide up without reflowing the chat transcript above. Uses inline
+  // styles for left/right/bottom because widget.css is hand-authored and
+  // doesn't ship `.persona-left-0` / `.persona-right-0` rules — without
+  // them the overlay shrink-wraps to content and collapses the sheet width.
+  const composerOverlay = createElement(
+    "div",
+    "persona-composer-overlay persona-pointer-events-none"
+  );
+  composerOverlay.setAttribute("data-persona-composer-overlay", "");
+  composerOverlay.style.position = "absolute";
+  composerOverlay.style.left = "0";
+  composerOverlay.style.right = "0";
+  composerOverlay.style.bottom = "0";
+  // Above .persona-scroll-to-bottom-indicator (z-index 10, sibling in the
+  // container) so suggestion chips and the ask-user-question sheet are not
+  // covered by the "jump to latest" button.
+  composerOverlay.style.zIndex = "20";
+
   if (showFooter) {
     container.append(composerElements.footer);
   } else {
@@ -201,10 +234,14 @@ export const buildPanel = (config?: AgentWidgetConfig, showClose = true): PanelE
     container.append(composerElements.footer);
   }
 
+  // Append overlay last so it stacks above the footer / body content.
+  container.append(composerOverlay);
+
   return {
     container,
     body,
     messagesWrapper,
+    composerOverlay,
     suggestions: composerElements.suggestions,
     textarea: composerElements.textarea,
     sendButton: composerElements.sendButton,

--- a/packages/widget/src/defaults.ts
+++ b/packages/widget/src/defaults.ts
@@ -143,6 +143,13 @@ export const DEFAULT_WIDGET_CONFIG: Partial<AgentWidgetConfig> = {
       speed: 120,
       duration: 1800,
     },
+    askUserQuestion: {
+      enabled: true,
+      slideInMs: 180,
+      freeTextLabel: "Other…",
+      freeTextPlaceholder: "Type your answer…",
+      submitLabel: "Send",
+    },
   },
   suggestionChips: [
     "What can you help me with?",
@@ -259,6 +266,8 @@ export function mergeWithDefaults(
       const csb = config.features?.scrollToBottom;
       const dsa = DEFAULT_WIDGET_CONFIG.features?.streamAnimation;
       const csa = config.features?.streamAnimation;
+      const dau = DEFAULT_WIDGET_CONFIG.features?.askUserQuestion;
+      const cau = config.features?.askUserQuestion;
       const mergedArtifacts =
         da === undefined && ca === undefined
           ? undefined
@@ -284,12 +293,24 @@ export function mergeWithDefaults(
               ...dsa,
               ...csa,
             };
+      const mergedAskUserQuestion =
+        dau === undefined && cau === undefined
+          ? undefined
+          : {
+              ...dau,
+              ...cau,
+              styles: {
+                ...dau?.styles,
+                ...cau?.styles,
+              },
+            };
       return {
         ...DEFAULT_WIDGET_CONFIG.features,
         ...config.features,
         ...(mergedScrollToBottom !== undefined ? { scrollToBottom: mergedScrollToBottom } : {}),
         ...(mergedArtifacts !== undefined ? { artifacts: mergedArtifacts } : {}),
         ...(mergedStreamAnimation !== undefined ? { streamAnimation: mergedStreamAnimation } : {}),
+        ...(mergedAskUserQuestion !== undefined ? { askUserQuestion: mergedAskUserQuestion } : {}),
       };
     })(),
     suggestionChips: config.suggestionChips ?? DEFAULT_WIDGET_CONFIG.suggestionChips,

--- a/packages/widget/src/index.ts
+++ b/packages/widget/src/index.ts
@@ -86,8 +86,23 @@ export type {
   EventStreamToolbarRenderContext,
   EventStreamPayloadRenderContext,
   // Controller event map
-  AgentWidgetControllerEventMap
+  AgentWidgetControllerEventMap,
+  // Ask-user-question (built-in answer-pill sheet) types
+  AskUserQuestionPayload,
+  AskUserQuestionPrompt,
+  AskUserQuestionOption,
+  AgentWidgetAskUserQuestionFeature,
+  AgentWidgetAskUserQuestionStyles
 } from "./types";
+
+export {
+  ASK_USER_QUESTION_TOOL_NAME,
+  createAskUserQuestionBubble,
+  ensureAskUserQuestionSheet,
+  removeAskUserQuestionSheet,
+  isAskUserQuestionMessage,
+  parseAskUserQuestionPayload
+} from "./components/ask-user-question-bubble";
 
 export { initAgentWidgetFn as initAgentWidget };
 export {

--- a/packages/widget/src/plugins/types.ts
+++ b/packages/widget/src/plugins/types.ts
@@ -1,6 +1,7 @@
 import {
   AgentWidgetMessage,
   AgentWidgetConfig,
+  AskUserQuestionPayload,
   LoadingIndicatorRenderContext,
   IdleIndicatorRenderContext,
   EventStreamViewRenderContext,
@@ -104,6 +105,62 @@ export interface AgentWidgetPlugin {
   renderToolCall?: (context: {
     message: AgentWidgetMessage;
     defaultRenderer: () => HTMLElement;
+    config: AgentWidgetConfig;
+  }) => HTMLElement | null;
+
+  /**
+   * Custom renderer for `ask_user_question` tool calls.
+   *
+   * When a plugin returns an `HTMLElement`, it is inserted into the transcript
+   * in place of the default (which is no transcript bubble — the built-in
+   * renders a sheet over the composer). The built-in composer-overlay sheet
+   * is suppressed so the plugin's UI fully owns the interaction.
+   *
+   * Return `null` to fall through to the built-in overlay sheet.
+   *
+   * The context gives you a pre-parsed `payload` (may be partial while the
+   * tool call is still streaming — check `complete`) and two callbacks:
+   * `resolve(answer)` resumes the paused LOCAL tool with the user's answer,
+   * and `dismiss()` cancels with the sentinel `"(dismissed)"`.
+   *
+   * @example
+   * ```typescript
+   * renderAskUserQuestion: ({ payload, resolve, dismiss }) => {
+   *   const prompt = payload.questions?.[0];
+   *   if (!prompt) return null;
+   *   const root = document.createElement("div");
+   *   root.textContent = prompt.question ?? "";
+   *   (prompt.options ?? []).forEach((option) => {
+   *     const btn = document.createElement("button");
+   *     btn.textContent = option.label;
+   *     btn.addEventListener("click", () => resolve(option.label));
+   *     root.appendChild(btn);
+   *   });
+   *   return root;
+   * }
+   * ```
+   */
+  renderAskUserQuestion?: (context: {
+    message: AgentWidgetMessage;
+    /**
+     * Parsed `{ questions: [...] }` payload. May be partial while the tool
+     * call is still streaming; see `complete`. `null` when no payload has
+     * arrived yet.
+     */
+    payload: Partial<AskUserQuestionPayload> | null;
+    /** `true` once the tool-call args have fully streamed in. */
+    complete: boolean;
+    /**
+     * Resume the paused LOCAL tool with the user's answer. Posts to the
+     * resume endpoint, pipes the SSE stream back into the session, and
+     * appends a user-visible answer bubble to the transcript.
+     */
+    resolve: (answer: string) => void;
+    /**
+     * Cancel the question. Resumes with the sentinel `"(dismissed)"` so the
+     * server doesn't sit in `waiting_for_local` forever. Idempotent.
+     */
+    dismiss: () => void;
     config: AgentWidgetConfig;
   }) => HTMLElement | null;
 

--- a/packages/widget/src/session.test.ts
+++ b/packages/widget/src/session.test.ts
@@ -337,3 +337,186 @@ describe('AgentWidgetSession - cancel()', () => {
     expect(stopVoicePlaybackSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('AgentWidgetSession.resolveAskUserQuestion', () => {
+  const makeAwaitingMessage = (): AgentWidgetMessage => ({
+    id: 'tool-msg-1',
+    role: 'assistant',
+    content: '',
+    createdAt: new Date().toISOString(),
+    variant: 'tool',
+    streaming: false,
+    toolCall: {
+      id: 'runtime_ask_user_question_1',
+      name: 'ask_user_question',
+      status: 'complete',
+      args: { questions: [{ question: 'Who?', options: [{ label: 'A' }] }] },
+      chunks: [],
+    },
+    agentMetadata: {
+      executionId: 'exec_abc',
+      awaitingLocalTool: true,
+    },
+  });
+
+  it('POSTs to /resume, appends a user bubble, and pipes the SSE stream through connectStream', async () => {
+    let capturedUrl: string | undefined;
+    let capturedBody: Record<string, unknown> | undefined;
+    global.fetch = vi.fn().mockImplementation(async (url: string, init: RequestInit) => {
+      capturedUrl = url;
+      capturedBody = JSON.parse(init.body as string);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+
+    const seen: AgentWidgetMessage[] = [];
+    const session = new AgentWidgetSession(
+      { apiUrl: 'http://localhost:43111/api/chat/dispatch' },
+      {
+        onMessagesChanged: (msgs) => { seen.splice(0, seen.length, ...msgs); },
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+      }
+    );
+
+    const connectSpy = vi.spyOn(session, 'connectStream').mockResolvedValue(undefined);
+    await session.resolveAskUserQuestion(makeAwaitingMessage(), 'Hobbyists');
+
+    expect(capturedUrl).toBe('http://localhost:43111/api/chat/dispatch/resume');
+    expect(capturedBody).toEqual({
+      executionId: 'exec_abc',
+      toolOutputs: { ["ask_user_question"]: 'Hobbyists' },
+      streamResponse: true,
+    });
+
+    const userBubble = seen.find((m) => m.role === 'user' && m.content === 'Hobbyists');
+    expect(userBubble).toBeDefined();
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('flips askUserQuestionAnswered on the tool message before the POST fires', async () => {
+    const awaiting = makeAwaitingMessage();
+
+    const fetchMock = vi.fn().mockImplementation(async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+    global.fetch = fetchMock;
+
+    let latest: AgentWidgetMessage[] = [];
+    const session = new AgentWidgetSession(
+      {
+        apiUrl: 'http://localhost:43111/api/chat/dispatch',
+        initialMessages: [awaiting],
+      },
+      {
+        onMessagesChanged: (msgs) => { latest = msgs; },
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+      }
+    );
+
+    vi.spyOn(session, 'connectStream').mockResolvedValue(undefined);
+
+    // Capture the flag state at the exact moment fetch is called — this is
+    // the "before the POST fires" assertion. The flag must be flipped BEFORE
+    // any network I/O so the subsequent stream-driven renders skip the sheet.
+    let flagAtFetch: { awaiting?: boolean; answered?: boolean } | undefined;
+    fetchMock.mockImplementationOnce(async () => {
+      const toolMsg = session.getMessages().find((m) => m.id === awaiting.id);
+      flagAtFetch = {
+        awaiting: toolMsg?.agentMetadata?.awaitingLocalTool,
+        answered: toolMsg?.agentMetadata?.askUserQuestionAnswered,
+      };
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          controller.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+
+    await session.resolveAskUserQuestion(awaiting, 'Hobbyists');
+
+    expect(flagAtFetch).toEqual({ awaiting: false, answered: true });
+
+    const finalToolMsg = latest.find((m) => m.id === awaiting.id);
+    expect(finalToolMsg?.agentMetadata?.askUserQuestionAnswered).toBe(true);
+    expect(finalToolMsg?.agentMetadata?.awaitingLocalTool).toBe(false);
+    expect(finalToolMsg?.agentMetadata?.executionId).toBe('exec_abc');
+  });
+
+  it('leaves the answered flag flipped even when resume fails', async () => {
+    const awaiting = makeAwaitingMessage();
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500, json: async () => ({ error: 'boom' }) });
+
+    const errors: Error[] = [];
+    let latest: AgentWidgetMessage[] = [];
+    const session = new AgentWidgetSession(
+      {
+        apiUrl: 'http://localhost:43111/api/chat/dispatch',
+        initialMessages: [awaiting],
+      },
+      {
+        onMessagesChanged: (msgs) => { latest = msgs; },
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+        onError: (e) => errors.push(e),
+      }
+    );
+
+    await session.resolveAskUserQuestion(awaiting, 'Hobbyists');
+
+    expect(errors.length).toBe(1);
+    const finalToolMsg = latest.find((m) => m.id === awaiting.id);
+    expect(finalToolMsg?.agentMetadata?.askUserQuestionAnswered).toBe(true);
+  });
+
+  it('markAskUserQuestionResolved is idempotent and a no-op when the message is not in state', () => {
+    const session = new AgentWidgetSession(
+      { apiUrl: 'http://localhost:8000' },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+      }
+    );
+    // No throw when the tool message isn't tracked in session state
+    expect(() => session.markAskUserQuestionResolved(makeAwaitingMessage())).not.toThrow();
+  });
+
+  it('surfaces errors through onError when the message is missing executionId', async () => {
+    const errors: Error[] = [];
+    const session = new AgentWidgetSession(
+      { apiUrl: 'http://localhost:8000' },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+        onError: (e) => errors.push(e),
+      }
+    );
+
+    const bad = makeAwaitingMessage();
+    bad.agentMetadata = { ...bad.agentMetadata, executionId: undefined };
+
+    await session.resolveAskUserQuestion(bad, 'x');
+    expect(errors.length).toBe(1);
+    expect(errors[0].message).toMatch(/executionId/);
+  });
+});

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -81,8 +81,21 @@ export class AgentWidgetSession {
     this.messages = this.sortMessages(this.messages);
     this.client = new AgentWidgetClient(config);
 
+    // Hydrate artifacts from config (mirrors `initialMessages`). Restored
+    // records are forced to `status: "complete"` — a mid-stream artifact should
+    // never reappear after a refresh with its skeleton still showing.
+    for (const rec of config.initialArtifacts ?? []) {
+      this.artifacts.set(rec.id, { ...rec, status: "complete" });
+    }
+    if (config.initialSelectedArtifactId != null) {
+      this.selectedArtifactId = config.initialSelectedArtifactId;
+    }
+
     if (this.messages.length) {
       this.callbacks.onMessagesChanged([...this.messages]);
+    }
+    if (this.artifacts.size > 0) {
+      this.emitArtifactsState();
     }
     this.callbacks.onStatusChanged(this.status);
   }
@@ -968,6 +981,194 @@ export class AgentWidgetSession {
     }
   }
 
+  /**
+   * Resolve a paused `ask_user_question` LOCAL tool call.
+   *
+   * When the server emits `step_await` for `ask_user_question`, the widget
+   * renders the answer-pill sheet and calls this method once the user
+   * picks. Steps:
+   *   1. POST the answer to `/resume` via `client.resumeFlow`.
+   *   2. Pipe the resulting SSE stream through `connectStream()` so the
+   *      paused agent execution continues.
+   *   3. Append a user-visible bubble with the answer text so the
+   *      transcript reads naturally.
+   */
+  /**
+   * Persist in-progress answers and the current page index for a multi-question
+   * `ask_user_question` payload, so a refresh resumes on the same page with
+   * prior answers intact. Called by ui.ts on every Back/Next/pick interaction.
+   */
+  public persistAskUserQuestionProgress(
+    toolMessage: AgentWidgetMessage,
+    progress: {
+      answers: Record<string, string | string[]>;
+      currentIndex: number;
+    }
+  ): void {
+    const current = this.messages.find((m) => m.id === toolMessage.id);
+    if (!current) return;
+    this.upsertMessage({
+      ...current,
+      agentMetadata: {
+        ...current.agentMetadata,
+        askUserQuestionAnswers: progress.answers,
+        askUserQuestionIndex: progress.currentIndex,
+      },
+    });
+  }
+
+  /**
+   * Flip an `ask_user_question` tool message from awaiting → answered so
+   * render passes stop re-mounting its answer-pill sheet. Idempotent.
+   * When `answers` is provided, persists the full structured answer Record
+   * atomically with the answered flag — guarding against later events that
+   * could re-emit the tool message and clobber the per-pick persisted
+   * answers via top-level merge.
+   */
+  public markAskUserQuestionResolved(
+    toolMessage: AgentWidgetMessage,
+    answers?: Record<string, string | string[]>
+  ): void {
+    const current = this.messages.find((m) => m.id === toolMessage.id);
+    if (!current) return;
+    this.upsertMessage({
+      ...current,
+      agentMetadata: {
+        ...current.agentMetadata,
+        awaitingLocalTool: false,
+        askUserQuestionAnswered: true,
+        ...(answers ? { askUserQuestionAnswers: answers } : {}),
+      },
+    });
+  }
+
+  public async resolveAskUserQuestion(
+    toolMessage: AgentWidgetMessage,
+    answer: string | Record<string, string | string[]>
+  ): Promise<void> {
+    // Idempotent — guards against rapid double-clicks on answer pills before
+    // the re-render swaps the card to its collapsed/answered state.
+    const live = this.messages.find((m) => m.id === toolMessage.id);
+    if (live?.agentMetadata?.askUserQuestionAnswered === true) return;
+
+    const executionId = toolMessage.agentMetadata?.executionId;
+    const toolName = toolMessage.toolCall?.name;
+    if (!executionId || !toolName) {
+      this.callbacks.onError?.(
+        new Error(
+          "resolveAskUserQuestion: message is missing executionId or toolCall.name"
+        )
+      );
+      return;
+    }
+
+    // Flip answered flag first so the next render skips the sheet re-mount,
+    // avoiding the race between removeAskUserQuestionSheet's 180ms slide-out
+    // timer and the renders that fire as the resume stream lands. Pass the
+    // structured answer Record (when present) so it's atomically persisted
+    // alongside the flag — the answered-state review card depends on
+    // `agentMetadata.askUserQuestionAnswers` being populated at render time.
+    //
+    // For single-question payloads, callers (built-in pick handler, plugins)
+    // resolve with a plain string. Derive a `{ [questionText]: answer }` Record
+    // from the toolCall args so the answered-card render path is consistent
+    // with grouped flows.
+    let structuredAnswers: Record<string, string | string[]> | undefined =
+      typeof answer === "string" ? undefined : answer;
+    if (structuredAnswers === undefined && typeof answer === "string") {
+      const args = toolMessage.toolCall?.args as
+        | { questions?: Array<{ question?: unknown }> }
+        | undefined;
+      const questions = Array.isArray(args?.questions) ? args!.questions : [];
+      if (questions.length === 1) {
+        const qText = typeof questions[0]?.question === "string"
+          ? (questions[0].question as string)
+          : "";
+        if (qText) structuredAnswers = { [qText]: answer };
+      }
+    }
+    this.markAskUserQuestionResolved(toolMessage, structuredAnswers);
+
+    // Inject Q→A pair messages — one assistant bubble per question, one user
+    // bubble per answer — so the transcript reads like a normal conversation.
+    // The original ask_user_question tool message is suppressed by the
+    // renderer once `askUserQuestionAnswered` is true. Skipped questions get
+    // a muted italic `*Skipped*` user bubble (rendered through the standard
+    // markdown pipeline).
+    const toolCallId = toolMessage.toolCall!.id;
+    const args = toolMessage.toolCall?.args as
+      | { questions?: Array<{ question?: unknown; header?: unknown }> }
+      | undefined;
+    const questions = Array.isArray(args?.questions) ? args!.questions : [];
+    if (questions.length === 0) {
+      const fallback =
+        typeof answer === "string"
+          ? answer
+          : Object.entries(answer)
+              .map(
+                ([q, v]) => `${q}: ${Array.isArray(v) ? v.join(", ") : v}`
+              )
+              .join(" | ");
+      this.appendMessage({
+        id: `ask-user-answer-${toolCallId}`,
+        role: "user",
+        content: fallback,
+        createdAt: new Date().toISOString(),
+        streaming: false,
+        sequence: this.nextSequence(),
+      });
+    } else {
+      const stored = structuredAnswers ?? {};
+      questions.forEach((p, i) => {
+        const qText = typeof p?.question === "string" ? p.question : "";
+        if (!qText) return;
+        const ans = stored[qText];
+        const answerStr = Array.isArray(ans)
+          ? ans.join(", ")
+          : typeof ans === "string"
+            ? ans
+            : "";
+        this.appendMessage({
+          id: `ask-user-q-${toolCallId}-${i}`,
+          role: "assistant",
+          content: qText,
+          createdAt: new Date().toISOString(),
+          streaming: false,
+          sequence: this.nextSequence(),
+        });
+        this.appendMessage({
+          id: `ask-user-a-${toolCallId}-${i}`,
+          role: "user",
+          content: answerStr || "*Skipped*",
+          createdAt: new Date().toISOString(),
+          streaming: false,
+          sequence: this.nextSequence(),
+        });
+      });
+    }
+
+    try {
+      const response = await this.client.resumeFlow(executionId, {
+        [toolName]: answer,
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        throw new Error(
+          errorData?.error ?? `Resume failed: ${response.status}`
+        );
+      }
+
+      if (response.body) {
+        await this.connectStream(response.body);
+      }
+    } catch (error) {
+      this.callbacks.onError?.(
+        error instanceof Error ? error : new Error(String(error))
+      );
+    }
+  }
+
   public cancel() {
     this.abortController?.abort();
     this.abortController = null;
@@ -1121,6 +1322,18 @@ export class AgentWidgetSession {
     this.setStreaming(false);
     this.setStatus("idle");
     this.callbacks.onMessagesChanged([...this.messages]);
+  }
+
+  public hydrateArtifacts(
+    artifacts: PersonaArtifactRecord[],
+    selectedId: string | null = null
+  ) {
+    this.artifacts.clear();
+    for (const rec of artifacts) {
+      this.artifacts.set(rec.id, { ...rec, status: "complete" });
+    }
+    this.selectedArtifactId = selectedId;
+    this.emitArtifactsState();
   }
 
   private handleEvent = (event: AgentWidgetEvent) => {
@@ -1317,9 +1530,35 @@ export class AgentWidgetSession {
       return;
     }
 
-    this.messages = this.messages.map((existing, idx) =>
-      idx === index ? { ...existing, ...withSequence } : existing
-    );
+    this.messages = this.messages.map((existing, idx) => {
+      if (idx !== index) return existing;
+      const merged = { ...existing, ...withSequence };
+      // Preserve `ask_user_question` answered state across re-emissions.
+      // Top-level merge would otherwise replace `agentMetadata` wholesale —
+      // post-resume events (e.g. `tool_complete` re-emitted from a stale
+      // client-side cache) would wipe `askUserQuestionAnswered` and
+      // `askUserQuestionAnswers`, causing the answered review card to
+      // lose its answers and revert to "(skipped)" placeholders.
+      if (
+        existing.agentMetadata?.askUserQuestionAnswered === true &&
+        withSequence.agentMetadata
+      ) {
+        merged.agentMetadata = {
+          ...withSequence.agentMetadata,
+          askUserQuestionAnswered: true,
+          ...(existing.agentMetadata.askUserQuestionAnswers
+            ? {
+                askUserQuestionAnswers:
+                  existing.agentMetadata.askUserQuestionAnswers,
+              }
+            : {}),
+          // Keep awaiting flag false once resolved — never let a stale
+          // re-emit flip us back to awaiting.
+          awaitingLocalTool: false,
+        };
+      }
+      return merged;
+    });
     this.messages = this.sortMessages(this.messages);
     this.callbacks.onMessagesChanged([...this.messages]);
   }

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1759,6 +1759,30 @@
   animation: persona-message-actions-fade-in 0.3s ease-out forwards;
 }
 
+/* ask_user_question — collapsed answered state.
+ * When the user picks an option, the interactive card is replaced with a
+ * plain assistant bubble showing the question text. A short fade + slight
+ * upward slide sells the "card resolved into history" feel.
+ */
+@keyframes persona-ask-resolved {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+[data-ask-answered="true"] {
+  animation: persona-ask-resolved 0.22s ease-out;
+}
+@media (prefers-reduced-motion: reduce) {
+  [data-ask-answered="true"] {
+    animation: none;
+  }
+}
+
 /* Action bar alignment */
 .persona-message-actions-left {
   justify-content: flex-start;
@@ -2955,5 +2979,413 @@
     background: none !important;
     -webkit-background-clip: border-box !important;
             background-clip: border-box !important;
+  }
+}
+
+/* ========================================================================
+ * ask_user_question — built-in answer-pill sheet
+ * Slides in over the composer when the assistant invokes `ask_user_question`.
+ * Overridable via `config.features.askUserQuestion.styles`.
+ * ======================================================================== */
+
+[data-persona-root] .persona-hidden {
+  display: none !important;
+}
+
+/* In-transcript stub — small "Awaiting…" chip. */
+[data-persona-root] .persona-ask-stub {
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  color: var(--persona-muted, #6b7280);
+  background: var(--persona-container, #f3f4f6);
+  border: 1px dashed var(--persona-border, #e5e7eb);
+}
+
+[data-persona-root] .persona-ask-stub-label {
+  font-weight: 500;
+}
+
+/* Sheet container — absolute inside composerOverlay. */
+[data-persona-root] .persona-ask-sheet {
+  position: absolute;
+  left: 0.75rem;
+  right: 0.75rem;
+  bottom: calc(100% + 0.5rem);
+  box-sizing: border-box;
+  padding: 0.85rem 1rem;
+  background: var(--persona-ask-sheet-bg, var(--persona-surface, #ffffff));
+  border: 1px solid var(--persona-ask-sheet-border, var(--persona-border, #e5e7eb));
+  border-radius: 1rem;
+  box-shadow: var(--persona-ask-sheet-shadow, 0 12px 28px -10px rgba(0, 0, 0, 0.15), 0 4px 10px -6px rgba(0, 0, 0, 0.08));
+  transition: transform var(--persona-ask-sheet-duration, 180ms) ease, opacity var(--persona-ask-sheet-duration, 180ms) ease;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+[data-persona-root] .persona-ask-sheet.persona-ask-sheet-enter {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+[data-persona-root] .persona-ask-sheet.persona-ask-sheet-leave {
+  opacity: 0;
+  transform: translateY(8px);
+  pointer-events: none;
+}
+
+/* Header row — question + close button */
+[data-persona-root] .persona-ask-sheet-header {
+  margin-bottom: 0.55rem;
+}
+
+[data-persona-root] .persona-ask-sheet-question {
+  font-size: 0.92rem;
+  font-weight: 500;
+  line-height: 1.35;
+  color: var(--persona-text, #1f2937);
+  min-height: 1.35em;
+}
+
+[data-persona-root] .persona-ask-question-skeleton {
+  display: block;
+  width: 60%;
+  height: 0.85rem;
+  border-radius: 0.3rem;
+  background: linear-gradient(90deg,
+    var(--persona-container, #f3f4f6) 0%,
+    var(--persona-border, #e5e7eb) 50%,
+    var(--persona-container, #f3f4f6) 100%);
+  background-size: 200% 100%;
+  animation: persona-ask-skeleton-shimmer 1.2s ease-in-out infinite;
+  color: transparent;
+}
+
+[data-persona-root] .persona-ask-sheet-step-inline {
+  flex: 0 0 auto;
+  font-size: 0.78rem;
+  line-height: 1;
+  color: var(--persona-text-muted, #6b7280);
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+}
+
+[data-persona-root] .persona-ask-sheet-step-inline:empty {
+  display: none;
+}
+
+/* Option list — stacked one per row by default ("rows" layout). The "pills"
+   layout opt-in switches to horizontal wrap with compact pills; see also
+   horizontalPillsAskPlugin example for a custom variant. */
+[data-persona-root] .persona-ask-pills {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  row-gap: 0.4rem;
+  column-gap: 0;
+}
+
+[data-persona-root] .persona-ask-pills--rows {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  gap: 0.4rem;
+}
+
+/* Pills layout opt-in — horizontal wrap, auto-width compact pills. */
+[data-persona-root] .persona-ask-sheet--pills .persona-ask-pills:not(.persona-ask-pills--rows) {
+  flex-direction: row;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+[data-persona-root] .persona-ask-sheet--pills .persona-ask-pills:not(.persona-ask-pills--rows) .persona-ask-pill {
+  width: auto;
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--persona-ask-pill-radius, 9999px);
+}
+
+[data-persona-root] .persona-ask-pill {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  width: 100%;
+  text-align: left;
+  padding: 0.65rem 0.9rem;
+  border-radius: var(--persona-ask-pill-radius, 0.6rem);
+  background: var(--persona-ask-pill-bg, transparent);
+  color: var(--persona-ask-pill-fg, var(--persona-text, #1f2937));
+  border: 1px solid var(--persona-border, #e5e7eb);
+  font-size: 0.9rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.1s ease;
+}
+
+[data-persona-root] .persona-ask-pill:hover:not(:disabled):not(.persona-ask-pill-skeleton):not(.persona-ask-pill-selected):not([aria-pressed="true"]) {
+  border-color: var(--persona-text, #1f2937);
+  background: var(--persona-container, #f3f4f6);
+}
+
+[data-persona-root] .persona-ask-pill:active {
+  transform: translateY(1px);
+}
+
+[data-persona-root] .persona-ask-pill-selected,
+[data-persona-root] .persona-ask-pill[aria-pressed="true"] {
+  background: var(--persona-ask-pill-bg-selected, var(--persona-accent, #0f0f0f));
+  color: var(--persona-ask-pill-fg-selected, #fafafa);
+  border-color: var(--persona-ask-pill-bg-selected, var(--persona-accent, #0f0f0f));
+}
+
+[data-persona-root] .persona-ask-pill:focus:not(:focus-visible) {
+  outline: none;
+}
+
+[data-persona-root] .persona-ask-pill:focus-visible {
+  outline: 2px solid var(--persona-accent, #0f0f0f);
+  outline-offset: 2px;
+}
+
+[data-persona-root] .persona-ask-pill-custom {
+  border-style: dashed;
+}
+
+[data-persona-root] .persona-ask-pill-skeleton {
+  min-width: 5rem;
+  height: 2rem;
+  padding: 0;
+  border: 1px solid var(--persona-border, #e5e7eb);
+  background: linear-gradient(90deg,
+    var(--persona-container, #f3f4f6) 0%,
+    var(--persona-border, #e5e7eb) 50%,
+    var(--persona-container, #f3f4f6) 100%);
+  background-size: 200% 100%;
+  animation: persona-ask-skeleton-shimmer 1.2s ease-in-out infinite;
+}
+
+@keyframes persona-ask-skeleton-shimmer {
+  0%   { background-position: 100% 50%; }
+  100% { background-position: -100% 50%; }
+}
+
+/* Row layout — full-width stacked rows with always-visible description
+   and a right-edge affordance (number badge for single-select, check for
+   multi-select). Layered on top of .persona-ask-pill base styles. */
+[data-persona-root] .persona-ask-row {
+  align-items: stretch;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.7rem 0.9rem;
+}
+
+[data-persona-root] .persona-ask-row-content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+[data-persona-root] .persona-ask-row-label {
+  font-size: 0.92rem;
+  font-weight: 600;
+  line-height: 1.25;
+  color: inherit;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+[data-persona-root] .persona-ask-row-description {
+  font-size: 0.82rem;
+  font-weight: 400;
+  line-height: 1.35;
+  color: var(--persona-text-muted, #6b7280);
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+
+[data-persona-root] .persona-ask-pill-selected .persona-ask-row-description,
+[data-persona-root] .persona-ask-pill[aria-pressed="true"] .persona-ask-row-description {
+  color: var(--persona-ask-pill-fg-selected, #fafafa);
+  opacity: 0.85;
+}
+
+[data-persona-root] .persona-ask-row-affordance {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  align-self: center;
+}
+
+[data-persona-root] .persona-ask-row-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: 0.4rem;
+  border: 1px solid var(--persona-border, #e5e7eb);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--persona-text-muted, #6b7280);
+  background: transparent;
+}
+
+[data-persona-root] .persona-ask-pill-selected .persona-ask-row-badge,
+[data-persona-root] .persona-ask-pill[aria-pressed="true"] .persona-ask-row-badge {
+  border-color: var(--persona-ask-pill-fg-selected, #fafafa);
+  color: var(--persona-ask-pill-fg-selected, #fafafa);
+}
+
+[data-persona-root] .persona-ask-row-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 0.35rem;
+  border: 1.5px solid var(--persona-border, #d1d5db);
+  background: transparent;
+  position: relative;
+}
+
+[data-persona-root] .persona-ask-pill-selected .persona-ask-row-check,
+[data-persona-root] .persona-ask-pill[aria-pressed="true"] .persona-ask-row-check {
+  background: var(--persona-ask-pill-fg-selected, #fafafa);
+  border-color: var(--persona-ask-pill-fg-selected, #fafafa);
+}
+
+[data-persona-root] .persona-ask-pill-selected .persona-ask-row-check::after,
+[data-persona-root] .persona-ask-pill[aria-pressed="true"] .persona-ask-row-check::after {
+  content: "";
+  width: 0.45rem;
+  height: 0.75rem;
+  border-right: 2px solid var(--persona-ask-pill-bg-selected, var(--persona-accent, #0f0f0f));
+  border-bottom: 2px solid var(--persona-ask-pill-bg-selected, var(--persona-accent, #0f0f0f));
+  transform: rotate(45deg) translate(-1px, -1px);
+}
+
+[data-persona-root] .persona-ask-row.persona-ask-pill-skeleton {
+  height: 3rem;
+}
+
+/* Other row (rows mode) — composite row that contains the free-text input
+ * directly. The input fills the row body; the badge sits on the right. */
+[data-persona-root] .persona-ask-row--other {
+  cursor: text;
+}
+
+[data-persona-root] .persona-ask-row-input {
+  flex: 1;
+  min-width: 0;
+  border: none;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  font-size: 0.92rem;
+  color: inherit;
+  outline: none;
+  width: 100%;
+}
+
+[data-persona-root] .persona-ask-row-input::placeholder {
+  color: var(--persona-text-muted, #6b7280);
+  opacity: 1;
+}
+
+/* Free-text expansion row (pills layout only) */
+[data-persona-root] .persona-ask-free-text {
+  width: 100%;
+}
+
+[data-persona-root] .persona-ask-free-text--rows {
+  margin-top: 0.4rem;
+}
+
+[data-persona-root] .persona-ask-free-text-input {
+  padding: 0.5rem 0.8rem;
+  border: 1px solid var(--persona-border, #e5e7eb);
+  border-radius: 0.55rem;
+  font-size: 0.88rem;
+  background: var(--persona-ask-input-bg, var(--persona-surface, #ffffff));
+  color: var(--persona-text, #1f2937);
+}
+
+[data-persona-root] .persona-ask-free-text-input:focus {
+  outline: 2px solid var(--persona-accent, #0f0f0f);
+  outline-offset: 1px;
+}
+
+[data-persona-root] .persona-ask-free-text-submit,
+[data-persona-root] .persona-ask-multi-submit {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.55rem;
+  background: var(--persona-accent, #0f0f0f);
+  color: #fafafa;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+[data-persona-root] .persona-ask-free-text-submit:disabled,
+[data-persona-root] .persona-ask-multi-submit:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Nav row — Back / Skip / Next-or-Submit buttons for grouped payloads. */
+[data-persona-root] .persona-ask-nav-back,
+[data-persona-root] .persona-ask-nav-skip {
+  padding: 0.45rem 0.85rem;
+  border: 1px solid transparent;
+  border-radius: 0.55rem;
+  background: transparent;
+  color: var(--persona-text-muted, #6b7280);
+  font-size: 0.85rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+[data-persona-root] .persona-ask-nav-back:hover:not(:disabled),
+[data-persona-root] .persona-ask-nav-skip:hover:not(:disabled) {
+  background: var(--persona-container, #f3f4f6);
+  color: var(--persona-text, #1f2937);
+}
+
+[data-persona-root] .persona-ask-nav-back:disabled {
+  opacity: 0.35;
+  cursor: not-allowed;
+}
+
+[data-persona-root] .persona-ask-nav-next {
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.55rem;
+  background: var(--persona-accent, #0f0f0f);
+  color: #fafafa;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity 0.15s ease;
+}
+
+[data-persona-root] .persona-ask-nav-next:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  [data-persona-root] .persona-ask-sheet,
+  [data-persona-root] .persona-ask-pill-skeleton,
+  [data-persona-root] .persona-ask-question-skeleton {
+    transition: none !important;
+    animation: none !important;
   }
 }

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -205,6 +205,31 @@ export type AgentMessageMetadata = {
    * or `prompt` step inside the nested flow). Stable key for that step.
    */
   parentStepId?: string;
+  /**
+   * Set to `true` on a tool-variant message produced from a `step_await`
+   * event (`awaitReason: "local_tool_required"`). Signals to UI code that
+   * the tool call is a LOCAL tool and the server is paused waiting for a
+   * `POST /v1/dispatch/resume` with the user's answer keyed by tool name.
+   */
+  awaitingLocalTool?: boolean;
+  /**
+   * Set to `true` once the user has picked / typed / dismissed an answer for
+   * an `ask_user_question` tool call, so renderers stop re-mounting the
+   * answer-pill sheet for this tool call on subsequent render passes.
+   */
+  askUserQuestionAnswered?: boolean;
+  /**
+   * In-progress answers for a multi-question `ask_user_question` payload,
+   * keyed by question text. Persisted across refresh so the user lands back
+   * where they were if the page reloads mid-flow. Cleared once
+   * `askUserQuestionAnswered` flips to `true`.
+   */
+  askUserQuestionAnswers?: Record<string, string | string[]>;
+  /**
+   * Current page index for a multi-question `ask_user_question` payload's
+   * paginated stepper. Persists alongside `askUserQuestionAnswers`.
+   */
+  askUserQuestionIndex?: number;
 };
 
 export type AgentWidgetRequestMiddlewareContext = {
@@ -270,6 +295,8 @@ export type AgentWidgetActionHandler = (
 export type AgentWidgetStoredState = {
   messages?: AgentWidgetMessage[];
   metadata?: Record<string, unknown>;
+  artifacts?: PersonaArtifactRecord[];
+  selectedArtifactId?: string | null;
 };
 
 export interface AgentWidgetStorageAdapter {
@@ -857,6 +884,118 @@ export type AgentWidgetFeatureFlags = {
   artifacts?: AgentWidgetArtifactsFeature;
   /** Reveal animation for streaming assistant text. */
   streamAnimation?: AgentWidgetStreamAnimationFeature;
+  /**
+   * Built-in interactive answer-pill sheet shown when the assistant invokes
+   * the `ask_user_question` tool. Slides up over the composer with tappable
+   * pills + optional free-text input.
+   */
+  askUserQuestion?: AgentWidgetAskUserQuestionFeature;
+};
+
+/**
+ * Single selectable option in an `ask_user_question` prompt.
+ * Mirrors Anthropic's AskUserQuestion schema.
+ */
+export type AskUserQuestionOption = {
+  /** Pill label (required). */
+  label: string;
+  /** Optional long-form description (shown as a subtitle on tap-hover). */
+  description?: string;
+  /** Optional rich preview — reserved for future rendering; ignored in v1. */
+  preview?: string;
+};
+
+/**
+ * A single question in an `ask_user_question` tool call.
+ * The tool may carry 1–8 prompts. When more than one is supplied, the built-in
+ * renderer paginates them as a "Question N of M" stepper with Back / Next /
+ * Submit-all controls; single-question payloads render without stepper chrome.
+ */
+export type AskUserQuestionPrompt = {
+  /** The question text shown to the user. */
+  question: string;
+  /** Optional short header label (≤12 chars) used as a compact group title. */
+  header?: string;
+  /** 2–4 selectable options. */
+  options: AskUserQuestionOption[];
+  /** When true, the user can pick multiple options and submit together. Default false. */
+  multiSelect?: boolean;
+  /** When true, a free-text "Other…" pill expands to an input. Default true. */
+  allowFreeText?: boolean;
+};
+
+/** Parsed payload of an `ask_user_question` tool call. */
+export type AskUserQuestionPayload = {
+  /** 1–8 questions. Anything beyond the renderer's cap is truncated with a console warning. */
+  questions: AskUserQuestionPrompt[];
+};
+
+/**
+ * Style overrides for the answer-pill sheet. All values are raw CSS strings
+ * and are plumbed through as CSS custom properties on the sheet root.
+ */
+export type AgentWidgetAskUserQuestionStyles = {
+  sheetBackground?: string;
+  sheetBorder?: string;
+  sheetShadow?: string;
+  pillBackground?: string;
+  pillBackgroundSelected?: string;
+  pillTextColor?: string;
+  pillTextColorSelected?: string;
+  pillBorderRadius?: string;
+  customInputBackground?: string;
+};
+
+/**
+ * Feature config for the built-in `ask_user_question` answer-pill sheet.
+ * When a tool call with the name `ask_user_question` arrives, the widget
+ * renders an interactive sheet over the composer in place of the generic
+ * tool bubble.
+ */
+export type AgentWidgetAskUserQuestionFeature = {
+  /** Enable the feature. Defaults to true. When false, `ask_user_question` renders as a regular tool bubble. */
+  enabled?: boolean;
+  /** Slide-in animation duration in ms. Defaults to 180. */
+  slideInMs?: number;
+  /** Label for the free-text pill. Defaults to "Other…". */
+  freeTextLabel?: string;
+  /** Placeholder text in the free-text input. Defaults to "Type your answer…". */
+  freeTextPlaceholder?: string;
+  /** Button label for submitting multi-select / free-text answers. Defaults to "Send". */
+  submitLabel?: string;
+  /** Button label advancing to the next question in grouped (paginated) payloads. Defaults to "Next". */
+  nextLabel?: string;
+  /** Button label moving back to the previous question in grouped payloads. Defaults to "Back". */
+  backLabel?: string;
+  /** Button label submitting all answers from the final page of a grouped payload. Defaults to "Submit all". */
+  submitAllLabel?: string;
+  /**
+   * In grouped (multi-question) mode, auto-advance to the next page after a
+   * single-select pill pick or free-text submit on intermediate pages.
+   * Defaults to `true`. The final page never auto-submits — users always
+   * confirm with an explicit "Submit all" click. Multi-select pages always
+   * require an explicit Next regardless of this setting.
+   */
+  groupedAutoAdvance?: boolean;
+  /**
+   * Visual layout for the option list.
+   * - `"rows"` (default) — full-width stacked rows with always-visible
+   *   descriptions, right-edge number badges (single-select) or checkboxes
+   *   (multi-select), and an always-visible inline "Other" input.
+   * - `"pills"` — legacy compact pill list with horizontal wrap; description
+   *   surfaces as a tooltip and the "Other…" pill expands on click.
+   */
+  layout?: "rows" | "pills";
+  /**
+   * Button label for skipping the current question in grouped payloads.
+   * Defaults to "Skip". On intermediate pages Skip advances without recording
+   * an answer; on the final page Skip submits the partial answer record
+   * (skipped questions absent from the resolved object). For single-question
+   * payloads Skip behaves like dismiss.
+   */
+  skipLabel?: string;
+  /** Style overrides for the sheet and pills. */
+  styles?: AgentWidgetAskUserQuestionStyles;
 };
 
 export type SSEEventRecord = {
@@ -2823,6 +2962,17 @@ export type AgentWidgetConfig = {
   autoFocusInput?: boolean;
   launcher?: AgentWidgetLauncherConfig;
   initialMessages?: AgentWidgetMessage[];
+  /**
+   * Artifacts to hydrate into the pane at init. Typically populated from
+   * `storageAdapter.load()` alongside `initialMessages` so the artifact pane
+   * survives a page refresh.
+   */
+  initialArtifacts?: PersonaArtifactRecord[];
+  /**
+   * Which artifact id (if any) should be selected in the pane at init. Paired
+   * with `initialArtifacts`.
+   */
+  initialSelectedArtifactId?: string | null;
   suggestionChips?: string[];
   suggestionChipsConfig?: AgentWidgetSuggestionChipsConfig;
   debug?: boolean;

--- a/packages/widget/src/types/theme.ts
+++ b/packages/widget/src/types/theme.ts
@@ -237,6 +237,19 @@ export interface MessageTokens {
   border?: TokenReference<'color'>;
 }
 
+/**
+ * Welcome / intro card rendered above the message list when no messages exist.
+ * Set `copy.showWelcomeCard: false` to hide it; use `layout.slots["body-top"]`
+ * to replace it wholesale.
+ */
+export interface IntroCardTokens extends ComponentTokenSet {
+  background?: TokenReference<'color'>;
+  borderRadius?: TokenReference<'radius'>;
+  padding?: TokenReference<'spacing'>;
+  /** Box-shadow on the intro card (token ref or raw CSS, e.g. `none`). */
+  shadow?: string;
+}
+
 /** Collapsible widget chrome (tool bubbles, reasoning bubbles, approval bubbles). */
 export interface CollapsibleWidgetTokens {
   /** Background for content areas. */
@@ -449,6 +462,8 @@ export interface ComponentTokens {
   panel: PanelTokens;
   header: HeaderTokens;
   message: MessageTokens;
+  /** Welcome / intro card shown above the message list. */
+  introCard?: IntroCardTokens;
   /** Markdown surfaces (chat + artifact pane). */
   markdown?: MarkdownTokens;
   voice: VoiceTokens;

--- a/packages/widget/src/ui.ask-user-question-plugin.test.ts
+++ b/packages/widget/src/ui.ask-user-question-plugin.test.ts
@@ -1,0 +1,649 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentExperience } from "./ui";
+import type { AgentWidgetPlugin } from "./plugins/types";
+
+const createMount = () => {
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  return mount;
+};
+
+const injectAskUserQuestion = (
+  controller: ReturnType<typeof createAgentExperience>,
+  { id = "tool-1", status = "complete" as const, args }: {
+    id?: string;
+    status?: "pending" | "running" | "complete";
+    args?: unknown;
+  } = {}
+) => {
+  controller.injectTestMessage({
+    type: "message",
+    message: {
+      id,
+      role: "assistant",
+      content: "",
+      createdAt: "2026-04-24T00:00:00.000Z",
+      streaming: false,
+      variant: "tool",
+      toolCall: {
+        id,
+        name: "ask_user_question",
+        status,
+        args: args ?? {
+          questions: [
+            { question: "Which audience?", options: [{ label: "Hobbyists" }, { label: "Pros" }] },
+          ],
+        },
+        chunks: [],
+      },
+      agentMetadata: {
+        executionId: "exec_123",
+        awaitingLocalTool: true,
+      },
+    },
+  });
+};
+
+describe("renderAskUserQuestion plugin hook", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    if (typeof localStorage !== "undefined") localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("renders a plugin-returned element inline in the transcript when provided", () => {
+    const plugin: AgentWidgetPlugin = {
+      id: "custom-asker",
+      renderAskUserQuestion: ({ payload }) => {
+        const root = document.createElement("div");
+        root.setAttribute("data-test-id", "custom-ask");
+        root.textContent = payload?.questions?.[0]?.question ?? "";
+        return root;
+      },
+    };
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      plugins: [plugin],
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller);
+
+    const custom = mount.querySelector('[data-test-id="custom-ask"]');
+    expect(custom).not.toBeNull();
+    expect(custom?.textContent).toBe("Which audience?");
+
+    // The built-in overlay sheet must NOT be mounted when a plugin handles the UI.
+    const overlaySheet = mount.querySelector("[data-persona-ask-sheet-for]");
+    expect(overlaySheet).toBeNull();
+
+    controller.destroy();
+  });
+
+  it("falls back to the built-in overlay sheet when the plugin returns null", () => {
+    const plugin: AgentWidgetPlugin = {
+      id: "passthrough-asker",
+      renderAskUserQuestion: () => null,
+    };
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      plugins: [plugin],
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller);
+
+    const overlaySheet = mount.querySelector("[data-persona-ask-sheet-for]");
+    expect(overlaySheet).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  it("does not duplicate the built-in sheet on re-render when a plugin owns the message", () => {
+    const plugin: AgentWidgetPlugin = {
+      id: "owning-plugin",
+      renderAskUserQuestion: ({ payload }) => {
+        const root = document.createElement("div");
+        root.setAttribute("data-test-id", "owning-plugin");
+        root.textContent = payload?.questions?.[0]?.question ?? "";
+        return root;
+      },
+    };
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      plugins: [plugin],
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller);
+    expect(mount.querySelector("[data-persona-ask-sheet-for]")).toBeNull();
+
+    // Force a re-render by injecting a second message — the ask_user_question
+    // wrapper now goes through the render path again. The built-in overlay
+    // sheet must NOT appear; the plugin still owns the UI.
+    controller.injectTestMessage({
+      type: "message",
+      message: {
+        id: "user-1",
+        role: "user",
+        content: "ping",
+        createdAt: "2026-04-26T00:00:00.000Z",
+        streaming: false,
+      },
+    });
+
+    expect(mount.querySelector("[data-persona-ask-sheet-for]")).toBeNull();
+    expect(mount.querySelector('[data-test-id="owning-plugin"]')).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  it("preserves plugin button click listeners across morph re-renders", () => {
+    const resolveSpy = vi.fn();
+    const plugin: AgentWidgetPlugin = {
+      id: "click-listener-plugin",
+      renderAskUserQuestion: ({ resolve }) => {
+        const root = document.createElement("div");
+        root.setAttribute("data-test-id", "click-root");
+        const btn = document.createElement("button");
+        btn.type = "button";
+        btn.setAttribute("data-test-id", "click-pill");
+        btn.textContent = "Pick me";
+        // Single delegated listener at root — pattern recommended for plugins.
+        root.addEventListener("click", (e) => {
+          if ((e.target as HTMLElement).getAttribute("data-test-id") === "click-pill") {
+            resolve("Pick me");
+            resolveSpy();
+          }
+        });
+        root.appendChild(btn);
+        return root;
+      },
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"type":"flow_complete","success":true}\n\n'));
+          c.close();
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      plugins: [plugin],
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller);
+
+    // Force a re-render before the click — this is exactly the scenario
+    // where innerHTML-based morph used to drop listeners on the freshly-built
+    // plugin root.
+    controller.injectTestMessage({
+      type: "message",
+      message: {
+        id: "noise",
+        role: "user",
+        content: "noise",
+        createdAt: "2026-04-26T00:00:00.000Z",
+        streaming: false,
+      },
+    });
+
+    const pill = mount.querySelector<HTMLButtonElement>('[data-test-id="click-pill"]');
+    expect(pill).not.toBeNull();
+    pill!.click();
+    expect(resolveSpy).toHaveBeenCalled();
+
+    controller.destroy();
+  });
+
+  it("suppresses the plugin's interactive sheet once answered and injects Q→A pair messages", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"type":"flow_complete","success":true}\n\n'));
+          c.close();
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    // Plugin renders an interactive card while the question is awaiting an
+    // answer. Once answered, the widget suppresses the original tool message
+    // entirely — the plugin renderer is invoked but returns null — and the
+    // session injects Q→A pair messages (assistant question + user answer)
+    // that render through the standard transcript pipeline.
+    const plugin: AgentWidgetPlugin = {
+      id: "click-pill-plugin",
+      renderAskUserQuestion: ({ message, payload, resolve }) => {
+        if (message?.agentMetadata?.askUserQuestionAnswered === true) {
+          return null;
+        }
+        const root = document.createElement("div");
+        root.setAttribute("data-test-id", "interactive-card");
+        const opts = payload?.questions?.[0]?.options ?? [];
+        opts.forEach((opt) => {
+          if (!opt?.label) return;
+          const btn = document.createElement("button");
+          btn.type = "button";
+          btn.textContent = opt.label;
+          btn.setAttribute("data-test-id", `pick-${opt.label}`);
+          btn.addEventListener("click", () => resolve(opt.label));
+          root.appendChild(btn);
+        });
+        return root;
+      },
+    };
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      plugins: [plugin],
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller);
+
+    expect(mount.querySelector('[data-test-id="interactive-card"]')).not.toBeNull();
+
+    const pick = mount.querySelector<HTMLButtonElement>('[data-test-id="pick-Hobbyists"]');
+    expect(pick).not.toBeNull();
+    pick!.click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // After answer: interactive card gone, no built-in answered card, and
+    // the transcript contains the Q→A pair messages with the picked answer.
+    expect(mount.querySelector('[data-test-id="interactive-card"]')).toBeNull();
+    expect(mount.querySelector('[data-ask-answered-card="true"]')).toBeNull();
+    expect(mount.textContent).toContain("Which audience?");
+    expect(mount.textContent).toContain("Hobbyists");
+
+    controller.destroy();
+  });
+
+  it("ignores rapid double-clicks on the same answer pill (idempotent resolve)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"type":"flow_complete","success":true}\n\n'));
+          c.close();
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    let resolveRef: ((answer: string) => void) | undefined;
+    const plugin: AgentWidgetPlugin = {
+      id: "double-click-plugin",
+      renderAskUserQuestion: ({ resolve }) => {
+        resolveRef = resolve;
+        const el = document.createElement("div");
+        el.setAttribute("data-test-id", "dbl");
+        return el;
+      },
+    };
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      plugins: [plugin],
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller);
+    expect(resolveRef).toBeDefined();
+
+    // Three rapid resolves before any re-render cycle settles.
+    resolveRef!("First");
+    resolveRef!("Second");
+    resolveRef!("Third");
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Only the FIRST answer should have hit the network.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+    expect(body.toolOutputs.ask_user_question).toBe("First");
+
+    controller.destroy();
+  });
+
+  it("auto-advances to the next page when a single-select pill is picked in grouped mode (default)", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller, {
+      args: {
+        questions: [
+          { question: "Q1?", options: [{ label: "A" }, { label: "B" }] },
+          { question: "Q2?", options: [{ label: "C" }, { label: "D" }] },
+          { question: "Q3?", options: [{ label: "E" }, { label: "F" }] },
+        ],
+      },
+    });
+
+    const sheet = mount.querySelector<HTMLElement>("[data-persona-ask-sheet-for]")!;
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("0");
+    (sheet.querySelector('[data-option-label="A"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("1");
+
+    // Final page: pick should NOT auto-submit — Submit-all button still present.
+    (sheet.querySelector('[data-option-label="C"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("2");
+    (sheet.querySelector('[data-option-label="E"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("2");
+    expect(sheet.querySelector('[data-ask-user-action="submit-all"]')).not.toBeNull();
+    expect(mount.querySelector("[data-persona-ask-sheet-for]")).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  it("injects Q→A pair messages with the user's picks (not '*Skipped*') after submit-all", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"type":"flow_complete","success":true}\n\n'));
+          c.close();
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller, {
+      args: {
+        questions: [
+          { header: "Tone", question: "Pick a tone", options: [{ label: "Story-driven" }, { label: "Punchy" }] },
+          { header: "Sections", question: "Pick a section", options: [{ label: "Testimonials" }, { label: "Hero" }] },
+          { header: "CTA", question: "Pick a CTA", options: [{ label: "Sign up" }, { label: "Buy now" }] },
+        ],
+      },
+    });
+
+    const sheet = mount.querySelector<HTMLElement>("[data-persona-ask-sheet-for]")!;
+
+    // Page 1 → pick Story-driven, auto-advance to page 2.
+    (sheet.querySelector('[data-option-label="Story-driven"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("1");
+
+    // Page 2 → pick Testimonials, auto-advance to page 3.
+    (sheet.querySelector('[data-option-label="Testimonials"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("2");
+
+    // Page 3 (final) → pick Sign up. Final page does NOT auto-submit.
+    (sheet.querySelector('[data-option-label="Sign up"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("2");
+
+    // Click Submit-all → fires resolveAskUserQuestion + transitions to answered.
+    const submitAll = sheet.querySelector<HTMLButtonElement>(
+      '[data-ask-user-action="submit-all"]'
+    )!;
+    expect(submitAll.disabled).toBe(false);
+    submitAll.click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Original tool message suppressed; transcript now contains assistant Q
+    // bubbles + user A bubbles in alternating order. Each picked answer
+    // appears in the transcript, none rendered as "*Skipped*".
+    expect(mount.querySelector('[data-ask-answered-card="true"]')).toBeNull();
+    const transcriptText = mount.textContent ?? "";
+    expect(transcriptText).toContain("Pick a tone");
+    expect(transcriptText).toContain("Story-driven");
+    expect(transcriptText).toContain("Pick a section");
+    expect(transcriptText).toContain("Testimonials");
+    expect(transcriptText).toContain("Pick a CTA");
+    expect(transcriptText).toContain("Sign up");
+    expect(transcriptText).not.toContain("*Skipped*");
+
+    controller.destroy();
+  });
+
+  it("includes pending free-text answer on the final page in the Q→A transcript (not '*Skipped*')", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"type":"flow_complete","success":true}\n\n'));
+          c.close();
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller, {
+      args: {
+        questions: [
+          { header: "Tone", question: "Pick a tone", options: [{ label: "Story-driven" }, { label: "Punchy" }] },
+          { header: "Sections", question: "Pick a section", options: [{ label: "Testimonials" }, { label: "Hero" }] },
+          { header: "CTA", question: "Pick a CTA", options: [{ label: "Sign up" }, { label: "Buy now" }] },
+        ],
+      },
+    });
+
+    const sheet = mount.querySelector<HTMLElement>("[data-persona-ask-sheet-for]")!;
+
+    // Page 1 → pick Story-driven, auto-advance to page 2.
+    (sheet.querySelector('[data-option-label="Story-driven"]') as HTMLElement).click();
+    // Page 2 → pick Testimonials, auto-advance to page 3.
+    (sheet.querySelector('[data-option-label="Testimonials"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("2");
+
+    // Page 3 → user types free-text "test" without clicking Send first, then
+    // hits Submit-all directly. The free-text input value must be flushed
+    // through to BOTH the structured payload AND the persisted metadata so
+    // the answered review card reflects the user's actual answer.
+    // User flow: type "test", press Enter to submit-free-text (which is the
+    // gate that persists the answer to message metadata + enables Submit-all),
+    // then click Submit-all.
+    const freeInput = sheet.querySelector<HTMLInputElement>(
+      '[data-ask-free-text-input="true"]'
+    )!;
+    freeInput.value = "test";
+    freeInput.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true })
+    );
+
+    const submitAll = sheet.querySelector<HTMLButtonElement>(
+      '[data-ask-user-action="submit-all"]'
+    )!;
+    submitAll.click();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mount.querySelector('[data-ask-answered-card="true"]')).toBeNull();
+    const transcriptText = mount.textContent ?? "";
+    expect(transcriptText).toContain("Story-driven");
+    expect(transcriptText).toContain("Testimonials");
+    // The free-text value typed on the final page should also appear.
+    expect(transcriptText).toContain("test");
+    expect(transcriptText).not.toContain("*Skipped*");
+
+    controller.destroy();
+  });
+
+  it("digit keyboard shortcut picks the matching row even when focus is on document.body", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller, {
+      args: {
+        questions: [
+          { question: "Q1?", options: [{ label: "Alpha" }, { label: "Beta" }, { label: "Gamma" }] },
+          { question: "Q2?", options: [{ label: "X" }, { label: "Y" }] },
+        ],
+      },
+    });
+
+    const sheet = mount.querySelector<HTMLElement>("[data-persona-ask-sheet-for]")!;
+    expect(sheet.getAttribute("data-ask-layout")).toBe("rows");
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("0");
+
+    // Focus on body — no element inside the overlay subtree is focused.
+    if (document.activeElement && document.activeElement !== document.body) {
+      (document.activeElement as HTMLElement).blur?.();
+    }
+
+    // Dispatch the digit keypress on `mount` — the listener on `mount`
+    // catches it regardless of focus location. In grouped single-select mode,
+    // a successful pick auto-advances to the next page (default behavior).
+    mount.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "2", bubbles: true })
+    );
+
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("1");
+
+    controller.destroy();
+  });
+
+  it("digit keypress is not hijacked when typing into the free-text input", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller, {
+      args: {
+        questions: [
+          {
+            question: "Pick one",
+            options: [{ label: "Alpha" }, { label: "Beta" }, { label: "Gamma" }],
+            allowFreeText: true,
+          },
+        ],
+      },
+    });
+
+    const sheet = mount.querySelector<HTMLElement>("[data-persona-ask-sheet-for]")!;
+    const input = sheet.querySelector<HTMLInputElement>(
+      '[data-ask-free-text-input="true"]'
+    )!;
+    input.focus();
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "2", bubbles: true })
+    );
+
+    // No row should have been picked — input is the focused target so the
+    // mount-level handler bails out.
+    const beta = sheet.querySelector<HTMLElement>('[data-option-label="Beta"]')!;
+    expect(beta.getAttribute("aria-pressed")).toBe("false");
+
+    controller.destroy();
+  });
+
+  it("respects groupedAutoAdvance: false — pick stays on current page", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      features: { askUserQuestion: { groupedAutoAdvance: false } },
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller, {
+      args: {
+        questions: [
+          { question: "Q1?", options: [{ label: "A" }, { label: "B" }] },
+          { question: "Q2?", options: [{ label: "C" }, { label: "D" }] },
+        ],
+      },
+    });
+
+    const sheet = mount.querySelector<HTMLElement>("[data-persona-ask-sheet-for]")!;
+    (sheet.querySelector('[data-option-label="A"]') as HTMLElement).click();
+    expect(sheet.getAttribute("data-ask-current-index")).toBe("0");
+    const pillA = sheet.querySelector('[data-option-label="A"]');
+    expect(pillA?.getAttribute("aria-pressed")).toBe("true");
+
+    controller.destroy();
+  });
+
+  it("wires resolve(answer) to session.resolveAskUserQuestion via /resume", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      body: new ReadableStream({
+        start(c) {
+          c.enqueue(new TextEncoder().encode('data: {"type":"flow_complete","success":true}\n\n'));
+          c.close();
+        },
+      }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    let resolveRef: ((answer: string) => void) | undefined;
+    const plugin: AgentWidgetPlugin = {
+      id: "capturing-asker",
+      renderAskUserQuestion: ({ resolve }) => {
+        resolveRef = resolve;
+        const el = document.createElement("div");
+        el.setAttribute("data-test-id", "capturing");
+        return el;
+      },
+    };
+
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      plugins: [plugin],
+    } as unknown as Parameters<typeof createAgentExperience>[1]);
+
+    injectAskUserQuestion(controller);
+
+    expect(resolveRef).toBeDefined();
+    resolveRef!("Hobbyists");
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalled();
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/resume$/);
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      executionId: "exec_123",
+      toolOutputs: { ["ask_user_question"]: "Hobbyists" },
+      streamResponse: true,
+    });
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -59,6 +59,20 @@ import { MessageTransform, MessageActionCallbacks, LoadingIndicatorRenderer } fr
 import { createStandardBubble, createTypingIndicator } from "./components/message-bubble";
 import { createReasoningBubble, reasoningExpansionState, updateReasoningBubbleUI } from "./components/reasoning-bubble";
 import { createToolBubble, toolExpansionState, updateToolBubbleUI } from "./components/tool-bubble";
+import {
+  buildStructuredAnswers,
+  ensureAskUserQuestionSheet,
+  getCurrentIndex,
+  getQuestionCount,
+  getSelectedLabels,
+  isAskUserQuestionMessage,
+  isGroupedSheet,
+  navigateToPage,
+  parseAskUserQuestionPayload,
+  readAnswersFromSheet,
+  removeAskUserQuestionSheet,
+  setCurrentAnswer,
+} from "./components/ask-user-question-bubble";
 import { formatElapsedMs } from "./utils/formatting";
 import { createApprovalBubble } from "./components/approval-bubble";
 import { createSuggestions } from "./components/suggestions";
@@ -328,6 +342,10 @@ type Controller = {
   upsertArtifact: (manual: PersonaArtifactManualUpsert) => PersonaArtifactRecord | null;
   selectArtifact: (id: string) => void;
   clearArtifacts: () => void;
+  /** Read current artifacts (useful on init to rebuild host-side tab state after hydration). */
+  getArtifacts: () => PersonaArtifactRecord[];
+  /** Read the currently selected artifact id (paired with `getArtifacts`). */
+  getSelectedArtifactId: () => string | null;
   /**
    * Focus the chat input. Returns true if focus succeeded, false if panel is closed
    * (launcher mode) or textarea is unavailable.
@@ -516,6 +534,13 @@ export const createAgentExperience = (
         }
         if (processedState.messages?.length) {
           config = { ...config, initialMessages: processedState.messages };
+        }
+        if (processedState.artifacts?.length) {
+          config = {
+            ...config,
+            initialArtifacts: processedState.artifacts,
+            initialSelectedArtifactId: processedState.selectedArtifactId ?? null
+          };
         }
       }
     } catch (error) {
@@ -1408,6 +1433,385 @@ export const createAgentExperience = (
     target.click();
   });
 
+  // --- ask_user_question sheet interaction ---
+  // Event delegation for the answer-pill sheet that mounts in the composer
+  // overlay. Handles pill pick (single), multi-select toggle + submit, free-
+  // text pill expansion + submit, and dismissal. Selection becomes a regular
+  // user message via session.sendMessage so the agent resumes on the next turn.
+  const askUserOverlay = panelElements.composerOverlay;
+
+  const submitAskUserAnswer = (
+    sheet: HTMLElement,
+    text: string,
+    meta: {
+      source: "pick" | "multi" | "free-text" | "submit-all";
+      values?: string[];
+      structured?: Record<string, string | string[]>;
+    }
+  ): void => {
+    const trimmed = text.trim();
+    if (!trimmed || !sessionRef.current) return;
+    const toolCallId = sheet.getAttribute("data-tool-call-id") ?? "";
+    const isFreeText = meta.source === "free-text";
+
+    // Dispatch before removing the sheet so listeners can still query DOM state.
+    mount.dispatchEvent(
+      new CustomEvent("persona:askUserQuestion:answered", {
+        detail: {
+          toolUseId: toolCallId,
+          answer: trimmed,
+          answers: meta.structured,
+          values: meta.values ?? (meta.source === "multi" ? trimmed.split(", ") : [trimmed]),
+          isFreeText,
+          source: meta.source,
+        },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    removeAskUserQuestionSheet(askUserOverlay, toolCallId);
+
+    // Branch: LOCAL-tool pause (step_await) resumes via /resume with structured
+    // toolOutputs; legacy path sends as a plain user message.
+    const sourceMessage = sessionRef.current
+      .getMessages()
+      .find((m) => m.toolCall?.id === toolCallId);
+    if (sourceMessage?.agentMetadata?.awaitingLocalTool) {
+      sessionRef.current.resolveAskUserQuestion(sourceMessage, meta.structured ?? trimmed);
+    } else {
+      sessionRef.current.sendMessage(trimmed);
+    }
+  };
+
+  /**
+   * Persist in-progress grouped-question answers + page index back to the
+   * source message so a refresh restores the user's spot.
+   */
+  const persistGroupedProgress = (sheet: HTMLElement): void => {
+    const session = sessionRef.current;
+    if (!session) return;
+    const toolCallId = sheet.getAttribute("data-tool-call-id") ?? "";
+    const sourceMessage = session.getMessages().find((m) => m.toolCall?.id === toolCallId);
+    if (!sourceMessage) return;
+    session.persistAskUserQuestionProgress(sourceMessage, {
+      answers: buildStructuredAnswers(sheet, sourceMessage),
+      currentIndex: getCurrentIndex(sheet),
+    });
+  };
+
+  /**
+   * Build a one-line summary string for the legacy `answer` field on the
+   * answered event when submit-all fires from a grouped sheet.
+   */
+  const stringifyStructured = (answers: Record<string, string | string[]>): string => {
+    return Object.entries(answers)
+      .map(([q, v]) => `${q}: ${Array.isArray(v) ? v.join(", ") : v}`)
+      .join(" | ");
+  };
+
+  /**
+   * If `groupedAutoAdvance` is enabled (default) and we're not on the final
+   * page, advance one step. The final page never auto-submits — users always
+   * confirm with an explicit Submit-all click so they can review.
+   */
+  const maybeAutoAdvance = (sheet: HTMLElement): void => {
+    if (config.features?.askUserQuestion?.groupedAutoAdvance === false) return;
+    const idx = getCurrentIndex(sheet);
+    const count = getQuestionCount(sheet);
+    if (idx >= count - 1) return;
+    const sourceMessage = sessionRef.current
+      ?.getMessages()
+      .find((m) => m.toolCall?.id === sheet.getAttribute("data-tool-call-id"));
+    if (!sourceMessage) return;
+    navigateToPage(sheet, sourceMessage, config, idx + 1);
+    persistGroupedProgress(sheet);
+  };
+
+  askUserOverlay.addEventListener("click", (event) => {
+    const target = event.target as HTMLElement;
+    const trigger = target.closest<HTMLElement>("[data-ask-user-action]");
+    if (!trigger) return;
+    const sheet = trigger.closest<HTMLElement>("[data-persona-ask-sheet-for]");
+    if (!sheet) return;
+
+    const action = trigger.getAttribute("data-ask-user-action");
+    event.preventDefault();
+    event.stopPropagation();
+
+    if (action === "dismiss") {
+      const toolCallId = sheet.getAttribute("data-tool-call-id") ?? "";
+      mount.dispatchEvent(
+        new CustomEvent("persona:askUserQuestion:dismissed", {
+          detail: { toolUseId: toolCallId },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      removeAskUserQuestionSheet(askUserOverlay, toolCallId);
+
+      // Best-effort: if this sheet corresponds to a LOCAL-awaiting tool,
+      // unblock the paused execution with a sentinel answer so the server
+      // doesn't sit in waiting_for_local forever. Fire-and-forget — errors
+      // are surfaced to the onError callback. Flip the answered flag first
+      // so a racing render pass doesn't re-mount the sheet mid-dismissal.
+      const sourceMessage = sessionRef.current
+        ?.getMessages()
+        .find((m) => m.toolCall?.id === toolCallId);
+      if (sourceMessage?.agentMetadata?.awaitingLocalTool) {
+        sessionRef.current?.markAskUserQuestionResolved(sourceMessage);
+        sessionRef.current?.resolveAskUserQuestion(sourceMessage, "(dismissed)");
+      }
+      return;
+    }
+
+    if (action === "pick") {
+      const label = trigger.getAttribute("data-option-label");
+      if (!label) return;
+      const multiSelect = sheet.getAttribute("data-multi-select") === "true";
+      const grouped = isGroupedSheet(sheet);
+
+      if (grouped && multiSelect) {
+        const stored = readAnswersFromSheet(sheet)[getCurrentIndex(sheet)];
+        const set = new Set<string>(Array.isArray(stored) ? stored : []);
+        if (set.has(label)) set.delete(label);
+        else set.add(label);
+        setCurrentAnswer(sheet, Array.from(set));
+        persistGroupedProgress(sheet);
+        return;
+      }
+
+      if (grouped) {
+        setCurrentAnswer(sheet, label);
+        persistGroupedProgress(sheet);
+        maybeAutoAdvance(sheet);
+        return;
+      }
+
+      // 1-question modes — preserve original UX.
+      if (multiSelect) {
+        const pressed = trigger.getAttribute("aria-pressed") === "true";
+        trigger.setAttribute("aria-pressed", pressed ? "false" : "true");
+        trigger.classList.toggle("persona-ask-pill-selected", !pressed);
+        const submitBtn = sheet.querySelector<HTMLButtonElement>(
+          '[data-ask-user-action="submit-multi"]'
+        );
+        if (submitBtn) {
+          submitBtn.disabled = getSelectedLabels(sheet).length === 0;
+        }
+        return;
+      }
+      submitAskUserAnswer(sheet, label, { source: "pick", values: [label] });
+      return;
+    }
+
+    if (action === "submit-multi") {
+      const labels = getSelectedLabels(sheet);
+      if (labels.length === 0) return;
+      submitAskUserAnswer(sheet, labels.join(", "), {
+        source: "multi",
+        values: labels,
+      });
+      return;
+    }
+
+    if (action === "open-free-text") {
+      const row = sheet.querySelector<HTMLElement>('[data-ask-free-text-row="true"]');
+      if (row) {
+        row.classList.remove("persona-hidden");
+        const input = row.querySelector<HTMLInputElement>('[data-ask-free-text-input="true"]');
+        input?.focus();
+      }
+      return;
+    }
+
+    if (action === "focus-free-text") {
+      // Rows-layout Other row: input lives inside the row container itself.
+      // Native click on the input already focuses it; this branch handles
+      // clicks on the badge or row chrome AND digit-shortcut activations.
+      const input = sheet.querySelector<HTMLInputElement>('[data-ask-free-text-input="true"]');
+      input?.focus();
+      return;
+    }
+
+    if (action === "submit-free-text") {
+      const input = sheet.querySelector<HTMLInputElement>('[data-ask-free-text-input="true"]');
+      const text = input?.value ?? "";
+      if (!text.trim()) return;
+      if (isGroupedSheet(sheet)) {
+        setCurrentAnswer(sheet, text.trim());
+        persistGroupedProgress(sheet);
+        maybeAutoAdvance(sheet);
+        return;
+      }
+      submitAskUserAnswer(sheet, text, { source: "free-text" });
+      return;
+    }
+
+    if (action === "next" || action === "back") {
+      if (!sessionRef.current) return;
+      const toolCallId = sheet.getAttribute("data-tool-call-id") ?? "";
+      const sourceMessage = sessionRef.current
+        .getMessages()
+        .find((m) => m.toolCall?.id === toolCallId);
+      if (!sourceMessage) return;
+      // Flush any unsubmitted free-text input as the current answer.
+      const freeInput = sheet.querySelector<HTMLInputElement>('[data-ask-free-text-input="true"]');
+      const pending = freeInput?.value?.trim() ?? "";
+      if (pending) {
+        const stored = readAnswersFromSheet(sheet)[getCurrentIndex(sheet)];
+        if (typeof stored !== "string" || stored !== pending) {
+          setCurrentAnswer(sheet, pending);
+        }
+      }
+      const direction = action === "next" ? 1 : -1;
+      const nextIdx = getCurrentIndex(sheet) + direction;
+      navigateToPage(sheet, sourceMessage, config, nextIdx);
+      persistGroupedProgress(sheet);
+      return;
+    }
+
+    if (action === "submit-all") {
+      if (!sessionRef.current) return;
+      const toolCallId = sheet.getAttribute("data-tool-call-id") ?? "";
+      const sourceMessage = sessionRef.current
+        .getMessages()
+        .find((m) => m.toolCall?.id === toolCallId);
+      if (!sourceMessage) return;
+      // Flush any pending free-text on the final page first.
+      const freeInput = sheet.querySelector<HTMLInputElement>('[data-ask-free-text-input="true"]');
+      const pending = freeInput?.value?.trim() ?? "";
+      if (pending) setCurrentAnswer(sheet, pending);
+
+      const structured = buildStructuredAnswers(sheet, sourceMessage);
+      // Persist final answers to message metadata BEFORE resolving so the
+      // answered-state review card (which reads `agentMetadata
+      // .askUserQuestionAnswers`) shows the user's actual picks instead of
+      // "(skipped)" placeholders. Without this, any answer set only via the
+      // pending-flush above (or via paths that bypassed the per-pick persist
+      // hook) would be missing from the transcript review even though it
+      // landed in the structured payload sent to the agent.
+      sessionRef.current.persistAskUserQuestionProgress(sourceMessage, {
+        answers: structured,
+        currentIndex: getCurrentIndex(sheet),
+      });
+      const summary = stringifyStructured(structured);
+      submitAskUserAnswer(sheet, summary || "(submitted)", {
+        source: "submit-all",
+        structured,
+      });
+      return;
+    }
+
+    if (action === "skip") {
+      if (!sessionRef.current) return;
+      const toolCallId = sheet.getAttribute("data-tool-call-id") ?? "";
+      const sourceMessage = sessionRef.current
+        .getMessages()
+        .find((m) => m.toolCall?.id === toolCallId);
+      if (!sourceMessage) return;
+
+      const grouped = isGroupedSheet(sheet);
+      const idx = getCurrentIndex(sheet);
+      const count = getQuestionCount(sheet);
+      const isFinal = idx >= count - 1;
+
+      // Single-question payloads behave like dismiss.
+      if (!grouped) {
+        mount.dispatchEvent(
+          new CustomEvent("persona:askUserQuestion:dismissed", {
+            detail: { toolUseId: toolCallId },
+            bubbles: true,
+            composed: true,
+          })
+        );
+        removeAskUserQuestionSheet(askUserOverlay, toolCallId);
+        if (sourceMessage.agentMetadata?.awaitingLocalTool) {
+          sessionRef.current.markAskUserQuestionResolved(sourceMessage);
+          sessionRef.current.resolveAskUserQuestion(sourceMessage, "(dismissed)");
+        }
+        return;
+      }
+
+      // Drop the current question's answer (if any) so it's absent from the
+      // resolved Record. setCurrentAnswer with an empty string deletes the
+      // index from the in-memory map.
+      setCurrentAnswer(sheet, "");
+      // Also clear any unsubmitted free-text on this page.
+      const freeInput = sheet.querySelector<HTMLInputElement>('[data-ask-free-text-input="true"]');
+      if (freeInput) freeInput.value = "";
+
+      if (isFinal) {
+        // Submit with whatever has been recorded so far.
+        const structured = buildStructuredAnswers(sheet, sourceMessage);
+        const summary = stringifyStructured(structured);
+        submitAskUserAnswer(sheet, summary || "(skipped)", {
+          source: "submit-all",
+          structured,
+        });
+        return;
+      }
+
+      // Intermediate page: advance one step without recording.
+      navigateToPage(sheet, sourceMessage, config, idx + 1);
+      persistGroupedProgress(sheet);
+      return;
+    }
+  });
+
+  // Enter on the free-text input → submit. Stays on the overlay because the
+  // event target IS the input, which lives inside the overlay subtree.
+  askUserOverlay.addEventListener("keydown", (event) => {
+    if (event.key !== "Enter") return;
+    const target = event.target as HTMLElement;
+    const input = target as HTMLInputElement;
+    if (!input.matches?.('[data-ask-free-text-input="true"]')) return;
+    const sheet = input.closest<HTMLElement>("[data-persona-ask-sheet-for]");
+    if (!sheet) return;
+    event.preventDefault();
+    const text = input.value;
+    if (!text.trim()) return;
+    if (isGroupedSheet(sheet)) {
+      setCurrentAnswer(sheet, text.trim());
+      persistGroupedProgress(sheet);
+      maybeAutoAdvance(sheet);
+      return;
+    }
+    submitAskUserAnswer(sheet, text, { source: "free-text" });
+  });
+
+  // Digit 1–9 → pick option N on the current rows-layout single-select page.
+  // Listens on `document` so the shortcut fires regardless of where focus
+  // currently sits (host page body, panel chrome, anywhere). The handler
+  // gates strictly: only fires when an active sheet is mounted in our
+  // overlay, and bails when focus is on any input/textarea/contenteditable
+  // (covers the free-text input, the chat composer, and any host-page input).
+  const handleAskUserDigitKey = (event: KeyboardEvent): void => {
+    if (!/^[1-9]$/.test(event.key)) return;
+    if (event.metaKey || event.ctrlKey || event.altKey) return;
+    const target = event.target as HTMLElement | null;
+    if (
+      target?.tagName === "INPUT" ||
+      target?.tagName === "TEXTAREA" ||
+      target?.isContentEditable
+    ) {
+      return;
+    }
+    const sheet = askUserOverlay.querySelector<HTMLElement>("[data-persona-ask-sheet-for]");
+    if (!sheet) return;
+    if (sheet.getAttribute("data-ask-layout") !== "rows") return;
+    if (sheet.getAttribute("data-multi-select") === "true") return;
+    const n = Number(event.key);
+    const pills = sheet.querySelectorAll<HTMLElement>(
+      '[data-ask-pill-list="true"] [data-ask-user-action="pick"], [data-ask-pill-list="true"] [data-ask-user-action="focus-free-text"]'
+    );
+    const target_pill = pills[n - 1];
+    if (!target_pill) return;
+    event.preventDefault();
+    target_pill.click();
+  };
+  document.addEventListener("keydown", handleAskUserDigitKey);
+
   let artifactSplitRoot: HTMLElement | null = null;
   let artifactResizeHandle: HTMLElement | null = null;
   let artifactResizeUnbind: (() => void) | null = null;
@@ -1965,6 +2369,10 @@ export const createAgentExperience = (
   applyArtifactPaneAppearance(mount, config);
 
   const destroyCallbacks: Array<() => void> = [];
+  // Clean up the document-level digit-key shortcut listener registered earlier.
+  destroyCallbacks.push(() => {
+    document.removeEventListener("keydown", handleAskUserDigitKey);
+  });
 
   let teardownHostStacking: (() => void) | null = null;
   let releaseScrollLock: (() => void) | null = null;
@@ -2056,6 +2464,10 @@ export const createAgentExperience = (
   let session: AgentWidgetSession;
   let isStreaming = false;
   const messageCache = createMessageCache();
+  // Tracks the last fingerprint we rendered a plugin-rendered ask_user_question
+  // bubble for, per message id. Lets us skip unnecessary rebuilds across
+  // re-renders so user state inside the plugin (typed text, focus) survives.
+  const lastAskBubbleFingerprint = new Map<string, string>();
   let configVersion = 0;
   const autoFollow = createFollowStateController();
   let lastScrollTop = 0;
@@ -2139,7 +2551,9 @@ export const createAgentExperience = (
 
     const payload = {
       messages,
-      metadata: persistentMetadata
+      metadata: persistentMetadata,
+      artifacts: lastArtifactsState.artifacts,
+      selectedArtifactId: lastArtifactsState.selectedId
     };
     try {
       const result = storageAdapter.save(payload);
@@ -2398,15 +2812,64 @@ export const createAgentExperience = (
 
     // Track active message IDs for cache pruning
     const activeMessageIds = new Set<string>();
+    // Track ask_user_question tool-call ids whose bubbles were rendered this
+    // pass — used to prune stale sheets from the composer overlay afterward.
+    const liveAskToolIds = new Set<string>();
+
+    // Plugins that render `ask_user_question` typically attach DOM listeners
+    // directly to their buttons. The wrapper cache uses `cloneNode(true)` and
+    // idiomorph inserts new nodes via `document.importNode` — both strip
+    // listeners. For plugin-handled ask messages we therefore append an empty
+    // stub during the morph pass and hydrate the live plugin bubble into the
+    // morphed wrapper afterward (see post-morph loop below). The stub carries
+    // `data-preserve-runtime` so subsequent passes leave the live wrapper
+    // (with its listener-bearing bubble) untouched.
+    const hasAskPlugin = plugins.some((p) => p.renderAskUserQuestion);
+    type AskPluginHydrate = {
+      messageId: string;
+      fingerprint: string;
+      bubble: HTMLElement | null;
+    };
+    const askPluginHydrate: AskPluginHydrate[] = [];
 
     messages.forEach((message) => {
       activeMessageIds.add(message.id);
 
-      // Fingerprint cache: skip re-rendering unchanged messages
-      const fingerprint = computeMessageFingerprint(message, configVersion);
-      const cachedWrapper = getCachedWrapper(messageCache, message.id, fingerprint);
+      const askWithPlugin = hasAskPlugin && isAskUserQuestionMessage(message);
+
+      // Fingerprint cache: skip re-rendering unchanged messages. Append the
+      // ask-user-question answered/answers state so flipping `askUserQuestionAnswered`
+      // (or accumulating answers) busts both the wrapper cache and the plugin's
+      // `lastAskBubbleFingerprint` check, forcing a re-render of the review UX.
+      const askMeta = isAskUserQuestionMessage(message)
+        ? `:${message.agentMetadata?.askUserQuestionAnswered ? "a" : "u"}:${
+            message.agentMetadata?.askUserQuestionAnswers
+              ? Object.keys(message.agentMetadata.askUserQuestionAnswers).length
+              : 0
+          }`
+        : "";
+      const fingerprint = computeMessageFingerprint(message, configVersion) + askMeta;
+      const cachedWrapper = askWithPlugin
+        ? null
+        : getCachedWrapper(messageCache, message.id, fingerprint);
       if (cachedWrapper) {
         tempContainer.appendChild(cachedWrapper.cloneNode(true));
+        // Keep the overlay sheet alive only while the server is actively
+        // waiting on the user (awaitingLocalTool === true). Before step_await
+        // fires, or after the answer resumes the flow, omit from
+        // liveAskToolIds so the prune loop below removes any stale DOM sheet.
+        // Guards against lingering skeleton sheets from tool_start events
+        // that never get a matching step_await (e.g. LLM-hallucinated trailing
+        // ask_user_question calls at end-of-turn).
+        if (
+          isAskUserQuestionMessage(message) &&
+          message.toolCall?.id &&
+          message.agentMetadata?.awaitingLocalTool === true &&
+          !message.agentMetadata?.askUserQuestionAnswered
+        ) {
+          liveAskToolIds.add(message.toolCall.id);
+          ensureAskUserQuestionSheet(message, config, panelElements.composerOverlay);
+        }
         return;
       }
 
@@ -2432,7 +2895,111 @@ export const createAgentExperience = (
       // Get message layout config
       const messageLayoutConfig = config.layout?.messages;
 
-      if (matchingPlugin) {
+      // ask_user_question has two rendering modes while waiting for an answer:
+      //   1. Plugin `renderAskUserQuestion` — returns an inline transcript
+      //      element with its own UI; the composer-overlay sheet is suppressed.
+      //   2. Built-in composer-overlay answer-pill sheet — no transcript stub.
+      // Plugins win when they return a non-null element; otherwise fall
+      // through to the built-in overlay.
+      //
+      // Once answered, the original tool message is suppressed entirely from
+      // the transcript. `session.resolveAskUserQuestion` injects one assistant
+      // bubble per question and one user bubble per answer (skipped questions
+      // become an italic `*Skipped*` user bubble), so the transcript reads
+      // like a normal Q→A conversation. Plugins do not render the answered
+      // state.
+      if (
+        isAskUserQuestionMessage(message) &&
+        message.agentMetadata?.askUserQuestionAnswered === true
+      ) {
+        // Drop any previously-mounted plugin bubble so the morph pass
+        // removes the now-stale interactive sheet.
+        lastAskBubbleFingerprint.delete(message.id);
+        const existing = container.querySelector<HTMLElement>(`#wrapper-${message.id}`);
+        existing?.removeAttribute("data-preserve-runtime");
+        return;
+      }
+
+      if (
+        isAskUserQuestionMessage(message) &&
+        config.features?.askUserQuestion?.enabled !== false
+      ) {
+        const askPlugin = plugins.find((p) => typeof p.renderAskUserQuestion === "function");
+        if (askPlugin && sessionRef.current) {
+          const lastFp = lastAskBubbleFingerprint.get(message.id);
+          // Whether to actually call the plugin renderer this pass. We do it
+          // on first sight of this message, or when its fingerprint changed
+          // (e.g. payload streamed in more options). Otherwise we rely on the
+          // already-mounted bubble in `container`.
+          const needsRebuild = lastFp !== fingerprint;
+
+          let pluginBubble: HTMLElement | null = null;
+          if (needsRebuild) {
+            const { payload, complete } = parseAskUserQuestionPayload(message);
+            const messageId = message.id;
+            const liveMessage = (): AgentWidgetMessage | undefined =>
+              sessionRef.current?.getMessages().find((m) => m.id === messageId);
+            pluginBubble = askPlugin.renderAskUserQuestion!({
+              message,
+              payload,
+              complete,
+              resolve: (answer) => {
+                const live = liveMessage();
+                if (live) sessionRef.current?.resolveAskUserQuestion(live, answer);
+              },
+              dismiss: () => {
+                const live = liveMessage();
+                if (live?.agentMetadata?.awaitingLocalTool) {
+                  sessionRef.current?.markAskUserQuestionResolved(live);
+                  sessionRef.current?.resolveAskUserQuestion(live, "(dismissed)");
+                }
+              },
+              config,
+            });
+          }
+
+          // If the plugin opted out (returned null on a fresh build) AND we
+          // have no previously-mounted bubble for this message, fall back to
+          // the built-in overlay sheet. If we already have a mounted bubble
+          // and the plugin didn't run this pass (cached), keep using it.
+          const previouslyMounted = lastFp != null;
+          if (needsRebuild && pluginBubble === null && !previouslyMounted) {
+            if (
+              message.agentMetadata?.awaitingLocalTool === true &&
+              !message.agentMetadata?.askUserQuestionAnswered
+            ) {
+              liveAskToolIds.add(message.toolCall!.id);
+              ensureAskUserQuestionSheet(message, config, panelElements.composerOverlay);
+            }
+            return;
+          }
+
+          // Append a stub wrapper for the morph pass; hydrate the real bubble
+          // into it post-morph so its event listeners survive.
+          const stub = document.createElement("div");
+          stub.className = "persona-flex";
+          stub.id = `wrapper-${message.id}`;
+          stub.setAttribute("data-wrapper-id", message.id);
+          stub.setAttribute("data-ask-plugin-stub", "true");
+          stub.setAttribute("data-preserve-runtime", "true");
+          tempContainer.appendChild(stub);
+          askPluginHydrate.push({
+            messageId: message.id,
+            fingerprint,
+            bubble: pluginBubble,
+          });
+          return;
+        } else {
+          if (
+            message.agentMetadata?.awaitingLocalTool === true &&
+            !message.agentMetadata?.askUserQuestionAnswered
+          ) {
+            liveAskToolIds.add(message.toolCall!.id);
+            ensureAskUserQuestionSheet(message, config, panelElements.composerOverlay);
+          }
+          return;
+        }
+      } else if (matchingPlugin) {
         if (message.variant === "reasoning" && message.reasoning && matchingPlugin.renderReasoning) {
           if (!showReasoning) return;
           bubble = matchingPlugin.renderReasoning({
@@ -2609,6 +3176,20 @@ export const createAgentExperience = (
       setCachedWrapper(messageCache, message.id, fingerprint, wrapper);
       tempContainer.appendChild(wrapper);
     });
+
+    // Prune any ask_user_question sheets whose source message is no longer in
+    // the message list (e.g. after clearChat or a splice).
+    if (panelElements.composerOverlay) {
+      const sheets = panelElements.composerOverlay.querySelectorAll<HTMLElement>(
+        "[data-persona-ask-sheet-for]"
+      );
+      sheets.forEach((sheet) => {
+        const id = sheet.getAttribute("data-persona-ask-sheet-for");
+        if (id && !liveAskToolIds.has(id)) {
+          removeAskUserQuestionSheet(panelElements.composerOverlay, id);
+        }
+      });
+    }
 
     if (config.features?.toolCallDisplay?.grouped) {
       const toolGroups: AgentWidgetMessage[][] = [];
@@ -2839,6 +3420,35 @@ export const createAgentExperience = (
 
     // Use idiomorph to morph the container contents
     morphMessages(container, tempContainer);
+
+    // Hydrate plugin-rendered ask-question bubbles into their stub wrappers.
+    // Idiomorph imports new nodes via `document.importNode`, which strips
+    // listeners — so we built only an empty stub during morph and now inject
+    // the real, listener-bearing bubble directly into the live DOM.
+    if (askPluginHydrate.length > 0) {
+      for (const { messageId, fingerprint, bubble } of askPluginHydrate) {
+        const wrapper = container.querySelector(`#wrapper-${messageId}`);
+        if (!wrapper) continue;
+        if (bubble === null) {
+          // No fresh bubble built this pass — either the plugin opted out
+          // and a previously-mounted bubble already lives here (preserved by
+          // `data-preserve-runtime`), or we skipped the rebuild because the
+          // fingerprint matched. Either way, leave the live wrapper alone.
+          continue;
+        }
+        wrapper.replaceChildren(bubble);
+        wrapper.setAttribute("data-bubble-fp", fingerprint);
+        lastAskBubbleFingerprint.set(messageId, fingerprint);
+      }
+    }
+
+    // Drop fingerprints for messages that are no longer present so a future
+    // re-appearance triggers a fresh plugin render.
+    if (lastAskBubbleFingerprint.size > 0) {
+      for (const id of lastAskBubbleFingerprint.keys()) {
+        if (!activeMessageIds.has(id)) lastAskBubbleFingerprint.delete(id);
+      }
+    }
   };
 
   // Alias for clarity - the implementation handles flicker prevention via typing indicator logic
@@ -3165,6 +3775,7 @@ export const createAgentExperience = (
     onArtifactsState(state) {
       lastArtifactsState = state;
       syncArtifactPane();
+      persistState();
     }
   });
 
@@ -3216,6 +3827,12 @@ export const createAgentExperience = (
         }
         if (state.messages?.length) {
           session.hydrateMessages(state.messages);
+        }
+        if (state.artifacts?.length) {
+          session.hydrateArtifacts(
+            state.artifacts,
+            state.selectedArtifactId ?? null
+          );
         }
       })
       .catch((error) => {
@@ -4067,6 +4684,9 @@ export const createAgentExperience = (
       session.clearMessages();
       messageCache.clear();
       resumeAutoScroll();
+
+      // Drop any open ask_user_question sheets — their source messages are gone.
+      removeAskUserQuestionSheet(panelElements.composerOverlay);
 
       // Always clear the default localStorage key
       try {
@@ -5742,6 +6362,12 @@ export const createAgentExperience = (
     clearArtifacts(): void {
       if (!artifactsSidebarEnabled(config)) return;
       session.clearArtifacts();
+    },
+    getArtifacts(): PersonaArtifactRecord[] {
+      return session?.getArtifacts() ?? [];
+    },
+    getSelectedArtifactId(): string | null {
+      return session?.getSelectedArtifactId() ?? null;
     },
     focusInput(): boolean {
       if (launcherEnabled && !open) return false;

--- a/packages/widget/src/utils/storage.ts
+++ b/packages/widget/src/utils/storage.ts
@@ -1,7 +1,8 @@
 import type {
   AgentWidgetMessage,
   AgentWidgetStorageAdapter,
-  AgentWidgetStoredState
+  AgentWidgetStoredState,
+  PersonaArtifactRecord
 } from "../types";
 
 const safeJsonParse = (value: string | null) => {
@@ -21,6 +22,12 @@ const sanitizeMessages = (messages: AgentWidgetMessage[]) =>
   messages.map((message) => ({
     ...message,
     streaming: false
+  }));
+
+const sanitizeArtifacts = (artifacts: PersonaArtifactRecord[]) =>
+  artifacts.map((artifact) => ({
+    ...artifact,
+    status: "complete" as const
   }));
 
 export const createLocalStorageAdapter = (
@@ -45,7 +52,8 @@ export const createLocalStorageAdapter = (
       try {
         const payload: AgentWidgetStoredState = {
           ...state,
-          messages: state.messages ? sanitizeMessages(state.messages) : undefined
+          messages: state.messages ? sanitizeMessages(state.messages) : undefined,
+          artifacts: state.artifacts ? sanitizeArtifacts(state.artifacts) : undefined
         };
         storage.setItem(key, JSON.stringify(payload));
       } catch (error) {

--- a/packages/widget/src/utils/theme.test.ts
+++ b/packages/widget/src/utils/theme.test.ts
@@ -252,6 +252,42 @@ describe('theme utils', () => {
     expect(cssVars['--persona-scroll-to-bottom-icon-size']).toBe('14px');
   });
 
+  it('maps introCard component tokens to dedicated CSS variables', () => {
+    const theme = createTheme({
+      components: {
+        introCard: {
+          background: 'palette.colors.accent.50',
+          borderRadius: 'palette.radius.xl',
+          padding: 'semantic.spacing.lg',
+          shadow: '0 10px 30px rgba(53, 44, 131, 0.15)',
+        },
+      },
+    } as any);
+
+    const cssVars = themeToCssVariables(theme);
+
+    expect(cssVars['--persona-components-introCard-background']).toBe('#ecfeff');
+    expect(cssVars['--persona-components-introCard-borderRadius']).toBe('0.75rem');
+    expect(cssVars['--persona-components-introCard-padding']).toBe('1.5rem');
+    expect(cssVars['--persona-components-introCard-shadow']).toBe(
+      '0 10px 30px rgba(53, 44, 131, 0.15)'
+    );
+    expect(cssVars['--persona-intro-card-bg']).toBe('#ecfeff');
+    expect(cssVars['--persona-intro-card-radius']).toBe('0.75rem');
+    expect(cssVars['--persona-intro-card-padding']).toBe('1.5rem');
+    expect(cssVars['--persona-intro-card-shadow']).toBe(
+      '0 10px 30px rgba(53, 44, 131, 0.15)'
+    );
+  });
+
+  it('falls back to the legacy intro-card shadow when no token is set', () => {
+    const theme = createTheme({});
+    const cssVars = themeToCssVariables(theme);
+    expect(cssVars['--persona-intro-card-shadow']).toBe(
+      '0 5px 15px rgba(15, 23, 42, 0.08)'
+    );
+  });
+
   it('lets config.toolCall.shadow override theme tool bubble shadow on the root element', () => {
     const el = document.createElement('div');
     applyThemeVariables(el, {

--- a/packages/widget/src/utils/tokens.ts
+++ b/packages/widget/src/utils/tokens.ts
@@ -318,6 +318,14 @@ export const DEFAULT_COMPONENTS: ComponentTokens = {
     },
     border: 'semantic.colors.border',
   },
+  introCard: {
+    // Defaults preserve the legacy `persona-shadow-sm` look exactly so existing
+    // pages render unchanged when no token is set.
+    background: 'semantic.colors.surface',
+    borderRadius: 'palette.radius.2xl',
+    padding: 'semantic.spacing.lg',
+    shadow: '0 5px 15px rgba(15, 23, 42, 0.08)',
+  },
   toolBubble: {
     shadow: 'palette.shadows.sm',
   },
@@ -762,6 +770,21 @@ export function themeToCssVariables(theme: PersonaTheme): Record<string, string>
   const headerTokens = theme.components?.header;
   if (headerTokens?.shadow) cssVars['--persona-header-shadow'] = headerTokens.shadow;
   if (headerTokens?.borderBottom) cssVars['--persona-header-border-bottom'] = headerTokens.borderBottom;
+
+  // Intro card aliases — short names the panel inline-styles read directly.
+  // The full-path `--persona-components-introCard-*` variables auto-emit above;
+  // these mirror them with sensible fallbacks so existing pages keep their look.
+  const introCardTokens = theme.components?.introCard;
+  cssVars['--persona-intro-card-bg'] =
+    cssVars['--persona-components-introCard-background'] ?? cssVars['--persona-surface'];
+  cssVars['--persona-intro-card-radius'] =
+    cssVars['--persona-components-introCard-borderRadius'] ?? '1rem';
+  cssVars['--persona-intro-card-padding'] =
+    cssVars['--persona-components-introCard-padding'] ?? '1.5rem';
+  cssVars['--persona-intro-card-shadow'] =
+    introCardTokens?.shadow
+      ?? cssVars['--persona-components-introCard-shadow']
+      ?? '0 5px 15px rgba(15, 23, 42, 0.08)';
 
   cssVars['--persona-input-background'] =
     cssVars['--persona-components-input-background'] ?? cssVars['--persona-surface'];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,9 @@ importers:
       '@runtypelabs/persona':
         specifier: workspace:^
         version: link:../../packages/widget
+      handlebars:
+        specifier: ^4.7.8
+        version: 4.7.9
       idiomorph:
         specifier: ^0.7.4
         version: 0.7.4
@@ -711,105 +714,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -931,79 +918,66 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -1611,6 +1585,11 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
+  handlebars@4.7.9:
+    resolution: {integrity: sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==}
+    engines: {node: '>=0.4.7'}
+    hasBin: true
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
@@ -1815,6 +1794,9 @@ packages:
     resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1843,6 +1825,9 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -2092,6 +2077,10 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
     engines: {node: '>= 12'}
@@ -2268,6 +2257,11 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  uglify-js@3.19.3:
+    resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
+    engines: {node: '>=0.8.0'}
+    hasBin: true
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -2459,6 +2453,9 @@ packages:
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wordwrap@1.0.0:
+    resolution: {integrity: sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==}
 
   workerd@1.20260305.0:
     resolution: {integrity: sha512-JkhfCLU+w+KbQmZ9k49IcDYc78GBo7eG8Mir8E2+KVjR7otQAmpcLlsous09YLh8WQ3Bt3Mi6/WMStvMAPukeA==}
@@ -3865,6 +3862,15 @@ snapshots:
 
   graphemer@1.4.0: {}
 
+  handlebars@4.7.9:
+    dependencies:
+      minimist: 1.2.8
+      neo-async: 2.6.2
+      source-map: 0.6.1
+      wordwrap: 1.0.0
+    optionalDependencies:
+      uglify-js: 3.19.3
+
   has-flag@4.0.0: {}
 
   hono@4.12.9: {}
@@ -4064,6 +4070,8 @@ snapshots:
     dependencies:
       brace-expansion: 2.0.2
 
+  minimist@1.2.8: {}
+
   minipass@7.1.3: {}
 
   mlly@1.8.0:
@@ -4088,6 +4096,8 @@ snapshots:
   nanoid@3.3.11: {}
 
   natural-compare@1.4.0: {}
+
+  neo-async@2.6.2: {}
 
   object-assign@4.1.1: {}
 
@@ -4334,6 +4344,8 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  source-map@0.6.1: {}
+
   source-map@0.7.6: {}
 
   spawn-command@0.0.2: {}
@@ -4497,6 +4509,9 @@ snapshots:
 
   ufo@1.6.3: {}
 
+  uglify-js@3.19.3:
+    optional: true
+
   undici-types@6.21.0: {}
 
   undici@7.18.2: {}
@@ -4629,6 +4644,8 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wordwrap@1.0.0: {}
 
   workerd@1.20260305.0:
     optionalDependencies:


### PR DESCRIPTION
**`@runtypelabs/persona`**

- **Human-in-the-loop (`ask_user_question`).** Support Runtype `step_await` (LOCAL tool pause), `client.resumeFlow()`, and `session.resolveAskUserQuestion()`. Synthesize tool messages with `agentMetadata.awaitingLocalTool`, render the answer UI, and resume via `POST` with `toolOutputs` (with `sendMessage` fallback for agents that do not use LOCAL tools). Idempotent `resolveAskUserQuestion` for rapid double-clicks.
- **Built-in answer UI.** Interactive sheet (stacked rows by default, optional `layout: "pills"`), optional free-text, progressive hydration from streaming tool args, feature flags under `features.askUserQuestion`, and `renderAskUserQuestion` / `parseAskUserQuestionPayload` for custom renderers. Plugins that delegate to the default should return `null` when `message.agentMetadata.askUserQuestionAnswered === true` so the widget owns the answered transcript.
- **Grouped questions.** Up to 8 questions per call, paginated stepper, `Record<questionText, string | string[]>` result shape, persistence of in-progress state across refresh, labels `nextLabel` / `backLabel` / `submitAllLabel` / `skipLabel`, and optional `groupedAutoAdvance: false`. UX aligned with common AskUserQuestion-style patterns: row layout, skip/back/submit, Q→A pair messages in the transcript, keyboard shortcuts 1–9, compact header, and optional “Other” input behavior per layout.
- **Fixes.** Composer overlay width and z-index; sheet lifecycle (answered flag, `awaitingLocalTool` gating, prune stale DOM); remove redundant “awaiting” stub when the sheet is the primary UI. Scroll-to-bottom control no longer covers the answer sheet.
- **Artifacts.** Persist artifact list and selection in `storageAdapter`; `initialArtifacts` / `initialSelectedArtifactId`, `hydrateArtifacts()`, and controller helpers for custom chrome; completed-only persistence for artifacts. Backward compatible with older stored state.
- **Theming.** `components.introCard` tokens and CSS variables for the welcome / intro card.

**`@runtypelabs/persona-proxy`**

- **`POST` resume route** (default under the chat path) forwarding `{ executionId, toolOutputs, streamResponse }` to the upstream `/resume` endpoint for LOCAL tool completion. Pre-configured `RuntypeFlowConfig` examples in this package can declare `ask_user_question` and other `runtimeTools` the same way as any custom flow.