### PR TITLE
fix(widget): clearer, configurable dispatch-error message

### DIFF
--- a/.changeset/clear-dispatch-error-message.md
+++ b/.changeset/clear-dispatch-error-message.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Improve the dispatch-failure fallback message and make it configurable. Replaces the misleading "proxy isn't returning a real response yet" copy with an honest message that explains the chat service couldn't be reached and surfaces the underlying error reason. Adds a new `errorMessage` config option (a static string or `(error) => string`) to override the copy; returning an empty string suppresses the fallback bubble while still firing `onError`.

--- a/.changeset/clear-dispatch-error-message.md
+++ b/.changeset/clear-dispatch-error-message.md
@@ -3,3 +3,5 @@
 ---
 
 Improve the dispatch-failure fallback message and make it configurable. Replaces the misleading "proxy isn't returning a real response yet" copy with an honest message that explains the chat service couldn't be reached and surfaces the underlying error reason. Adds a new `errorMessage` config option (a static string or `(error) => string`) to override the copy; returning an empty string suppresses the fallback bubble while still firing `onError`.
+
+Also fixes abort handling on `continueConversation`: a cancelled continuation (e.g. a superseded in-flight stream) no longer shows the dispatch-error bubble or fires `onError`, matching `sendMessage`'s behavior — only genuine failures surface.

--- a/.changeset/composer-keyboard-ux.md
+++ b/.changeset/composer-keyboard-ux.md
@@ -1,0 +1,9 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Composer keyboard UX improvements:
+
+- **Enter no longer stops a streaming response.** Pressing Enter while a response streams is now inert (it never aborts generation). Use the visible Stop button or press Escape to stop.
+- **Escape stops streaming.** While a response streams, pressing Escape within the widget aborts it (scoped to the widget; the composer-bar Escape-to-collapse behavior still applies when not streaming).
+- **Up/Down arrows navigate message history.** In the composer, Up recalls previously sent user messages for quick re-entry or editing and Down walks back toward the in-progress draft (shell / Slack style). History is only entered when the caret is at the start of the input, preserving normal multi-line cursor movement. Disable via `features.composerHistory: false`.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ Optional side-panel for rendering markdown and component content. Desktop split 
 ### Event Stream Inspector
 Optional real-time event capture with search/filter, badge coloring, timestamps, and expandable payloads. Enable via `features.showEventStreamToggle`. Customize rows, toolbar, and payload rendering through plugin hooks.
 
+### Composer Keyboard Shortcuts
+`Enter` sends a message (`Shift+Enter` for a newline) and is inert while a response is streaming — it never interrupts generation. Press `Esc` within the widget to stop an in-flight response (the visible Stop button does the same). `Up`/`Down` navigate previously sent messages for quick re-entry or editing — entered only when the caret is at the start of the input, so multi-line editing is preserved, and your in-progress draft is restored when you page back to the present. History navigation is on by default; disable via `features.composerHistory: false`.
+
 ### Themes & Styling
 Light and dark themes included. Full design token system (palette, semantic, component-level) with CSS variable support. Extend with built-in plugins for accessibility, reduced motion, high contrast, and branding — or create your own.
 

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -2278,6 +2278,7 @@ config: {
 | `showReasoning` | `boolean?` | Show thinking/reasoning bubbles. Default: `true`. |
 | `showToolCalls` | `boolean?` | Show tool usage bubbles. Default: `true`. |
 | `showEventStreamToggle` | `boolean?` | Show the event stream inspector toggle in the header. Default: `false`. |
+| `composerHistory` | `boolean?` | `Up`/`Down` arrows in the composer navigate previously sent user messages for re-entry/editing (shell / Slack style). Entered only when the caret is at the start of the input, so multi-line cursor movement is preserved. Default: `true`. |
 | `eventStream` | `EventStreamConfig?` | Event stream inspector configuration: `badgeColors`, `timestampFormat`, `showSequenceNumbers`, `maxEvents`, `descriptionFields`, `classNames`. |
 | `artifacts` | `AgentWidgetArtifactsFeature?` | Artifact sidebar: `enabled`, `allowedTypes`, optional `layout` (see below). |
 

--- a/packages/widget/src/session.test.ts
+++ b/packages/widget/src/session.test.ts
@@ -794,3 +794,160 @@ describe('AgentWidgetSession.resolveApproval', () => {
     expect(errors.length).toBe(1);
   });
 });
