### PR TITLE
feat(theme-editor): expose theme editor as WebMCP tools

### DIFF
--- a/.changeset/theme-editor-rgb-color-scale-fix.md
+++ b/.changeset/theme-editor-rgb-color-scale-fix.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix theme editor `set_brand_colors` (and contrast checks) corrupting palettes when given `rgb()`/`rgba()` color input. `hexToHsl` and `wcagContrastRatio` now parse rgb strings instead of producing `#NaNNaNNaN` shades. Adds an `rgbToHex` color utility.

--- a/.changeset/theme-editor-webmcp-tools.md
+++ b/.changeset/theme-editor-webmcp-tools.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add WebMCP tools for the theme editor. `@runtypelabs/persona/theme-editor` now exports `createThemeEditorTools(state)`, a transport-agnostic factory that returns intent-level WebMCP tools (set brand colors, assign color roles, set typography/roundness/color-scheme, apply presets, configure the widget, check WCAG contrast, plus a low-level field escape hatch and session/export controls). Wiring the tools to a `ThemeEditorState` lets a browser agent configure a theme — including a Persona widget styling itself.

--- a/examples/embedded-app/package.json
+++ b/examples/embedded-app/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@mcp-b/webmcp-polyfill": "^3.0.0",
     "@runtypelabs/persona": "workspace:^",
     "handlebars": "^4.7.8",
     "idiomorph": "^0.7.4",

--- a/examples/embedded-app/src/theme-configurator/index.ts
+++ b/examples/embedded-app/src/theme-configurator/index.ts
@@ -14,6 +14,7 @@ import type {
 } from '@runtypelabs/persona';
 import type { OnChangeCallback, ControlResult } from './types';
 import * as state from './state';
+import { mountThemeEditorMcp } from './webmcp/register';
 import { initSearchUI, pruneSearchIndex, resetSearchIndex } from './search';
 import * as styleTab from './sections/appearance';
 import type { DrilldownView } from './sections/appearance';
@@ -215,6 +216,11 @@ function init(): void {
     }
     previewManager?.update();
   });
+
+  // Expose the theme editor as WebMCP tools so a browser agent can configure
+  // the theme; routed through `state` so the preview + controls update for free.
+  const unmountMcp = mountThemeEditorMcp(state);
+  window.addEventListener('beforeunload', unmountMcp);
 }
 
 // ─── Tabs ────────────────────────────────────────────────────────

--- a/examples/embedded-app/src/theme-configurator/webmcp/install.ts
+++ b/examples/embedded-app/src/theme-configurator/webmcp/install.ts
@@ -1,0 +1,41 @@
+/**
+ * Client-side helper that guarantees a usable `document.modelContext` before we
+ * register the theme-editor WebMCP tools.
+ *
+ * Backed by `@mcp-b/webmcp-polyfill`. `initializeWebMCPPolyfill()` is idempotent
+ * and preserves a native `document.modelContext` when the browser ships one, so
+ * this is a no-op on supporting browsers. Never throws.
+ */
+
+import type { WebMcpTool } from '@runtypelabs/persona/theme-editor';
+
+export interface RegisterToolOptions {
+  signal?: AbortSignal;
+}
+
+export interface ModelContext {
+  registerTool(tool: WebMcpTool, options?: RegisterToolOptions): unknown;
+}
+
+/**
+ * Returns a `ModelContext` to register tools on, or `null` when WebMCP cannot be
+ * used in the current environment (SSR or a polyfill load failure).
+ */
+export async function ensureModelContext(): Promise<ModelContext | null> {
+  if (typeof window === 'undefined' || typeof document === 'undefined') {
+    return null;
+  }
+
+  try {
+    const { initializeWebMCPPolyfill } = await import('@mcp-b/webmcp-polyfill');
+    initializeWebMCPPolyfill();
+    // Read through `unknown` so our local `ModelContext` shape is the contract,
+    // decoupled from the polyfill's published types.
+    const doc = document as unknown as { modelContext?: ModelContext };
+    const nav = navigator as unknown as { modelContext?: ModelContext };
+    return doc.modelContext ?? nav.modelContext ?? null;
+  } catch (error) {
+    console.warn('[persona] WebMCP polyfill unavailable; theme tools not registered.', error);
+    return null;
+  }
+}

--- a/examples/embedded-app/src/theme-configurator/webmcp/register.ts
+++ b/examples/embedded-app/src/theme-configurator/webmcp/register.ts
@@ -1,0 +1,29 @@
+/**
+ * Registers the theme-editor WebMCP tools against the live editor `state`
+ * singleton, so an agent's tool calls update the preview, the form controls, and
+ * localStorage exactly like a human edit.
+ *
+ * Vanilla analog of the React `useEffect` cleanup pattern: returns an unmount
+ * function that aborts the registration signal (unregistering all tools).
+ */
+
+import { createThemeEditorTools } from '@runtypelabs/persona/theme-editor';
+import type { ThemeEditorLike } from '@runtypelabs/persona/theme-editor';
+import { ensureModelContext } from './install';
+
+export function mountThemeEditorMcp(state: ThemeEditorLike): () => void {
+  const controller = new AbortController();
+
+  void (async () => {
+    const modelContext = await ensureModelContext();
+    if (!modelContext || controller.signal.aborted) return;
+
+    const tools = createThemeEditorTools(state);
+    for (const tool of tools) {
+      modelContext.registerTool(tool, { signal: controller.signal });
+    }
+    console.info(`[persona] Registered ${tools.length} theme-editor WebMCP tools.`);
+  })();
+
+  return () => controller.abort();
+}

