### PR TITLE
fix(widget): seal assistant text bubble at each agent_tool_start

### DIFF
--- a/.changeset/fix-agent-turn-text-tool-interleave.md
+++ b/.changeset/fix-agent-turn-text-tool-interleave.md
@@ -1,0 +1,11 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix agent-turn text/tool interleaving so a `text → tool → text → tool → text` sequence within a single `agent_turn` renders as separate, chronologically ordered bubbles instead of one merged text bubble below all the tool cards.
+
+Previously, all `agent_turn_delta` (text) events within a turn accumulated into a single `assistantMessage` that was only finalized at iteration/step boundaries. Because each `agent_tool_start` created a tool message with an earlier `createdAt` than the still-growing text message, the timeline sorted tools before the consolidated narration — so an assistant that said *"Let me scrape a few more pages"* before kicking off a Firecrawl tool would appear to "explain itself" below the tool card it triggered.
+
+The widget now seals the in-flight assistant text bubble at every `agent_tool_start`, so the next text delta in that turn creates a new bubble. `agent_turn_complete.stopReason` continues to attach to the final visible text segment (whether it was sealed by a tool boundary or by turn-complete itself).
+
+No wire-protocol changes; relies on existing `seq`-ordered events and treats `agent_tool_start` as the natural segment boundary.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -2718,6 +2718,240 @@ describe('AgentWidgetClient - stopReason propagation', () => {
 });
 
 // ============================================================================
+// Within-turn text/tool interleaving — assistant text bubbles must seal at
+// each agent_tool_start so the chronological text→tool→text→tool sequence
+// renders as distinct timeline entries instead of one merged bubble that
+// appears below all the tool cards.
+// ============================================================================
+
+describe('AgentWidgetClient - agent_turn text/tool interleaving', () => {
+  const collectMessages = (events: AgentWidgetEvent[]): AgentWidgetMessage[] => {
+    const byId = new Map<string, AgentWidgetMessage>();
+    const order: string[] = [];
+    for (const e of events) {
+      if (e.type !== 'message') continue;
+      if (!byId.has(e.message.id)) order.push(e.message.id);
+      byId.set(e.message.id, e.message);
+    }
+    return order.map((id) => byId.get(id)!);
+  };
+
+  it('seals the assistant text bubble at each agent_tool_start so subsequent text creates a new bubble', async () => {
+    const execId = 'exec_interleave';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxTurns: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxTurns: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_start', {
+        executionId: execId, iteration: 1, turnIndex: 0,
+        role: 'assistant', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'before tool 1',
+        contentType: 'text', turnId: 'turn_1', seq: 4,
+      }),
+      sseEvent('agent_tool_start', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_1', toolName: 'search', toolType: 'builtin', seq: 5,
+      }),
+      sseEvent('agent_tool_complete', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_1', toolName: 'search', success: true,
+        executionTime: 10, seq: 6,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'between tools',
+        contentType: 'text', turnId: 'turn_1', seq: 7,
+      }),
+      sseEvent('agent_tool_start', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_2', toolName: 'fetch', toolType: 'builtin', seq: 8,
+      }),
+      sseEvent('agent_tool_complete', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_2', toolName: 'fetch', success: true,
+        executionTime: 10, seq: 9,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'after tool 2',
+        contentType: 'text', turnId: 'turn_1', seq: 10,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 1, role: 'assistant',
+        turnId: 'turn_1', completedAt: new Date().toISOString(),
+        stopReason: 'end_turn', seq: 11,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 1, toolCallsMade: 2,
+        stopConditionMet: true, completedAt: new Date().toISOString(), seq: 12,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'complete',
+        completedAt: new Date().toISOString(), seq: 13,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const messages = collectMessages(events);
+    const assistants = messages.filter((m) => m.role === 'assistant' && m.variant !== 'tool');
+    const tools = messages.filter((m) => m.variant === 'tool');
+
+    expect(assistants.map((m) => m.content)).toEqual([
+      'before tool 1',
+      'between tools',
+      'after tool 2',
+    ]);
+    expect(tools.map((m) => m.toolCall?.name)).toEqual(['search', 'fetch']);
+    expect(new Set(assistants.map((m) => m.id)).size).toBe(3);
+  });
+
+  it('attaches agent_turn_complete.stopReason to the final assistant text segment when the turn ends with text', async () => {
+    const execId = 'exec_stopreason_tail_text';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxTurns: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxTurns: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_start', {
+        executionId: execId, iteration: 1, turnIndex: 0,
+        role: 'assistant', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'first segment',
+        contentType: 'text', turnId: 'turn_1', seq: 4,
+      }),
+      sseEvent('agent_tool_start', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_1', toolName: 'search', toolType: 'builtin', seq: 5,
+      }),
+      sseEvent('agent_tool_complete', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_1', toolName: 'search', success: true,
+        executionTime: 10, seq: 6,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'final segment',
+        contentType: 'text', turnId: 'turn_1', seq: 7,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 1, role: 'assistant',
+        turnId: 'turn_1', completedAt: new Date().toISOString(),
+        stopReason: 'length', seq: 8,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 1, toolCallsMade: 1,
+        stopConditionMet: true, completedAt: new Date().toISOString(), seq: 9,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'complete',
+        completedAt: new Date().toISOString(), seq: 10,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const assistants = collectMessages(events).filter(
+      (m) => m.role === 'assistant' && m.variant !== 'tool'
+    );
+    expect(assistants).toHaveLength(2);
+    expect(assistants[0].content).toBe('first segment');
+    expect(assistants[0].stopReason).toBeUndefined();
+    expect(assistants[1].content).toBe('final segment');
+    expect(assistants[1].stopReason).toBe('length');
+  });
+
+  it('attaches agent_turn_complete.stopReason to the preceding text segment when the turn ends with a tool call', async () => {
+    const execId = 'exec_stopreason_tail_tool';
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxTurns: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxTurns: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_start', {
+        executionId: execId, iteration: 1, turnIndex: 0,
+        role: 'assistant', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'about to call tool',
+        contentType: 'text', turnId: 'turn_1', seq: 4,
+      }),
+      sseEvent('agent_tool_start', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_1', toolName: 'search', toolType: 'builtin', seq: 5,
+      }),
+      sseEvent('agent_tool_complete', {
+        executionId: execId, iteration: 1,
+        toolCallId: 'call_1', toolName: 'search', success: true,
+        executionTime: 10, seq: 6,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 1, role: 'assistant',
+        turnId: 'turn_1', completedAt: new Date().toISOString(),
+        stopReason: 'max_tool_calls', seq: 7,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 1, toolCallsMade: 1,
+        stopConditionMet: true, completedAt: new Date().toISOString(), seq: 8,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_tool_calls',
+        completedAt: new Date().toISOString(), seq: 9,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const assistants = collectMessages(events).filter(
+      (m) => m.role === 'assistant' && m.variant !== 'tool'
+    );
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0].content).toBe('about to call tool');
+    expect(assistants[0].stopReason).toBe('max_tool_calls');
+  });
+});
+
+// ============================================================================
 // step_await (LOCAL tool pause) + resumeFlow
 // ============================================================================
 

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1125,6 +1125,11 @@ export class AgentWidgetClient {
     };
 
     let assistantMessage: AgentWidgetMessage | null = null;