+
+describe('AgentWidgetSession - dispatch error fallback', () => {
+  const originalFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  // Make fetch reject so client.dispatch throws and the session falls back.
+  const failFetchWith = (error: Error) => {
+    global.fetch = vi.fn().mockRejectedValue(error);
+  };
+
+  const lastAssistantMessage = (
+    session: AgentWidgetSession
+  ): AgentWidgetMessage | undefined =>
+    [...session.getMessages()].reverse().find((m) => m.role === 'assistant');
+
+  it('shows the default message with the underlying error detail and fires onError', async () => {
+    failFetchWith(new Error('Failed to fetch'));
+    const errors: Error[] = [];
+    const session = new AgentWidgetSession(
+      { apiUrl: 'http://example.invalid/chat' },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+        onError: (e) => errors.push(e),
+      }
+    );
+
+    await session.sendMessage('Hello');
+
+    const assistant = lastAssistantMessage(session);
+    expect(assistant?.content).toContain("I couldn't reach the assistant");
+    expect(assistant?.content).toContain('_Details: Failed to fetch_');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toBe('Failed to fetch');
+    expect(session.isStreaming()).toBe(false);
+    expect(session.getStatus()).toBe('idle');
+  });
+
+  it('uses a static errorMessage override verbatim', async () => {
+    failFetchWith(new Error('boom'));
+    const session = new AgentWidgetSession(
+      {
+        apiUrl: 'http://example.invalid/chat',
+        errorMessage: 'We are having trouble connecting.',
+      },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+      }
+    );
+
+    await session.sendMessage('Hello');
+
+    const assistant = lastAssistantMessage(session);
+    expect(assistant?.content).toBe('We are having trouble connecting.');
+    expect(assistant?.content).not.toContain('Details');
+  });
+
+  it('passes the error to a function errorMessage override', async () => {
+    failFetchWith(new Error('Failed to fetch'));
+    const seen: Error[] = [];
+    const session = new AgentWidgetSession(
+      {
+        apiUrl: 'http://example.invalid/chat',
+        errorMessage: (error) => {
+          seen.push(error);
+          return error.message.includes('Failed to fetch')
+            ? 'You appear to be offline.'
+            : 'Something went wrong.';
+        },
+      },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+      }
+    );
+
+    await session.sendMessage('Hello');
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeInstanceOf(Error);
+    expect(lastAssistantMessage(session)?.content).toBe(
+      'You appear to be offline.'
+    );
+  });
+
+  it('suppresses the fallback bubble when the override returns an empty string but still fires onError', async () => {
+    failFetchWith(new Error('boom'));
+    const errors: Error[] = [];
+    const session = new AgentWidgetSession(
+      {
+        apiUrl: 'http://example.invalid/chat',
+        errorMessage: () => '',
+      },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+        onError: (e) => errors.push(e),
+      }
+    );
+
+    await session.sendMessage('Hello');
+
+    expect(lastAssistantMessage(session)).toBeUndefined();
+    expect(errors).toHaveLength(1);
+    expect(session.isStreaming()).toBe(false);
+    expect(session.getStatus()).toBe('idle');
+  });
+
+  it('does NOT show a fallback bubble when the dispatch is aborted', async () => {
+    const abortErr = new Error('The operation was aborted');
+    abortErr.name = 'AbortError';
+    failFetchWith(abortErr);
+    const errors: Error[] = [];
+    const session = new AgentWidgetSession(
+      { apiUrl: 'http://example.invalid/chat' },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+        onError: (e) => errors.push(e),
+      }
+    );
+
+    await session.sendMessage('Hello');
+
+    expect(lastAssistantMessage(session)).toBeUndefined();
+    expect(errors).toHaveLength(0);
+  });
+
+  it('applies the override on continueConversation failures too', async () => {
+    failFetchWith(new Error('boom'));
+    const session = new AgentWidgetSession(
+      {
+        apiUrl: 'http://example.invalid/chat',
+        errorMessage: 'Custom continue error.',
+      },
+      {
+        onMessagesChanged: () => {},
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+      }
+    );
+
+    await session.continueConversation();
+
+    expect(lastAssistantMessage(session)?.content).toBe('Custom continue error.');
+  });
+});

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -913,30 +913,43 @@ export class AgentWidgetSession {
         this.handleEvent
       );
     } catch (error) {
-      const content = buildDispatchErrorContent(
-        error,
-        this.config.errorMessage
-      );
-      // An override that returns "" suppresses the fallback bubble entirely
-      // (onError still fires below).
-      if (content) {
-        const fallback: AgentWidgetMessage = {
-          id: assistantMessageId,
-          role: "assistant",
-          createdAt: new Date().toISOString(),
-          content,
-          sequence: this.nextSequence()
-        };
+      // Check if this is an abort error (a prior in-flight stream was canceled,
+      // the user navigated away, etc.). In these cases, don't show fallback or
+      // fire onError - the request was intentionally interrupted.
+      const isAbortError =
+        error instanceof Error &&
+        (error.name === 'AbortError' ||
+         error.message.includes('aborted') ||
+         error.message.includes('abort'));
 
-        this.appendMessage(fallback);
+      if (!isAbortError) {
+        const content = buildDispatchErrorContent(
+          error,
+          this.config.errorMessage
+        );
+        // An override that returns "" suppresses the fallback bubble entirely
+        // (onError still fires below).
+        if (content) {
+          const fallback: AgentWidgetMessage = {
+            id: assistantMessageId,
+            role: "assistant",
+            createdAt: new Date().toISOString(),
+            content,
+            sequence: this.nextSequence()
+          };
+
+          this.appendMessage(fallback);
+        }
       }
       this.setStatus("idle");
       this.setStreaming(false);
       this.abortController = null;
-      if (error instanceof Error) {
-        this.callbacks.onError?.(error);
-      } else {
-        this.callbacks.onError?.(new Error(String(error)));
+      if (!isAbortError) {
+        if (error instanceof Error) {
+          this.callbacks.onError?.(error);
+        } else {
+          this.callbacks.onError?.(new Error(String(error)));
+        }
       }
     }
   }

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -49,6 +49,31 @@ type SessionCallbacks = {
   }) => void;
 };
 
