### PR TITLE
feat: add llms.txt and llms-full.txt to persona-chat.dev

### DIFF
--- a/examples/embedded-app/llms.txt
+++ b/examples/embedded-app/llms.txt
@@ -1,0 +1,229 @@
+# Persona
+
+> Themeable, pluggable AI chat widget for websites. Zero framework dependencies.
+> Source: https://github.com/runtypelabs/persona
+> npm: https://www.npmjs.com/package/@runtypelabs/persona
+> Docs & demos: https://persona-chat.dev
+> Full reference (config + theming): https://persona-chat.dev/llms-full.txt
+> Agent skills: https://github.com/runtypelabs/skills
+
+Persona is a drop-in streaming chat UI for AI assistants that works on any website. It's built in TypeScript with vanilla JS — no React, Vue, or framework dependency. It renders inside a Shadow DOM for style isolation and ships as ESM, CJS, and IIFE (script tag).
+
+The fastest way to deploy an AI chat experience is with [Runtype](https://runtype.com) — Persona is pre-integrated, so you get streaming chat with tools, voice, theming, and analytics out of the box with zero backend code. Just set a `clientToken` and go. It also works with any SSE-capable backend if you want to bring your own.
+
+## Agent Skills
+
+If you're an AI coding agent, install the Runtype skills for guided help with Persona integration, Runtype product building, and more:
+
+```bash
+npx skills add runtypelabs/skills
+```
+
+This registers skills that activate contextually in Claude Code, Cursor, Copilot, Codex, Windsurf, and 30+ other agents. Key skills:
+
+- **`runtype-persona`** — Embedding, configuring, theming, and debugging Persona widgets. Prefers MCP-generated embed code over hand-written snippets.
+- **`runtype`** — Umbrella skill for all Runtype platform questions. Routes to focused skills and includes detailed reference material.
+- **`runtype-build-product`** — Building and deploying Runtype products (agents, flows, tools, surfaces).
+- **`runtype-admin`** — Operating and debugging live Runtype accounts (traces, logs, evals).
+- **`runtype-templates`** — Packaging products as distributable FPO templates.
+- **`runtype-sdk-marathon`** — Code-first workflows with the TypeScript/Python SDK and Marathon task harness.
+
+Browse and discover skills at [skills.sh](https://skills.sh).
+
+## Install
+
+```bash
+npm install @runtypelabs/persona
+```
+
+## Quick Start — ES Modules
+
+```ts
+import '@runtypelabs/persona/widget.css';
+import { initAgentWidget, markdownPostprocessor } from '@runtypelabs/persona';
+
+const chat = initAgentWidget({
+  target: 'body',
+  config: {
+    apiUrl: '/api/chat/dispatch',
+    launcher: { enabled: true, title: 'AI Assistant' },
+    theme: { accent: '#2563eb' },
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+  },
+});
+
+chat.open();
+chat.submitMessage('Hello!');
+chat.on('assistant:complete', (msg) => console.log(msg.content));
+```
+
+## Quick Start — Script Tag (CDN)
+
+```html
+<script>
+  window.siteAgentConfig = {
+    target: 'body',
+    config: {
+      apiUrl: 'https://your-proxy.com/api/chat/dispatch',
+      launcher: { enabled: true, title: 'AI Assistant' },
+    },
+  };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"></script>
+```
+
+## Quick Start — Client Token (No Proxy)
+
+```ts
+initAgentWidget({
+  target: 'body',
+  config: {
+    clientToken: 'ct_live_flow01k7_...',
+    launcher: { enabled: true },
+  },
+});
+```
+
+## Initialization
+
+Two entry points:
+
+- `initAgentWidget({ target, config, useShadowDom?, onReady?, windowKey? })` — floating launcher or docked panel. Returns a controller.
+- `createAgentExperience(element, config)` — inline embed with no launcher. Returns a controller.
+
+### Controller API
+
+| Method | Description |
+|---|---|
+| `open()` / `close()` / `toggle()` | Panel visibility |
+| `setMessage(text)` | Set input text without submitting |
+| `submitMessage(text?)` | Send a message |
+| `clearChat()` | Clear conversation |
+| `update(config)` | Merge new config at runtime |
+| `destroy()` | Remove widget and clean up |
+| `on(event, callback)` / `off(event, callback)` | Subscribe to events |
+| `injectAssistantMessage({ content, llmContent? })` | Inject a message programmatically |
+| `injectUserMessage(...)` / `injectSystemMessage(...)` | Inject user/system messages |
+| `injectComponentDirective({ component, props })` | Render a registered component |
+| `startVoiceRecognition()` / `stopVoiceRecognition()` | Voice control |
+| `focusInput()` | Focus the composer |
+| `showEventStream()` / `hideEventStream()` | Event inspector panel |
+
+### Controller Events
+
+| Event | Payload |
+|---|---|
+| `user:message` | `AgentWidgetMessage` (includes `viaVoice`) |
+| `assistant:message` | `AgentWidgetMessage` (stream start) |
+| `assistant:complete` | `AgentWidgetMessage` (stream end) |
+| `voice:state` | `{ active, source, timestamp }` |
+| `widget:opened` / `widget:closed` | `{ open, source, timestamp }` |
+| `widget:state` | `{ open, launcherEnabled, voiceActive, streaming }` |
+| `action:detected` | `{ action, message }` |
+| `message:feedback` | `{ type: 'upvote'|'downvote', messageId, message }` |
+| `message:copy` | `AgentWidgetMessage` |
+
+## Core Config Sections
+
+The full config is passed as `config` to `initAgentWidget()`. Key sections:
+
+- **`apiUrl`** — Your proxy endpoint (or use `clientToken` for direct browser-to-API)
+- **`flowId`** — Runtype flow ID for server-side flow selection
+- **`agent`** — Agent loop config (model, systemPrompt, tools, loopConfig) — mutually exclusive with `flowId`
+- **`theme` / `darkTheme`** — Design tokens (palette, semantic, component-level). See `llms-full.txt` for the full token reference.
+- **`colorScheme`** — `'light'`, `'dark'`, or `'auto'`
+- **`launcher`** — Button/panel config (enabled, title, subtitle, position, mountMode, dock)
+- **`layout`** — Header, messages, and slot configuration
+- **`voiceRecognition`** — Speech-to-text (browser Web Speech API or Runtype WebSocket)
+- **`textToSpeech`** — TTS for assistant responses
+- **`features`** — Feature flags (showReasoning, showToolCalls, artifacts, showEventStreamToggle)
+- **`plugins`** — Array of plugin objects with render hooks
+- **`parserType`** — `'plain'`, `'json'`, `'regex-json'`, or `'xml'` for structured streaming
+- **`attachments`** — File upload config (types, size limits)
+- **`messageActions`** — Copy/upvote/downvote buttons
+- **`suggestionChips`** — Quick-reply buttons above the composer
+- **`persistState`** — Save widget state across page navigations
+- **`postprocessMessage`** — Transform message text before rendering (return HTML)
+
+## Launcher Modes
+
+- **Floating** (default): `launcher.mountMode: 'floating'` — corner-anchored button + popup panel
+- **Docked**: `launcher.mountMode: 'docked'` — side panel that wraps a content container. `dock.reveal` controls the animation: `'resize'` (default), `'emerge'`, `'overlay'`, `'push'`
+
+## Message Injection
+
+Inject messages from external code (tool callbacks, navigation events, etc.):
+
+```ts
+chat.injectAssistantMessage({
+  content: 'Displayed to user',
+  llmContent: 'Sent to the LLM instead',
+});
+```
+
+Content priority: `contentParts > llmContent > content`.
+
+## Plugin System
+
+14 render hooks for customizing any part of the UI:
+
+```ts
+const plugin = {
+  id: 'my-plugin',
+  renderLauncher: (ctx) => { /* return HTMLElement or null */ },
+  renderHeader: (ctx) => { /* ... */ },
+  renderMessage: (ctx) => { /* ... */ },
+  renderToolCall: (ctx) => { /* ... */ },
+  renderReasoning: (ctx) => { /* ... */ },
+  renderLoadingIndicator: (ctx) => { /* ... */ },
+  renderIdleIndicator: (ctx) => { /* ... */ },
+  renderAskUserQuestion: (ctx) => { /* ... */ },
+  // ... and more
+};
+initAgentWidget({ target: 'body', config: { plugins: [plugin] } });
+```
+
+Plugins are priority-ordered. Return `null` from a hook to fall through to the next plugin or the default renderer.
+
+## Proxy Server
+
+Optional `@runtypelabs/persona-proxy` package for server-side API key management:
+
+```ts
+import { createChatProxyApp } from '@runtypelabs/persona-proxy';
+
+export default createChatProxyApp({
+  path: '/api/chat/dispatch',
+  allowedOrigins: ['https://example.com'],
+  flowId: 'flow_abc123', // or flowConfig: { ... }
+});
+```
+
+Set `RUNTYPE_API_KEY` in the environment.
+
+## Framework Integration
+
+Works with any framework. In React/Next.js/Remix/etc., initialize in a `useEffect` and call `handle.destroy()` on cleanup. Next.js App Router needs `'use client'`. For SSR frameworks, use dynamic import or `typeof window` guard.
+
+## Key Exports
+
+| Export | Purpose |
+|---|---|
+| `initAgentWidget` | Mount floating/docked widget, returns controller |
+| `createAgentExperience` | Mount inline widget, returns controller |
+| `DEFAULT_WIDGET_CONFIG` | Sensible default config to spread over |
+| `mergeWithDefaults` | Deep-merge your overrides with defaults |
+| `markdownPostprocessor` | Render markdown in messages |
+| `createJsonStreamParser` | JSON stream parser factory |
+| `createXmlParser` | XML stream parser factory |
+| `createPlainTextParser` | Plain text parser (default) |
+| `componentRegistry` | Register custom components for directive rendering |
+| `createTheme` | Build a theme from token overrides |
+| `brandPlugin` / `accessibilityPlugin` | Built-in theme plugins |
+| `createDropdownMenu` | Dropdown menu utility |
+| `createIconButton` / `createLabelButton` / `createToggleGroup` | Button utilities |
+| `collectEnrichedPageContext` / `formatEnrichedContext` | DOM context collection for tool use |
+
+## License
+
+MIT

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -231,6 +231,68 @@ function serveWidgetDist(): Plugin {
   };
 }
 
+function llmsTxt(): Plugin {
+  const llmsTxtPath = path.resolve(__dirname, "llms.txt");
+  const widgetReadmePath = path.resolve(__dirname, "../../packages/widget/README.md");
+  const themeConfigPath = path.resolve(__dirname, "../../packages/widget/THEME-CONFIG.md");
+
+  function buildLlmsTxt(): string {
+    return fs.readFileSync(llmsTxtPath, "utf-8");
+  }
+
+  function buildLlmsFullTxt(): string {
+    const overview = fs.readFileSync(llmsTxtPath, "utf-8");
+    const widgetReadme = fs.readFileSync(widgetReadmePath, "utf-8");
+    const themeConfig = fs.readFileSync(themeConfigPath, "utf-8");
+    return [
+      overview.replace(
+        /^(> Full reference .*)$/m,
+        "> This is the full reference. For the overview only, see https://persona-chat.dev/llms.txt"
+      ),
+      "",
+      "---",
+      "",
+      "# Widget Configuration Reference",
+      "",
+      "The sections below are the complete widget README (initialization, programmatic control, config tables, parsers, proxy setup, framework guides) and the theme/token reference.",
+      "",
+      widgetReadme,
+      "",
+      "---",
+      "",
+      themeConfig,
+    ].join("\n");
+  }
+
+  function serveMiddleware(middlewares: {
+    use: (path: string, handler: (req: any, res: any) => void) => void;
+  }): void {
+    middlewares.use("/llms.txt", (_req, res) => {
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end(buildLlmsTxt());
+    });
+    middlewares.use("/llms-full.txt", (_req, res) => {
+      res.setHeader("Content-Type", "text/plain; charset=utf-8");
+      res.end(buildLlmsFullTxt());
+    });
+  }
+
+  return {
+    name: "llms-txt",
+    configureServer(server) {
+      serveMiddleware(server.middlewares);
+    },
+    configurePreviewServer(server) {
+      serveMiddleware(server.middlewares);
+    },
+    writeBundle(options) {
+      const outDir = options.dir ?? path.resolve(__dirname, "dist");
+      fs.writeFileSync(path.join(outDir, "llms.txt"), buildLlmsTxt());
+      fs.writeFileSync(path.join(outDir, "llms-full.txt"), buildLlmsFullTxt());
+    },
+  };
+}
+
 function previewEmbedCheck(): Plugin {
   return {
     name: "preview-embed-check",
@@ -245,7 +307,7 @@ function previewEmbedCheck(): Plugin {
 
 export default defineConfig({
   base: './',
-  plugins: [serveWidgetDist(), previewEmbedCheck()],
+  plugins: [serveWidgetDist(), llmsTxt(), previewEmbedCheck()],
   resolve: {
     alias: {
       "@runtypelabs/persona/theme-editor": path.resolve(


### PR DESCRIPTION
## Summary

- Adds a hand-written `examples/embedded-app/llms.txt` (229 lines) purpose-built for LLM consumption: project overview, install, quick-start snippets (ESM/CDN/client-token), controller API, config sections, plugin system, framework integration, key exports, and agent skills with `npx skills add runtypelabs/skills`
- Adds a `llmsTxt()` Vite plugin that serves `/llms.txt` as-is and assembles `/llms-full.txt` by appending the widget README config reference + THEME-CONFIG.md — keeps the full reference in sync without content duplication
- Both files are served during dev/preview via middleware and emitted to `dist/` at build time

## Test plan

- [ ] `pnpm dev:widget` — verify `http://localhost:5173/llms.txt` and `http://localhost:5173/llms-full.txt` serve correctly with `text/plain` content type
- [ ] `npx vite build` in `examples/embedded-app` — verify `dist/llms.txt` and `dist/llms-full.txt` are emitted
- [ ] Confirm `llms-full.txt` contains the overview, widget README, and THEME-CONFIG.md sections with proper separators

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and static-file serving only; no runtime chat, auth, or API behavior changes.
> 
> **Overview**
> Adds **LLM-oriented documentation** for persona-chat.dev: a new `examples/embedded-app/llms.txt` overview (install, quick starts, controller API, config, plugins, skills) and wiring so **`/llms.txt`** and **`/llms-full.txt`** are available in dev, preview, and production builds.
> 
> A new **`llmsTxt()`** Vite plugin serves **`/llms.txt`** from that file and builds **`/llms-full.txt`** by appending `packages/widget/README.md` and `THEME-CONFIG.md`, with a one-line swap so the full doc points back to the overview URL. **`writeBundle`** writes both files into **`dist/`** so deploys match local behavior without duplicating the long references in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19f3fd04fa8d760ae48d6fd8af19d8fc7f05ddc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->