+    // Tracks the most recently touched assistant text message for the
+    // current agent turn so `agent_turn_complete.stopReason` can attach
+    // to the final visible text segment even after `assistantMessage`
+    // has been finalized at a tool-call boundary within the turn.
+    let lastAssistantInTurn: AgentWidgetMessage | null = null;
     // Reference to track assistant message for custom event handler
     const assistantMessageRef = { current: null as AgentWidgetMessage | null };
     // Track current partId for message segmentation at tool boundaries
@@ -2464,7 +2469,11 @@ export class AgentWidgetClient {
             }
           }
         } else if (payloadType === "agent_turn_start") {
-          // Nothing to do - turn tracking is handled by deltas
+          // Reset the per-turn assistant tracker. lastAssistantInTurn is
+          // used by agent_turn_complete to attach stopReason to the final
+          // text segment of the turn even if that segment was sealed by an
+          // intervening tool-call boundary.
+          lastAssistantInTurn = null;
         } else if (payloadType === "agent_turn_delta") {
           if (payload.contentType === 'text') {
             // Stream text to assistant message
@@ -2476,6 +2485,7 @@ export class AgentWidgetClient {
               turnId: payload.turnId,
               agentName: agentExecution?.agentName
             };
+            lastAssistantInTurn = assistant;
             emitMessage(assistant);
           } else if (payload.contentType === 'thinking') {
             // Stream thinking content to a reasoning message
@@ -2526,19 +2536,33 @@ export class AgentWidgetClient {
           // Attach the turn-level stopReason to the assistant message
           // produced by this turn. Only overwrite the current message —
           // prior turns already sealed their own stopReason via step_complete.
+          // Falls back to lastAssistantInTurn when the current bubble was
+          // sealed at a tool-call boundary mid-turn, so the notice still
+          // attaches to the final visible text segment.
           const turnStopReason = (payload as any).stopReason as
             | StopReasonKind
             | undefined;
-          if (turnStopReason && assistantMessage !== null) {
+          const stopReasonTarget = assistantMessage ?? lastAssistantInTurn;
+          if (turnStopReason && stopReasonTarget !== null) {
             const turnId = payload.turnId;
             const matchesTurn =
-              !turnId || assistantMessage.agentMetadata?.turnId === turnId;
+              !turnId || stopReasonTarget.agentMetadata?.turnId === turnId;
             if (matchesTurn) {
-              assistantMessage.stopReason = turnStopReason;
-              emitMessage(assistantMessage);
+              stopReasonTarget.stopReason = turnStopReason;
+              emitMessage(stopReasonTarget);
             }
           }
         } else if (payloadType === "agent_tool_start") {
+          // Finalize any in-flight assistant text bubble so subsequent text
+          // deltas in this turn create a NEW bubble. Without this, text
+          // emitted before AND after a tool call accumulates into one
+          // message that renders below all the tool bubbles, losing the
+          // chronological text→tool→text→tool interleaving.
+          if (assistantMessage) {
+            assistantMessage.streaming = false;
+            emitMessage(assistantMessage);
+            assistantMessage = null;
+          }
           const toolId = payload.toolCallId ?? `agent-tool-${nextSequence()}`;
           trackToolId(getToolCallKey(payload), toolId);
           const toolMessage = ensureToolMessage(toolId);


### PR DESCRIPTION
## Summary

- Fix agent-turn text/tool interleaving so a `text → tool → text → tool → text` sequence within a single `agent_turn` renders as separate, chronologically ordered bubbles instead of one merged text bubble below all the tool cards.
- Track `lastAssistantInTurn` so `agent_turn_complete.stopReason` still attaches to the final visible text segment (preserving the 3.17.0 "Stopped after calling a tool" affordance even when the turn ends with a tool).

## Repro

Observed in the Runtype dashboard's "Chat with Agent" panel: an agent turn that emitted

```
text₁ → tool₁ → tool₂ → tool₃ → text₂ → tool₄ → … → textₙ
```

was rendering as:

```
[tool₁] [tool₂] [tool₃] [tool₄] [tool₅] [tool₆] [tool₇]
[text₁ + text₂ + … + textₙ]   ← one merged bubble at the end
```

The merged bubble started *"Now let me scrape a few more pages for richer detail:"* but rendered below the very Firecrawl tool cards that line was introducing.

## Root cause

`packages/widget/src/client.ts` kept a single mutable `assistantMessage` ref across the whole agent turn:

- `agent_turn_delta` (text) appended to it via `ensureAssistantMessage()`.
- `agent_tool_start` created a separate tool message but **did not null `assistantMessage`**.

So text₁, text₂, … textₙ all merged into the same message object. Because each tool message got an earlier `createdAt` than the still-growing text, `session.ts:sortMessages` placed tools first and the consolidated text last.

## Fix

In `agent_tool_start`, finalize the in-flight `assistantMessage` (`streaming = false`, emit, null) so the next text delta in that turn creates a **new** bubble. Result: `text-segment, tool, text-segment, tool, …` each as a separate timeline entry in chronological order.

To preserve `stopReason` attachment when a turn ends with a tool call (the 3.17.0 "Stopped after calling a tool. Send a follow-up to continue." affordance), add a `lastAssistantInTurn` ref updated on every text delta and reset on `agent_turn_start`. `agent_turn_complete` falls back to it when `assistantMessage` has been sealed.

No wire-protocol changes; relies on existing `seq`-ordered events and treats `agent_tool_start` as the natural segment boundary.

## Test plan

- [x] `pnpm --filter @runtypelabs/persona typecheck` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm --filter @runtypelabs/persona test:run` — 835/835 passing (3 new + 832 preserved)
- [x] New regression tests in `client.test.ts`:
  - Interleaving: text→tool→text→tool→text produces `[assistant("text1"), tool("search"), assistant("text2"), tool("fetch"), assistant("text3")]` in order
  - `stopReason` attaches to the final text segment when the turn ends with text
  - `stopReason` attaches to the preceding text segment when the turn ends with a tool call (max_tool_calls case)
- [ ] Manual repro against a multi-tool agent in the dashboard after publish + dashboard bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts agent-loop message segmentation and stop-reason attachment during streaming; bugs here can affect chat timeline ordering and termination affordances across tool-heavy turns.
> 
> **Overview**
> Fixes **within-turn text/tool interleaving** in the widget: on `agent_tool_start`, the client now finalizes any in-flight assistant text message so later `agent_turn_delta` text becomes a new bubble, preserving chronological `text → tool → text` ordering.
> 
> Adds `lastAssistantInTurn` tracking so `agent_turn_complete.stopReason` attaches to the final visible text segment even if the current text bubble was sealed at a mid-turn tool boundary. Includes new regression tests covering interleaving and stopReason behavior, plus a changeset for a patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1922ca3835b1a3e5105f8b222b6e8907d86b5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->