--- a/packages/widget/src/theme-editor/color-utils.test.ts
+++ b/packages/widget/src/theme-editor/color-utils.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import {
+  rgbToHex,
+  hexToHsl,
+  generateColorScale,
+  wcagContrastRatio,
+  SHADE_KEYS,
+} from './color-utils';
+
+describe('rgbToHex', () => {
+  it('parses integer rgb()', () => {
+    expect(rgbToHex('rgb(255, 0, 0)')).toBe('#ff0000');
+    expect(rgbToHex('rgb(37, 99, 235)')).toBe('#2563eb');
+  });
+
+  it('drops the alpha channel from rgba()', () => {
+    expect(rgbToHex('rgba(0, 128, 0, 0.5)')).toBe('#008000');
+  });
+
+  it('parses percentage channels and clamps out-of-range values', () => {
+    expect(rgbToHex('rgb(100%, 0%, 0%)')).toBe('#ff0000');
+    expect(rgbToHex('rgb(300, -20, 0)')).toBe('#ff0000');
+  });
+
+  it('returns null for non-rgb input', () => {
+    expect(rgbToHex('#2563eb')).toBeNull();
+    expect(rgbToHex('blue')).toBeNull();
+    expect(rgbToHex('rgb(1, 2)')).toBeNull();
+  });
+});
+
+describe('hexToHsl with rgb() input', () => {
+  it('produces the same HSL as the equivalent hex', () => {
+    const fromRgb = hexToHsl('rgb(37, 99, 235)');
+    const fromHex = hexToHsl('#2563eb');
+    expect(fromRgb.h).toBeCloseTo(fromHex.h, 5);
+    expect(fromRgb.s).toBeCloseTo(fromHex.s, 5);
+    expect(fromRgb.l).toBeCloseTo(fromHex.l, 5);
+  });
+});
+
+describe('generateColorScale with rgb() input', () => {
+  it('does not emit NaN shades for rgb() base colors', () => {
+    const scale = generateColorScale('rgb(255, 0, 0)');
+    for (const shade of SHADE_KEYS) {
+      expect(scale[shade]).toMatch(/^#[0-9a-f]{6}$/);
+      expect(scale[shade]).not.toContain('NaN');
+    }
+  });
+});
+
+describe('wcagContrastRatio with rgb() input', () => {
+  it('matches the hex equivalent', () => {
+    expect(wcagContrastRatio('rgb(255, 255, 255)', 'rgb(0, 0, 0)')).toBeCloseTo(
+      wcagContrastRatio('#ffffff', '#000000'),
+      5
+    );
+  });
+});

--- a/packages/widget/src/theme-editor/color-utils.ts
+++ b/packages/widget/src/theme-editor/color-utils.ts
@@ -64,6 +64,36 @@ export function isValidHex(value: string): boolean {
   return /^#[0-9A-Fa-f]{6}$/.test(value);
 }
 
+/**
+ * Parse an `rgb()` / `rgba()` string into `#rrggbb`. Accepts integer (0-255) or
+ * percentage channels; any alpha component is dropped. Returns `null` when the
+ * string is not a parseable rgb/rgba value, so callers can fall back. This lets
+ * the HSL/luminance paths — which otherwise `parseInt` hex digits — accept the
+ * `rgb()` inputs that `coerceColor` admits without producing `#NaNNaNNaN`.
+ */
+export function rgbToHex(value: string): string | null {
+  const match = value.trim().toLowerCase().match(/^rgba?\(([^)]+)\)$/);
+  if (!match) return null;
+
+  const parts = match[1].split(',').map((p) => p.trim());
+  if (parts.length < 3) return null;
+
+  const channel = (raw: string): number => {
+    const isPct = raw.endsWith('%');
+    const n = parseFloat(isPct ? raw.slice(0, -1) : raw);
+    if (!Number.isFinite(n)) return NaN;
+    return Math.max(0, Math.min(255, Math.round(isPct ? (n / 100) * 255 : n)));
+  };
+
+  const r = channel(parts[0]);
+  const g = channel(parts[1]);
+  const b = channel(parts[2]);
+  if (!Number.isFinite(r) || !Number.isFinite(g) || !Number.isFinite(b)) return null;
+
+  const toHex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
 // ─── WCAG Contrast ──────────────────────────────────────────────
 
 /**
@@ -72,7 +102,8 @@ export function isValidHex(value: string): boolean {
  */
 export function wcagContrastRatio(hex1: string, hex2: string): number {
   const luminance = (hex: string): number => {
-    const norm = normalizeColorValue(hex);
+    const normalized = normalizeColorValue(hex);
+    const norm = normalized.startsWith('rgb') ? rgbToHex(normalized) ?? '#000000' : normalized;
     const channels = [1, 3, 5].map((i) => {
       const v = parseInt(norm.slice(i, i + 2), 16) / 255;
       return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
@@ -87,7 +118,12 @@ export function wcagContrastRatio(hex1: string, hex2: string): number {
 // ─── HSL Conversion ─────────────────────────────────────────────
 
 export function hexToHsl(hex: string): { h: number; s: number; l: number } {
-  const normalized = normalizeColorValue(hex);
+  const normalizedValue = normalizeColorValue(hex);
+  // `rgb()`/`rgba()` is valid color input (see coerceColor) but can't be sliced
+  // as hex digits; convert it first so the scale isn't built from NaN channels.
+  const normalized = normalizedValue.startsWith('rgb')
+    ? rgbToHex(normalizedValue) ?? '#000000'
+    : normalizedValue;
   const r = parseInt(normalized.slice(1, 3), 16) / 255;
   const g = parseInt(normalized.slice(3, 5), 16) / 255;
   const b = parseInt(normalized.slice(5, 7), 16) / 255;

--- a/packages/widget/src/theme-editor/index.ts
+++ b/packages/widget/src/theme-editor/index.ts
@@ -138,3 +138,37 @@ export {
   resolveThemeColorPath,
   tokenRefDisplayName,
 } from './color-utils';
+
+// WebMCP tools (transport-agnostic factory for agent-driven theming)
+export {
+  createThemeEditorTools,
+  toolResult,
+  buildSummary,
+  runContrastChecks,
+  quickContrastWarnings,
+  CONTRAST_PAIRS,
+  RADIUS_PRESETS,
+  coerceColor,
+  coerceFamily,
+  coerceIntensity,
+  coerceScheme,
+  coerceRoundnessStyle,
+  coerceRadius,
+  CSS_NAMED_COLORS,
+} from './webmcp';
+export type {
+  WebMcpTool,
+  ToolResult,
+  ToolAnnotations,
+  ToolTextContent,
+  ToolExecute,
+  ThemeEditorLike,
+  EditTarget,
+  CreateThemeEditorToolsOptions,
+  ThemeSummary,
+  RoleState,
+  ContrastReport,
+  ContrastCheck,
+  ContrastWarning,
+  ContrastLevel,
+} from './webmcp';

--- a/packages/widget/src/theme-editor/index.ts
+++ b/packages/widget/src/theme-editor/index.ts
@@ -128,6 +128,7 @@ export {
   convertFromPx,
   normalizeColorValue,
   isValidHex,
+  rgbToHex,
   wcagContrastRatio,
   hexToHsl,
   hslToHex,

--- a/packages/widget/src/theme-editor/webmcp/coerce.test.ts
+++ b/packages/widget/src/theme-editor/webmcp/coerce.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import {
+  coerceColor,
+  coerceFamily,
+  coerceIntensity,
+  coerceScheme,
+  coerceRoundnessStyle,
+  coerceRadius,
+  coerceTypographyRef,
+  FONT_WEIGHT_REFS,
+} from './coerce';
+
+describe('coerceColor', () => {
+  it('normalizes bare and short hex', () => {
+    expect(coerceColor('2563eb')).toBe('#2563eb');
+    expect(coerceColor('#18f')).toBe('#1188ff');
+    expect(coerceColor('#2563EB')).toBe('#2563eb');
+  });
+
+  it('maps CSS color names', () => {
+    expect(coerceColor('blue')).toBe('#0000ff');
+    expect(coerceColor('SlateBlue')).toBe('#6a5acd');
+  });
+
+  it('passes through rgb and transparent', () => {
+    expect(coerceColor('transparent')).toBe('transparent');
+    expect(coerceColor('rgb(1, 2, 3)')).toBe('rgb(1, 2, 3)');
+  });
+
+  it('throws with guidance on garbage', () => {
+    expect(() => coerceColor('notacolor')).toThrow(/not a recognized color/);
+    expect(() => coerceColor('')).toThrow();
+  });
+});
+
+describe('enum coercion', () => {
+  it('coerces families with neutral synonyms', () => {
+    expect(coerceFamily('gray')).toBe('neutral');
+    expect(coerceFamily('Primary')).toBe('primary');
+    expect(() => coerceFamily('neutral', false)).toThrow(/Valid families/);
+  });
+
+  it('coerces intensity defaulting to solid', () => {
+    expect(coerceIntensity(undefined)).toBe('solid');
+    expect(coerceIntensity('SOFT')).toBe('soft');
+    expect(() => coerceIntensity('bright')).toThrow();
+  });
+
+  it('coerces scheme with system → auto', () => {
+    expect(coerceScheme('system')).toBe('auto');
+    expect(coerceScheme('Dark')).toBe('dark');
+  });
+
+  it('coerces roundness synonyms', () => {
+    expect(coerceRoundnessStyle('square')).toBe('sharp');
+    expect(coerceRoundnessStyle('circle')).toBe('pill');
+    expect(coerceRoundnessStyle('round')).toBe('rounded');
+  });
+});
+
+describe('coerceRadius', () => {
+  it('turns numbers into px', () => {
+    expect(coerceRadius(8)).toBe('8px');
+  });
+  it('normalizes css strings', () => {
+    expect(coerceRadius('0.5rem')).toBe('0.5rem');
+    expect(coerceRadius('9999px')).toBe('9999px');
+  });
+});
+
+describe('coerceTypographyRef', () => {
+  it('maps numeric weights to token refs', () => {
+    expect(coerceTypographyRef(600, FONT_WEIGHT_REFS, 'fontWeight')).toBe(
+      'palette.typography.fontWeight.semibold'
+    );
+  });
+  it('throws on unknown', () => {
+    expect(() => coerceTypographyRef('chunky', FONT_WEIGHT_REFS, 'fontWeight')).toThrow();
+  });
+});

--- a/packages/widget/src/theme-editor/webmcp/coerce.test.ts
+++ b/packages/widget/src/theme-editor/webmcp/coerce.test.ts
@@ -22,9 +22,15 @@ describe('coerceColor', () => {
     expect(coerceColor('SlateBlue')).toBe('#6a5acd');
   });
 
-  it('passes through rgb and transparent', () => {
+  it('passes through valid rgb/rgba and transparent', () => {
     expect(coerceColor('transparent')).toBe('transparent');
     expect(coerceColor('rgb(1, 2, 3)')).toBe('rgb(1, 2, 3)');
+    expect(coerceColor('rgba(1,2,3,0.5)')).toBe('rgba(1,2,3,0.5)');
+  });
+
+  it('rejects malformed rgb-prefixed garbage', () => {
+    expect(() => coerceColor('rgbfoo')).toThrow(/not a recognized color/);
+    expect(() => coerceColor('rgba(')).toThrow(/not a recognized color/);
   });
 
   it('throws with guidance on garbage', () => {

--- a/packages/widget/src/theme-editor/webmcp/coerce.ts
+++ b/packages/widget/src/theme-editor/webmcp/coerce.ts
@@ -1,0 +1,259 @@
+/**
+ * Input coercion for the WebMCP theme tools.
+ *
+ * Agent inputs are flexible by design (arcade.dev "parameter coercion"): colors
+ * accept hex with/without `#`, 3-digit hex, rgb(), and common CSS color names;
+ * enums accept friendly synonyms. Each coercer throws an Error whose message
+ * lists the valid options (arcade.dev "error-guided recovery").
+ */
+
+import {
+  normalizeColorValue,
+  isValidHex,
+  parseCssValue,
+  formatCssValue,
+} from '../color-utils';
+
+// ─── CSS named colors (common subset) ───────────────────────────
+
+export const CSS_NAMED_COLORS: Record<string, string> = {
+  black: '#000000',
+  white: '#ffffff',
+  red: '#ff0000',
+  green: '#008000',
+  lime: '#00ff00',
+  blue: '#0000ff',
+  yellow: '#ffff00',
+  cyan: '#00ffff',
+  aqua: '#00ffff',
+  magenta: '#ff00ff',
+  fuchsia: '#ff00ff',
+  silver: '#c0c0c0',
+  gray: '#808080',
+  grey: '#808080',
+  maroon: '#800000',
+  olive: '#808000',
+  purple: '#800080',
+  teal: '#008080',
+  navy: '#000080',
+  orange: '#ffa500',
+  pink: '#ffc0cb',
+  hotpink: '#ff69b4',
+  gold: '#ffd700',
+  indigo: '#4b0082',
+  violet: '#ee82ee',
+  brown: '#a52a2a',
+  beige: '#f5f5dc',
+  ivory: '#fffff0',
+  khaki: '#f0e68c',
+  coral: '#ff7f50',
+  salmon: '#fa8072',
+  tomato: '#ff6347',
+  crimson: '#dc143c',
+  turquoise: '#40e0d0',
+  lavender: '#e6e6fa',
+  plum: '#dda0dd',
+  orchid: '#da70d6',
+  tan: '#d2b48c',
+  chocolate: '#d2691e',
+  sienna: '#a0522d',
+  slategray: '#708090',
+  slategrey: '#708090',
+  steelblue: '#4682b4',
+  royalblue: '#4169e1',
+  dodgerblue: '#1e90ff',
+  skyblue: '#87ceeb',
+  lightblue: '#add8e6',
+  midnightblue: '#191970',
+  forestgreen: '#228b22',
+  seagreen: '#2e8b57',
+  limegreen: '#32cd32',
+  olivedrab: '#6b8e23',
+  darkgreen: '#006400',
+  emerald: '#50c878',
+  mint: '#3eb489',
+  goldenrod: '#daa520',
+  firebrick: '#b22222',
+  darkred: '#8b0000',
+  indianred: '#cd5c5c',
+  deeppink: '#ff1493',
+  mediumpurple: '#9370db',
+  rebeccapurple: '#663399',
+  darkviolet: '#9400d3',
+  slateblue: '#6a5acd',
+  cornflowerblue: '#6495ed',
+  teal2: '#008080',
+  charcoal: '#36454f',
+  graphite: '#3b3b3b',
+  transparent: 'transparent',
+};
+
+// ─── Colors ─────────────────────────────────────────────────────
+
+/**
+ * Coerce a flexible color input into a canonical CSS color string.
+ * Accepts: `#1d4ed8`, `1d4ed8`, `#18f`, `rgb(...)`, `transparent`, and common
+ * CSS color names. Throws with guidance when the value can't be understood.
+ */
+export function coerceColor(input: unknown): string {
+  if (typeof input !== 'string' || input.trim() === '') {
+    throw new Error('Color must be a non-empty string (e.g. "#2563eb" or "blue").');
+  }
+  const trimmed = input.trim().toLowerCase();
+
+  const named = CSS_NAMED_COLORS[trimmed];
+  if (named) return named;
+
+  const normalized = normalizeColorValue(trimmed);
+  if (
+    isValidHex(normalized) ||
+    normalized === 'transparent' ||
+    normalized.startsWith('rgb')
+  ) {
+    return normalized;
+  }
+
+  throw new Error(
+    `"${input}" is not a recognized color. Pass a hex value like "#ef4444" or a CSS color name (e.g. ${Object.keys(
+      CSS_NAMED_COLORS
+    )
+      .slice(0, 6)
+      .join(', ')}).`
+  );
+}
+
+// ─── Enums ──────────────────────────────────────────────────────
+
+export type BrandFamily = 'primary' | 'secondary' | 'accent';
+export type RoleFamilyInput = BrandFamily | 'neutral';
+
+const FAMILY_SYNONYMS: Record<string, RoleFamilyInput> = {
+  primary: 'primary',
+  secondary: 'secondary',
+  accent: 'accent',
+  neutral: 'neutral',
+  gray: 'neutral',
+  grey: 'neutral',
+};
+
+/** Coerce a palette family. Set `allowNeutral` for role assignments. */
+export function coerceFamily(input: unknown, allowNeutral = true): RoleFamilyInput {
+  const key = String(input ?? '').trim().toLowerCase();
+  const family = FAMILY_SYNONYMS[key];
+  if (!family || (!allowNeutral && family === 'neutral')) {
+    const valid = allowNeutral
+      ? 'primary, secondary, accent, neutral'
+      : 'primary, secondary, accent';
+    throw new Error(`Unknown color family "${input}". Valid families: ${valid}.`);
+  }
+  return family;
+}
+
+export function coerceIntensity(input: unknown): 'solid' | 'soft' {
+  const key = String(input ?? 'solid').trim().toLowerCase();
+  if (key === 'solid' || key === 'soft') return key;
+  throw new Error(`Unknown intensity "${input}". Valid intensities: solid, soft.`);
+}
+
+export function coerceScheme(input: unknown): 'light' | 'dark' | 'auto' {
+  const key = String(input ?? '').trim().toLowerCase();
+  if (key === 'light' || key === 'dark' || key === 'auto') return key;
+  if (key === 'system') return 'auto';
+  throw new Error(`Unknown color scheme "${input}". Valid: light, dark, auto.`);
+}
+
+export type RoundnessStyle = 'sharp' | 'default' | 'rounded' | 'pill';
+
+const ROUNDNESS_SYNONYMS: Record<string, RoundnessStyle> = {
+  sharp: 'sharp',
+  square: 'sharp',
+  none: 'sharp',
+  default: 'default',
+  normal: 'default',
+  rounded: 'rounded',
+  round: 'rounded',
+  soft: 'rounded',
+  pill: 'pill',
+  circle: 'pill',
+  full: 'pill',
+};
+
+export function coerceRoundnessStyle(input: unknown): RoundnessStyle {
+  const key = String(input ?? '').trim().toLowerCase();
+  const style = ROUNDNESS_SYNONYMS[key];
+  if (!style) {
+    throw new Error(`Unknown roundness "${input}". Valid: sharp, default, rounded, pill.`);
+  }
+  return style;
+}
+
+// ─── Sizes ──────────────────────────────────────────────────────
+
+/** Coerce a radius value: numbers become `${n}px`; CSS strings are normalized. */
+export function coerceRadius(input: unknown): string {
+  if (typeof input === 'number' && Number.isFinite(input)) {
+    return `${input}px`;
+  }
+  if (typeof input === 'string' && input.trim() !== '') {
+    const trimmed = input.trim();
+    if (trimmed === '9999px' || /^(100%|9999px)$/.test(trimmed)) return '9999px';
+    const parsed = parseCssValue(trimmed);
+    return formatCssValue(parsed.value, parsed.unit);
+  }
+  throw new Error('Radius must be a number (px) or a CSS length string like "0.5rem".');
+}
+
+// ─── Typography keyword → token-ref maps (verbatim from sections.ts) ─
+
+export const FONT_FAMILY_REFS: Record<string, string> = {
+  sans: 'palette.typography.fontFamily.sans',
+  serif: 'palette.typography.fontFamily.serif',
+  mono: 'palette.typography.fontFamily.mono',
+  monospace: 'palette.typography.fontFamily.mono',
+};
+
+export const FONT_SIZE_REFS: Record<string, string> = {
+  xs: 'palette.typography.fontSize.xs',
+  sm: 'palette.typography.fontSize.sm',
+  small: 'palette.typography.fontSize.sm',
+  base: 'palette.typography.fontSize.base',
+  md: 'palette.typography.fontSize.base',
+  medium: 'palette.typography.fontSize.base',
+  lg: 'palette.typography.fontSize.lg',
+  large: 'palette.typography.fontSize.lg',
+  xl: 'palette.typography.fontSize.xl',
+};
+
+export const FONT_WEIGHT_REFS: Record<string, string> = {
+  normal: 'palette.typography.fontWeight.normal',
+  '400': 'palette.typography.fontWeight.normal',
+  medium: 'palette.typography.fontWeight.medium',
+  '500': 'palette.typography.fontWeight.medium',
+  semibold: 'palette.typography.fontWeight.semibold',
+  '600': 'palette.typography.fontWeight.semibold',
+  bold: 'palette.typography.fontWeight.bold',
+  '700': 'palette.typography.fontWeight.bold',
+};
+
+export const LINE_HEIGHT_REFS: Record<string, string> = {
+  tight: 'palette.typography.lineHeight.tight',
+  '1.25': 'palette.typography.lineHeight.tight',
+  normal: 'palette.typography.lineHeight.normal',
+  '1.5': 'palette.typography.lineHeight.normal',
+  relaxed: 'palette.typography.lineHeight.relaxed',
+  '1.625': 'palette.typography.lineHeight.relaxed',
+};
+
+export function coerceTypographyRef(
+  input: unknown,
+  refs: Record<string, string>,
+  label: string
+): string {
+  const key = String(input ?? '').trim().toLowerCase();
+  const ref = refs[key];
+  if (!ref) {
+    const valid = [...new Set(Object.values(refs).map((r) => r.split('.').pop()))].join(', ');
+    throw new Error(`Unknown ${label} "${input}". Valid: ${valid}.`);
+  }
+  return ref;
+}

--- a/packages/widget/src/theme-editor/webmcp/coerce.ts
+++ b/packages/widget/src/theme-editor/webmcp/coerce.ts
@@ -13,6 +13,8 @@ import {
   parseCssValue,
   formatCssValue,
 } from '../color-utils';
+import { ROLE_FAMILIES } from '../role-mappings';
+import { STYLE_SECTIONS } from '../sections';
 
 // ─── CSS named colors (common subset) ───────────────────────────
 
@@ -90,6 +92,14 @@ export const CSS_NAMED_COLORS: Record<string, string> = {
 
 // ─── Colors ─────────────────────────────────────────────────────
 
+/** Structural validation for rgb()/rgba() so malformed "rgb…" input is rejected. */
+const RGB_RE =
+  /^rgba?\(\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*,\s*\d{1,3}%?\s*(,\s*(0|1|0?\.\d+|\d{1,3}%)\s*)?\)$/;
+
+function isValidRgb(value: string): boolean {
+  return RGB_RE.test(value);
+}
+
 /**
  * Coerce a flexible color input into a canonical CSS color string.
  * Accepts: `#1d4ed8`, `1d4ed8`, `#18f`, `rgb(...)`, `transparent`, and common
@@ -105,11 +115,7 @@ export function coerceColor(input: unknown): string {
   if (named) return named;
 
   const normalized = normalizeColorValue(trimmed);
-  if (
-    isValidHex(normalized) ||
-    normalized === 'transparent' ||
-    normalized.startsWith('rgb')
-  ) {
+  if (isValidHex(normalized) || normalized === 'transparent' || isValidRgb(normalized)) {
     return normalized;
   }
 
@@ -127,11 +133,18 @@ export function coerceColor(input: unknown): string {
 export type BrandFamily = 'primary' | 'secondary' | 'accent';
 export type RoleFamilyInput = BrandFamily | 'neutral';
 
+/**
+ * Tool-facing family names, derived from the role layer's `ROLE_FAMILIES`. The
+ * role layer's canonical neutral family is `gray`; tools surface it as
+ * `neutral`. Deriving here keeps the tool vocabulary in sync if a family is
+ * added to `ROLE_FAMILIES`.
+ */
+export const ROLE_FAMILY_NAMES: RoleFamilyInput[] = ROLE_FAMILIES.map((f) =>
+  f === 'gray' ? 'neutral' : (f as RoleFamilyInput)
+);
+
 const FAMILY_SYNONYMS: Record<string, RoleFamilyInput> = {
-  primary: 'primary',
-  secondary: 'secondary',
-  accent: 'accent',
-  neutral: 'neutral',
+  ...Object.fromEntries(ROLE_FAMILY_NAMES.map((f) => [f, f])),
   gray: 'neutral',
   grey: 'neutral',
 };
@@ -203,45 +216,59 @@ export function coerceRadius(input: unknown): string {
   throw new Error('Radius must be a number (px) or a CSS length string like "0.5rem".');
 }
 
-// ─── Typography keyword → token-ref maps (verbatim from sections.ts) ─
+// ─── Typography keyword → token-ref maps ────────────────────────
+// Base maps are derived from the editor's typography <select> options in
+// sections.ts (keyed by each option value's last path segment), so the
+// high-level tool's accepted values track the editor. Only the friendly
+// synonyms (monospace, small/medium/large, numeric weights/line-heights) are
+// hand-maintained on top.
+
+function refsFromTypographyField(fieldId: string): Record<string, string> {
+  for (const section of STYLE_SECTIONS) {
+    const field = section.fields.find((f) => f.id === fieldId);
+    if (field?.options) {
+      const map: Record<string, string> = {};
+      for (const opt of field.options) {
+        const key = opt.value.split('.').pop();
+        if (key) map[key] = opt.value;
+      }
+      return map;
+    }
+  }
+  return {};
+}
+
+const FAMILY_BASE = refsFromTypographyField('typo-font-family');
+const SIZE_BASE = refsFromTypographyField('typo-font-size');
+const WEIGHT_BASE = refsFromTypographyField('typo-font-weight');
+const LINE_BASE = refsFromTypographyField('typo-line-height');
 
 export const FONT_FAMILY_REFS: Record<string, string> = {
-  sans: 'palette.typography.fontFamily.sans',
-  serif: 'palette.typography.fontFamily.serif',
-  mono: 'palette.typography.fontFamily.mono',
-  monospace: 'palette.typography.fontFamily.mono',
+  ...FAMILY_BASE,
+  monospace: FAMILY_BASE.mono,
 };
 
 export const FONT_SIZE_REFS: Record<string, string> = {
-  xs: 'palette.typography.fontSize.xs',
-  sm: 'palette.typography.fontSize.sm',
-  small: 'palette.typography.fontSize.sm',
-  base: 'palette.typography.fontSize.base',
-  md: 'palette.typography.fontSize.base',
-  medium: 'palette.typography.fontSize.base',
-  lg: 'palette.typography.fontSize.lg',
-  large: 'palette.typography.fontSize.lg',
-  xl: 'palette.typography.fontSize.xl',
+  ...SIZE_BASE,
+  small: SIZE_BASE.sm,
+  md: SIZE_BASE.base,
+  medium: SIZE_BASE.base,
+  large: SIZE_BASE.lg,
 };
 
 export const FONT_WEIGHT_REFS: Record<string, string> = {
-  normal: 'palette.typography.fontWeight.normal',
-  '400': 'palette.typography.fontWeight.normal',
-  medium: 'palette.typography.fontWeight.medium',
-  '500': 'palette.typography.fontWeight.medium',
-  semibold: 'palette.typography.fontWeight.semibold',
-  '600': 'palette.typography.fontWeight.semibold',
-  bold: 'palette.typography.fontWeight.bold',
-  '700': 'palette.typography.fontWeight.bold',
+  ...WEIGHT_BASE,
+  '400': WEIGHT_BASE.normal,
+  '500': WEIGHT_BASE.medium,
+  '600': WEIGHT_BASE.semibold,
+  '700': WEIGHT_BASE.bold,
 };
 
 export const LINE_HEIGHT_REFS: Record<string, string> = {
-  tight: 'palette.typography.lineHeight.tight',
-  '1.25': 'palette.typography.lineHeight.tight',
-  normal: 'palette.typography.lineHeight.normal',
-  '1.5': 'palette.typography.lineHeight.normal',
-  relaxed: 'palette.typography.lineHeight.relaxed',
-  '1.625': 'palette.typography.lineHeight.relaxed',
+  ...LINE_BASE,
+  '1.25': LINE_BASE.tight,
+  '1.5': LINE_BASE.normal,
+  '1.625': LINE_BASE.relaxed,
 };
 
 export function coerceTypographyRef(

--- a/packages/widget/src/theme-editor/webmcp/index.ts
+++ b/packages/widget/src/theme-editor/webmcp/index.ts
@@ -1,0 +1,45 @@
+/**
+ * WebMCP tools for the Persona theme editor.
+ *
+ * Transport-agnostic: `createThemeEditorTools(state)` returns plain tool
+ * definitions. Host code (e.g. an example app or a self-styling widget) is
+ * responsible for obtaining a `document.modelContext` and calling
+ * `registerTool` for each — this module has no polyfill dependency.
+ */
+
+export { createThemeEditorTools } from './tools';
+export { toolResult } from './types';
+export type {
+  WebMcpTool,
+  ToolResult,
+  ToolAnnotations,
+  ToolTextContent,
+  ToolExecute,
+  ThemeEditorLike,
+  EditTarget,
+  CreateThemeEditorToolsOptions,
+} from './types';
+export {
+  buildSummary,
+  runContrastChecks,
+  quickContrastWarnings,
+  CONTRAST_PAIRS,
+  RADIUS_PRESETS,
+} from './summary';
+export type {
+  ThemeSummary,
+  RoleState,
+  ContrastReport,
+  ContrastCheck,
+  ContrastWarning,
+  ContrastLevel,
+} from './summary';
+export {
+  coerceColor,
+  coerceFamily,
+  coerceIntensity,
+  coerceScheme,
+  coerceRoundnessStyle,
+  coerceRadius,
+  CSS_NAMED_COLORS,
+} from './coerce';

--- a/packages/widget/src/theme-editor/webmcp/summary.ts
+++ b/packages/widget/src/theme-editor/webmcp/summary.ts
@@ -1,0 +1,288 @@
+/**
+ * Theme state summarization + contrast feedback for the WebMCP tools.
+ *
+ * Every mutation tool returns a compact `ThemeSummary` plus any contrast
+ * warnings, so an agent gets actionable feedback without a follow-up read
+ * (arcade.dev "proactive state-returning").
+ */
+
+import { wcagContrastRatio, SHADE_KEYS } from '../color-utils';
+import { ALL_ROLES, detectRoleAssignment } from '../role-mappings';
+import type { ThemeEditorLike } from './types';
+import type { RoundnessStyle } from './coerce';
+
+// ─── Radius presets (verbatim from sections.ts shape section) ───
+
+export const RADIUS_PRESETS: Record<RoundnessStyle, Record<string, string>> = {
+  sharp: { sm: '1px', md: '2px', lg: '3px', xl: '4px', full: '4px' },
+  default: { sm: '0.125rem', md: '0.375rem', lg: '0.5rem', xl: '0.75rem', full: '9999px' },
+  rounded: { sm: '0.5rem', md: '0.75rem', lg: '1rem', xl: '1.5rem', full: '9999px' },
+  pill: { sm: '9999px', md: '9999px', lg: '9999px', xl: '9999px', full: '9999px' },
+};
+
+const RADIUS_KEYS = ['sm', 'md', 'lg', 'xl', 'full'] as const;
+
+// ─── Variant-aware color resolution ─────────────────────────────
+
+/**
+ * Resolve a theme token path to a concrete color, following `palette.*`,
+ * `semantic.*`, and `components.*` references. When resolving the `darkTheme`
+ * variant, tokens the dark theme doesn't define fall back to the light theme —
+ * mirroring the widget's runtime merge behavior.
+ */
+export function resolveColor(
+  state: ThemeEditorLike,
+  path: string,
+  prefix: 'theme' | 'darkTheme' = 'theme',
+  depth = 0
+): string | null {
+  if (depth > 6) return null;
+  const raw = state.get(`${prefix}.${path}`);
+  if (typeof raw !== 'string' || raw === '') {
+    return prefix === 'darkTheme' ? resolveColor(state, path, 'theme', depth) : null;
+  }
+  if (raw.startsWith('#') || raw.startsWith('rgb') || raw === 'transparent') return raw;
+  if (
+    raw.startsWith('palette.') ||
+    raw.startsWith('semantic.') ||
+    raw.startsWith('components.')
+  ) {
+    return resolveColor(state, raw, prefix, depth + 1);
+  }
+  return null;
+}
+
+// ─── Summary ────────────────────────────────────────────────────
+
+export interface RoleState {
+  family: string;
+  intensity: string;
+}
+
+export interface ThemeSummary {
+  brand: { primary: string | null; secondary: string | null; accent: string | null };
+  roles: Record<string, RoleState | null>;
+  typography: {
+    fontFamily: string;
+    fontSize: string;
+    fontWeight: string;
+    lineHeight: string;
+  };
+  roundness: { style: RoundnessStyle | 'custom'; radius: Record<string, string> };
+  colorScheme: string;
+  history: { index: number; canUndo: boolean; canRedo: boolean };
+}
+
+function refSuffix(state: ThemeEditorLike, path: string): string {
+  const raw = state.get(path);
+  if (typeof raw !== 'string') return 'unknown';
+  const parts = raw.split('.');
+  return parts[parts.length - 1] || String(raw);
+}
+
+/** Friendly role key, e.g. `role-user-messages` → `user-messages`. */
+export function roleKey(roleId: string): string {
+  return roleId.replace(/^role-/, '');
+}
+
+function detectRoundness(radius: Record<string, string>): RoundnessStyle | 'custom' {
+  for (const [style, preset] of Object.entries(RADIUS_PRESETS) as [
+    RoundnessStyle,
+    Record<string, string>,
+  ][]) {
+    if (RADIUS_KEYS.every((k) => radius[k] === preset[k])) return style;
+  }
+  return 'custom';
+}
+
+export function buildSummary(state: ThemeEditorLike): ThemeSummary {
+  const radius: Record<string, string> = {};
+  for (const k of RADIUS_KEYS) {
+    radius[k] = String(state.get(`theme.palette.radius.${k}`) ?? '');
+  }
+
+  const roles: Record<string, RoleState | null> = {};
+  for (const role of ALL_ROLES) {
+    roles[roleKey(role.roleId)] = detectRoleAssignment(
+      (p) => state.get(`theme.${p}`),
+      role
+    );
+  }
+
+  return {
+    brand: {
+      primary: asColor(state.get('theme.palette.colors.primary.500')),
+      secondary: asColor(state.get('theme.palette.colors.secondary.500')),
+      accent: asColor(state.get('theme.palette.colors.accent.500')),
+    },
+    roles,
+    typography: {
+      fontFamily: refSuffix(state, 'theme.semantic.typography.fontFamily'),
+      fontSize: refSuffix(state, 'theme.semantic.typography.fontSize'),
+      fontWeight: refSuffix(state, 'theme.semantic.typography.fontWeight'),
+      lineHeight: refSuffix(state, 'theme.semantic.typography.lineHeight'),
+    },
+    roundness: { style: detectRoundness(radius), radius },
+    colorScheme: String(state.get('colorScheme') ?? 'light'),
+    history: {
+      index: state.getHistoryIndex(),
+      canUndo: state.canUndo(),
+      canRedo: state.canRedo(),
+    },
+  };
+}
+
+function asColor(value: unknown): string | null {
+  return typeof value === 'string' && value !== '' ? value : null;
+}
+
+// ─── Contrast ───────────────────────────────────────────────────
+
+export interface ContrastPair {
+  key: string;
+  label: string;
+  fg: string;
+  bg: string;
+}
+
+export const CONTRAST_PAIRS: ContrastPair[] = [
+  { key: 'user-message', label: 'User message text', fg: 'components.message.user.text', bg: 'components.message.user.background' },
+  { key: 'assistant-message', label: 'Assistant message text', fg: 'components.message.assistant.text', bg: 'components.message.assistant.background' },
+  { key: 'header', label: 'Header title', fg: 'components.header.titleForeground', bg: 'components.header.background' },
+  { key: 'primary-button', label: 'Primary button label', fg: 'components.button.primary.foreground', bg: 'components.button.primary.background' },
+  { key: 'body', label: 'Body text on background', fg: 'semantic.colors.text', bg: 'semantic.colors.background' },
+  { key: 'surface', label: 'Body text on surface', fg: 'semantic.colors.text', bg: 'semantic.colors.surface' },
+];
+
+export interface ContrastWarning {
+  code: 'contrast';
+  pair: string;
+  variant: 'light' | 'dark';
+  ratio: number;
+  threshold: number;
+  message: string;
+}
+
+export const CONTRAST_THRESHOLDS = { AA: 4.5, AAA: 7 } as const;
+export type ContrastLevel = keyof typeof CONTRAST_THRESHOLDS;
+
+function round2(n: number): number {
+  return Math.round(n * 100) / 100;
+}
+
+/**
+ * Suggest a same-family shade for `fgPath` that meets `threshold` against
+ * `bgHex`, preferring the passing shade closest to the current one. Returns a
+ * token-ref string (e.g. `palette.colors.primary.700`) or null.
+ */
+function suggestShade(
+  state: ThemeEditorLike,
+  fgPath: string,
+  bgHex: string,
+  threshold: number,
+  prefix: 'theme' | 'darkTheme'
+): string | null {
+  const raw = state.get(`${prefix}.${fgPath}`);
+  if (typeof raw !== 'string') return null;
+  const m = raw.match(/^palette\.colors\.(\w+)\.(\d+)$/);
+  if (!m) return null;
+  const family = m[1];
+  const currentIdx = SHADE_KEYS.indexOf(m[2] as (typeof SHADE_KEYS)[number]);
+
+  let best: string | null = null;
+  let bestDistance = Infinity;
+  SHADE_KEYS.forEach((shade, idx) => {
+    const hex = state.get(`${prefix}.palette.colors.${family}.${shade}`);
+    if (typeof hex !== 'string' || !(hex.startsWith('#') || hex.startsWith('rgb'))) return;
+    if (wcagContrastRatio(hex, bgHex) >= threshold) {
+      const distance = currentIdx >= 0 ? Math.abs(idx - currentIdx) : idx;
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = `palette.colors.${family}.${shade}`;
+      }
+    }
+  });
+  return best;
+}
+
+export interface ContrastCheck {
+  pair: string;
+  label: string;
+  variant: 'light' | 'dark';
+  fg: string;
+  bg: string;
+  ratio: number;
+  threshold: number;
+  passes: boolean;
+  suggestion?: string;
+}
+
+export interface ContrastReport {
+  level: ContrastLevel;
+  checks: ContrastCheck[];
+  failures: ContrastCheck[];
+}
+
+/** Run contrast over the named pairs (default: all) for the given variant(s). */
+export function runContrastChecks(
+  state: ThemeEditorLike,
+  level: ContrastLevel = 'AA',
+  variant: 'light' | 'dark' | 'both' = 'both',
+  pairKeys?: string[]
+): ContrastReport {
+  const threshold = CONTRAST_THRESHOLDS[level];
+  const variants: ('light' | 'dark')[] = variant === 'both' ? ['light', 'dark'] : [variant];
+  const pairs = pairKeys
+    ? CONTRAST_PAIRS.filter((p) => pairKeys.includes(p.key))
+    : CONTRAST_PAIRS;
+
+  const checks: ContrastCheck[] = [];
+  for (const v of variants) {
+    const prefix = v === 'light' ? 'theme' : 'darkTheme';
+    for (const pair of pairs) {
+      const fg = resolveColor(state, pair.fg, prefix);
+      const bg = resolveColor(state, pair.bg, prefix);
+      if (!fg || !bg) continue;
+      const ratio = round2(wcagContrastRatio(fg, bg));
+      const passes = ratio >= threshold;
+      const check: ContrastCheck = {
+        pair: pair.key,
+        label: pair.label,
+        variant: v,
+        fg,
+        bg,
+        ratio,
+        threshold,
+        passes,
+      };
+      if (!passes) {
+        const suggestion = suggestShade(state, pair.fg, bg, threshold, prefix);
+        if (suggestion) check.suggestion = suggestion;
+      }
+      checks.push(check);
+    }
+  }
+
+  return { level, checks, failures: checks.filter((c) => !c.passes) };
+}
+
+/** Compact contrast warnings for the regions a mutation touched. */
+export function quickContrastWarnings(
+  state: ThemeEditorLike,
+  pairKeys: string[],
+  variant: 'light' | 'dark' | 'both' = 'light',
+  level: ContrastLevel = 'AA'
+): ContrastWarning[] {
+  if (pairKeys.length === 0) return [];
+  const report = runContrastChecks(state, level, variant, pairKeys);
+  return report.failures.map((f) => ({
+    code: 'contrast' as const,
+    pair: f.pair,
+    variant: f.variant,
+    ratio: f.ratio,
+    threshold: f.threshold,
+    message: `${f.label} (${f.variant}) has a contrast ratio of ${f.ratio}:1, below the ${level} threshold of ${f.threshold}:1${
+      f.suggestion ? `. Try ${f.suggestion} for the foreground.` : '.'
+    }`,
+  }));
+}

--- a/packages/widget/src/theme-editor/webmcp/summary.ts
+++ b/packages/widget/src/theme-editor/webmcp/summary.ts
@@ -8,17 +8,39 @@
 
 import { wcagContrastRatio, SHADE_KEYS } from '../color-utils';
 import { ALL_ROLES, detectRoleAssignment } from '../role-mappings';
+import { STYLE_SECTIONS } from '../sections';
+import type { RoleAssignmentOptions } from '../types';
 import type { ThemeEditorLike } from './types';
 import type { RoundnessStyle } from './coerce';
 
-// ─── Radius presets (verbatim from sections.ts shape section) ───
+// ─── Radius presets (derived from the editor's shape section) ───
+// The editor's shape section in sections.ts owns the canonical radius preset
+// values (default/sharp/rounded); we derive them here so the tool and the GUI
+// can't drift, and add the "pill" preset the editor doesn't expose.
 
-export const RADIUS_PRESETS: Record<RoundnessStyle, Record<string, string>> = {
-  sharp: { sm: '1px', md: '2px', lg: '3px', xl: '4px', full: '4px' },
-  default: { sm: '0.125rem', md: '0.375rem', lg: '0.5rem', xl: '0.75rem', full: '9999px' },
-  rounded: { sm: '0.5rem', md: '0.75rem', lg: '1rem', xl: '1.5rem', full: '9999px' },
-  pill: { sm: '9999px', md: '9999px', lg: '9999px', xl: '9999px', full: '9999px' },
-};
+const RADIUS_PATH_PREFIX = 'theme.palette.radius.';
+
+function buildRadiusPresets(): Record<string, Record<string, string>> {
+  const presets: Record<string, Record<string, string>> = {
+    pill: { sm: '9999px', md: '9999px', lg: '9999px', xl: '9999px', full: '9999px' },
+  };
+  for (const section of STYLE_SECTIONS) {
+    for (const preset of section.presets ?? []) {
+      const match = preset.id.match(/^radius-(\w+)$/);
+      if (!match) continue;
+      const radius: Record<string, string> = {};
+      for (const [path, value] of Object.entries(preset.values)) {
+        if (path.startsWith(RADIUS_PATH_PREFIX) && typeof value === 'string') {
+          radius[path.slice(RADIUS_PATH_PREFIX.length)] = value;
+        }
+      }
+      presets[match[1]] = radius;
+    }
+  }
+  return presets;
+}
+
+export const RADIUS_PRESETS: Record<string, Record<string, string>> = buildRadiusPresets();
 
 const RADIUS_KEYS = ['sm', 'md', 'lg', 'xl', 'full'] as const;
 
@@ -150,9 +172,23 @@ export const CONTRAST_PAIRS: ContrastPair[] = [
   { key: 'assistant-message', label: 'Assistant message text', fg: 'components.message.assistant.text', bg: 'components.message.assistant.background' },
   { key: 'header', label: 'Header title', fg: 'components.header.titleForeground', bg: 'components.header.background' },
   { key: 'primary-button', label: 'Primary button label', fg: 'components.button.primary.foreground', bg: 'components.button.primary.background' },
+  { key: 'input', label: 'Input placeholder', fg: 'components.input.placeholder', bg: 'components.input.background' },
+  { key: 'link', label: 'Link text', fg: 'components.markdown.link.foreground', bg: 'semantic.colors.background' },
+  { key: 'scroll', label: 'Scroll-to-bottom icon', fg: 'components.scrollToBottom.foreground', bg: 'components.scrollToBottom.background' },
   { key: 'body', label: 'Body text on background', fg: 'semantic.colors.text', bg: 'semantic.colors.background' },
   { key: 'surface', label: 'Body text on surface', fg: 'semantic.colors.text', bg: 'semantic.colors.surface' },
 ];
+
+/**
+ * The contrast-pair keys relevant to a role, derived by intersecting the role's
+ * target token paths with the contrast pairs. This replaces a hand-maintained
+ * map so a new role or contrast pair is covered automatically. Roles with no
+ * text pair (e.g. borders) correctly yield `[]`.
+ */
+export function roleContrastPairKeys(role: RoleAssignmentOptions): string[] {
+  const targets = new Set(role.targets.map((t) => t.path));
+  return CONTRAST_PAIRS.filter((p) => targets.has(p.fg) || targets.has(p.bg)).map((p) => p.key);
+}
 
 export interface ContrastWarning {
   code: 'contrast';

--- a/packages/widget/src/theme-editor/webmcp/tools.test.ts
+++ b/packages/widget/src/theme-editor/webmcp/tools.test.ts
@@ -151,6 +151,27 @@ describe('createThemeEditorTools', () => {
     expect(reports.find((r: any) => r.field === 'totally-unknown').ok).toBe(false);
   });
 
+  it('set_theme_fields field-ids honor the edit target (both → light + dark)', async () => {
+    await call(tools.get('set_theme_fields')!, {
+      updates: [{ field: 'brand-primary', value: '#123456' }],
+    });
+    // 'brand-primary' resolves to theme.palette.colors.primary.500; default
+    // editTarget is 'both', so it must scope to dark as well.
+    expect(state.get('theme.palette.colors.primary.500')).toBe('#123456');
+    expect(state.get('darkTheme.palette.colors.primary.500')).toBe('#123456');
+  });
+
+  it('assign_color_role on input is covered by contrast checks (no silent no-op)', async () => {
+    // ROLE_INPUT used to map to no contrast pairs; derived keys now include it.
+    const out = await call(tools.get('assign_color_role')!, {
+      role: 'input',
+      family: 'primary',
+      intensity: 'soft',
+    });
+    expect(out.applied.role).toBe('input');
+    expect(Array.isArray(out.warnings)).toBe(true);
+  });
+
   it('check_contrast returns checks and is read-only', async () => {
     const tool = tools.get('check_contrast')!;
     expect(tool.annotations?.readOnlyHint).toBe(true);

--- a/packages/widget/src/theme-editor/webmcp/tools.test.ts
+++ b/packages/widget/src/theme-editor/webmcp/tools.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { ThemeEditorState } from '../state';
+import { createThemeEditorTools } from './tools';
+import type { WebMcpTool } from './types';
+
+function toolMap(state: ThemeEditorState, opts?: Parameters<typeof createThemeEditorTools>[1]) {
+  const tools = createThemeEditorTools(state, opts);
+  const map = new Map<string, WebMcpTool>();
+  for (const t of tools) map.set(t.name, t);
+  return map;
+}
+
+async function call(tool: WebMcpTool, input: unknown): Promise<any> {
+  const res = await tool.execute(input);
+  return res.structuredContent;
+}
+
+describe('createThemeEditorTools', () => {
+  let state: ThemeEditorState;
+  let tools: Map<string, WebMcpTool>;
+
+  beforeEach(() => {
+    state = new ThemeEditorState();
+    tools = toolMap(state);
+  });
+
+  it('exposes the expected catalog', () => {
+    expect([...tools.keys()].sort()).toEqual(
+      [
+        'apply_preset',
+        'assign_color_role',
+        'check_contrast',
+        'configure_widget',
+        'get_theme_overview',
+        'manage_session',
+        'set_brand_colors',
+        'set_color_scheme',
+        'set_copy_and_suggestions',
+        'set_roundness',
+        'set_theme_fields',
+        'set_typography',
+      ].sort()
+    );
+  });
+
+  it('get_theme_overview returns summary + presets and is read-only', async () => {
+    const overview = tools.get('get_theme_overview')!;
+    expect(overview.annotations?.readOnlyHint).toBe(true);
+    const out = await call(overview, {});
+    expect(out.summary.brand.primary).toMatch(/^#/);
+    expect(out.presets.map((p: any) => p.id)).toContain('default-dark');
+    expect(out.availableRoles.some((r: any) => r.role === 'header')).toBe(true);
+  });
+
+  it('set_brand_colors generates a full scale and applies to light + dark', async () => {
+    const out = await call(tools.get('set_brand_colors')!, { primary: 'blue' });
+    expect(out.ok).toBe(true);
+    expect(out.applied.primary).toBe('#0000ff');
+    // Whole scale written, not just 500.
+    expect(state.get('theme.palette.colors.primary.50')).toMatch(/^#/);
+    expect(state.get('theme.palette.colors.primary.700')).toMatch(/^#/);
+    expect(state.get('darkTheme.palette.colors.primary.500')).toMatch(/^#/);
+  });
+
+  it('assign_color_role writes role tokens to both variants', async () => {
+    const out = await call(tools.get('assign_color_role')!, {
+      role: 'header',
+      family: 'primary',
+      intensity: 'solid',
+    });
+    expect(out.applied.role).toBe('header');
+    expect(out.applied.tokensWritten).toBeGreaterThan(0);
+    expect(state.get('theme.components.header.background')).toBe('palette.colors.primary.500');
+    expect(state.get('darkTheme.components.header.background')).toBe('palette.colors.primary.500');
+  });
+
+  it('coerces neutral family alias', async () => {
+    await call(tools.get('assign_color_role')!, { role: 'borders', family: 'gray' });
+    expect(state.get('theme.semantic.colors.border')).toBe('palette.colors.gray.600');
+  });
+
+  it('set_typography maps keywords to token refs', async () => {
+    await call(tools.get('set_typography')!, { fontFamily: 'serif', fontWeight: 600 });
+    expect(state.get('theme.semantic.typography.fontFamily')).toBe(
+      'palette.typography.fontFamily.serif'
+    );
+    expect(state.get('theme.semantic.typography.fontWeight')).toBe(
+      'palette.typography.fontWeight.semibold'
+    );
+  });
+
+  it('set_roundness applies a keyword preset', async () => {
+    await call(tools.get('set_roundness')!, { style: 'pill' });
+    expect(state.get('theme.palette.radius.md')).toBe('9999px');
+    const out = await call(tools.get('get_theme_overview')!, {});
+    expect(out.summary.roundness.style).toBe('pill');
+  });
+
+  it('set_color_scheme sets scheme and editTarget scopes later writes', async () => {
+    await call(tools.get('set_color_scheme')!, { scheme: 'dark', editTarget: 'light' });
+    expect(state.get('colorScheme')).toBe('dark');
+    // editTarget=light → brand write should not touch darkTheme.
+    const before = state.get('darkTheme.palette.colors.accent.500');
+    await call(tools.get('set_brand_colors')!, { accent: 'red' });
+    expect(state.get('theme.palette.colors.accent.500')).toBe('#ff0000');
+    expect(state.get('darkTheme.palette.colors.accent.500')).toBe(before);
+  });
+
+  it('apply_preset validates id and applies', async () => {
+    const out = await call(tools.get('apply_preset')!, { presetId: 'default-dark' });
+    expect(out.applied.appliedPreset.id).toBe('default-dark');
+    expect(() => tools.get('apply_preset')!.execute({ presetId: 'nope' })).toThrow(
+      /Valid presets/
+    );
+  });
+
+  it('configure_widget writes config paths', async () => {
+    await call(tools.get('configure_widget')!, {
+      launcherPosition: 'bottom-left',
+      features: { voice: true, attachments: true },
+      layout: { avatars: true, messageStyle: 'flat' },
+    });
+    expect(state.get('launcher.position')).toBe('bottom-left');
+    expect(state.get('voiceRecognition.enabled')).toBe(true);
+    expect(state.get('attachments.enabled')).toBe(true);
+    expect(state.get('layout.messages.avatar.show')).toBe(true);
+    expect(state.get('layout.messages.layout')).toBe('flat');
+  });
+
+  it('set_copy_and_suggestions sets copy + chips', async () => {
+    await call(tools.get('set_copy_and_suggestions')!, {
+      title: 'Hi there',
+      suggestions: ['a', 'b'],
+    });
+    expect(state.get('copy.welcomeTitle')).toBe('Hi there');
+    expect(state.get('suggestionChips')).toEqual(['a', 'b']);
+  });
+
+  it('set_theme_fields resolves field ids and reports per-update status', async () => {
+    const out = await call(tools.get('set_theme_fields')!, {
+      updates: [
+        { field: 'launch-enabled', value: false },
+        { field: 'theme.palette.radius.md', value: '20px' },
+        { field: 'totally-unknown', value: 'x' },
+      ],
+    });
+    expect(state.get('launcher.enabled')).toBe(false);
+    expect(state.get('theme.palette.radius.md')).toBe('20px');
+    const reports = out.applied.updates;
+    expect(reports.find((r: any) => r.field === 'launch-enabled').ok).toBe(true);
+    expect(reports.find((r: any) => r.field === 'totally-unknown').ok).toBe(false);
+  });
+
+  it('check_contrast returns checks and is read-only', async () => {
+    const tool = tools.get('check_contrast')!;
+    expect(tool.annotations?.readOnlyHint).toBe(true);
+    const out = await call(tool, { level: 'AA', variant: 'light' });
+    expect(out.total).toBeGreaterThan(0);
+    expect(Array.isArray(out.checks)).toBe(true);
+  });
+
+  it('manage_session undo reverts the last change', async () => {
+    await call(tools.get('set_brand_colors')!, { primary: 'red' });
+    expect(state.get('theme.palette.colors.primary.500')).toBe('#ff0000');
+    const out = await call(tools.get('manage_session')!, { action: 'undo' });
+    expect(out.ok).toBe(true);
+    expect(state.get('theme.palette.colors.primary.500')).not.toBe('#ff0000');
+  });
+
+  it('manage_session export returns a snapshot', async () => {
+    const out = await call(tools.get('manage_session')!, { action: 'export' });
+    expect(out.snapshot.version).toBe(2);
+    expect(out.snapshot.theme).toBeDefined();
+  });
+});

--- a/packages/widget/src/theme-editor/webmcp/tools.test.ts
+++ b/packages/widget/src/theme-editor/webmcp/tools.test.ts
@@ -62,6 +62,15 @@ describe('createThemeEditorTools', () => {
     expect(state.get('darkTheme.palette.colors.primary.500')).toMatch(/^#/);
   });
 
+  it('set_brand_colors accepts rgb() input without corrupting the scale', async () => {
+    const out = await call(tools.get('set_brand_colors')!, { primary: 'rgb(37, 99, 235)' });
+    expect(out.ok).toBe(true);
+    for (const shade of ['50', '500', '700', '950']) {
+      expect(state.get(`theme.palette.colors.primary.${shade}`)).toMatch(/^#[0-9a-f]{6}$/);
+      expect(state.get(`darkTheme.palette.colors.primary.${shade}`)).not.toContain('NaN');
+    }
+  });
+
   it('assign_color_role writes role tokens to both variants', async () => {
     const out = await call(tools.get('assign_color_role')!, {
       role: 'header',

--- a/packages/widget/src/theme-editor/webmcp/tools.ts
+++ b/packages/widget/src/theme-editor/webmcp/tools.ts
@@ -236,13 +236,13 @@ export function createThemeEditorTools(
     name: 'set_brand_colors',
     title: 'Set brand colors',
     description:
-      'Set one or more brand colors (primary, secondary, accent). Each color auto-generates a full 50–950 shade scale and applies to the light and dark themes (per the current edit target). Accepts hex ("#2563eb", "2563eb", "#18f") or CSS color names ("blue", "slateblue").',
+      'Set one or more brand colors (primary, secondary, accent). Each color auto-generates a full 50–950 shade scale and applies to the light and dark themes (per the current edit target). Accepts hex ("#2563eb", "2563eb", "#18f"), rgb()/rgba() ("rgb(37, 99, 235)"), or CSS color names ("blue", "slateblue").',
     inputSchema: {
       type: 'object',
       properties: {
-        primary: { type: 'string', description: 'Hex or CSS color name.' },
-        secondary: { type: 'string', description: 'Hex or CSS color name.' },
-        accent: { type: 'string', description: 'Hex or CSS color name.' },
+        primary: { type: 'string', description: 'Hex, rgb()/rgba(), or CSS color name.' },
+        secondary: { type: 'string', description: 'Hex, rgb()/rgba(), or CSS color name.' },
+        accent: { type: 'string', description: 'Hex, rgb()/rgba(), or CSS color name.' },
       },
       additionalProperties: false,
     },

--- a/packages/widget/src/theme-editor/webmcp/tools.ts
+++ b/packages/widget/src/theme-editor/webmcp/tools.ts
@@ -1,0 +1,794 @@
+/**
+ * WebMCP tool factory for the Persona theme editor.
+ *
+ * `createThemeEditorTools(state)` returns transport-agnostic tool definitions
+ * designed for Agent Experience: intent-level operations (set brand colors,
+ * assign a color role, set roundness…) rather than a 1:1 mapping of the ~150
+ * editor fields. Two altitudes — high-level semantic tools plus a low-level
+ * escape hatch (`set_theme_fields`) — keep the catalog small without losing
+ * coverage. Every mutation returns a compact summary + contrast warnings.
+ */
+
+import { createTheme } from '../../utils/theme';
+import type { AgentWidgetConfig } from '../../types';
+import type { PersonaTheme } from '../../types/theme';
+import { generateColorScale, SHADE_KEYS } from '../color-utils';
+import { ALL_ROLES, resolveRoleAssignment } from '../role-mappings';
+import type { RoleAssignmentOptions, FieldDef } from '../types';
+import { THEME_EDITOR_PRESETS, getThemeEditorPreset } from '../presets';
+import { ALL_TABS, CONFIGURE_SUB_GROUPS } from '../sections';
+import {
+  toolResult,
+  type WebMcpTool,
+  type ThemeEditorLike,
+  type EditTarget,
+  type CreateThemeEditorToolsOptions,
+} from './types';
+import {
+  coerceColor,
+  coerceFamily,
+  coerceIntensity,
+  coerceScheme,
+  coerceRoundnessStyle,
+  coerceRadius,
+  coerceTypographyRef,
+  FONT_FAMILY_REFS,
+  FONT_SIZE_REFS,
+  FONT_WEIGHT_REFS,
+  LINE_HEIGHT_REFS,
+} from './coerce';
+import {
+  buildSummary,
+  quickContrastWarnings,
+  runContrastChecks,
+  RADIUS_PRESETS,
+  roleKey,
+  type ContrastWarning,
+  type ContrastLevel,
+} from './summary';
+
+// ─── Role lookup ────────────────────────────────────────────────
+
+const ROLE_ALIASES: Record<string, RoleAssignmentOptions> = {};
+for (const role of ALL_ROLES) {
+  const key = roleKey(role.roleId);
+  ROLE_ALIASES[key] = role; // e.g. "user-messages"
+  ROLE_ALIASES[role.roleId] = role; // e.g. "role-user-messages"
+}
+Object.assign(ROLE_ALIASES, {
+  surface: ROLE_ALIASES['surfaces'],
+  background: ROLE_ALIASES['surfaces'],
+  backgrounds: ROLE_ALIASES['surfaces'],
+  user: ROLE_ALIASES['user-messages'],
+  'user-message': ROLE_ALIASES['user-messages'],
+  assistant: ROLE_ALIASES['assistant-messages'],
+  'assistant-message': ROLE_ALIASES['assistant-messages'],
+  actions: ROLE_ALIASES['primary-actions'],
+  buttons: ROLE_ALIASES['primary-actions'],
+  composer: ROLE_ALIASES['input'],
+  links: ROLE_ALIASES['links-focus'],
+  focus: ROLE_ALIASES['links-focus'],
+  border: ROLE_ALIASES['borders'],
+  dividers: ROLE_ALIASES['borders'],
+  scroll: ROLE_ALIASES['scroll-to-bottom'],
+});
+
+function coerceRole(input: unknown): RoleAssignmentOptions {
+  const key = String(input ?? '').trim().toLowerCase();
+  const role = ROLE_ALIASES[key];
+  if (!role) {
+    const valid = ALL_ROLES.map((r) => roleKey(r.roleId)).join(', ');
+    throw new Error(`Unknown role "${input}". Valid roles: ${valid}.`);
+  }
+  return role;
+}
+
+/** Contrast pairs to check after a role recolor. */
+const ROLE_CONTRAST_KEYS: Record<string, string[]> = {
+  'role-header': ['header'],
+  'role-user-messages': ['user-message'],
+  'role-assistant-messages': ['assistant-message'],
+  'role-primary-actions': ['primary-button'],
+  'role-surfaces': ['body', 'surface'],
+};
+
+// ─── Field index (escape hatch) ─────────────────────────────────
+
+function buildFieldIndex(): Map<string, FieldDef> {
+  const index = new Map<string, FieldDef>();
+  const addSections = (sections: { fields: FieldDef[] }[]) => {
+    for (const section of sections) {
+      for (const field of section.fields) {
+        if (!index.has(field.id)) index.set(field.id, field);
+      }
+    }
+  };
+  for (const tab of ALL_TABS) addSections(tab.sections);
+  for (const group of CONFIGURE_SUB_GROUPS) addSections(group.sections);
+  return index;
+}
+
+// ─── Config-tool path maps ──────────────────────────────────────
+
+const FEATURE_PATHS: Record<string, string> = {
+  voice: 'voiceRecognition.enabled',
+  artifacts: 'features.artifacts.enabled',
+  attachments: 'attachments.enabled',
+  toolCalls: 'features.showToolCalls',
+  reasoning: 'features.showReasoning',
+  feedback: 'messageActions.enabled',
+};
+
+const LAYOUT_PATHS: Record<string, string> = {
+  avatars: 'layout.messages.avatar.show',
+  timestamps: 'layout.messages.timestamp.show',
+  showHeader: 'layout.showHeader',
+  messageStyle: 'layout.messages.layout',
+};
+
+const LAUNCHER_POSITIONS = ['bottom-right', 'bottom-left', 'top-right', 'top-left'];
+const MESSAGE_STYLES = ['bubble', 'flat', 'minimal'];
+
+const COPY_PATHS: Record<string, string> = {
+  title: 'copy.welcomeTitle',
+  subtitle: 'copy.welcomeSubtitle',
+  placeholder: 'copy.inputPlaceholder',
+  sendLabel: 'copy.sendButtonLabel',
+};
+
+// ─── Factory ────────────────────────────────────────────────────
+
+export function createThemeEditorTools(
+  state: ThemeEditorLike,
+  options?: CreateThemeEditorToolsOptions
+): WebMcpTool[] {
+  let editTarget: EditTarget = options?.editTarget ?? 'both';
+  let fieldIndex: Map<string, FieldDef> | null = null;
+
+  const rec = (input: unknown): Record<string, unknown> =>
+    input && typeof input === 'object' ? (input as Record<string, unknown>) : {};
+
+  /** Expand a theme-relative path to light/dark writes per editTarget. */
+  const expandScoped = (
+    themeRelPath: string,
+    value: unknown,
+    target: EditTarget = editTarget
+  ): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    if (target === 'light' || target === 'both') out[`theme.${themeRelPath}`] = value;
+    if (target === 'dark' || target === 'both') out[`darkTheme.${themeRelPath}`] = value;
+    return out;
+  };
+
+  /** Drop light/dark writes that fall outside the current editTarget. */
+  const filterByEditTarget = (writes: Record<string, string>): Record<string, string> => {
+    if (editTarget === 'both') return writes;
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(writes)) {
+      if (editTarget === 'light' && k.startsWith('theme.')) out[k] = v;
+      else if (editTarget === 'dark' && k.startsWith('darkTheme.')) out[k] = v;
+    }
+    return out;
+  };
+
+  const result = (applied: unknown, warnings: ContrastWarning[] = []) =>
+    toolResult({ ok: true, summary: buildSummary(state), warnings, applied });
+
+  // ── Tools ──────────────────────────────────────────────────
+
+  const getThemeOverview: WebMcpTool = {
+    name: 'get_theme_overview',
+    title: 'Get current theme & what is editable',
+    description:
+      'Read the current widget theme (brand colors, per-role color assignments, typography, roundness, color scheme, undo/redo state), the available presets, and the high-level levers you can change. Call this FIRST before editing.',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        verbosity: {
+          type: 'string',
+          enum: ['summary', 'full'],
+          description: "Use 'full' to also include the field-id index for set_theme_fields.",
+        },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const { verbosity } = rec(input);
+      const payload: Record<string, unknown> = {
+        summary: buildSummary(state),
+        availableRoles: ALL_ROLES.map((r) => ({
+          role: roleKey(r.roleId),
+          helper: r.helper,
+        })),
+        availableFamilies: ['primary', 'secondary', 'accent', 'neutral'],
+        presets: THEME_EDITOR_PRESETS.map((p) => ({
+          id: p.id,
+          name: p.name,
+          description: p.description,
+          tags: p.tags ?? [],
+        })),
+        tools: [
+          { tool: 'set_brand_colors', hint: 'Recolor the palette (primary/secondary/accent) — auto-generates shade scales.' },
+          { tool: 'assign_color_role', hint: 'Recolor a region (header, user/assistant messages, actions, input, links, borders, surfaces, scroll) with a family + intensity.' },
+          { tool: 'set_typography', hint: 'Set font family, size, weight, line height.' },
+          { tool: 'set_roundness', hint: 'Set corner roundness (sharp/default/rounded/pill) or granular radii.' },
+          { tool: 'set_color_scheme', hint: 'Set light/dark/auto and which variant edits target.' },
+          { tool: 'apply_preset', hint: 'Apply a complete built-in preset.' },
+          { tool: 'configure_widget', hint: 'Toggle launcher position, features, and layout.' },
+          { tool: 'set_copy_and_suggestions', hint: 'Set welcome copy, placeholder, and suggestion chips.' },
+          { tool: 'set_theme_fields', hint: 'Advanced escape hatch: set any field by id or dot-path.' },
+          { tool: 'check_contrast', hint: 'Audit WCAG contrast across key text/background pairs.' },
+          { tool: 'manage_session', hint: 'Undo, redo, reset, or export the theme.' },
+        ],
+      };
+      if (verbosity === 'full') {
+        fieldIndex ??= buildFieldIndex();
+        payload.fieldIndex = Array.from(fieldIndex.values()).map((f) => ({
+          id: f.id,
+          path: f.path,
+          type: f.type,
+          label: f.label,
+          options: f.options?.map((o) => o.value),
+        }));
+      }
+      return toolResult(payload);
+    },
+  };
+
+  const setBrandColors: WebMcpTool = {
+    name: 'set_brand_colors',
+    title: 'Set brand colors',
+    description:
+      'Set one or more brand colors (primary, secondary, accent). Each color auto-generates a full 50–950 shade scale and applies to the light and dark themes (per the current edit target). Accepts hex ("#2563eb", "2563eb", "#18f") or CSS color names ("blue", "slateblue").',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        primary: { type: 'string', description: 'Hex or CSS color name.' },
+        secondary: { type: 'string', description: 'Hex or CSS color name.' },
+        accent: { type: 'string', description: 'Hex or CSS color name.' },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const families: Array<'primary' | 'secondary' | 'accent'> = ['primary', 'secondary', 'accent'];
+      const writes: Record<string, unknown> = {};
+      const applied: Record<string, string> = {};
+
+      for (const family of families) {
+        if (args[family] === undefined) continue;
+        const base = coerceColor(args[family]);
+        applied[family] = base;
+        const scale = generateColorScale(base);
+        for (const shade of SHADE_KEYS) {
+          const value = scale[shade];
+          if (value === undefined) continue;
+          Object.assign(writes, expandScoped(`palette.colors.${family}.${shade}`, value));
+        }
+      }
+
+      if (Object.keys(applied).length === 0) {
+        throw new Error('Provide at least one of: primary, secondary, accent.');
+      }
+
+      state.setBatch(writes);
+      const warnings = quickContrastWarnings(state, ['primary-button', 'user-message'], 'light');
+      return result(applied, warnings);
+    },
+  };
+
+  const assignColorRole: WebMcpTool = {
+    name: 'assign_color_role',
+    title: 'Assign a color family to an interface role',
+    description:
+      'Recolor a semantic region of the widget by choosing a palette family and intensity. One call writes all related tokens (background, text, border, icon) consistently. Roles: header, user-messages, assistant-messages, primary-actions, input, links, borders, surfaces, scroll-to-bottom. Families: primary, secondary, accent, neutral. Intensity: solid (bold) or soft (tinted).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        role: { type: 'string', description: 'Interface role, e.g. "header" or "user-messages".' },
+        family: { type: 'string', enum: ['primary', 'secondary', 'accent', 'neutral'] },
+        intensity: { type: 'string', enum: ['solid', 'soft'], description: "Defaults to 'solid'." },
+      },
+      required: ['role', 'family'],
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const role = coerceRole(args.role);
+      const family = coerceFamily(args.family, true);
+      const intensity = coerceIntensity(args.intensity);
+
+      const writes = filterByEditTarget(resolveRoleAssignment(family, intensity, role));
+      const tokensWritten = Object.keys(writes).length;
+      state.setBatch(writes);
+
+      const warnings = quickContrastWarnings(
+        state,
+        ROLE_CONTRAST_KEYS[role.roleId] ?? [],
+        'light'
+      );
+      return result(
+        { role: roleKey(role.roleId), family, intensity, tokensWritten },
+        warnings
+      );
+    },
+  };
+
+  const setTypography: WebMcpTool = {
+    name: 'set_typography',
+    title: 'Set typography',
+    description:
+      'Set font family, base size, weight, and line height in one call. fontFamily: sans|serif|mono. fontSize: xs|sm|base|lg|xl. fontWeight: normal|medium|semibold|bold (or 400–700). lineHeight: tight|normal|relaxed (or 1.25/1.5/1.625).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        fontFamily: { type: 'string' },
+        fontSize: { type: 'string' },
+        fontWeight: { type: ['string', 'number'] },
+        lineHeight: { type: ['string', 'number'] },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const writes: Record<string, unknown> = {};
+      const applied: Record<string, string> = {};
+
+      const apply = (
+        key: 'fontFamily' | 'fontSize' | 'fontWeight' | 'lineHeight',
+        refs: Record<string, string>
+      ) => {
+        if (args[key] === undefined) return;
+        const ref = coerceTypographyRef(args[key], refs, key);
+        applied[key] = ref.split('.').pop() ?? ref;
+        Object.assign(writes, expandScoped(`semantic.typography.${key}`, ref));
+      };
+
+      apply('fontFamily', FONT_FAMILY_REFS);
+      apply('fontSize', FONT_SIZE_REFS);
+      apply('fontWeight', FONT_WEIGHT_REFS);
+      apply('lineHeight', LINE_HEIGHT_REFS);
+
+      if (Object.keys(applied).length === 0) {
+        throw new Error('Provide at least one of: fontFamily, fontSize, fontWeight, lineHeight.');
+      }
+      state.setBatch(writes);
+      return result(applied);
+    },
+  };
+
+  const setRoundness: WebMcpTool = {
+    name: 'set_roundness',
+    title: 'Set corner roundness',
+    description:
+      'Set overall corner roundness with a keyword (sharp, default, rounded, pill) which maps the full radius scale, OR pass granular radius values. Provide at least one of `style` or `radius`.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        style: { type: 'string', enum: ['sharp', 'default', 'rounded', 'pill'] },
+        radius: {
+          type: 'object',
+          description: 'Granular overrides (px number or CSS length).',
+          properties: {
+            sm: { type: ['string', 'number'] },
+            md: { type: ['string', 'number'] },
+            lg: { type: ['string', 'number'] },
+            xl: { type: ['string', 'number'] },
+            full: { type: ['string', 'number'] },
+          },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const writes: Record<string, unknown> = {};
+      const applied: Record<string, unknown> = {};
+
+      if (args.style !== undefined) {
+        const style = coerceRoundnessStyle(args.style);
+        applied.style = style;
+        for (const [key, value] of Object.entries(RADIUS_PRESETS[style])) {
+          Object.assign(writes, expandScoped(`palette.radius.${key}`, value));
+        }
+      }
+
+      if (args.radius !== undefined) {
+        const radius = rec(args.radius);
+        const overrides: Record<string, string> = {};
+        for (const key of ['sm', 'md', 'lg', 'xl', 'full']) {
+          if (radius[key] === undefined) continue;
+          const value = coerceRadius(radius[key]);
+          overrides[key] = value;
+          Object.assign(writes, expandScoped(`palette.radius.${key}`, value));
+        }
+        applied.radius = overrides;
+      }
+
+      if (Object.keys(writes).length === 0) {
+        throw new Error('Provide `style` (sharp|default|rounded|pill) or a `radius` object.');
+      }
+      state.setBatch(writes);
+      return result(applied);
+    },
+  };
+
+  const setColorScheme: WebMcpTool = {
+    name: 'set_color_scheme',
+    title: 'Set color scheme',
+    description:
+      'Set the shipped widget color scheme (light, dark, or auto/follow-system). Optionally set `editTarget` to choose which theme variant subsequent styling edits write to (light, dark, or both — default both).',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        scheme: { type: 'string', enum: ['light', 'dark', 'auto'] },
+        editTarget: { type: 'string', enum: ['light', 'dark', 'both'] },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const applied: Record<string, unknown> = {};
+      if (args.scheme !== undefined) {
+        const scheme = coerceScheme(args.scheme);
+        state.set('colorScheme', scheme);
+        applied.scheme = scheme;
+      }
+      if (args.editTarget !== undefined) {
+        const t = String(args.editTarget).trim().toLowerCase();
+        if (t !== 'light' && t !== 'dark' && t !== 'both') {
+          throw new Error(`Unknown editTarget "${args.editTarget}". Valid: light, dark, both.`);
+        }
+        editTarget = t;
+        applied.editTarget = t;
+      }
+      if (Object.keys(applied).length === 0) {
+        throw new Error('Provide `scheme` and/or `editTarget`.');
+      }
+      return toolResult({ ok: true, summary: buildSummary(state), warnings: [], applied, editTarget });
+    },
+  };
+
+  const applyPreset: WebMcpTool = {
+    name: 'apply_preset',
+    title: 'Apply a built-in theme preset',
+    description:
+      'Apply a complete built-in preset, replacing theme tokens. Call get_theme_overview to list preset ids.',
+    inputSchema: {
+      type: 'object',
+      properties: { presetId: { type: 'string' } },
+      required: ['presetId'],
+      additionalProperties: false,
+    },
+    execute(input) {
+      const { presetId } = rec(input);
+      const preset = getThemeEditorPreset(String(presetId ?? ''));
+      if (!preset) {
+        const valid = THEME_EDITOR_PRESETS.map((p) => p.id).join(', ');
+        throw new Error(`Unknown preset "${presetId}". Valid presets: ${valid}.`);
+      }
+      const theme = createTheme(preset.theme, { validate: false });
+      const config: AgentWidgetConfig = { ...state.getConfig() };
+      if (preset.darkTheme) {
+        config.darkTheme = createTheme(preset.darkTheme, { validate: false }) as PersonaTheme;
+      }
+      if (preset.toolCall) config.toolCall = preset.toolCall;
+      state.setFullConfig(config, theme);
+      const warnings = quickContrastWarnings(state, ['body', 'assistant-message'], 'light');
+      return result({ appliedPreset: { id: preset.id, name: preset.name } }, warnings);
+    },
+  };
+
+  const configureWidget: WebMcpTool = {
+    name: 'configure_widget',
+    title: 'Configure launcher, features, and layout',
+    description:
+      'Toggle non-theme widget configuration. launcherPosition: bottom-right|bottom-left|top-right|top-left. features: { voice, artifacts, attachments, toolCalls, reasoning, feedback } booleans. layout: { avatars, timestamps, showHeader } booleans and messageStyle: bubble|flat|minimal.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        launcherPosition: { type: 'string', enum: LAUNCHER_POSITIONS },
+        features: {
+          type: 'object',
+          properties: {
+            voice: { type: 'boolean' },
+            artifacts: { type: 'boolean' },
+            attachments: { type: 'boolean' },
+            toolCalls: { type: 'boolean' },
+            reasoning: { type: 'boolean' },
+            feedback: { type: 'boolean' },
+          },
+          additionalProperties: false,
+        },
+        layout: {
+          type: 'object',
+          properties: {
+            avatars: { type: 'boolean' },
+            timestamps: { type: 'boolean' },
+            showHeader: { type: 'boolean' },
+            messageStyle: { type: 'string', enum: MESSAGE_STYLES },
+          },
+          additionalProperties: false,
+        },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const writes: Record<string, unknown> = {};
+      const applied: Record<string, unknown> = {};
+
+      if (args.launcherPosition !== undefined) {
+        const pos = String(args.launcherPosition);
+        if (!LAUNCHER_POSITIONS.includes(pos)) {
+          throw new Error(`Unknown launcherPosition "${pos}". Valid: ${LAUNCHER_POSITIONS.join(', ')}.`);
+        }
+        writes['launcher.position'] = pos;
+        applied.launcherPosition = pos;
+      }
+
+      const features = rec(args.features);
+      for (const [key, path] of Object.entries(FEATURE_PATHS)) {
+        if (features[key] === undefined) continue;
+        writes[path] = Boolean(features[key]);
+        (applied.features ??= {} as Record<string, boolean>);
+        (applied.features as Record<string, boolean>)[key] = Boolean(features[key]);
+      }
+
+      const layout = rec(args.layout);
+      for (const [key, path] of Object.entries(LAYOUT_PATHS)) {
+        if (layout[key] === undefined) continue;
+        if (key === 'messageStyle') {
+          const style = String(layout[key]);
+          if (!MESSAGE_STYLES.includes(style)) {
+            throw new Error(`Unknown messageStyle "${style}". Valid: ${MESSAGE_STYLES.join(', ')}.`);
+          }
+          writes[path] = style;
+          (applied.layout ??= {} as Record<string, unknown>);
+          (applied.layout as Record<string, unknown>)[key] = style;
+        } else {
+          writes[path] = Boolean(layout[key]);
+          (applied.layout ??= {} as Record<string, unknown>);
+          (applied.layout as Record<string, unknown>)[key] = Boolean(layout[key]);
+        }
+      }
+
+      if (Object.keys(writes).length === 0) {
+        throw new Error('Provide launcherPosition, features, and/or layout.');
+      }
+      state.setBatch(writes);
+      return result(applied);
+    },
+  };
+
+  const setCopyAndSuggestions: WebMcpTool = {
+    name: 'set_copy_and_suggestions',
+    title: 'Set welcome copy and suggestion chips',
+    description:
+      'Set the widget welcome copy and suggestion chips. title/subtitle are the welcome card text; placeholder is the input placeholder; sendLabel is the send button label; suggestions is an array of suggestion-chip strings (replaces the existing list); greeting sets the initial assistant message shown in the transcript.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        title: { type: 'string' },
+        subtitle: { type: 'string' },
+        placeholder: { type: 'string' },
+        sendLabel: { type: 'string' },
+        suggestions: { type: 'array', items: { type: 'string' } },
+        greeting: { type: 'string' },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const writes: Record<string, unknown> = {};
+      const applied: Record<string, unknown> = {};
+
+      for (const [key, path] of Object.entries(COPY_PATHS)) {
+        if (args[key] === undefined) continue;
+        writes[path] = String(args[key]);
+        applied[key] = String(args[key]);
+      }
+
+      if (args.suggestions !== undefined) {
+        if (!Array.isArray(args.suggestions)) {
+          throw new Error('`suggestions` must be an array of strings.');
+        }
+        const chips = args.suggestions.filter((s): s is string => typeof s === 'string');
+        writes['suggestionChips'] = chips;
+        applied.suggestions = chips;
+      }
+
+      if (args.greeting !== undefined) {
+        const content = String(args.greeting);
+        writes['initialMessages'] = [
+          { id: 'mcp-initial', role: 'assistant', content, createdAt: new Date().toISOString() },
+        ];
+        applied.greeting = content;
+      }
+
+      if (Object.keys(writes).length === 0) {
+        throw new Error('Provide at least one of: title, subtitle, placeholder, sendLabel, suggestions, greeting.');
+      }
+      state.setBatch(writes);
+      return result(applied);
+    },
+  };
+
+  const setThemeFields: WebMcpTool = {
+    name: 'set_theme_fields',
+    title: 'Set theme fields by id or path (advanced)',
+    description:
+      'Advanced escape hatch: set individual editor fields by field id (see get_theme_overview verbosity:"full") or by raw dot-path (theme.* / darkTheme.* / a config path). Use only when a higher-level tool does not cover the need. Values are validated against the field metadata.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        updates: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              field: { type: 'string', description: 'Field id or dot-path.' },
+              value: { type: ['string', 'number', 'boolean'] },
+            },
+            required: ['field', 'value'],
+            additionalProperties: false,
+          },
+        },
+      },
+      required: ['updates'],
+      additionalProperties: false,
+    },
+    execute(input) {
+      const { updates } = rec(input);
+      if (!Array.isArray(updates) || updates.length === 0) {
+        throw new Error('`updates` must be a non-empty array of { field, value }.');
+      }
+      fieldIndex ??= buildFieldIndex();
+
+      const writes: Record<string, unknown> = {};
+      const report: Array<{ field: string; resolvedPath?: string; ok: boolean; error?: string }> = [];
+
+      for (const raw of updates) {
+        const entry = rec(raw);
+        const fieldKey = String(entry.field ?? '');
+        try {
+          const def = fieldIndex.get(fieldKey);
+          const path = def ? def.path : fieldKey;
+          if (!def && !/^(theme|darkTheme)\.|\./.test(path)) {
+            // A bare token with no field def and no dotted path is ambiguous.
+            throw new Error(
+              `Unknown field "${fieldKey}". Pass a known field id or a dot-path (e.g. theme.palette.radius.md).`
+            );
+          }
+          const value = coerceFieldValue(def, entry.value);
+          writes[path] = value;
+          report.push({ field: fieldKey, resolvedPath: path, ok: true });
+        } catch (err) {
+          report.push({ field: fieldKey, ok: false, error: (err as Error).message });
+        }
+      }
+
+      const okWrites = report.filter((r) => r.ok);
+      if (Object.keys(writes).length > 0) state.setBatch(writes);
+      return toolResult({
+        ok: okWrites.length > 0,
+        summary: buildSummary(state),
+        warnings: [],
+        applied: { updates: report },
+      });
+    },
+  };
+
+  const checkContrast: WebMcpTool = {
+    name: 'check_contrast',
+    title: 'Check accessibility contrast',
+    description:
+      'Run WCAG contrast checks over the key text/background pairs (message text, header title, input/body text, primary button). Returns each ratio, whether it passes, and a suggested foreground shade for failures.',
+    annotations: { readOnlyHint: true },
+    inputSchema: {
+      type: 'object',
+      properties: {
+        level: { type: 'string', enum: ['AA', 'AAA'], description: "Defaults to 'AA'." },
+        variant: { type: 'string', enum: ['light', 'dark', 'both'], description: "Defaults to 'both'." },
+      },
+      additionalProperties: false,
+    },
+    execute(input) {
+      const args = rec(input);
+      const level = (args.level === 'AAA' ? 'AAA' : 'AA') as ContrastLevel;
+      const variant =
+        args.variant === 'light' || args.variant === 'dark' ? args.variant : 'both';
+      const report = runContrastChecks(state, level, variant);
+      return toolResult({
+        level: report.level,
+        passing: report.checks.length - report.failures.length,
+        total: report.checks.length,
+        checks: report.checks,
+        failures: report.failures,
+      });
+    },
+  };
+
+  const manageSession: WebMcpTool = {
+    name: 'manage_session',
+    title: 'Undo, redo, reset, or export the theme',
+    description:
+      'Session action. "undo"/"redo" step through edit history; "reset" restores defaults; "export" returns the embeddable theme snapshot (config + theme JSON) with no side effects.',
+    inputSchema: {
+      type: 'object',
+      properties: { action: { type: 'string', enum: ['undo', 'redo', 'reset', 'export'] } },
+      required: ['action'],
+      additionalProperties: false,
+    },
+    execute(input) {
+      const { action } = rec(input);
+      switch (action) {
+        case 'undo':
+          state.undo();
+          return result({ action: 'undo' });
+        case 'redo':
+          state.redo();
+          return result({ action: 'redo' });
+        case 'reset':
+          state.resetToDefaults();
+          return result({ action: 'reset' });
+        case 'export':
+          return toolResult({ ok: true, snapshot: state.exportSnapshot() });
+        default:
+          throw new Error(`Unknown action "${action}". Valid: undo, redo, reset, export.`);
+      }
+    },
+  };
+
+  return [
+    getThemeOverview,
+    setBrandColors,
+    assignColorRole,
+    setTypography,
+    setRoundness,
+    setColorScheme,
+    applyPreset,
+    configureWidget,
+    setCopyAndSuggestions,
+    setThemeFields,
+    checkContrast,
+    manageSession,
+  ];
+}
+
+// ─── Field value validation (escape hatch) ──────────────────────
+
+function coerceFieldValue(def: FieldDef | undefined, value: unknown): unknown {
+  if (!def) return value;
+
+  switch (def.type) {
+    case 'color':
+      return def.parseValue ? def.parseValue(coerceColor(value)) : coerceColor(value);
+    case 'toggle':
+      return typeof value === 'boolean' ? value : value === 'true' || value === 1;
+    case 'slider': {
+      const num = Number(value);
+      if (!Number.isFinite(num)) throw new Error(`"${def.id}" expects a number.`);
+      if (def.slider) {
+        const { min, max } = def.slider;
+        if (num < min || num > max) {
+          throw new Error(`"${def.id}" must be between ${min} and ${max}.`);
+        }
+      }
+      return def.parseValue ? def.parseValue(num) : num;
+    }
+    case 'select': {
+      const str = String(value);
+      if (def.options && !def.options.some((o) => o.value === str)) {
+        throw new Error(
+          `"${def.id}" must be one of: ${def.options.map((o) => o.value).join(', ')}.`
+        );
+      }
+      return def.parseValue ? def.parseValue(str) : str;
+    }
+    default:
+      return def.parseValue ? def.parseValue(value) : value;
+  }
+}

--- a/packages/widget/src/theme-editor/webmcp/tools.ts
+++ b/packages/widget/src/theme-editor/webmcp/tools.ts
@@ -32,6 +32,7 @@ import {
   coerceRoundnessStyle,
   coerceRadius,
   coerceTypographyRef,
+  ROLE_FAMILY_NAMES,
   FONT_FAMILY_REFS,
   FONT_SIZE_REFS,
   FONT_WEIGHT_REFS,
@@ -41,6 +42,7 @@ import {
   buildSummary,
   quickContrastWarnings,
   runContrastChecks,
+  roleContrastPairKeys,
   RADIUS_PRESETS,
   roleKey,
   type ContrastWarning,
@@ -82,15 +84,6 @@ function coerceRole(input: unknown): RoleAssignmentOptions {
   }
   return role;
 }
-
-/** Contrast pairs to check after a role recolor. */
-const ROLE_CONTRAST_KEYS: Record<string, string[]> = {
-  'role-header': ['header'],
-  'role-user-messages': ['user-message'],
-  'role-assistant-messages': ['assistant-message'],
-  'role-primary-actions': ['primary-button'],
-  'role-surfaces': ['body', 'surface'],
-};
 
 // ─── Field index (escape hatch) ─────────────────────────────────
 
@@ -171,6 +164,9 @@ export function createThemeEditorTools(
     return out;
   };
 
+  /** Which variant a color mutation should be contrast-checked against. */
+  const warnVariant = (): 'light' | 'dark' => (editTarget === 'dark' ? 'dark' : 'light');
+
   const result = (applied: unknown, warnings: ContrastWarning[] = []) =>
     toolResult({ ok: true, summary: buildSummary(state), warnings, applied });
 
@@ -201,7 +197,7 @@ export function createThemeEditorTools(
           role: roleKey(r.roleId),
           helper: r.helper,
         })),
-        availableFamilies: ['primary', 'secondary', 'accent', 'neutral'],
+        availableFamilies: ROLE_FAMILY_NAMES,
         presets: THEME_EDITOR_PRESETS.map((p) => ({
           id: p.id,
           name: p.name,
@@ -273,7 +269,11 @@ export function createThemeEditorTools(
       }
 
       state.setBatch(writes);
-      const warnings = quickContrastWarnings(state, ['primary-button', 'user-message'], 'light');
+      const warnings = quickContrastWarnings(
+        state,
+        ['primary-button', 'user-message'],
+        warnVariant()
+      );
       return result(applied, warnings);
     },
   };
@@ -287,7 +287,7 @@ export function createThemeEditorTools(
       type: 'object',
       properties: {
         role: { type: 'string', description: 'Interface role, e.g. "header" or "user-messages".' },
-        family: { type: 'string', enum: ['primary', 'secondary', 'accent', 'neutral'] },
+        family: { type: 'string', enum: ROLE_FAMILY_NAMES },
         intensity: { type: 'string', enum: ['solid', 'soft'], description: "Defaults to 'solid'." },
       },
       required: ['role', 'family'],
@@ -303,11 +303,7 @@ export function createThemeEditorTools(
       const tokensWritten = Object.keys(writes).length;
       state.setBatch(writes);
 
-      const warnings = quickContrastWarnings(
-        state,
-        ROLE_CONTRAST_KEYS[role.roleId] ?? [],
-        'light'
-      );
+      const warnings = quickContrastWarnings(state, roleContrastPairKeys(role), warnVariant());
       return result(
         { role: roleKey(role.roleId), family, intensity, tokensWritten },
         warnings
@@ -567,7 +563,7 @@ export function createThemeEditorTools(
     name: 'set_copy_and_suggestions',
     title: 'Set welcome copy and suggestion chips',
     description:
-      'Set the widget welcome copy and suggestion chips. title/subtitle are the welcome card text; placeholder is the input placeholder; sendLabel is the send button label; suggestions is an array of suggestion-chip strings (replaces the existing list); greeting sets the initial assistant message shown in the transcript.',
+      'Set the widget welcome copy and suggestion chips. title/subtitle are the welcome card text; placeholder is the input placeholder; sendLabel is the send button label; suggestions is an array of suggestion-chip strings (replaces the existing list).',
     inputSchema: {
       type: 'object',
       properties: {
@@ -576,7 +572,6 @@ export function createThemeEditorTools(
         placeholder: { type: 'string' },
         sendLabel: { type: 'string' },
         suggestions: { type: 'array', items: { type: 'string' } },
-        greeting: { type: 'string' },
       },
       additionalProperties: false,
     },
@@ -600,16 +595,8 @@ export function createThemeEditorTools(
         applied.suggestions = chips;
       }
 
-      if (args.greeting !== undefined) {
-        const content = String(args.greeting);
-        writes['initialMessages'] = [
-          { id: 'mcp-initial', role: 'assistant', content, createdAt: new Date().toISOString() },
-        ];
-        applied.greeting = content;
-      }
-
       if (Object.keys(writes).length === 0) {
-        throw new Error('Provide at least one of: title, subtitle, placeholder, sendLabel, suggestions, greeting.');
+        throw new Error('Provide at least one of: title, subtitle, placeholder, sendLabel, suggestions.');
       }
       state.setBatch(writes);
       return result(applied);
@@ -620,7 +607,7 @@ export function createThemeEditorTools(
     name: 'set_theme_fields',
     title: 'Set theme fields by id or path (advanced)',
     description:
-      'Advanced escape hatch: set individual editor fields by field id (see get_theme_overview verbosity:"full") or by raw dot-path (theme.* / darkTheme.* / a config path). Use only when a higher-level tool does not cover the need. Values are validated against the field metadata.',
+      'Advanced escape hatch: set individual editor fields by field id (see get_theme_overview verbosity:"full") — theme field ids follow the current edit target (light/dark/both) — or by raw dot-path (theme.* / darkTheme.* / a config path), which is written as-is. Use only when a higher-level tool does not cover the need. Values are validated against the field metadata.',
     inputSchema: {
       type: 'object',
       properties: {
@@ -648,7 +635,12 @@ export function createThemeEditorTools(
       fieldIndex ??= buildFieldIndex();
 
       const writes: Record<string, unknown> = {};
-      const report: Array<{ field: string; resolvedPath?: string; ok: boolean; error?: string }> = [];
+      const report: Array<{
+        field: string;
+        resolvedPath?: string | string[];
+        ok: boolean;
+        error?: string;
+      }> = [];
 
       for (const raw of updates) {
         const entry = rec(raw);
@@ -663,8 +655,17 @@ export function createThemeEditorTools(
             );
           }
           const value = coerceFieldValue(def, entry.value);
-          writes[path] = value;
-          report.push({ field: fieldKey, resolvedPath: path, ok: true });
+          if (def && path.startsWith('theme.')) {
+            // Field ids resolve to light-theme paths; honor the active edit
+            // target so dark-only / both edits are reachable by id (not only by
+            // raw darkTheme.* dot-path).
+            const scoped = expandScoped(path.slice('theme.'.length), value);
+            Object.assign(writes, scoped);
+            report.push({ field: fieldKey, resolvedPath: Object.keys(scoped), ok: true });
+          } else {
+            writes[path] = value;
+            report.push({ field: fieldKey, resolvedPath: path, ok: true });
+          }
         } catch (err) {
           report.push({ field: fieldKey, ok: false, error: (err as Error).message });
         }

--- a/packages/widget/src/theme-editor/webmcp/types.ts
+++ b/packages/widget/src/theme-editor/webmcp/types.ts
@@ -1,0 +1,87 @@
+/**
+ * Minimal local typings for the WebMCP `document.modelContext` surface, plus the
+ * structural state interface the tool factory operates on.
+ *
+ * We deliberately keep our own small WebMCP types rather than depending on
+ * `@mcp-b/webmcp-types`, so the tool definitions are transport-agnostic and the
+ * widget package takes on no polyfill dependency. These mirror the WebMCP draft
+ * (`registerTool(tool, { signal })`) and the MCP tool-result envelope that
+ * `@mcp-b/webmcp-polyfill` expects `execute` to return.
+ */
+
+import type { AgentWidgetConfig } from '../../types';
+import type { PersonaTheme } from '../../types/theme';
+import type { ConfiguratorSnapshot } from '../types';
+
+// ─── WebMCP tool surface ────────────────────────────────────────
+
+export interface ToolTextContent {
+  type: 'text';
+  text: string;
+}
+
+export interface ToolResult {
+  content: ToolTextContent[];
+  /** Optional machine-readable mirror of the text content. */
+  structuredContent?: unknown;
+  isError?: boolean;
+}
+
+export interface ToolAnnotations {
+  /** The tool has no side effects (pure read). */
+  readOnlyHint?: boolean;
+  /** The tool's output may contain text not to be trusted as instructions. */
+  untrustedContentHint?: boolean;
+}
+
+export type ToolExecute = (input: unknown) => Promise<ToolResult> | ToolResult;
+
+export interface WebMcpTool {
+  name: string;
+  description: string;
+  title?: string;
+  inputSchema?: object;
+  annotations?: ToolAnnotations;
+  execute: ToolExecute;
+}
+
+/** Wrap a JSON-serializable payload in the MCP tool-result envelope. */
+export function toolResult(payload: unknown): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+    structuredContent: payload,
+  };
+}
+
+// ─── State surface the tools drive ──────────────────────────────
+
+/**
+ * Structural subset of `ThemeEditorState` (and the example app's `state`
+ * module) that the tools require. Anything satisfying this shape can be wired
+ * to the tools — the headless `ThemeEditorState`, or a host's stateful wrapper
+ * that also drives a live preview (e.g. a Persona widget styling itself).
+ */
+export interface ThemeEditorLike {
+  get(path: string): unknown;
+  set(path: string, value: unknown): void;
+  setBatch(updates: Record<string, unknown>): void;
+  setTheme(theme: PersonaTheme): void;
+  setFullConfig(config: AgentWidgetConfig, theme?: PersonaTheme): void;
+  undo(): void;
+  redo(): void;
+  canUndo(): boolean;
+  canRedo(): boolean;
+  getHistoryIndex(): number;
+  getTheme(): PersonaTheme;
+  getConfig(): AgentWidgetConfig;
+  exportSnapshot(): ConfiguratorSnapshot;
+  resetToDefaults(): void;
+}
+
+/** Which theme variant(s) styling tools write to. */
+export type EditTarget = 'light' | 'dark' | 'both';
+
+export interface CreateThemeEditorToolsOptions {
+  /** Default variant for styling writes. Defaults to `'both'`. */
+  editTarget?: EditTarget;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
 
   examples/embedded-app:
     dependencies:
+      '@mcp-b/webmcp-polyfill':
+        specifier: ^3.0.0
+        version: 3.0.0
       '@runtypelabs/persona':
         specifier: workspace:^
         version: link:../../packages/widget
@@ -204,6 +207,9 @@ packages:
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@changesets/apply-release-plan@7.0.14':
     resolution: {integrity: sha512-ddBvf9PHdy2YY0OUiEl3TV78mH9sckndJR14QAt87KLEbIov81XO0q0QAmvooBxXlqRRP8I9B7XOzZwQG7JkWA==}
@@ -714,89 +720,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -855,6 +877,13 @@ packages:
 
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
+
+  '@mcp-b/webmcp-polyfill@3.0.0':
+    resolution: {integrity: sha512-TCrCOZCTfRWrTp8MpWU8EO4U7r7IvDDaIYW9Ej0aBD2KVR2hvwr4t3T7kPkSYssGhpIZJrq19owSzN1vZabW+A==}
+    engines: {node: '>=18'}
+
+  '@mcp-b/webmcp-types@3.0.0':
+    resolution: {integrity: sha512-MmKHNAtlyZoK5khz5GnmgEj/ehk5esoUbgOaFndrlZvpjq3ppmIY3BDrwCv6xaihuuIMOoLLDlf0E65wUd4q7A==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -918,66 +947,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2555,6 +2597,8 @@ snapshots:
     dependencies:
       css-tree: 3.2.1
 
+  '@cfworker/json-schema@4.1.1': {}
+
   '@changesets/apply-release-plan@7.0.14':
     dependencies:
       '@changesets/config': 3.1.2
@@ -3089,6 +3133,14 @@ snapshots:
       fs-extra: 8.1.0
       globby: 11.1.0
       read-yaml-file: 1.1.0
+
+  '@mcp-b/webmcp-polyfill@3.0.0':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@mcp-b/webmcp-types': 3.0.0
+      '@standard-schema/spec': 1.1.0
+
+  '@mcp-b/webmcp-types@3.0.0': {}
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
## Summary

Wires Persona's theme editor up as **WebMCP tools** a browser agent can call to configure the theme — architected for Agent Experience (intent-level operations), not a 1:1 mapping of the ~150 editor fields. Following the [arcade.dev MCP tool patterns](https://www.arcade.dev/blog/mcp-tool-patterns/): parameter coercion, error-guided recovery, batching, multiple abstraction levels, and proactive state-returning.

This also unlocks the "**widget styles itself**" scenario — a Persona widget wired to its own `ThemeEditorState` could call these tools to restyle itself.

## What ships where

**Widget package (transport-agnostic, reusable)** — `packages/widget/src/theme-editor/webmcp/`, re-exported from `@runtypelabs/persona/theme-editor`:
- `createThemeEditorTools(state): WebMcpTool[]` — returns plain tool objects. **Zero polyfill dependency.**
- `coerce.ts` (flexible color/enum/size inputs + CSS named colors), `summary.ts` (state snapshot + WCAG contrast with shade-walk suggestions), `types.ts` (`WebMcpTool`/`toolResult` + the structural `ThemeEditorLike` interface satisfied by both `ThemeEditorState` and the app `state` module).

**Example app (the transport host)** — `examples/embedded-app/src/theme-configurator/webmcp/`:
- `install.ts` (`ensureModelContext()` via `@mcp-b/webmcp-polyfill`) + `register.ts` (`mountThemeEditorMcp(state)` with `AbortController` cleanup), mounted in `index.ts`.
- Routed through the existing `state` singleton, so an agent edit updates the **live preview + form controls + localStorage** exactly like a human edit.

## The 12 tools (two altitudes + escape hatch)

`get_theme_overview` · `check_contrast` · `set_brand_colors` (auto-generates full shade scales) · `assign_color_role` (the marquee tool — one semantic choice → many atomic token writes via the existing Interface Roles system) · `set_typography` · `set_roundness` · `set_color_scheme` (light/dark/both edit target) · `apply_preset` · `configure_widget` · `set_copy_and_suggestions` · `set_theme_fields` (low-level escape hatch by field id or dot-path) · `manage_session` (undo/redo/reset/export).

Every mutator returns `{ ok, summary, warnings, applied }` with proactive contrast warnings, so the agent gets feedback without a second read.

## Testing

- 27 new unit tests (`coerce.test.ts`, `tools.test.ts`); full widget suite green (862 tests)
- Widget typecheck + lint clean
- Full example-app build succeeds (factory bundled, polyfill dynamically imported)

**Manual:** `pnpm dev`, open `/theme.html`, confirm `document.modelContext` exposes the tools, then call e.g. `assign_color_role({role:'header', family:'primary', intensity:'soft'})` and watch the header recolor live with a contrast warning in the response.

## Changeset

Included — `@runtypelabs/persona` `minor`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large new public API and agent-driven writes to full widget/theme config; mitigated by tests, coercion, and routing through existing editor state rather than ad-hoc DOM hacks.
> 
> **Overview**
> Adds **WebMCP** support so a browser agent can drive the Persona theme editor the same way a human would.
> 
> **`@runtypelabs/persona/theme-editor`** now exports a transport-agnostic **`createThemeEditorTools(state)`** factory: twelve intent-level tools (brand colors with auto shade scales, color roles, typography, roundness, color scheme / edit target, presets, widget config, copy & chips, WCAG contrast, session undo/redo/reset/export) plus **`set_theme_fields`** as an escape hatch. Mutations return a compact **summary** and **contrast warnings**; inputs go through flexible **coercion** with error messages that list valid options. The widget package stays free of any WebMCP polyfill.
> 
> The **embedded-app** theme configurator mounts those tools on the live **`state`** singleton via **`@mcp-b/webmcp-polyfill`** (`ensureModelContext` + `mountThemeEditorMcp` with `AbortSignal` cleanup on `beforeunload`), so tool calls update preview, controls, and persistence like manual edits.
> 
> New **unit tests** cover coercion and the full tool catalog; changeset bumps **`@runtypelabs/persona`** minor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 709120fbabb1b31d4fd767c7beb780305e1c3a35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->