### PR TITLE
Switch default + example flow model to minimax-m2.7

### DIFF
--- a/.changeset/proxy-model-minimax-m27.md
+++ b/.changeset/proxy-model-minimax-m27.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Switch the default flow model (and all bundled example flows) to `minimax-m2.7`.

--- a/examples/embedded-app/src/agent-demo.ts
+++ b/examples/embedded-app/src/agent-demo.ts
@@ -41,7 +41,7 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
     ),
     agent: {
       name: "Travel Planner Assistant",
-      model: "mercury-2",
+      model: "minimax-m2.7",
       systemPrompt:
         "You are a travel planning assistant with access to the Exa web search tool. " +
         "For itinerary requests, complete work in exactly 3 iterations: " +

--- a/examples/embedded-app/src/fullscreen-assistant-demo.ts
+++ b/examples/embedded-app/src/fullscreen-assistant-demo.ts
@@ -460,7 +460,7 @@ const config = mergeWithDefaults({
   },
   agent: {
     name: "Chat Assistant",
-    model: "mercury-2",
+    model: "minimax-m2.7",
     systemPrompt: "You are a helpful assistant. Be friendly, concise, and helpful. If you don't know something, say so.",
     artifacts: { enabled: true, types: ["markdown", "component"] },
   },

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -226,7 +226,7 @@ const homeDemoInputPlaceholder =
 const homeDemoSharedAssistant = {
   agent: {
     name: "Persona Documentation Assistant",
-    model: "claude-haiku-4-5-20251001",
+    model: "minimax-m2.7",
     systemPrompt: PERSONA_SYSTEM_PROMPT,
     temperature: 0.5,
     tools: {

--- a/packages/proxy/src/flows/bakery-assistant.ts
+++ b/packages/proxy/src/flows/bakery-assistant.ts
@@ -20,7 +20,7 @@ export const BAKERY_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/components.ts
+++ b/packages/proxy/src/flows/components.ts
@@ -14,7 +14,7 @@ export const COMPONENT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/conversational.ts
+++ b/packages/proxy/src/flows/conversational.ts
@@ -14,7 +14,7 @@ export const CONVERSATIONAL_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/scheduling.ts
+++ b/packages/proxy/src/flows/scheduling.ts
@@ -14,7 +14,7 @@ export const FORM_DIRECTIVE_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/shopping-assistant.ts
+++ b/packages/proxy/src/flows/shopping-assistant.ts
@@ -18,7 +18,7 @@ export const SHOPPING_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",
@@ -97,7 +97,7 @@ export const SHOPPING_ASSISTANT_METADATA_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/storefront-assistant.ts
+++ b/packages/proxy/src/flows/storefront-assistant.ts
@@ -23,7 +23,7 @@ export const STOREFRONT_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -84,7 +84,7 @@ const DEFAULT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "minimax-m2.7",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",


### PR DESCRIPTION
## What

Switches the model from `mercury-2` / `claude-haiku-4-5-20251001` to **`minimax-m2.7`** across the proxy flows and example apps.

Changed (11 occurrences, 10 files):
- `packages/proxy/src/index.ts` — `DEFAULT_FLOW`
- `packages/proxy/src/flows/*` — conversational, scheduling, components, shopping-assistant (×2), bakery-assistant, storefront-assistant
- `examples/embedded-app/src/{main,agent-demo,fullscreen-assistant-demo}.ts` — `main.ts` is the agent config that drives the live "Try it live" widget on persona-chat.dev

## Why

Standardize the demos on `minimax-m2.7` (platform-key supported, ~200k context).

## Notes

- `minimax-m2.7` validated against the platform model list (provider `vercel`, `keyStatus: platform`).
- Left untouched: widget unit-test fixtures and `types.ts` JSDoc (`openai:gpt-4o-mini`) — not examples.
- Includes a `patch` changeset for `@runtypelabs/persona-proxy`.
- The live `www.persona-chat.dev` widget reads its model from `embedded-app` (agent mode, forwarded by the proxy), so it picks up the new model once that app is rebuilt/redeployed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only model ID swaps in demos and default flows; no auth, data, or control-flow changes, though live demo behavior may differ with the new model.
> 
> **Overview**
> Standardizes Persona demos and proxy flows on **`minimax-m2.7`**, replacing **`mercury-2`** on bundled flow steps and embedded-app agent configs, and **`claude-haiku-4-5-20251001`** on the home “Try it live” documentation assistant in `main.ts`.
> 
> **`@runtypelabs/persona-proxy`**: `DEFAULT_FLOW` in `packages/proxy/src/index.ts` and every bundled example flow under `packages/proxy/src/flows/*` (conversational, scheduling, components, shopping ×2, bakery, storefront) now use `minimax-m2.7` on their prompt steps—no prompt/system logic changes.
> 
> **`examples/embedded-app`**: agent model strings updated in `agent-demo.ts`, `fullscreen-assistant-demo.ts`, and `main.ts` so redeployed demos (including persona-chat.dev agent mode) route through the new model.
> 
> Includes a **patch** changeset for `@runtypelabs/persona-proxy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7881c699d0ef962ae206501b111a7ba14b3928f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->