+/**
+ * Build the user-facing content shown when a dispatch fails before any
+ * assistant content streamed back. This fires on real network/server errors
+ * (connection refused, CORS, 4xx/5xx, malformed stream) — not just an
+ * un-wired proxy — so the copy stays honest about the failure and surfaces the
+ * underlying reason to help with debugging.
+ *
+ * Callers can override the copy via `config.errorMessage` (a static string or
+ * a function of the error). An override that returns an empty string yields ""
+ * here, which the caller treats as "suppress the fallback bubble".
+ */
+function buildDispatchErrorContent(
+  error: unknown,
+  override?: AgentWidgetConfig["errorMessage"]
+): string {
+  const err = error instanceof Error ? error : new Error(String(error));
+
+  if (typeof override === "string") return override;
+  if (typeof override === "function") return override(err);
+
+  const base =
+    "Sorry — I couldn't reach the assistant. The chat service didn't respond. Please check that your proxy or backend is running and reachable, then try again.";
+  return err.message ? `${base}\n\n_Details: ${err.message}_` : base;
+}
+
 export class AgentWidgetSession {
   private client: AgentWidgetClient;
   private messages: AgentWidgetMessage[];
@@ -818,16 +843,23 @@ export class AgentWidgetSession {
          error.message.includes('abort'));
 
       if (!isAbortError) {
-        const fallback: AgentWidgetMessage = {
-          id: assistantMessageId, // Use the pre-generated ID for fallback too
-          role: "assistant",
-          createdAt: new Date().toISOString(),
-          content:
-            "It looks like the proxy isn't returning a real response yet. Here's a sample message so you can continue testing locally.",
-          sequence: this.nextSequence()
-        };
+        const content = buildDispatchErrorContent(
+          error,
+          this.config.errorMessage
+        );
+        // An override that returns "" suppresses the fallback bubble entirely
+        // (onError still fires below).
+        if (content) {
+          const fallback: AgentWidgetMessage = {
+            id: assistantMessageId, // Use the pre-generated ID for fallback too
+            role: "assistant",
+            createdAt: new Date().toISOString(),
+            content,
+            sequence: this.nextSequence()
+          };
 
-        this.appendMessage(fallback);
+          this.appendMessage(fallback);
+        }
       }
 
       this.setStatus("idle");
@@ -881,16 +913,23 @@ export class AgentWidgetSession {
         this.handleEvent
       );
     } catch (error) {
-      const fallback: AgentWidgetMessage = {
-        id: assistantMessageId,
-        role: "assistant",
-        createdAt: new Date().toISOString(),
-        content:
-          "It looks like the proxy isn't returning a real response yet. Here's a sample message so you can continue testing locally.",
-        sequence: this.nextSequence()
-      };
+      const content = buildDispatchErrorContent(
+        error,
+        this.config.errorMessage
+      );
+      // An override that returns "" suppresses the fallback bubble entirely
+      // (onError still fires below).
+      if (content) {
+        const fallback: AgentWidgetMessage = {
+          id: assistantMessageId,
+          role: "assistant",
+          createdAt: new Date().toISOString(),
+          content,
+          sequence: this.nextSequence()
+        };
 
-      this.appendMessage(fallback);
+        this.appendMessage(fallback);
+      }
       this.setStatus("idle");
       this.setStreaming(false);
       this.abortController = null;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -897,6 +897,14 @@ export type AgentWidgetFeatureFlags = {
   showReasoning?: boolean;
   showToolCalls?: boolean;
   showEventStreamToggle?: boolean;
+  /**
+   * Up/Down arrow navigation through previously sent user messages in the
+   * composer, for quick re-entry or editing (shell / Slack style). History is
+   * only entered when the caret is at the start of the input, so normal
+   * multi-line cursor movement is preserved. Set to `false` to disable.
+   * @default true
+   */
+  composerHistory?: boolean;
   /** Shared transcript + event stream scroll-to-bottom affordance. */
   scrollToBottom?: AgentWidgetScrollToBottomFeature;
   /** Collapsed transcript behavior for tool call rows. */

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -2917,6 +2917,31 @@ export type AgentWidgetConfig = {
   apiUrl?: string;
   flowId?: string;
   /**
+   * Override the assistant-bubble copy shown when a dispatch fails before any
+   * response streams back (connection refused, CORS, 4xx/5xx, malformed
+   * stream). Provide a static string, or a function of the error so you can
+   * tailor the message per failure and decide whether to surface the raw
+   * reason. When omitted, a default message is shown that includes the
+   * underlying error detail.
+   *
+   * Returning an empty string suppresses the fallback bubble entirely (the
+   * `onError` callback still fires).
+   *
+   * @example
+   * ```typescript
+   * config: {
+   *   // Static
+   *   errorMessage: "We're having trouble connecting. Please try again."
+   *   // Or dynamic
+   *   errorMessage: (error) =>
+   *     error.message.includes("Failed to fetch")
+   *       ? "You appear to be offline."
+   *       : "Something went wrong. Please try again."
+   * }
+   * ```
+   */
+  errorMessage?: string | ((error: Error) => string);
+  /**
    * Agent configuration for agent execution mode.
    * When provided, the widget uses agent loop execution instead of flow dispatch.
    * Mutually exclusive with `flowId`.

--- a/packages/widget/src/ui.composer-keyboard.test.ts
+++ b/packages/widget/src/ui.composer-keyboard.test.ts
@@ -1,0 +1,229 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentExperience } from "./ui";
+
+const createMount = () => {
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  return mount;
+};
+
+const flush = async (times = 4) => {
+  for (let i = 0; i < times; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await Promise.resolve();
+  }
+};
+
+const getTextarea = (mount: HTMLElement) =>
+  mount.querySelector<HTMLTextAreaElement>("[data-persona-composer-input]")!;
+
+const press = (el: Element, key: string) =>
+  el.dispatchEvent(
+    new KeyboardEvent("keydown", { key, bubbles: true, cancelable: true })
+  );
+
+describe("createAgentExperience composer keyboard — Enter / Esc while streaming", () => {
+  const originalFetch = global.fetch;
+  let capturedSignals: AbortSignal[] = [];
+
+  beforeEach(() => {
+    capturedSignals = [];
+    vi.stubGlobal("requestAnimationFrame", (cb: (time: number) => void) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    window.scrollTo = vi.fn();
+
+    // Fetch hangs until aborted — models an in-flight SSE stream so the widget
+    // stays "streaming".
+    global.fetch = vi.fn().mockImplementation((_url: string, options: any) => {
+      const signal = options.signal as AbortSignal;
+      capturedSignals.push(signal);
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      });
+    }) as any;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    global.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  const startStreaming = async (mount: HTMLElement) => {
+    const textarea = getTextarea(mount);
+    textarea.value = "Hello";
+    mount
+      .querySelector<HTMLButtonElement>("[data-persona-composer-submit]")!
+      .click();
+    await flush();
+    return textarea;
+  };
+
+  it("Enter while streaming does NOT stop the stream and does not send", async () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    });
+
+    const textarea = await startStreaming(mount);
+    expect(controller.getState().streaming).toBe(true);
+    expect(capturedSignals).toHaveLength(1);
+
+    // Type something new, then hit Enter — it must be inert mid-stream.
+    textarea.value = "queued text";
+    press(textarea, "Enter");
+    await flush();
+
+    expect(controller.getState().streaming).toBe(true);
+    expect(capturedSignals[0].aborted).toBe(false);
+    // No second request fired (nothing sent).
+    expect(capturedSignals).toHaveLength(1);
+
+    controller.destroy();
+  });
+
+  it("Escape while streaming stops the stream", async () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    });
+
+    const textarea = await startStreaming(mount);
+    expect(controller.getState().streaming).toBe(true);
+
+    press(textarea, "Escape");
+    await flush();
+
+    expect(controller.getState().streaming).toBe(false);
+    expect(capturedSignals[0].aborted).toBe(true);
+
+    controller.destroy();
+  });
+
+  it("Escape while NOT streaming does not throw and leaves state idle", async () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+    });
+
+    const textarea = getTextarea(mount);
+    press(textarea, "Escape");
+    await flush();
+
+    expect(controller.getState().streaming).toBe(false);
+    expect(capturedSignals).toHaveLength(0);
+
+    controller.destroy();
+  });
+});
+
+describe("createAgentExperience composer keyboard — Up/Down history", () => {
+  beforeEach(() => {
+    window.scrollTo = vi.fn();
+    try {
+      window.localStorage.clear();
+    } catch {
+      /* jsdom edge cases */
+    }
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  const seededConfig = (composerHistory?: boolean) => ({
+    apiUrl: "https://api.example.com/chat",
+    launcher: { enabled: false } as const,
+    ...(composerHistory === undefined
+      ? {}
+      : { features: { composerHistory } }),
+    initialMessages: [
+      {
+        id: "u1",
+        role: "user" as const,
+        content: "first message",
+        createdAt: "2026-01-01T00:00:00.000Z",
+      },
+      {
+        id: "a1",
+        role: "assistant" as const,
+        content: "a reply",
+        createdAt: "2026-01-01T00:00:01.000Z",
+      },
+      {
+        id: "u2",
+        role: "user" as const,
+        content: "second message",
+        createdAt: "2026-01-01T00:00:02.000Z",
+      },
+    ],
+  });
+
+  it("Up recalls the most recent user message; repeated Up steps older; Down restores the draft", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, seededConfig());
+    const textarea = getTextarea(mount);
+
+    textarea.value = "draft in progress";
+    textarea.setSelectionRange(0, 0); // caret at start
+
+    press(textarea, "ArrowUp");
+    expect(textarea.value).toBe("second message");
+
+    press(textarea, "ArrowUp");
+    expect(textarea.value).toBe("first message");
+
+    // Down walks back toward the present...
+    press(textarea, "ArrowDown");
+    expect(textarea.value).toBe("second message");
+
+    // ...and past the newest entry restores the saved draft.
+    press(textarea, "ArrowDown");
+    expect(textarea.value).toBe("draft in progress");
+
+    controller.destroy();
+  });
+
+  it("does not hijack Up when the caret is not at the start (multi-line editing)", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, seededConfig());
+    const textarea = getTextarea(mount);
+
+    textarea.value = "line one\nline two";
+    textarea.setSelectionRange(5, 5); // caret mid-text
+
+    press(textarea, "ArrowUp");
+    // Value unchanged — Up moved the cursor instead of recalling history.
+    expect(textarea.value).toBe("line one\nline two");
+
+    controller.destroy();
+  });
+
+  it("can be disabled via features.composerHistory: false", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, seededConfig(false));
+    const textarea = getTextarea(mount);
+
+    textarea.value = "";
+    textarea.setSelectionRange(0, 0);
+
+    press(textarea, "ArrowUp");
+    expect(textarea.value).toBe("");
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -33,6 +33,11 @@ import { resolveTokenValue } from "./utils/tokens";
 import { renderLucideIcon } from "./utils/icons";
 import { createElement, createElementInDocument } from "./utils/dom";
 import { morphMessages } from "./utils/morph";
