### PR TITLE
feat(examples): refine docked panel coachmark animation

### DIFF
--- a/examples/embedded-app/docked-panel-demo.html
+++ b/examples/embedded-app/docked-panel-demo.html
@@ -302,6 +302,68 @@
         inset 0 -12px 22px rgba(125, 211, 252, 0.17),
         inset 0 -2px 0 rgba(255, 255, 255, 0.26);
     }
+    #assistant-toggle.assistant-toggle--persist-highlight {
+      animation:
+        assistant-toggle-arrive 0.7s cubic-bezier(0.22, 1, 0.36, 1) both,
+        assistant-toggle-pulse 2.8s ease-in-out infinite;
+      animation-delay: var(--arrive-delay, 1.0s), var(--pulse-delay, 1.8s);
+    }
+    @keyframes assistant-toggle-arrive {
+      0% {
+        box-shadow:
+          0 0 14px rgba(56, 189, 248, 0.22),
+          inset 0 12px 26px rgba(0, 0, 0, 0.88),
+          inset 0 5px 14px rgba(0, 0, 0, 0.72),
+          inset 0 -12px 22px rgba(125, 211, 252, 0.14),
+          inset 0 -2px 0 rgba(255, 255, 255, 0.22);
+        border-color: rgba(56, 189, 248, 0.5);
+      }
+      22% {
+        box-shadow:
+          0 0 28px rgba(56, 189, 248, 0.6),
+          0 0 48px rgba(125, 211, 252, 0.3),
+          inset 0 12px 26px rgba(0, 0, 0, 0.76),
+          inset 0 5px 14px rgba(0, 0, 0, 0.6),
+          inset 0 -12px 22px rgba(125, 211, 252, 0.24),
+          inset 0 -2px 0 rgba(255, 255, 255, 0.3);
+        border-color: rgba(56, 189, 248, 0.85);
+      }
+      100% {
+        box-shadow:
+          0 0 14px rgba(56, 189, 248, 0.22),
+          inset 0 12px 26px rgba(0, 0, 0, 0.88),
+          inset 0 5px 14px rgba(0, 0, 0, 0.72),
+          inset 0 -12px 22px rgba(125, 211, 252, 0.14),
+          inset 0 -2px 0 rgba(255, 255, 255, 0.22);
+        border-color: rgba(56, 189, 248, 0.5);
+      }
+    }
+    @keyframes assistant-toggle-pulse {
+      0%, 100% {
+        box-shadow:
+          0 0 14px rgba(56, 189, 248, 0.22),
+          inset 0 12px 26px rgba(0, 0, 0, 0.88),
+          inset 0 5px 14px rgba(0, 0, 0, 0.72),
+          inset 0 -12px 22px rgba(125, 211, 252, 0.14),
+          inset 0 -2px 0 rgba(255, 255, 255, 0.22);
+        border-color: rgba(56, 189, 248, 0.5);
+      }
+      50% {
+        box-shadow:
+          0 0 22px rgba(56, 189, 248, 0.38),
+          0 0 36px rgba(125, 211, 252, 0.12),
+          inset 0 12px 26px rgba(0, 0, 0, 0.84),
+          inset 0 5px 14px rgba(0, 0, 0, 0.68),
+          inset 0 -12px 22px rgba(125, 211, 252, 0.19),
+          inset 0 -2px 0 rgba(255, 255, 255, 0.26);
+        border-color: rgba(56, 189, 248, 0.68);
+      }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      #assistant-toggle.assistant-toggle--persist-highlight {
+        animation: none;
+      }
+    }
     #assistant-toggle svg {
       width: 22px;
       height: 22px;
@@ -348,27 +410,73 @@
       white-space: nowrap;
       flex-shrink: 0;
       pointer-events: none;
-      animation: assistant-coachmark-glow 2.4s ease-in-out infinite;
+      position: relative;
+      overflow: hidden;
+      opacity: 0;
+      transform: translateX(-12px);
+      animation:
+        assistant-coachmark-enter 0.5s cubic-bezier(0.22, 1, 0.36, 1) 2s forwards,
+        assistant-coachmark-settle 1.1s cubic-bezier(0.33, 1, 0.68, 1) 3.6s forwards;
     }
