### PR TITLE
fix(widget): refresh client session before WebMCP resume

### DIFF
--- a/.changeset/webmcp-client-resume-session-refresh.md
+++ b/.changeset/webmcp-client-resume-session-refresh.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Refresh the client session before resuming a paused flow in client-token mode. A WebMCP local-tool approval can sit awaiting user input long enough for the session to expire; `resumeFlow` now awaits `initSession()` (which returns the live session while valid, else re-inits) and threads the refreshed `sessionId` to `POST /v1/client/resume`, instead of trusting a possibly-stale cached session.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -3129,9 +3129,45 @@ describe('AgentWidgetClient.resumeFlow', () => {
       clientToken: 'ct_live_demo',
       apiUrl: 'https://api.runtype-staging.com/v1/dispatch',
     });
+    // A live session so initSession() short-circuits instead of fetching /init.
+    (client as unknown as { clientSession: { sessionId: string; expiresAt: Date } }).clientSession = {
+      sessionId: 'cs_123',
+      expiresAt: new Date(Date.now() + 60_000),
+    };
     await client.resumeFlow('exec_abc', {});
 
     expect(capturedUrl).toBe('https://api.runtype-staging.com/v1/client/resume');
+  });
+
+  it('refreshes the session via initSession() before resuming when stale (BugBot r3367875360)', async () => {
+    let capturedBody: Record<string, unknown> | undefined;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+      capturedBody = JSON.parse(init.body as string);
+      return { ok: true, body: null };
+    });
+
+    const client = new AgentWidgetClient({
+      clientToken: 'ct_live_demo',
+      apiUrl: 'https://api.runtype-staging.com',
+    });
+    // A stale session that has already expired — a long WebMCP approval wait can
+    // outlive it, so resumeFlow must not trust this.clientSession directly.
+    (client as unknown as { clientSession: { sessionId: string; expiresAt: Date } }).clientSession = {
+      sessionId: 'cs_stale',
+      expiresAt: new Date(Date.now() - 60_000),
+    };
+    // initSession() is the single source of truth for a live session (it returns
+    // the existing one while unexpired, else re-inits). Assert resumeFlow awaits
+    // it and sends the refreshed sessionId, not the stale one.
+    const initSpy = vi
+      .spyOn(client, 'initSession')
+      .mockResolvedValue({ sessionId: 'cs_fresh', expiresAt: new Date(Date.now() + 60_000) } as never);
+
+    await client.resumeFlow('exec_xyz', { toolu_A: { ok: true } });
+
+    expect(initSpy).toHaveBeenCalledTimes(1);
+    expect(capturedBody!.sessionId).toBe('cs_fresh');
+    expect(capturedBody!.sessionId).not.toBe('cs_stale');
   });
 });
 

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -885,6 +885,18 @@ export class AgentWidgetClient {
       ? this.getClientApiUrl('resume')
       : `${this.config.apiUrl?.replace(/\/+$/, '') || DEFAULT_CLIENT_API_BASE}/resume`;
 
+    // The client-token resume route authenticates the session, not a Bearer
+    // key. A WebMCP approval can sit awaiting user input for a long time, so by
+    // the time we resume the original session may have expired. Re-validate (and
+    // silently re-init if needed) via initSession() — which returns the live
+    // session when `new Date() < expiresAt`, else mints a fresh one — instead of
+    // trusting the possibly-stale `this.clientSession`. (core#3889; BugBot
+    // PR #214 r3367875360.)
+    let resumeSessionId: string | undefined;
+    if (isClientToken) {
+      resumeSessionId = (await this.initSession()).sessionId;
+    }
+
     let headers: Record<string, string> = {
       'Content-Type': 'application/json',
       ...this.headers
@@ -898,10 +910,9 @@ export class AgentWidgetClient {
       toolOutputs,
       streamResponse: options?.streamResponse ?? true,
     };
-    // The client-token resume route authenticates the session, not a Bearer
-    // key — thread the active sessionId through like `/v1/client/chat` does.
-    if (isClientToken && this.clientSession?.sessionId) {
-      body.sessionId = this.clientSession.sessionId;
+    // Thread the (refreshed) sessionId through like `/v1/client/chat` does.
+    if (resumeSessionId) {
+      body.sessionId = resumeSessionId;
     }
 
     return fetch(url, {


### PR DESCRIPTION
## What

In client-token mode, `resumeFlow` read `this.clientSession?.sessionId` directly and never re-validated it before `POST /v1/client/resume`. A WebMCP local-tool approval can sit awaiting user input long enough for the session to expire — when it does, the resume fails and the paused turn sticks (the original dispatch succeeded, so it's a confusing partial failure).

## Fix

In the client-token branch, `await this.initSession()` — which returns the live session while `new Date() < expiresAt`, else silently re-inits — and thread *that* session's `sessionId` into the resume body. Dispatch/proxy mode is unchanged.

## Test

Adds `refreshes the session via initSession() before resuming when stale`: pre-sets an expired `clientSession`, spies on `initSession()` returning a fresh session, and asserts `resumeFlow` awaits it and sends the refreshed `sessionId` (not the stale one). Existing client-token resume tests updated to pre-seed a live session so `initSession()` short-circuits. 980 widget tests green; typecheck + lint clean.

## Context

Carryover BugBot finding from #214 (r3367875360, Medium) — the last open thread on that now-merged PR. core#3889.

Changeset: patch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow widget client change in client-token resume only, with targeted tests; no auth or server changes.
> 
> **Overview**
> Fixes **client-token** flows where a long **WebMCP local-tool approval** could expire the session before **`resumeFlow`** runs, causing **`POST /v1/client/resume`** to fail with a stale **`sessionId`**.
> 
> **`resumeFlow`** now **`await`s `initSession()`** in client-token mode (reuse live session or silently re-init) and puts that **`sessionId`** on the resume body, matching **`/v1/client/chat`**. Dispatch/proxy resume is unchanged.
> 
> Tests seed a live session for existing client-token resume cases and add coverage that an expired cached session triggers **`initSession()`** and sends the refreshed id. Patch changeset for **`@runtypelabs/persona`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be504a20d0e0f47df6c77608262db742ac2176de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->