### PR TITLE
fix(proxy): forward WebMCP clientTools[] in flow-dispatch mode

### DIFF
--- a/.changeset/proxy-forward-clienttools.md
+++ b/.changeset/proxy-forward-clienttools.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Forward WebMCP `clientTools[]` to the upstream API in flow-dispatch mode. The proxy rebuilds the flow-dispatch payload from scratch, which previously dropped the page-discovered tools the widget snapshots from `document.modelContext` — so a WebMCP-enabled flow behind the proxy never received them and the agent could not call page tools. The flow path now copies `clientTools` through (agent mode already forwarded the payload as-is), pairing with the existing `/resume` endpoint to complete the local-tool round-trip.

--- a/packages/proxy/src/index.test.ts
+++ b/packages/proxy/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { createChatProxyApp } from "./index";
 
 describe("CORS middleware", () => {
@@ -68,5 +68,82 @@ describe("CORS middleware", () => {
     const app = createChatProxyApp();
     const res = await preflight(app, "https://example.com");
     expect(res.headers.get("Vary")).toBe("Origin");
+  });
+});
+
+describe("dispatch — WebMCP clientTools forwarding", () => {
+  const realFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  // Capture whatever body the proxy POSTs upstream, and return a minimal
+  // streaming Response so the handler completes.
+  const captureUpstream = () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> | null }> = [];
+    globalThis.fetch = vi.fn(async (url: unknown, init?: { body?: unknown }) => {
+      calls.push({
+        url: String(url),
+        body:
+          typeof init?.body === "string"
+            ? (JSON.parse(init.body) as Record<string, unknown>)
+            : null,
+      });
+      return new Response("data: {}\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+    }) as unknown as typeof fetch;
+    return calls;
+  };
+
+  const dispatch = (
+    app: ReturnType<typeof createChatProxyApp>,
+    body: Record<string, unknown>,
+  ) =>
+    app.request("/api/chat/dispatch", {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Origin: "https://example.com" },
+      body: JSON.stringify(body),
+    });
+
+  const clientTools = [
+    {
+      name: "search_products",
+      description: "Search the catalog.",
+      parametersSchema: { type: "object", properties: { query: { type: "string" } } },
+      origin: "webmcp",
+      pageOrigin: "https://example.com",
+    },
+  ];
+
+  it("forwards clientTools[] to the upstream in flow-dispatch mode", async () => {
+    const calls = captureUpstream();
+    const app = createChatProxyApp({ apiKey: "test-key" });
+    const res = await dispatch(app, {
+      messages: [{ role: "user", content: "search for shoes" }],
+      clientTools,
+    });
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body?.clientTools).toEqual(clientTools);
+  });
+
+  it("omits clientTools from the upstream payload when none are provided", async () => {
+    const calls = captureUpstream();
+    const app = createChatProxyApp({ apiKey: "test-key" });
+    await dispatch(app, { messages: [{ role: "user", content: "hi" }] });
+    expect(calls[0]!.body).not.toHaveProperty("clientTools");
+  });
+
+  it("omits clientTools when an empty array is sent", async () => {
+    const calls = captureUpstream();
+    const app = createChatProxyApp({ apiKey: "test-key" });
+    await dispatch(app, {
+      messages: [{ role: "user", content: "hi" }],
+      clientTools: [],
+    });
+    expect(calls[0]!.body).not.toHaveProperty("clientTools");
   });
 });

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -280,6 +280,20 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
       } else {
         runtypePayload.flow = flowConfig;
       }
+
+      // WebMCP: forward page-discovered tools so the upstream flow's agent step
+      // can call them. The widget snapshots `document.modelContext` per turn and
+      // ships them as `clientTools[]`; the flow-dispatch payload is rebuilt from
+      // scratch above, so without this they'd be silently dropped and the agent
+      // would never see the page tools. (Agent mode forwards the payload as-is,
+      // so it already carries `clientTools`.) The matching results come back via
+      // the `${path}/resume` endpoint below.
+      if (
+        Array.isArray(clientPayload.clientTools) &&
+        clientPayload.clientTools.length > 0
+      ) {
+        runtypePayload.clientTools = clientPayload.clientTools;
+      }
     }
 
     // Development only: do not log key material or full bodies in production.


### PR DESCRIPTION
## What

Makes the proxy forward WebMCP **`clientTools[]`** to the upstream API in **flow-dispatch** mode, so a WebMCP-enabled flow behind the proxy actually receives the page-discovered tools.

## Why

While verifying the merged WebMCP consumption feature (#211) on the deployed demo, I found it doesn't work via the proxy. The widget side is fine — the polyfill loads, tools register, and `clientTools[]` is sent. But the proxy's **flow-dispatch** branch rebuilds the upstream payload from scratch (`messages` / `inputs` / `flow` / `metadata`) and never copies `clientTools`, so they're dropped before reaching the model.

Reproduced live on `persona-chat.dev/webmcp-demo.html`: sending "search for blue running shoes" produced a generic text answer (real-world shoe brands) and **`search_products` was never called** — the page log shows no tool execution.

Agent mode (`runtypePayload = clientPayload`) already forwards the payload as-is, so it carried `clientTools` already; this just closes the gap on the flow path. The `${path}/resume` endpoint that completes the round-trip was already present.

## Change

```ts
// flow-dispatch branch, after building runtypePayload:
if (Array.isArray(clientPayload.clientTools) && clientPayload.clientTools.length > 0) {
  runtypePayload.clientTools = clientPayload.clientTools;
}
```

## Tests

Adds 3 dispatch tests (mock upstream `fetch`): forwards `clientTools` to the upstream body; omits the key when absent; omits it when an empty array is sent. `pnpm --filter @runtypelabs/persona-proxy` typecheck + lint clean; `npx vitest run` in `packages/proxy` → 11 pass.

## Remaining steps to light it up on persona-chat.dev (out of scope here)

1. The **flow behind `proxy.persona-chat.dev`** must be WebMCP-enabled (server-side config) and on a core build with the #3863 fix.
2. The "search **and** add" parallel-tool flow is still blocked by **runtypelabs/core#3870** until that lands (single-tool turns work).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, conditional addition to the flow-dispatch payload builder with unit tests; no auth or data-model changes.
> 
> **Overview**
> Fixes WebMCP behind the persona proxy in **flow-dispatch** mode by copying **`clientTools[]`** from the widget into the rebuilt upstream payload when the array is non-empty. Agent mode already forwarded the body unchanged, so page tools from `document.modelContext` were only dropped on the flow path—blocking the agent from calling page tools until **`/resume`** could complete a round-trip.
> 
> Adds three dispatch tests (mocked upstream `fetch`): asserts `clientTools` is forwarded, and that the key is omitted when missing or when an empty array is sent. Includes a patch changeset for `@runtypelabs/persona-proxy`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e3d0c134fcdf71d4860d3dc3219d972a7120922. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->