-    @keyframes assistant-coachmark-glow {
-      0%,
+    .assistant-coachmark::before {
+      content: '';
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(
+        90deg,
+        transparent 0%,
+        rgba(255, 255, 255, 0.2) 35%,
+        rgba(186, 230, 253, 0.45) 50%,
+        rgba(255, 255, 255, 0.2) 65%,
+        transparent 100%
+      );
+      transform: translateX(-110%);
+      animation: assistant-coachmark-sweep 1.4s cubic-bezier(0.76, 0, 0.24, 1) 2.7s forwards;
+      pointer-events: none;
+      border-radius: inherit;
+    }
+    @keyframes assistant-coachmark-enter {
+      0% {
+        opacity: 0;
+        transform: translateX(-12px) scale(0.97);
+      }
       100% {
+        opacity: 1;
+        transform: translateX(0) scale(1);
+      }
+    }
+    @keyframes assistant-coachmark-sweep {
+      0%   { transform: translateX(-110%); }
+      100% { transform: translateX(110%); }
+    }
+    @keyframes assistant-coachmark-settle {
+      0% {
         box-shadow:
           0 0 0 1px rgba(0, 0, 0, 0.25),
           0 4px 18px rgba(56, 189, 248, 0.45),
           inset 0 1px 0 rgba(255, 255, 255, 0.35);
+        border-color: rgba(186, 230, 253, 0.85);
+        opacity: 1;
       }
-      50% {
+      100% {
         box-shadow:
-          0 0 0 1px rgba(0, 0, 0, 0.25),
-          0 4px 22px rgba(56, 189, 248, 0.65),
-          0 0 28px rgba(125, 211, 252, 0.35),
-          inset 0 1px 0 rgba(255, 255, 255, 0.45);
+          0 0 0 1px rgba(0, 0, 0, 0.1),
+          0 2px 6px rgba(56, 189, 248, 0.1),
+          inset 0 1px 0 rgba(255, 255, 255, 0.1);
+        border-color: rgba(186, 230, 253, 0.3);
+        opacity: 0.6;
       }
     }
     @media (prefers-reduced-motion: reduce) {
       .assistant-coachmark {
         animation: none;
+        opacity: 0.6;
+        transform: none;
+        border-color: rgba(186, 230, 253, 0.3);
+      }
+      .assistant-coachmark::before {
+        animation: none;
+        display: none;
       }
     }
     .assistant-coachmark__arrow {
@@ -376,16 +484,11 @@
       flex-shrink: 0;
       color: #e0f2fe;
       filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
-      animation: assistant-coachmark-nudge 1.1s ease-in-out infinite;
+      animation: assistant-coachmark-nudge 0.5s cubic-bezier(0.22, 1.4, 0.36, 1) 3.2s 2 both;
     }
     @keyframes assistant-coachmark-nudge {
-      0%,
-      100% {
-        transform: translateX(0);
-      }
-      50% {
-        transform: translateX(5px);
-      }
+      0%, 100% { transform: translateX(0); }
+      50%      { transform: translateX(6px); }
     }
     @media (prefers-reduced-motion: reduce) {
       .assistant-coachmark__arrow {

--- a/examples/embedded-app/src/docked-panel-demo.ts
+++ b/examples/embedded-app/src/docked-panel-demo.ts
@@ -193,7 +193,45 @@ function applyDockSettings(): void {
   updateStatus("Layout updated.");
 }
 
+/**
+ * Compute when the coachmark shimmer would physically arrive at the button,
+ * accounting for the gap between the two elements and the shimmer's exit velocity.
+ *
+ * Sweep: translateX(-110%) → +110% over SWEEP_DUR with cubic-bezier(0.76,0,0.24,1).
+ * The shimmer center exits the coachmark right edge at ~56.5% of the sweep time
+ * (inverse of the easing curve at 72.7% linear progress).  At that point the
+ * instantaneous velocity is ~2.49× the average sweep speed.  We project that
+ * velocity across the measured gap to get the button-arrive delay.
+ */
+function syncCoachmarkTiming(): void {
+  const coachmark = document.getElementById("assistant-coachmark");
+  if (!coachmark) return;
+
+  const coachRect = coachmark.getBoundingClientRect();
+  const btnRect = assistantToggle.getBoundingClientRect();
+
+  const ENTRANCE_TOTAL = 2.5;
+  const SWEEP_START = ENTRANCE_TOTAL + 0.2;
+  const SWEEP_DUR = 1.4;
+  const EXIT_FRAC = 0.565;
+  const exitTime = SWEEP_START + SWEEP_DUR * EXIT_FRAC;
+
+  const totalDist = 2.2 * coachRect.width;
+  const exitVelocity = 2.493 * totalDist / SWEEP_DUR;
+
+  const gap = btnRect.left + btnRect.width / 2 - coachRect.right;
+  const transit = Math.max(0, gap / exitVelocity);
+
+  const ARRIVE_DUR = 0.7;
+  const arriveDelay = exitTime + transit;
+  const pulseDelay = arriveDelay + ARRIVE_DUR;
+
+  assistantToggle.style.setProperty("--arrive-delay", `${arriveDelay.toFixed(3)}s`);
+  assistantToggle.style.setProperty("--pulse-delay", `${pulseDelay.toFixed(3)}s`);
+}
+
 syncWorkspaceMainDockSide();
+syncCoachmarkTiming();
 controller = createController();
 bindControllerEvents();
 syncToggleUi();
@@ -214,5 +252,7 @@ assistantToggle.addEventListener("mousedown", (e) => {
 });
 
 assistantToggle.addEventListener("click", () => {
+  assistantToggle.classList.remove("assistant-toggle--persist-highlight");
+  document.getElementById("assistant-coachmark")?.remove();
   controller.toggle();
 });


### PR DESCRIPTION
## Summary

- **Staged entrance**: coachmark starts invisible, fades+slides in after 2s so the user can orient on the page before being directed to the assistant button
- **One-shot shimmer sweep**: replaces the infinite glow with a single left-to-right highlight pass using a dramatic S-curve easing (`cubic-bezier(0.76, 0, 0.24, 1)`)
- **Contiguous motion**: JS measures the pixel gap between the coachmark and button at runtime, then computes the button-arrive delay from the shimmer's exit velocity so the glow lands at the physically correct moment
- **Gentle pulse**: after the arrive glow settles, the button pulses softly until clicked — then the coachmark is removed from the DOM and the pulse stops
- All animations respect `prefers-reduced-motion`

## Test plan

- [ ] Open `docked-panel-demo.html` — verify the coachmark is invisible for ~2s, then fades+slides in
- [ ] Watch the shimmer sweep from left to right, followed by a glow that arrives on the sparkles button without a perceptible gap
- [ ] Confirm the button gently pulses after the arrive animation
- [ ] Click the sparkles button — coachmark should disappear permanently and pulse should stop
- [ ] Close the panel — coachmark should not reappear
- [ ] Enable `prefers-reduced-motion` — coachmark should appear immediately in its settled state with no animations

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to example HTML/CSS/TS for the docked-panel demo; no production auth, API, or data paths.
> 
> **Overview**
> The docked-panel demo’s assistant coachmark is reworked into a **timed onboarding sequence** instead of looping glow effects. The label stays hidden briefly, then enters with a **one-shot shimmer** and a short arrow nudge; the sparkles button gets **arrive + soft pulse** animations driven by CSS custom properties.
> 
> **`syncCoachmarkTiming()`** in the demo script measures the layout gap and sets `--arrive-delay` / `--pulse-delay` so the button highlight lines up with when the shimmer would reach it. **First click** removes the coachmark from the DOM and stops the persistent highlight before toggling the panel. **`prefers-reduced-motion`** paths skip motion and show a settled, subdued coachmark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 258b236d7a8a4ec95a6e466261f814e8c6ca63d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->