+import {
+  navigateComposerHistory,
+  INITIAL_HISTORY_STATE,
+  type ComposerHistoryState
+} from "./utils/composer-history";
 import { computeMessageFingerprint, createMessageCache, getCachedWrapper, setCachedWrapper, pruneCache } from "./utils/message-fingerprint";
 import {
   createFollowStateController,
@@ -4577,6 +4582,7 @@ export const createAgentExperience = (
 
     textarea.value = "";
     textarea.style.height = "auto"; // Reset height after clearing
+    resetHistoryNavigation();
 
     // Send message with optional content parts
     session.sendMessage(value, { contentParts });
@@ -4587,11 +4593,107 @@ export const createAgentExperience = (
     }
   };
 
-  const handleInputEnter = (event: KeyboardEvent) => {
+  // --- Composer message-history navigation (Up/Down arrows) ---
+  // Lets users recall and edit previously sent messages, shell/Slack style.
+  // The pure state machine lives in utils/composer-history.ts; here we feed it
+  // caret info and apply the value it returns. Text-only recall — attachments
+  // on past messages are not restored.
+  const historyNavigationEnabled = () =>
+    config.features?.composerHistory !== false;
+
+  let composerHistoryState: ComposerHistoryState = { ...INITIAL_HISTORY_STATE };
+  // Guards the reset-on-edit listener so our own programmatic value sets (which
+  // dispatch an `input` event for auto-resize) don't exit navigation mode.
+  let suppressHistoryReset = false;
+
+  const resetHistoryNavigation = () => {
+    composerHistoryState = { ...INITIAL_HISTORY_STATE };
+  };
+
+  const getUserMessageHistory = (): string[] =>
+    session
+      .getMessages()
+      .filter((message) => message.role === "user")
+      .map((message) => message.content ?? "")
+      .filter((text) => text.length > 0);
+
+  const applyHistoryValue = (value: string) => {
+    if (!textarea) return;
+    suppressHistoryReset = true;
+    textarea.value = value;
+    // Trigger the auto-resize handler (it listens on `input`).
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    suppressHistoryReset = false;
+    // Caret to end for natural editing / appending.
+    const end = textarea.value.length;
+    textarea.setSelectionRange(end, end);
+  };
+
+  const handleComposerInput = () => {
+    // A real edit leaves history-navigation mode.
+    if (suppressHistoryReset) return;
+    resetHistoryNavigation();
+  };
+
+  const handleComposerKeydown = (event: KeyboardEvent) => {
+    if (!textarea) return;
+
+    // Up/Down: walk through previously sent user messages.
+    if (
+      historyNavigationEnabled() &&
+      (event.key === "ArrowUp" || event.key === "ArrowDown") &&
+      !event.shiftKey &&
+      !event.metaKey &&
+      !event.ctrlKey &&
+      !event.altKey &&
+      !event.isComposing
+    ) {
+      const atStart =
+        textarea.selectionStart === 0 && textarea.selectionEnd === 0;
+      const result = navigateComposerHistory({
+        direction: event.key === "ArrowUp" ? "up" : "down",
+        history: getUserMessageHistory(),
+        currentValue: textarea.value,
+        atStart,
+        state: composerHistoryState
+      });
+      composerHistoryState = result.state;
+      if (result.handled) {
+        event.preventDefault();
+        if (result.value !== undefined) {
+          applyHistoryValue(result.value);
+        }
+        return;
+      }
+      // Not handled — fall through to default cursor movement.
+    }
+
+    // Enter: send, unless a response is streaming. While streaming, Enter is
+    // inert (never a stop trigger) — the visible Stop button / Esc stop it.
     if (event.key === "Enter" && !event.shiftKey) {
+      if (session.isStreaming()) {
+        event.preventDefault();
+        return;
+      }
+      resetHistoryNavigation();
       event.preventDefault();
       sendButton.click();
     }
+  };
+
+  // Esc-to-stop: while a response streams, Escape within this widget aborts it.
+  // Capture phase + registered at init so it runs before the composer-bar Esc
+  // collapse listener (attached later on open); stopImmediatePropagation keeps
+  // a stream-stop from also collapsing the panel. Scoped via composedPath so a
+  // page-wide Escape elsewhere doesn't hijack.
+  const handleEscStop = (event: KeyboardEvent) => {
+    if (event.key !== "Escape" || event.isComposing) return;
+    if (!session.isStreaming()) return;
+    if (!event.composedPath().includes(container)) return;
+    session.cancel();
+    resetHistoryNavigation();
+    event.preventDefault();
+    event.stopImmediatePropagation();
   };
 
   const handleInputPaste = async (event: ClipboardEvent) => {
@@ -5465,8 +5567,12 @@ export const createAgentExperience = (
   if (composerForm) {
     composerForm.addEventListener("submit", handleSubmit);
   }
-  textarea?.addEventListener("keydown", handleInputEnter);
+  textarea?.addEventListener("keydown", handleComposerKeydown);
+  textarea?.addEventListener("input", handleComposerInput);
   textarea?.addEventListener("paste", handleInputPaste);
+
+  const escStopDoc = mount.ownerDocument ?? document;
+  escStopDoc.addEventListener("keydown", handleEscStop, true);
 
   const ATTACHMENT_DROP_ACTIVE_CLASS = "persona-attachment-drop-active";
   let attachmentFileDragDepth = 0;
@@ -5544,8 +5650,10 @@ export const createAgentExperience = (
     if (composerForm) {
       composerForm.removeEventListener("submit", handleSubmit);
     }
-    textarea?.removeEventListener("keydown", handleInputEnter);
+    textarea?.removeEventListener("keydown", handleComposerKeydown);
+    textarea?.removeEventListener("input", handleComposerInput);
     textarea?.removeEventListener("paste", handleInputPaste);
+    escStopDoc.removeEventListener("keydown", handleEscStop, true);
   });
 
   destroyCallbacks.push(() => {

--- a/packages/widget/src/utils/composer-history.test.ts
+++ b/packages/widget/src/utils/composer-history.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from "vitest";
+import {
+  navigateComposerHistory,
+  INITIAL_HISTORY_STATE,
+  type ComposerHistoryState
+} from "./composer-history";
+
+const history = ["first", "second", "third"]; // oldest -> newest
+
+const up = (
+  state: ComposerHistoryState,
+  overrides: Partial<Parameters<typeof navigateComposerHistory>[0]> = {}
+) =>
+  navigateComposerHistory({
+    direction: "up",
+    history,
+    currentValue: "",
+    atStart: true,
+    state,
+    ...overrides
+  });
+
+const down = (
+  state: ComposerHistoryState,
+  overrides: Partial<Parameters<typeof navigateComposerHistory>[0]> = {}
+) =>
+  navigateComposerHistory({
+    direction: "down",
+    history,
+    currentValue: "",
+    atStart: true,
+    state,
+    ...overrides
+  });
+
+describe("navigateComposerHistory", () => {
+  it("Up from a fresh composer recalls the newest message and saves the draft", () => {
+    const result = up(
+      { ...INITIAL_HISTORY_STATE },
+      { currentValue: "my draft" }
+    );
+    expect(result.handled).toBe(true);
+    expect(result.value).toBe("third");
+    expect(result.state).toEqual({ index: 2, draft: "my draft" });
+  });
+
+  it("repeated Up steps toward older messages", () => {
+    let state = up({ ...INITIAL_HISTORY_STATE }).state;
+    expect(state.index).toBe(2);
+
+    const second = up(state);
+    expect(second.value).toBe("second");
+    state = second.state;
+
+    const third = up(state);
+    expect(third.value).toBe("first");
+    state = third.state;
+    expect(state.index).toBe(0);
+  });
+
+  it("Up at the oldest entry is consumed but does not change the value", () => {
+    const state: ComposerHistoryState = { index: 0, draft: "" };
+    const result = up(state);
+    expect(result.handled).toBe(true);
+    expect(result.value).toBeUndefined();
+    expect(result.state.index).toBe(0);
+  });
+
+  it("does not hijack Up when not navigating and the caret is not at the start", () => {
+    const result = up({ ...INITIAL_HISTORY_STATE }, { atStart: false });
+    expect(result.handled).toBe(false);
+    expect(result.value).toBeUndefined();
+  });
+
+  it("continues navigating Up even when the caret is not at the start", () => {
+    // Already in history mode (caret sits at end after a recall).
+    const state: ComposerHistoryState = { index: 2, draft: "draft" };
+    const result = up(state, { atStart: false });
+    expect(result.handled).toBe(true);
+    expect(result.value).toBe("second");
+  });
+
+  it("Down steps toward newer messages while navigating", () => {
+    const state: ComposerHistoryState = { index: 0, draft: "draft" };
+    const result = down(state);
+    expect(result.handled).toBe(true);
+    expect(result.value).toBe("second");
+    expect(result.state.index).toBe(1);
+  });
+
+  it("Down past the newest entry restores the saved draft and exits", () => {
+    const state: ComposerHistoryState = { index: 2, draft: "saved draft" };
+    const result = down(state);
+    expect(result.handled).toBe(true);
+    expect(result.value).toBe("saved draft");
+    expect(result.state).toEqual(INITIAL_HISTORY_STATE);
+  });
+
+  it("Down does nothing when not navigating history", () => {
+    const result = down({ ...INITIAL_HISTORY_STATE });
+    expect(result.handled).toBe(false);
+    expect(result.value).toBeUndefined();
+  });
+
+  it("does nothing when there is no history", () => {
+    const result = navigateComposerHistory({
+      direction: "up",
+      history: [],
+      currentValue: "",
+      atStart: true,
+      state: { ...INITIAL_HISTORY_STATE }
+    });
+    expect(result.handled).toBe(false);
+  });
+
+  it("round-trips: Up then Down returns to the original draft", () => {
+    const draft = "in progress";
+    let state = { ...INITIAL_HISTORY_STATE };
+
+    const u1 = up(state, { currentValue: draft });
+    state = u1.state;
+    expect(u1.value).toBe("third");
+
+    const d1 = down(state); // back past newest -> restore draft
+    expect(d1.value).toBe(draft);
+    expect(d1.state).toEqual(INITIAL_HISTORY_STATE);
+  });
+});

--- a/packages/widget/src/utils/composer-history.ts
+++ b/packages/widget/src/utils/composer-history.ts
@@ -1,0 +1,113 @@
+/**
+ * Pure state machine for composer message-history navigation (Up/Down arrows).
+ *
+ * Mirrors the shell / Slack convention: pressing Up recalls previously sent
+ * user messages for re-entry or editing; Down walks back toward the present
+ * and restores the in-progress draft once you page past the newest entry.
+ *
+ * Kept free of DOM access so it can be unit-tested in the Node test env. The
+ * UI layer (`ui.ts`) supplies caret information and applies the returned value
+ * to the textarea.
+ */
+
+export interface ComposerHistoryState {
+  /** Index into the history list, or -1 when not navigating. */
+  index: number;
+  /** The user's in-progress text, saved when navigation begins. */
+  draft: string;
+}
+
+export const INITIAL_HISTORY_STATE: ComposerHistoryState = {
+  index: -1,
+  draft: ""
+};
+
+export interface ComposerHistoryInput {
+  direction: "up" | "down";
+  /** Previously sent user-message texts, oldest first. */
+  history: string[];
+  /** Current textarea value (saved as the draft when navigation begins). */
+  currentValue: string;
+  /** True when the caret sits at the very start of the textarea. */
+  atStart: boolean;
+  state: ComposerHistoryState;
+}
+
+export interface ComposerHistoryResult {
+  /** Whether the key was consumed (caller should preventDefault). */
+  handled: boolean;
+  /** New textarea value to apply — only present when it should change. */
+  value?: string;
+  /** Next navigation state. */
+  state: ComposerHistoryState;
+}
+
+/**
+ * Compute the next navigation state for an Up/Down key press.
+ *
+ * - **Up** enters history only from the top boundary (`atStart`), then keeps
+ *   stepping toward older messages on each subsequent press while navigating.
+ * - **Down** only acts while already navigating, stepping toward newer messages
+ *   and finally restoring the saved draft once it walks past the newest entry.
+ */
+export function navigateComposerHistory(
+  input: ComposerHistoryInput
+): ComposerHistoryResult {
+  const { direction, history, currentValue, atStart, state } = input;
+  const inHistory = state.index !== -1;
+
+  if (history.length === 0) {
+    return { handled: false, state };
+  }
+
+  if (direction === "up") {
+    // Only hijack Up from the top boundary so normal multi-line cursor
+    // movement keeps working until the user is actually cycling history.
+    if (!inHistory && !atStart) {
+      return { handled: false, state };
+    }
+
+    if (!inHistory) {
+      // First step: stash the draft and jump to the newest entry.
+      const index = history.length - 1;
+      return {
+        handled: true,
+        value: history[index],
+        state: { index, draft: currentValue }
+      };
+    }
+
+    if (state.index > 0) {
+      const index = state.index - 1;
+      return {
+        handled: true,
+        value: history[index],
+        state: { index, draft: state.draft }
+      };
+    }
+
+    // Already at the oldest entry — consume the key but don't change.
+    return { handled: true, state };
+  }
+
+  // direction === "down": only meaningful while navigating history.
+  if (!inHistory) {
+    return { handled: false, state };
+  }
+
+  if (state.index < history.length - 1) {
+    const index = state.index + 1;
+    return {
+      handled: true,
+      value: history[index],
+      state: { index, draft: state.draft }
+    };
+  }
+
+  // Stepped past the newest entry — restore the saved draft and exit.
+  return {
+    handled: true,
+    value: state.draft,
+    state: { ...INITIAL_HISTORY_STATE }
+  };
+}


### PR DESCRIPTION
## Summary

The widget's dispatch-failure fallback showed:

> It looks like the proxy isn't returning a real response yet. Here's a sample message so you can continue testing locally.

This fires on **every** dispatch failure (connection refused, CORS, 4xx/5xx, malformed stream), yet it presumes one specific cause and frames the failure as expected ("sample message"), which is misleading in production.

This PR:

- **Improves the default copy** to be honest and actionable, and surfaces the underlying error reason for easier debugging:
  > Sorry — I couldn't reach the assistant. The chat service didn't respond. Please check that your proxy or backend is running and reachable, then try again.
  >
  > _Details: &lt;underlying error&gt;_
- **Makes it configurable** via a new `AgentWidgetConfig.errorMessage` option:
  - `string` — fixed message
  - `(error: Error) => string` — dynamic, lets callers branch on the failure and decide whether to expose the raw reason
  - returning `""` suppresses the fallback bubble entirely (`onError` still fires)
- Applies to both `sendMessage` and `continueConversation` failure paths.

```ts
config: {
  errorMessage: (error) =>
    error.message.includes("Failed to fetch")
      ? "You appear to be offline."
      : "Something went wrong. Please try again."
}
```

## Tests

Adds a `dispatch error fallback` suite to `session.test.ts` covering: default message + error detail + `onError`, static override, function override (receives the error), empty-string suppression, abort-error still shows no bubble, and the `continueConversation` path.

## Changeset

`minor` — new public config option.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing copy and an optional public config flag only; no auth, data, or dispatch protocol changes.
> 
> **Overview**
> Replaces the widget’s **dispatch-failure** assistant bubble copy that implied a dev-only “sample” proxy response with messaging that states the **chat service didn’t respond**, plus optional `_Details: …_` from the underlying error.
> 
> Adds **`AgentWidgetConfig.errorMessage`** (`string` or `(error) => string`) so hosts can override that text; returning **`""`** hides the fallback bubble while **`onError`** still runs. The same helper is used on **`sendMessage`** and **`continueConversation`**; **abort** failures on send still show no bubble and no **`onError`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3db148d5c64b3d26b08b67c180f18a85e5bb88f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->