### PR TITLE
fix(composer): stop send button rendering a doubled icon after send→stop→send

### DIFF
--- a/.changeset/fix-send-button-doubled-icon.md
+++ b/.changeset/fix-send-button-doubled-icon.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix the composer send button rendering two stacked icons (e.g. a doubled send arrow) after the first send→stop→send cycle. `setMode` swapped the icon via `replaceChild(next, prev)` against a captured `prev` node reference; when an external re-render/morph (such as a host calling `controller.update()`) replaced the live icon child with a clone, that reference was detached and the `appendChild` fallback left both icons mounted. `setMode` now uses `replaceChildren(next)`, so the button always holds exactly one icon regardless of any intervening DOM morph.

--- a/packages/widget/src/components/composer-parts.test.ts
+++ b/packages/widget/src/components/composer-parts.test.ts
@@ -69,6 +69,40 @@ describe("createSendButton", () => {
     send.setMode("send");
     expect(send.button.textContent).toBe("Send");
   });
+
+  describe("icon mode", () => {
+    const iconConfig: AgentWidgetConfig = {
+      ...baseConfig,
+      sendButton: { useIcon: true, iconName: "send", stopIconName: "square" },
+    };
+    const iconCount = (btn: HTMLElement) => btn.querySelectorAll("svg").length;
+
+    it("keeps exactly one icon across a send→stop→send cycle", () => {
+      const send = createSendButton(iconConfig);
+      expect(iconCount(send.button)).toBe(1);
+      send.setMode("stop");
+      expect(iconCount(send.button)).toBe(1);
+      send.setMode("send");
+      expect(iconCount(send.button)).toBe(1);
+    });
+
+    it("does not stack a stale icon when an external re-render swapped the live icon node", () => {
+      const send = createSendButton(iconConfig);
+      // Simulate a DOM morph/re-render (e.g. a host calling controller.update())
+      // that replaces the live icon child with a clone. This detaches the
+      // captured `sendIcon` reference, so `sendIcon.parentNode !== button`.
+      // The old replaceChild/appendChild fallback then left BOTH icons mounted,
+      // producing the doubled send-arrow after the first send→stop→send cycle.
+      const live = send.button.firstElementChild as SVGElement;
+      send.button.replaceChildren(live.cloneNode(true));
+      expect(iconCount(send.button)).toBe(1);
+
+      send.setMode("stop");
+      expect(iconCount(send.button)).toBe(1);
+      send.setMode("send");
+      expect(iconCount(send.button)).toBe(1);
+    });
+  });
 });
 
 describe("createMicButton", () => {

--- a/packages/widget/src/components/composer-parts.ts
+++ b/packages/widget/src/components/composer-parts.ts
@@ -218,12 +218,15 @@ export const createSendButton = (config?: AgentWidgetConfig): SendButtonParts =>
     if (useIcon) {
       if (sendIcon && stopIcon) {
         const next = mode === "stop" ? stopIcon : sendIcon;
-        const prev = mode === "stop" ? sendIcon : stopIcon;
-        if (prev.parentNode === button) {
-          button.replaceChild(next, prev);
-        } else {
-          button.appendChild(next);
-        }
+        // Replace whatever icon is currently mounted — the button only ever
+        // holds the single active icon. We use replaceChildren(next) rather
+        // than replaceChild(next, prev) against a captured `prev` reference:
+        // an external re-render/morph can swap the live icon child out from
+        // under us, detaching our captured node so `prev.parentNode !== button`.
+        // The old appendChild fallback then left BOTH icons mounted, which is
+        // how the send button ended up showing two stacked arrows after the
+        // first send→stop→send cycle.
+        button.replaceChildren(next);
       }
     } else {
       button.textContent = mode === "stop" ? stopLabel : sendLabel;


### PR DESCRIPTION
## Problem

When testing an agent/flow chat in the Runtype dashboard, after the first message the composer **send button renders two stacked paper-airplane icons** instead of one (squished side-by-side). It appears on the first `send → stop → send` cycle and then stays pinned at two icons.

Reproduced live on the staging dashboard and traced to the DOM-mutation level: the duplicated element is a real second `<svg>` mounted as a direct child of `<button data-persona-composer-submit>`.

## Root cause

`createSendButton` → `setMode()` swaps the idle/streaming icon with:

```ts
const prev = mode === "stop" ? sendIcon : stopIcon;
if (prev.parentNode === button) button.replaceChild(next, prev);
else button.appendChild(next);   // ← fallback leaks
```

`sendIcon` / `stopIcon` are **captured node references**. When an external re-render/morph (e.g. a host calling `controller.update()`, which the dashboard does on theme-resolve) replaces the live icon child with a clone, the captured reference is detached, so `prev.parentNode !== button`. The `appendChild` fallback then mounts the new icon **without removing the old one**:

- Start: `[send]`
- `setMode("stop")` → guard fails → `appendChild(square)` → `[send, square]`
- `setMode("send")` (stream end) → `replaceChild(send, square)` → `[send, send]` ← two arrows, stuck at 2

## Fix

Use `replaceChildren(next)` — the button only ever holds the single active icon, so clearing-then-mounting is always correct and is robust to any intervening DOM morph. This matches the existing icon-swap idiom already used elsewhere in the widget (`ui.ts`, `host-layout.ts`).

## Tests

Added a `createSendButton > icon mode` block:
- clean `send→stop→send` keeps exactly one icon
- simulates an external re-render (clones the live icon to detach the captured ref) and asserts no stacking

Verified the stale-ref test **fails on the old code** (`expected 2 to be 1`) and passes with the fix.

- ✅ 18/18 tests pass (`composer-parts` + `ui.stop-button`)
- ✅ `tsc --noEmit` clean
- ✅ `eslint` clean on changed files

Changeset: `@runtypelabs/persona` patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized widget composer DOM fix with regression tests; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes the composer **send** button showing **two stacked icons** after the first **send → stop → send** cycle when icon mode is enabled.
> 
> `setMode` no longer swaps icons with `replaceChild` / `appendChild` against captured `sendIcon` / `stopIcon` nodes. If a host re-render (e.g. `controller.update()`) replaced the live child with a clone, the stale reference caused a fallback that left multiple `<svg>` elements mounted. Icon swaps now use **`button.replaceChildren(next)`** so the submit button always has exactly one child.
> 
> Adds **icon-mode** tests for a normal mode cycle and for an external DOM morph before toggling. Ships a **`@runtypelabs/persona` patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b09c60f9653fbae891e72958332c5422b8a8f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->