### PR TITLE
feat(examples): rebuild WebMCP demo as themed "Switchback" storefront

### DIFF
--- a/examples/embedded-app/src/demo-shared.css
+++ b/examples/embedded-app/src/demo-shared.css
@@ -1148,59 +1148,9 @@ body.demo-code-active [data-persona-root] { display: none; }
 .notes-section code { font-size: 0.78em; }
 .notes-section .code-block { margin-top: 0.6rem; }
 
-/* WebMCP demo — simulated cart panel */
-.webmcp-cart {
-  border: 1px solid var(--border);
-  border-radius: var(--radius-md, 8px);
-  background: var(--paper);
-  padding: 0.6rem 0.75rem;
-  font-size: 0.85rem;
-}
-.webmcp-cart-empty {
-  margin: 0;
-  color: var(--muted, #6b7280);
-  font-style: italic;
-}
-.webmcp-cart-lines {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-.webmcp-cart-line {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  align-items: baseline;
-  gap: 0.35rem 0.5rem;
-}
-.webmcp-cart-qty {
-  font-variant-numeric: tabular-nums;
-  color: var(--muted, #6b7280);
-}
-.webmcp-cart-title { font-weight: 600; }
-.webmcp-cart-sku {
-  grid-column: 2;
-  font-size: 0.72rem;
-  color: var(--muted, #6b7280);
-  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-}
-.webmcp-cart-price {
-  grid-row: 1 / span 2;
-  grid-column: 3;
-  align-self: center;
-  font-variant-numeric: tabular-nums;
-}
-.webmcp-cart-total {
-  display: flex;
-  justify-content: space-between;
-  align-items: baseline;
-  margin-top: 0.6rem;
-  padding-top: 0.5rem;
-  border-top: 1px solid var(--border);
-  font-variant-numeric: tabular-nums;
-}
+/* WebMCP demo cart/catalog/wire styling now lives in the page-scoped
+   webmcp-shop.css ("Switchback" storefront skin), linked only from
+   webmcp-demo.html so it doesn't touch the other gallery demos. */
 
 .notes details {
   border: 1px solid var(--border);

--- a/examples/embedded-app/src/webmcp-catalog.ts
+++ b/examples/embedded-app/src/webmcp-catalog.ts
@@ -121,18 +121,32 @@ const STOPWORDS = new Set([
   "i", "want", "need", "show", "find", "please", "buy", "get",
 ]);
 
+// Query tokens that describe price intent rather than the product itself —
+// dropped before matching so "waterproof trail shoe under $170" still matches on
+// "waterproof/trail/shoe" (the agent reasons over the returned prices itself).
+const PRICE_WORDS = new Set([
+  "under", "below", "over", "above", "cheap", "cheapest", "budget", "than",
+  "less", "more", "around", "about", "max", "min", "price", "priced",
+]);
+
 /**
  * Filter the catalog by a free-text query. A product matches when every
  * meaningful query token appears somewhere in its searchable text
- * (title/brand/category/color). Results are sorted cheapest-first so prompts
- * like "the cheapest blue running shoe" have a deterministic top hit. An empty
- * query returns the whole catalog (cheapest-first).
+ * (title/brand/category/color/description). Results are sorted cheapest-first so
+ * prompts like "the cheapest blue running shoe" have a deterministic top hit. An
+ * empty query returns the whole catalog (cheapest-first).
  */
 export function searchCatalog(query: string): CatalogProduct[] {
   const tokens = query
     .toLowerCase()
     .split(/[^a-z0-9]+/)
-    .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+    .filter(
+      (t) =>
+        t.length >= 2 &&
+        !STOPWORDS.has(t) &&
+        !PRICE_WORDS.has(t) &&
+        !/^\d+$/.test(t), // bare numbers (e.g. a "$170" budget) aren't catalog text
+    );
 
   const byPrice = (a: CatalogProduct, b: CatalogProduct): number =>
     a.price - b.price;
@@ -143,7 +157,7 @@ export function searchCatalog(query: string): CatalogProduct[] {
 
   return CATALOG.filter((p) => {
     const haystack =
-      `${p.title} ${p.brand} ${p.category} ${p.color}`.toLowerCase();
+      `${p.title} ${p.brand} ${p.category} ${p.color} ${p.description}`.toLowerCase();
     return tokens.every((t) => haystack.includes(t));
   }).sort(byPrice);
 }

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -493,24 +493,28 @@ if (!modelContext) {
       annotations: { readOnlyHint: false },
       execute(input): unknown {
         const { sku, quantity } = input as { sku: string; quantity?: number };
-        const line = cart.get(sku);
-        if (!line) {
+        // Resolve the SKU the same way add_to_cart/view_product do (trimmed,
+        // case-insensitive) — the cart is keyed by the canonical product.sku, so
+        // a raw `cart.get(sku)` would miss on different casing/spacing.
+        const product = findBySku(sku);
+        const line = product ? cart.get(product.sku) : undefined;
+        if (!product || !line) {
           logWire("exec", "remove_from_cart", `<b>${esc(sku)}</b> → not in cart`);
           return { removed: false, error: `"${sku}" is not in the cart.`, cart: cartSummary() };
         }
         if (quantity && quantity < line.quantity) {
           line.quantity -= quantity;
         } else {
-          cart.delete(sku);
+          cart.delete(product.sku);
         }
         renderCart();
         flashCart();
         logWire(
           "exec",
           "remove_from_cart",
-          `<b>${esc(sku)}</b>${quantity ? ` ×${esc(quantity)}` : ""} → removed`,
+          `<b>${esc(product.sku)}</b>${quantity ? ` ×${esc(quantity)}` : ""} → removed`,
         );
-        return { removed: true, sku, cart: cartSummary() };
+        return { removed: true, sku: product.sku, cart: cartSummary() };
       },
     },
     { signal: ac.signal },

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -7,27 +7,27 @@ import {
   markdownPostprocessor,
   DEFAULT_WIDGET_CONFIG,
   type AgentWidgetConfig,
-  type AgentWidgetController,
   type WebMcpConfirmInfo,
 } from "@runtypelabs/persona";
 import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
 import { setupMountMode, renderInlineMount, renderLauncherScene } from "./mount-mode";
 import type { Mode } from "./examples-nav";
-import { searchCatalog, findBySku, type CatalogProduct } from "./webmcp-catalog";
+import { CATALOG, searchCatalog, findBySku, type CatalogProduct } from "./webmcp-catalog";
 
-// ---------------------------------------------------------------------------
-// 1. Install the polyfill and register two page tools.
+// ===========================================================================
+// "Switchback" — a tiny trail/road running storefront that exposes its own
+// page tools via WebMCP. The page renders a live catalog + cart + a wire log;
+// Persona drives the tools and every round-trip is visible on the page.
+//
+// 1. Install the polyfill and register the page tools.
 //
 // `@mcp-b/webmcp-polyfill` polyfills the strict standard surface on
-// `document.modelContext` (registerTool / getTools / executeTool). It also
-// auto-initializes on import, but we call `initializeWebMCPPolyfill()`
-// explicitly so the order is obvious — it is idempotent and no-ops if a native
-// `document.modelContext` is already present.
-//
-// Persona (the widget) also lazily installs the polyfill from inside its WebMCP
-// bridge, but the *producer* page should install it itself before registering
-// tools so the global exists by the time `registerTool` runs.
-// ---------------------------------------------------------------------------
+// `document.modelContext` (registerTool / getTools / executeTool). We call
+// `initializeWebMCPPolyfill()` explicitly so the order is obvious — it is
+// idempotent and no-ops if a native `document.modelContext` is already present.
+// The widget also lazily installs it from its WebMCP bridge, but the *producer*
+// page should install it first so the global exists by the time we register.
+// ===========================================================================
 
 /**
  * Minimal structural view of the producer surface we use here. The full type
@@ -50,19 +50,132 @@ interface RegisterableModelContext {
   ): void;
 }
 
-const log = document.getElementById("webmcp-log");
-const writeLog = (msg: string): void => {
-  if (!log) return;
+// ---------------------------------------------------------------------------
+// Tiny escaping helper — everything we render with innerHTML below mixes static
+// catalog data with agent-supplied args (query, sku, promo code), so escape any
+// dynamic value before it lands in the DOM.
+// ---------------------------------------------------------------------------
+const esc = (value: unknown): string =>
+  String(value ?? "").replace(/[&<>"']/g, (ch) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] as string,
+  );
+
+const money = (n: number): string => `$${n.toFixed(2)}`;
+
+// ===========================================================================
+// 2. Wire log — make the round-trip legible.
+//
+// Two honest sources feed it:
+//   • page-side events we own directly (tool registration, the approval-gate
+//     decision, and each page-tool execution), and
+//   • the *actual outgoing request bodies*, captured by a thin fetch wrapper:
+//     the dispatch turn carries `clientTools[]`, and the resume turn carries
+//     `toolOutputs` keyed by per-call id — which is exactly where parallel calls
+//     show up batched into ONE /resume.
+// ===========================================================================
+
+type WireKind = "reg" | "send" | "gate" | "exec" | "resume";
+
+const wireBody = document.getElementById("webmcp-wire");
+const wireCount = document.getElementById("shop-wire-count");
+let wireEvents = 0;
+
+const logWire = (kind: WireKind, tag: string, detailHtml: string): void => {
+  if (!wireBody) return;
   const ts = new Date().toLocaleTimeString();
-  log.textContent = `[${ts}] ${msg}\n${log.textContent ?? ""}`;
+  const row = document.createElement("div");
+  row.className = `wire-row ${kind}`;
+  row.innerHTML =
+    `<span class="wire-time">${esc(ts)}</span>` +
+    `<span class="wire-detail"><span class="wire-tag">${esc(tag)}</span> ${detailHtml}</span>`;
+  wireBody.prepend(row);
+  wireEvents += 1;
+  if (wireCount) wireCount.textContent = `${wireEvents} event${wireEvents === 1 ? "" : "s"}`;
 };
 
-// ---------------------------------------------------------------------------
-// Simulated cart — the visible side effect of the `add_to_cart` page tool.
-// Mutating the cart re-renders the on-page panel so you can watch the agent's
-// tool calls take effect, and add_to_cart echoes the cart state back to the
-// agent so it can summarize the running total.
-// ---------------------------------------------------------------------------
+const shortId = (id: string): string =>
+  id.length > 16 ? `${id.slice(0, 10)}…${id.slice(-4)}` : id;
+
+/**
+ * Wrap `window.fetch` once so we can read the request bodies Persona sends for
+ * dispatch/resume/init. We never touch the response — just observe the body and
+ * pass the call straight through.
+ */
+const installWireTap = (): void => {
+  const w = window as Window & { __webmcpFetchPatched?: boolean };
+  if (w.__webmcpFetchPatched) return;
+  w.__webmcpFetchPatched = true;
+  const originalFetch = window.fetch.bind(window);
+
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    try {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const body = init?.body;
+      if (url && typeof body === "string") {
+        if (/\/resume(\b|$)/.test(url)) {
+          const parsed = JSON.parse(body) as {
+            executionId?: string;
+            toolOutputs?: Record<string, unknown>;
+          };
+          const ids = Object.keys(parsed.toolOutputs ?? {});
+          logWire(
+            "resume",
+            "batched /resume",
+            `<b>${ids.length}</b> tool output${ids.length === 1 ? "" : "s"} → ` +
+              `${ids.map((id) => `<b>${esc(shortId(id))}</b>`).join(", ") || "—"}` +
+              (parsed.executionId ? ` · exec ${esc(shortId(parsed.executionId))}` : ""),
+          );
+        } else if (/\/(chat|dispatch)(\b|$)/.test(url)) {
+          const parsed = JSON.parse(body) as {
+            clientTools?: Array<{ name?: string; origin?: string }>;
+          };
+          const tools = parsed.clientTools ?? [];
+          if (tools.length > 0) {
+            const names = tools.map((t) => esc(t.name ?? "?")).join(", ");
+            const origin = tools.find((t) => t.origin)?.origin;
+            logWire(
+              "send",
+              "dispatch",
+              `ships <b>clientTools[${tools.length}]</b>: ${names}` +
+                (origin ? ` <span style="opacity:.7">(origin: ${esc(origin)})</span>` : ""),
+            );
+          }
+        } else if (/\/init(\b|$)/.test(url)) {
+          logWire("send", "session", `bootstrapping client session`);
+        }
+      }
+    } catch {
+      /* never let observation break the request */
+    }
+    return originalFetch(input, init);
+  };
+};
+
+installWireTap();
+
+// ===========================================================================
+// 3. Storefront state — catalog grid + cart, the visible side effects.
+// ===========================================================================
+
+// Named colors → swatch hex for the catalog grid.
+const COLOR_HEX: Record<string, string> = {
+  blue: "#2563eb",
+  black: "#1f2937",
+  white: "#f3f4f6",
+  red: "#dc2626",
+  green: "#16a34a",
+  grey: "#9ca3af",
+  gray: "#9ca3af",
+  navy: "#1e3a8a",
+};
+
+// Promo codes the storefront honors (apply_promo validates against this).
+const PROMOS: Record<string, { rate: number; label: string }> = {
+  TRAIL10: { rate: 0.1, label: "10% off — TRAIL10" },
+  TRAILVIP: { rate: 0.15, label: "15% off — TRAILVIP" },
+  SUMMIT20: { rate: 0.2, label: "20% off — SUMMIT20" },
+};
 
 interface CartLine {
   sku: string;
@@ -72,12 +185,15 @@ interface CartLine {
 }
 
 const cart = new Map<string, CartLine>();
-const money = (n: number): string => `$${n.toFixed(2)}`;
+let promo: { code: string; rate: number; label: string } | null = null;
 
 const cartSummary = (): {
   items: Array<{ sku: string; title: string; quantity: number; lineTotal: number }>;
   itemCount: number;
+  subtotal: number;
+  discount: number;
   total: number;
+  promoCode: string | null;
 } => {
   const items = [...cart.values()].map((line) => ({
     sku: line.sku,
@@ -85,38 +201,134 @@ const cartSummary = (): {
     quantity: line.quantity,
     lineTotal: Number((line.price * line.quantity).toFixed(2)),
   }));
+  const subtotal = Number(items.reduce((sum, i) => sum + i.lineTotal, 0).toFixed(2));
+  const discount = promo ? Number((subtotal * promo.rate).toFixed(2)) : 0;
   return {
     items,
     itemCount: items.reduce((n, i) => n + i.quantity, 0),
-    total: Number(items.reduce((sum, i) => sum + i.lineTotal, 0).toFixed(2)),
+    subtotal,
+    discount,
+    total: Number((subtotal - discount).toFixed(2)),
+    promoCode: promo?.code ?? null,
   };
 };
 
+// ---- Catalog grid -----------------------------------------------------------
+
+const catalogRoot = document.getElementById("shop-catalog");
+const catalogMeta = document.getElementById("shop-catalog-meta");
+
+const renderCatalog = (): void => {
+  if (!catalogRoot) return;
+  catalogRoot.innerHTML = CATALOG.map((p) => {
+    const swatch = COLOR_HEX[p.color.toLowerCase()] ?? "#9ca3af";
+    return `
+      <article class="shop-product" data-sku="${esc(p.sku)}">
+        <span class="shop-incart-badge" data-incart-badge></span>
+        <div class="shop-product-top">
+          <span class="shop-swatch" style="background:${esc(swatch)}"></span>
+          <span class="shop-product-cat">${esc(p.category)}</span>
+        </div>
+        <div class="shop-product-title">${esc(p.title)}</div>
+        <div class="shop-product-sub">${esc(p.brand)} · ${esc(p.color)}</div>
+        <div class="shop-product-foot">
+          <span class="shop-product-price">${esc(money(p.price))}</span>
+          <span class="shop-product-sku">${esc(p.sku)}</span>
+        </div>
+      </article>`;
+  }).join("");
+  if (catalogMeta) catalogMeta.textContent = `${CATALOG.length} products`;
+  syncCatalogCartState();
+};
+
+const cardForSku = (sku: string): HTMLElement | null =>
+  catalogRoot?.querySelector<HTMLElement>(`.shop-product[data-sku="${CSS.escape(sku)}"]`) ?? null;
+
+const flashCard = (sku: string): void => {
+  const card = cardForSku(sku);
+  if (!card) return;
+  card.classList.remove("just-changed");
+  // reflow so the animation restarts even on a rapid second call
+  void card.offsetWidth;
+  card.classList.add("just-changed");
+  card.scrollIntoView({ block: "nearest", inline: "nearest" });
+};
+
+const highlightHits = (skus: string[]): void => {
+  catalogRoot
+    ?.querySelectorAll<HTMLElement>(".shop-product.is-hit")
+    .forEach((el) => el.classList.remove("is-hit"));
+  skus.forEach((sku) => cardForSku(sku)?.classList.add("is-hit"));
+};
+
+// Reflect cart quantities onto the catalog cards (in-cart ring + qty badge).
+const syncCatalogCartState = (): void => {
+  catalogRoot?.querySelectorAll<HTMLElement>(".shop-product").forEach((card) => {
+    const sku = card.dataset.sku ?? "";
+    const line = cart.get(sku);
+    const badge = card.querySelector<HTMLElement>("[data-incart-badge]");
+    if (line) {
+      card.classList.add("in-cart");
+      if (badge) badge.textContent = `${line.quantity}`;
+    } else {
+      card.classList.remove("in-cart");
+      if (badge) badge.textContent = "";
+    }
+  });
+};
+
+// ---- Cart -------------------------------------------------------------------
+
+const cartRoot = document.getElementById("shop-cart");
+const cartMeta = document.getElementById("shop-cart-meta");
+
 const renderCart = (): void => {
-  const root = document.getElementById("webmcp-cart");
-  if (!root) return;
+  if (!cartRoot) return;
   const summary = cartSummary();
   if (summary.items.length === 0) {
-    root.innerHTML = `<p class="webmcp-cart-empty">Your cart is empty.</p>`;
+    cartRoot.innerHTML = `<p class="shop-cart-empty">Your cart is empty — ask the assistant to add something.</p>`;
+    if (cartMeta) cartMeta.textContent = "";
+    syncCatalogCartState();
     return;
   }
   const rows = [...cart.values()]
     .map(
       (line) => `
-      <li class="webmcp-cart-line">
-        <span class="webmcp-cart-qty">${line.quantity}×</span>
-        <span class="webmcp-cart-title">${line.title}</span>
-        <span class="webmcp-cart-sku">${line.sku}</span>
-        <span class="webmcp-cart-price">${money(line.price * line.quantity)}</span>
+      <li class="shop-cart-line">
+        <span class="shop-cart-qty">${line.quantity}×</span>
+        <span class="shop-cart-title">${esc(line.title)}</span>
+        <span class="shop-cart-sku">${esc(line.sku)}</span>
+        <span class="shop-cart-price">${esc(money(line.price * line.quantity))}</span>
       </li>`,
     )
     .join("");
-  root.innerHTML = `
-    <ul class="webmcp-cart-lines">${rows}</ul>
-    <div class="webmcp-cart-total">
-      <span>${summary.itemCount} item${summary.itemCount === 1 ? "" : "s"}</span>
-      <strong>${money(summary.total)}</strong>
+  const promoRow = promo
+    ? `<div class="shop-cart-row promo">
+         <span><span class="shop-cart-chip">${esc(promo.code)}</span> ${esc(promo.label)}</span>
+         <span>−${esc(money(summary.discount))}</span>
+       </div>`
+    : "";
+  cartRoot.innerHTML = `
+    <ul class="shop-cart-lines">${rows}</ul>
+    <div class="shop-cart-foot">
+      <div class="shop-cart-row muted">
+        <span>Subtotal</span><span>${esc(money(summary.subtotal))}</span>
+      </div>
+      ${promoRow}
+      <div class="shop-cart-row total">
+        <span>${summary.itemCount} item${summary.itemCount === 1 ? "" : "s"}</span>
+        <strong>${esc(money(summary.total))}</strong>
+      </div>
     </div>`;
+  if (cartMeta) cartMeta.textContent = `${summary.itemCount} item${summary.itemCount === 1 ? "" : "s"}`;
+  syncCatalogCartState();
+};
+
+const flashCart = (): void => {
+  if (!cartRoot) return;
+  cartRoot.classList.remove("just-changed");
+  void cartRoot.offsetWidth;
+  cartRoot.classList.add("just-changed");
 };
 
 const addToCart = (product: CatalogProduct, quantity: number): void => {
@@ -132,9 +344,16 @@ const addToCart = (product: CatalogProduct, quantity: number): void => {
     });
   }
   renderCart();
+  flashCard(product.sku);
+  flashCart();
 };
 
+renderCatalog();
 renderCart();
+
+// ===========================================================================
+// 4. Register the page tools.
+// ===========================================================================
 
 initializeWebMCPPolyfill();
 
@@ -143,38 +362,40 @@ const modelContext = (
 ).modelContext;
 
 if (!modelContext) {
-  writeLog("document.modelContext unavailable — WebMCP tools not registered.");
+  logWire("reg", "register", "document.modelContext unavailable — tools NOT registered");
 } else {
-  writeLog("document.modelContext ready (@mcp-b/webmcp-polyfill)");
-
   const ac = new AbortController();
 
+  // -- search_products (read-only) --
   modelContext.registerTool(
     {
       name: "search_products",
       description:
-        "Search the product catalog by free-text query (e.g. 'blue running shoes', 'trail', 'jacket'). Returns matching products with SKU, title, color, and price.",
+        "Search the product catalog by free-text query (e.g. 'waterproof trail shoe', 'blue running', 'jacket'). Returns matching products with SKU, title, brand, color, and price.",
       inputSchema: {
         type: "object",
-        properties: {
-          query: { type: "string", description: "Free-text search query." },
-        },
+        properties: { query: { type: "string", description: "Free-text search query." } },
         required: ["query"],
       },
       annotations: { readOnlyHint: true },
       execute(input): unknown {
         const { query } = input as { query: string };
         const hits = searchCatalog(query ?? "");
-        writeLog(`search_products("${query}") → ${hits.length} hit(s)`);
+        highlightHits(hits.map((p) => p.sku));
+        logWire(
+          "exec",
+          "search_products",
+          `query <b>${esc(query)}</b> → ${hits.length} hit${hits.length === 1 ? "" : "s"}`,
+        );
         return {
           query,
           count: hits.length,
           hits: hits.map((p) => ({
             sku: p.sku,
             title: p.title,
-            color: p.color,
             brand: p.brand,
             category: p.category,
+            color: p.color,
             price: p.price,
             description: p.description,
           })),
@@ -184,6 +405,44 @@ if (!modelContext) {
     { signal: ac.signal },
   );
 
+  // -- view_product (read-only) --
+  modelContext.registerTool(
+    {
+      name: "view_product",
+      description:
+        "Look at one product in detail by SKU (from search_products results). Highlights it on the page and returns its full description. Read-only.",
+      inputSchema: {
+        type: "object",
+        properties: { sku: { type: "string" } },
+        required: ["sku"],
+      },
+      annotations: { readOnlyHint: true },
+      execute(input): unknown {
+        const { sku } = input as { sku: string };
+        const product = findBySku(sku);
+        if (!product) {
+          logWire("exec", "view_product", `<b>${esc(sku)}</b> → not found`);
+          return { found: false, error: `No product with SKU "${sku}".` };
+        }
+        highlightHits([product.sku]);
+        flashCard(product.sku);
+        logWire("exec", "view_product", `<b>${esc(product.sku)}</b> — ${esc(product.title)}`);
+        return {
+          found: true,
+          sku: product.sku,
+          title: product.title,
+          brand: product.brand,
+          category: product.category,
+          color: product.color,
+          price: product.price,
+          description: product.description,
+        };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  // -- add_to_cart (mutating) --
   modelContext.registerTool(
     {
       name: "add_to_cart",
@@ -191,30 +450,22 @@ if (!modelContext) {
         "Add a product to the shopper's cart by SKU (from search_products results). Returns the updated cart so you can confirm the running total.",
       inputSchema: {
         type: "object",
-        properties: {
-          sku: { type: "string" },
-          quantity: { type: "integer", minimum: 1 },
-        },
+        properties: { sku: { type: "string" }, quantity: { type: "integer", minimum: 1 } },
         required: ["sku"],
       },
       annotations: { readOnlyHint: false },
       execute(input): unknown {
-        const { sku, quantity = 1 } = input as {
-          sku: string;
-          quantity?: number;
-        };
+        const { sku, quantity = 1 } = input as { sku: string; quantity?: number };
         const product = findBySku(sku);
         if (!product) {
-          writeLog(`add_to_cart("${sku}") → not found`);
+          logWire("exec", "add_to_cart", `<b>${esc(sku)}</b> → not found`);
           return {
             added: false,
             error: `No product with SKU "${sku}". Call search_products first to get valid SKUs.`,
           };
         }
-        // Approval is handled by Persona's confirm gate before this runs — the
-        // page tool just performs the action and updates the visible cart.
         addToCart(product, quantity);
-        writeLog(`add_to_cart("${sku}" ×${quantity}) → ${product.title}`);
+        logWire("exec", "add_to_cart", `<b>${esc(product.sku)}</b> ×${esc(quantity)} → ${esc(product.title)}`);
         return {
           added: true,
           sku: product.sku,
@@ -228,42 +479,224 @@ if (!modelContext) {
     { signal: ac.signal },
   );
 
-  writeLog("registered: search_products, add_to_cart");
+  // -- remove_from_cart (mutating) --
+  modelContext.registerTool(
+    {
+      name: "remove_from_cart",
+      description:
+        "Remove a product from the cart by SKU, or reduce its quantity. Omit quantity to remove the line entirely. Returns the updated cart.",
+      inputSchema: {
+        type: "object",
+        properties: { sku: { type: "string" }, quantity: { type: "integer", minimum: 1 } },
+        required: ["sku"],
+      },
+      annotations: { readOnlyHint: false },
+      execute(input): unknown {
+        const { sku, quantity } = input as { sku: string; quantity?: number };
+        const line = cart.get(sku);
+        if (!line) {
+          logWire("exec", "remove_from_cart", `<b>${esc(sku)}</b> → not in cart`);
+          return { removed: false, error: `"${sku}" is not in the cart.`, cart: cartSummary() };
+        }
+        if (quantity && quantity < line.quantity) {
+          line.quantity -= quantity;
+        } else {
+          cart.delete(sku);
+        }
+        renderCart();
+        flashCart();
+        logWire(
+          "exec",
+          "remove_from_cart",
+          `<b>${esc(sku)}</b>${quantity ? ` ×${esc(quantity)}` : ""} → removed`,
+        );
+        return { removed: true, sku, cart: cartSummary() };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  // -- apply_promo (mutating) --
+  modelContext.registerTool(
+    {
+      name: "apply_promo",
+      description:
+        "Apply a promo code to the cart (e.g. TRAIL10, TRAILVIP, SUMMIT20). Returns whether it was accepted and the updated cart with the discount applied.",
+      inputSchema: {
+        type: "object",
+        properties: { code: { type: "string" } },
+        required: ["code"],
+      },
+      annotations: { readOnlyHint: false },
+      execute(input): unknown {
+        const { code } = input as { code: string };
+        const key = (code ?? "").trim().toUpperCase();
+        const match = PROMOS[key];
+        if (!match) {
+          logWire("exec", "apply_promo", `<b>${esc(code)}</b> → rejected`);
+          return {
+            applied: false,
+            error: `"${code}" is not a valid promo code. Try TRAIL10, TRAILVIP, or SUMMIT20.`,
+            cart: cartSummary(),
+          };
+        }
+        promo = { code: key, rate: match.rate, label: match.label };
+        renderCart();
+        flashCart();
+        logWire("exec", "apply_promo", `<b>${esc(key)}</b> → ${esc(match.label)}`);
+        return { applied: true, code: key, discountRate: match.rate, cart: cartSummary() };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  logWire(
+    "reg",
+    "register",
+    "5 page tools on <b>document.modelContext</b>: " +
+      "search_products, view_product, add_to_cart, remove_from_cart, apply_promo",
+  );
 }
 
-// ---------------------------------------------------------------------------
-// 2. Mount Persona with WebMCP enabled.
-// ---------------------------------------------------------------------------
+// ===========================================================================
+// 5. Mount Persona with WebMCP enabled, themed as the Switchback storefront.
+// ===========================================================================
 
 // Two wiring modes (see README → "WebMCP Demo"):
 //   1. Client-token mode (used by the live persona-chat.dev deploy and for
 //      staging end-to-end tests): set VITE_PERSONA_CLIENT_TOKEN +
 //      VITE_PERSONA_API_URL (the API *base*, e.g. https://api.runtype.com).
-//      The widget talks to the Runtype API directly. WebMCP requires the
-//      token's surface to have `behavior.webmcp.enabled`. Set the token via
-//      .env.local locally, or Vercel env on the deploy — never commit it.
+//      WebMCP requires the token's surface to have `behavior.webmcp.enabled`.
 //   2. Proxy mode (fallback when no client token): routes through the local
 //      proxy on VITE_PROXY_PORT.
-const clientToken = import.meta.env.VITE_PERSONA_CLIENT_TOKEN as
-  | string
-  | undefined;
-const clientApiBase = import.meta.env.VITE_PERSONA_API_URL as
-  | string
-  | undefined;
+const clientToken = import.meta.env.VITE_PERSONA_CLIENT_TOKEN as string | undefined;
+const clientApiBase = import.meta.env.VITE_PERSONA_API_URL as string | undefined;
 
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
 const proxyApiUrl = import.meta.env.VITE_PROXY_URL
   ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
   : `http://localhost:${proxyPort}/api/chat/dispatch`;
 
+// Tools the storefront treats as read-only (safe to run without approval). We
+// gate by name rather than by the registered `readOnlyHint` annotation because
+// @mcp-b/webmcp-polyfill@3.0.0's `getTools()` does NOT echo annotations back to
+// consumers, so the widget can't populate `WebMcpConfirmInfo.annotations` — the
+// page is the authority on which of *its own* tools mutate state. (The tools
+// still carry `readOnlyHint` for spec-correctness and the server snapshot.)
+const READ_ONLY_TOOLS = new Set(["search_products", "view_product"]);
+
 const usingClientToken = Boolean(clientToken);
-writeLog(
+logWire(
+  "send",
+  "mode",
   usingClientToken
-    ? `mode: client-token → ${clientApiBase ?? "https://api.runtype.com"}`
-    : `mode: proxy → ${proxyApiUrl}`,
+    ? `client-token → ${esc(clientApiBase ?? "https://api.runtype.com")}`
+    : `proxy → ${esc(proxyApiUrl)}`,
 );
 
-let activeController: AgentWidgetController | null = null;
+// --- Switchback brand theme (mirrors webmcp-shop.css; both follow the OS
+//     light/dark preference via colorScheme:'auto'). Warm artisan palette
+//     inspired by the bakery demo: espresso primary + caramel accent on cream.
+//     White-on-espresso send button ≈ 16:1; on dark, caramel becomes the
+//     interactive primary with espresso text (≈8:1). ---
+const shopTheme: NonNullable<AgentWidgetConfig["theme"]> = {
+  palette: {
+    colors: {
+      primary: { 500: "#1c1917", 600: "#292524", 700: "#44403c" },
+      accent: { 500: "#b8814b", 600: "#8a5a2b" },
+      gray: {
+        50: "#ffffff",
+        100: "#f6f4f0",
+        200: "#e7e5e4",
+        500: "#78716c",
+        900: "#1c1917",
+      },
+    },
+    radius: { md: "0.5rem", lg: "0.75rem", xl: "1rem" },
+  },
+  semantic: {
+    colors: {
+      primary: "#1c1917",
+      accent: "#b8814b",
+      surface: "#ffffff",
+      background: "#ffffff",
+      container: "#f6f4f0",
+      text: "#1c1917",
+      textMuted: "#78716c",
+      border: "#e7e5e4",
+      divider: "#e7e5e4",
+      interactive: {
+        default: "#1c1917",
+        hover: "#292524",
+        focus: "#44403c",
+        active: "#0c0a09",
+      },
+      feedback: { info: "#1c1917" },
+    },
+  },
+  components: {
+    // Keep the header a dark espresso bar with a caramel icon in BOTH schemes
+    // (decoupled from `primary`, which flips to caramel in dark mode and would
+    // otherwise leave light header text on a light caramel bar).
+    header: {
+      background: "#1c1917",
+      titleForeground: "#fafaf9",
+      subtitleForeground: "#d6d3d1",
+      iconBackground: "#b8814b",
+      iconForeground: "#1c1917",
+      actionIconForeground: "#e7e5e4",
+    },
+  },
+};
+
+const shopDarkTheme: NonNullable<AgentWidgetConfig["darkTheme"]> = {
+  palette: {
+    colors: {
+      primary: { 500: "#d4a574", 600: "#e0b787", 700: "#ecd3b0" },
+      accent: { 500: "#d4a574", 600: "#e0b787" },
+      gray: {
+        50: "#f5f5f4",
+        100: "#292524",
+        200: "#44403c",
+        500: "#a8a29e",
+        900: "#1c1917",
+        950: "#141110",
+      },
+    },
+  },
+  semantic: {
+    colors: {
+      primary: "#d4a574",
+      accent: "#d4a574",
+      surface: "#292524",
+      background: "#1c1917",
+      container: "#2c2724",
+      text: "#f5f5f4",
+      textMuted: "#a8a29e",
+      textInverse: "#1c1917",
+      border: "#44403c",
+      divider: "#44403c",
+      interactive: {
+        default: "#d4a574",
+        hover: "#e0b787",
+        focus: "#ecd3b0",
+        active: "#f0e0c8",
+        disabled: "#57534e",
+      },
+      feedback: { info: "#d4a574" },
+    },
+  },
+  components: {
+    header: {
+      background: "#292524",
+      titleForeground: "#f5f5f4",
+      subtitleForeground: "#a8a29e",
+      iconBackground: "#d4a574",
+      iconForeground: "#1c1917",
+      actionIconForeground: "#d6d3d1",
+    },
+  },
+};
 
 const buildConfig = (mode: Mode): AgentWidgetConfig => {
   const showLauncherChrome = mode === "launcher";
@@ -274,36 +707,51 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
       : { apiUrl: proxyApiUrl }),
     storageAdapter: createLocalStorageAdapter(`persona-state-webmcp-${mode}`),
     postprocessMessage: ({ text }) => markdownPostprocessor(text),
-    // Demo starter pills, ordered to show off escalating tool-call shapes:
-    //   1. single read-only call (auto-approved, no bubble)
-    //   2. single mutating call (native approval bubble → cart update)
-    //   3. multi-step continuation — the agent searches, then runs a SECOND
-    //      turn to add the cheapest hit, proving the loop continues after a
-    //      tool result.
-    //   4. PARALLEL same-tool calls — adding two SKUs "at once" makes the model
-    //      emit two add_to_cart calls in one turn. The widget batches their
-    //      outputs into ONE /resume keyed by per-call id (runtypelabs/core#3878);
-    //      each call still renders its own approval bubble.
+    theme: shopTheme,
+    darkTheme: shopDarkTheme,
+    colorScheme: "auto",
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Switchback Assistant",
+      welcomeSubtitle:
+        "I can search the catalog, pull up a product, and manage your cart — using this page's own tools. Try one of the prompts below.",
+      inputPlaceholder: "Find me a trail shoe…",
+    },
+    // Starter pills, ordered to walk through the gate policy and tool surface:
+    //   1. read-only search (auto-approved, cards light up)
+    //   2. read-only detail view (auto-approved, card flashes)
+    //   3. PARALLEL mutating add — two add_to_cart calls in one turn, each with
+    //      its own approval bubble, batched into ONE /resume (core#3878)
+    //   4. mutating promo (approval bubble → discount line in the cart)
     suggestionChips: [
-      "Search for blue running shoes",
-      "Add SHOE-001 to my cart",
-      "Find the cheapest blue running shoe and add it to my cart",
-      "Add SHOE-001 and SHOE-007 to my cart",
+      "Find a waterproof trail shoe under $170",
+      "Tell me about SHOE-005",
+      "Add SHOE-001 and SHOE-007 at the same time",
+      "Apply code TRAIL10 and show my cart total",
     ],
     webmcp: {
       enabled: true,
-      // Per-tool gate policy: auto-allow the read-only search so it runs
-      // frictionlessly, and let the mutating add_to_cart fall through to
-      // Persona's native in-panel approval bubble (no custom onConfirm — the
-      // widget renders the approval chrome and waits for Approve/Deny).
+      // Gate policy: auto-approve the storefront's read-only tools so they run
+      // frictionlessly, and route every mutating call to Persona's native
+      // in-panel approval bubble. (See READ_ONLY_TOOLS above for why this is
+      // name-based rather than annotation-based.)
       autoApprove: (info: WebMcpConfirmInfo): boolean => {
-        writeLog(`gate: ${info.toolName}`);
-        return info.toolName !== "add_to_cart";
+        const readOnly = READ_ONLY_TOOLS.has(info.toolName);
+        logWire(
+          "gate",
+          "gate",
+          `${esc(info.toolName)} — ${readOnly ? "read-only → <b>auto-approve</b>" : "mutating → <b>approval bubble</b>"}`,
+        );
+        return readOnly;
       },
     },
-    launcher: showLauncherChrome
-      ? { enabled: true, autoExpand: false, width: "420px", fullHeight: true }
-      : { enabled: false, autoExpand: true, width: "100%", fullHeight: true },
+    launcher: {
+      title: "Switchback",
+      subtitle: "Trail & road running assistant",
+      ...(showLauncherChrome
+        ? { enabled: true, autoExpand: false, width: "420px", fullHeight: true }
+        : { enabled: false, autoExpand: true, width: "100%", fullHeight: true }),
+    },
   };
 };
 
@@ -313,24 +761,13 @@ setupMountMode({
   mount: (mode, { stage }) => {
     if (mode === "launcher") {
       const { mountEl } = renderLauncherScene(stage);
-      const handle = initAgentWidget({
-        target: mountEl,
-        config: buildConfig("launcher"),
-      });
-      activeController = handle as unknown as AgentWidgetController;
-      return () => {
-        handle.destroy();
-        activeController = null;
-      };
+      const handle = initAgentWidget({ target: mountEl, config: buildConfig("launcher") });
+      return () => handle.destroy();
     }
 
     const mount = renderInlineMount(stage);
     mount.style.height = "100%";
     const controller = createAgentExperience(mount, buildConfig(mode));
-    activeController = controller;
-    return () => {
-      controller.destroy();
-      activeController = null;
-    };
+    return () => controller.destroy();
   },
 });

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -497,13 +497,30 @@ if (!modelContext) {
         // case-insensitive) — the cart is keyed by the canonical product.sku, so
         // a raw `cart.get(sku)` would miss on different casing/spacing.
         const product = findBySku(sku);
-        const line = product ? cart.get(product.sku) : undefined;
-        if (!product || !line) {
-          logWire("exec", "remove_from_cart", `<b>${esc(sku)}</b> → not in cart`);
-          return { removed: false, error: `"${sku}" is not in the cart.`, cart: cartSummary() };
+        if (!product) {
+          logWire("exec", "remove_from_cart", `<b>${esc(sku)}</b> → not found`);
+          return {
+            removed: false,
+            error: `No product with SKU "${sku}". Call search_products first to get valid SKUs.`,
+            cart: cartSummary(),
+          };
         }
-        if (quantity && quantity < line.quantity) {
-          line.quantity -= quantity;
+        const line = cart.get(product.sku);
+        if (!line) {
+          logWire("exec", "remove_from_cart", `<b>${esc(product.sku)}</b> → not in cart`);
+          return {
+            removed: false,
+            error: `"${product.sku}" is not in the cart.`,
+            cart: cartSummary(),
+          };
+        }
+        // Only a positive partial quantity decrements; anything else (omitted,
+        // ≤0, or ≥ the line qty) removes the whole line — so a negative quantity
+        // can't subtract-a-negative and inflate the cart.
+        const partial =
+          typeof quantity === "number" && quantity >= 1 && quantity < line.quantity;
+        if (partial) {
+          line.quantity -= quantity as number;
         } else {
           cart.delete(product.sku);
         }
@@ -512,7 +529,7 @@ if (!modelContext) {
         logWire(
           "exec",
           "remove_from_cart",
-          `<b>${esc(product.sku)}</b>${quantity ? ` ×${esc(quantity)}` : ""} → removed`,
+          `<b>${esc(product.sku)}</b>${partial ? ` ×${esc(quantity)}` : ""} → removed`,
         );
         return { removed: true, sku: product.sku, cart: cartSummary() };
       },

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -656,10 +656,14 @@ const shopTheme: NonNullable<AgentWidgetConfig["theme"]> = {
     },
   },
   components: {
+    // Square the panel's outer edges so it sits flush in the inline/fullscreen
+    // stage instead of letting the page show through rounded corners.
+    panel: { borderRadius: "0" },
     // Keep the header a dark espresso bar with a caramel icon in BOTH schemes
     // (decoupled from `primary`, which flips to caramel in dark mode and would
     // otherwise leave light header text on a light caramel bar).
     header: {
+      borderRadius: "0",
       background: "#1c1917",
       titleForeground: "#fafaf9",
       subtitleForeground: "#d6d3d1",
@@ -708,7 +712,9 @@ const shopDarkTheme: NonNullable<AgentWidgetConfig["darkTheme"]> = {
     },
   },
   components: {
+    panel: { borderRadius: "0" },
     header: {
+      borderRadius: "0",
       background: "#292524",
       titleForeground: "#f5f5f4",
       subtitleForeground: "#a8a29e",

--- a/examples/embedded-app/src/webmcp-shop.css
+++ b/examples/embedded-app/src/webmcp-shop.css
@@ -31,15 +31,20 @@ body.webmcp-shop {
   --shop-line: #e7e5e4;
   --shop-line-strong: #d6d3d1;
 
-  /* Wire-inspector palette (warm instrument readout) */
-  --wire-bg: #211c18;
-  --wire-fg: #e7e0d6;
+  /* Wire-inspector palette (warm instrument readout) — light scheme.
+     Category colors are the deeper variants so the tags + left rules read on a
+     light panel; the dark scheme below swaps in the brighter set. */
+  --wire-bg: #f4f1ea;
+  --wire-fg: #4b4640;
   --wire-faint: #9a8f80;
-  --wire-reg: #86efac;     /* registration */
-  --wire-send: #7dd3fc;    /* outgoing dispatch */
-  --wire-gate: #fcd34d;    /* approval gate */
-  --wire-exec: #d6bcfa;    /* page-tool execution */
-  --wire-resume: #e0a868;  /* batched resume (caramel) */
+  --wire-line: #e4ddcf;
+  --wire-head-bg: #ece5d8;
+  --wire-row-bg: rgba(28, 25, 23, 0.035);
+  --wire-reg: #15803d;     /* registration */
+  --wire-send: #0369a1;    /* outgoing dispatch */
+  --wire-gate: #a16207;    /* approval gate */
+  --wire-exec: #6d28d9;    /* page-tool execution */
+  --wire-resume: #c2410c;  /* batched resume */
 
   --shop-radius: 14px;
   --shop-radius-sm: 9px;
@@ -78,6 +83,19 @@ body.webmcp-shop {
 
     --shop-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
     --shop-shadow-md: 0 16px 36px -22px rgba(0, 0, 0, 0.7);
+
+    /* Wire-inspector palette — dark scheme (brighter category set). */
+    --wire-bg: #211c18;
+    --wire-fg: #e7e0d6;
+    --wire-faint: #9a8f80;
+    --wire-line: rgba(255, 255, 255, 0.08);
+    --wire-head-bg: #2a241f;
+    --wire-row-bg: rgba(255, 255, 255, 0.03);
+    --wire-reg: #86efac;
+    --wire-send: #7dd3fc;
+    --wire-gate: #fcd34d;
+    --wire-exec: #d6bcfa;
+    --wire-resume: #e0a868;
   }
 }
 
@@ -367,7 +385,7 @@ body.webmcp-shop .shop-wire-head {
   text-align: left;
   list-style: none;
   padding: 0.6rem 0.8rem;
-  background: color-mix(in srgb, #ffffff 5%, var(--wire-bg));
+  background: var(--wire-head-bg);
   color: var(--wire-fg);
   font-family: var(--font-label, sans-serif);
   font-size: 0.72rem;
@@ -418,7 +436,7 @@ body.webmcp-shop .wire-row {
   padding: 0.32rem 0.4rem;
   border-radius: 6px;
   border-left: 3px solid var(--wire-faint);
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--wire-row-bg);
   color: var(--wire-fg);
 }
 body.webmcp-shop .wire-row .wire-time { color: var(--wire-faint); }
@@ -445,7 +463,7 @@ body.webmcp-shop .shop-wire-legend {
   flex-wrap: wrap;
   gap: 0.35rem 0.7rem;
   padding: 0.45rem 0.7rem 0.6rem;
-  border-top: 1px solid color-mix(in srgb, #ffffff 8%, transparent);
+  border-top: 1px solid var(--wire-line);
 }
 body.webmcp-shop .shop-wire-legend span {
   display: inline-flex;

--- a/examples/embedded-app/src/webmcp-shop.css
+++ b/examples/embedded-app/src/webmcp-shop.css
@@ -1,0 +1,469 @@
+/* ════════════════════════════════════════════════════════════════════════
+   WebMCP demo — "Switchback" storefront skin
+   ───────────────────────────────────────────────────────────────────────
+   Page-scoped under `body.webmcp-shop` so it never leaks into the other ~35
+   gallery demos (which share demo-shared.css :root). This dresses the demo
+   page as a small trail/road running outfitter so the Persona widget reads as
+   *that store's* assistant rather than gallery chrome. The matching widget
+   theme is set in buildConfig() (webmcp-demo.ts); the two share the same brand
+   green + trail-orange accent and both follow the OS light/dark preference.
+
+   The gallery shell header (top nav) intentionally keeps its neutral gallery
+   styling — it's the gallery wrapper, not part of the store.
+   ════════════════════════════════════════════════════════════════════════ */
+
+body.webmcp-shop {
+  /* Brand — warm artisan palette (espresso + caramel), inspired by the
+     "Flour & Stone" bakery demo. */
+  --shop-brand: #1c1917;          /* espresso — primary fills, header */
+  --shop-brand-strong: #292524;   /* hover / deeper */
+  --shop-brand-ink: #fafaf9;      /* text on brand fills (≈16:1 on #1c1917) */
+  --shop-accent: #b8814b;         /* caramel — highlights, borders */
+  --shop-accent-strong: #8a5a2b;  /* deep caramel — accent text on cream (≈5:1) */
+
+  /* Paper + ink (warm stone neutrals) */
+  --shop-bg: #f6f4f0;
+  --shop-paper: #ffffff;
+  --shop-card: #ffffff;
+  --shop-ink: #1c1917;
+  --shop-ink-soft: #78716c;
+  --shop-faint: #a8a29e;
+  --shop-line: #e7e5e4;
+  --shop-line-strong: #d6d3d1;
+
+  /* Wire-inspector palette (warm instrument readout) */
+  --wire-bg: #211c18;
+  --wire-fg: #e7e0d6;
+  --wire-faint: #9a8f80;
+  --wire-reg: #86efac;     /* registration */
+  --wire-send: #7dd3fc;    /* outgoing dispatch */
+  --wire-gate: #fcd34d;    /* approval gate */
+  --wire-exec: #d6bcfa;    /* page-tool execution */
+  --wire-resume: #e0a868;  /* batched resume (caramel) */
+
+  --shop-radius: 14px;
+  --shop-radius-sm: 9px;
+  --shop-shadow: 0 1px 2px rgba(28, 25, 23, 0.05);
+  --shop-shadow-md: 0 14px 32px -20px rgba(28, 25, 23, 0.28);
+
+  /* Give the storefront rail room for a 2-up product grid on this page only. */
+  --stage-controls: minmax(440px, 42%);
+
+  background-color: var(--shop-bg);
+  /* Replace the gallery's grey grid with a calm warm wash. */
+  background-image:
+    radial-gradient(circle at 18% -8%, color-mix(in srgb, var(--shop-accent) 8%, transparent), transparent 42%),
+    radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--shop-brand) 5%, transparent), transparent 38%);
+  background-attachment: fixed;
+  color: var(--shop-ink);
+}
+
+@media (prefers-color-scheme: dark) {
+  body.webmcp-shop {
+    /* Warm espresso night: caramel becomes the interactive primary. */
+    --shop-brand: #d4a574;
+    --shop-brand-strong: #e0b787;
+    --shop-brand-ink: #1c1917;
+    --shop-accent: #d4a574;
+    --shop-accent-strong: #e0b787;
+
+    --shop-bg: #1c1917;
+    --shop-paper: #292524;
+    --shop-card: #2c2724;
+    --shop-ink: #f5f5f4;
+    --shop-ink-soft: #a8a29e;
+    --shop-faint: #78716c;
+    --shop-line: #3a3530;
+    --shop-line-strong: #44403c;
+
+    --shop-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shop-shadow-md: 0 16px 36px -22px rgba(0, 0, 0, 0.7);
+  }
+}
+
+/* ── Storefront hero ───────────────────────────────────────────────────── */
+
+body.webmcp-shop .shop-hero {
+  margin: 0 0 1.25rem 0;
+  padding-bottom: 1.1rem;
+  border-bottom: 1px solid var(--shop-line-strong);
+}
+body.webmcp-shop .shop-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0 0 0.5rem 0;
+  font-family: var(--font-display, Georgia, serif);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--shop-ink);
+}
+body.webmcp-shop .shop-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 9px;
+  background: var(--shop-brand);
+  color: var(--shop-brand-ink);
+  flex: none;
+}
+body.webmcp-shop .shop-mark svg { width: 1.05rem; height: 1.05rem; }
+body.webmcp-shop .shop-tagline {
+  margin: 0 0 0.7rem 0;
+  font-size: 0.9rem;
+  color: var(--shop-ink-soft);
+}
+body.webmcp-shop .shop-explainer {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--shop-ink-soft);
+}
+body.webmcp-shop .shop-explainer code {
+  background: color-mix(in srgb, var(--shop-ink) 7%, transparent);
+  color: var(--shop-ink);
+  font-size: 0.82em;
+  padding: 0.08em 0.38em;
+  border-radius: 5px;
+}
+body.webmcp-shop .shop-hero .mount-toolbar { justify-content: flex-start; margin: 0.85rem 0 0; min-height: 0; }
+
+/* ── Section scaffolding ───────────────────────────────────────────────── */
+
+body.webmcp-shop .shop-section { margin-bottom: 1.25rem; }
+body.webmcp-shop .shop-section:last-child { margin-bottom: 0; }
+body.webmcp-shop .shop-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin: 0 0 0.6rem 0;
+}
+body.webmcp-shop .shop-section-title {
+  font-family: var(--font-label, sans-serif);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--shop-faint);
+  margin: 0;
+}
+body.webmcp-shop .shop-section-meta {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.68rem;
+  color: var(--shop-faint);
+}
+
+/* ── Catalog grid ──────────────────────────────────────────────────────── */
+
+body.webmcp-shop .shop-catalog {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(186px, 1fr));
+  gap: 0.6rem;
+}
+body.webmcp-shop .shop-product {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.7rem 0.8rem 0.75rem;
+  background: var(--shop-card);
+  border: 1px solid var(--shop-line);
+  border-radius: var(--shop-radius-sm);
+  box-shadow: var(--shop-shadow);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+body.webmcp-shop .shop-product-top {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+body.webmcp-shop .shop-swatch {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  flex: none;
+  border: 1px solid color-mix(in srgb, var(--shop-ink) 18%, transparent);
+  box-shadow: inset 0 0 0 2px var(--shop-card);
+}
+body.webmcp-shop .shop-product-cat {
+  font-family: var(--font-label, sans-serif);
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--shop-faint);
+}
+body.webmcp-shop .shop-product-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  color: var(--shop-ink);
+}
+body.webmcp-shop .shop-product-sub {
+  font-size: 0.74rem;
+  color: var(--shop-ink-soft);
+}
+body.webmcp-shop .shop-product-foot {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem;
+  margin-top: auto;
+  padding-top: 0.4rem;
+}
+body.webmcp-shop .shop-product-price {
+  font-weight: 700;
+  font-size: 0.92rem;
+  color: var(--shop-ink);
+  font-variant-numeric: tabular-nums;
+}
+body.webmcp-shop .shop-product-sku {
+  font-family: var(--font-mono, monospace);
+  font-size: 0.66rem;
+  color: var(--shop-faint);
+}
+
+/* Search-hit highlight (read-only search_products / view_product). */
+body.webmcp-shop .shop-product.is-hit {
+  border-color: var(--shop-brand);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--shop-brand) 30%, transparent);
+}
+/* In-cart badge (mutating add_to_cart). */
+body.webmcp-shop .shop-product.in-cart {
+  border-color: color-mix(in srgb, var(--shop-accent) 45%, var(--shop-line));
+}
+body.webmcp-shop .shop-product .shop-incart-badge {
+  position: absolute;
+  top: -0.5rem;
+  right: -0.5rem;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.32rem;
+  display: none;
+  place-items: center;
+  background: var(--shop-accent);
+  color: #1c1917;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.66rem;
+  font-weight: 700;
+  border-radius: 999px;
+  box-shadow: var(--shop-shadow-md);
+}
+body.webmcp-shop .shop-product.in-cart .shop-incart-badge { display: grid; }
+
+/* Flash when a tool mutates / reads a specific card. */
+body.webmcp-shop .shop-product.just-changed { animation: shop-flash 0.9s ease; }
+@keyframes shop-flash {
+  0%   { box-shadow: 0 0 0 0 color-mix(in srgb, var(--shop-accent) 60%, transparent); }
+  30%  { box-shadow: 0 0 0 5px color-mix(in srgb, var(--shop-accent) 28%, transparent); }
+  100% { box-shadow: var(--shop-shadow); }
+}
+
+/* ── Cart ──────────────────────────────────────────────────────────────── */
+
+body.webmcp-shop .shop-cart {
+  border: 1px solid var(--shop-line);
+  border-radius: var(--shop-radius);
+  background: var(--shop-paper);
+  box-shadow: var(--shop-shadow);
+  padding: 0.85rem 0.95rem;
+  font-size: 0.85rem;
+  transition: box-shadow 0.2s ease;
+}
+body.webmcp-shop .shop-cart.just-changed { animation: shop-flash 0.9s ease; }
+body.webmcp-shop .shop-cart-empty {
+  margin: 0;
+  color: var(--shop-ink-soft);
+  font-style: italic;
+}
+body.webmcp-shop .shop-cart-lines {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+body.webmcp-shop .shop-cart-line {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 0.2rem 0.55rem;
+}
+body.webmcp-shop .shop-cart-qty {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--shop-brand);
+}
+body.webmcp-shop .shop-cart-title { font-weight: 600; color: var(--shop-ink); }
+body.webmcp-shop .shop-cart-sku {
+  grid-column: 2;
+  font-size: 0.7rem;
+  color: var(--shop-faint);
+  font-family: var(--font-mono, monospace);
+}
+body.webmcp-shop .shop-cart-price {
+  grid-row: 1 / span 2;
+  grid-column: 3;
+  align-self: center;
+  font-variant-numeric: tabular-nums;
+  color: var(--shop-ink);
+}
+body.webmcp-shop .shop-cart-foot {
+  margin-top: 0.7rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--shop-line);
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+}
+body.webmcp-shop .shop-cart-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-variant-numeric: tabular-nums;
+}
+body.webmcp-shop .shop-cart-row.muted { color: var(--shop-ink-soft); font-size: 0.8rem; }
+body.webmcp-shop .shop-cart-row.promo { color: var(--shop-accent-strong); font-size: 0.8rem; }
+body.webmcp-shop .shop-cart-row.total { font-size: 1rem; }
+body.webmcp-shop .shop-cart-row.total strong { color: var(--shop-ink); }
+body.webmcp-shop .shop-cart-chip {
+  display: inline-block;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.66rem;
+  padding: 0.04rem 0.4rem;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--shop-accent) 16%, transparent);
+  color: var(--shop-accent-strong);
+}
+
+/* ── Wire inspector ────────────────────────────────────────────────────── */
+
+body.webmcp-shop .shop-wire {
+  border: 1px solid var(--shop-line-strong);
+  border-radius: var(--shop-radius);
+  overflow: hidden;
+  background: var(--wire-bg);
+}
+body.webmcp-shop .shop-wire-head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  list-style: none;
+  padding: 0.6rem 0.8rem;
+  background: color-mix(in srgb, #ffffff 5%, var(--wire-bg));
+  color: var(--wire-fg);
+  font-family: var(--font-label, sans-serif);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+body.webmcp-shop .shop-wire-head::before {
+  content: "";
+  width: 0; height: 0;
+  border: 4px solid transparent;
+  border-left-color: currentColor;
+  transition: transform 0.15s ease;
+  flex: none;
+}
+body.webmcp-shop .shop-wire-head::-webkit-details-marker { display: none; }
+body.webmcp-shop .shop-wire[open] .shop-wire-head::before { transform: rotate(90deg); }
+body.webmcp-shop .shop-wire-count {
+  margin-left: auto;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.66rem;
+  letter-spacing: 0;
+  color: var(--wire-faint);
+  text-transform: none;
+}
+body.webmcp-shop .shop-wire-body {
+  max-height: 290px;
+  overflow-y: auto;
+  padding: 0.5rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+body.webmcp-shop .shop-wire:not([open]) .shop-wire-body { display: none; }
+body.webmcp-shop .shop-wire-empty {
+  color: var(--wire-faint);
+  font-family: var(--font-mono, monospace);
+  font-size: 0.72rem;
+  padding: 0.4rem 0.2rem;
+}
+body.webmcp-shop .wire-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.7rem;
+  line-height: 1.5;
+  padding: 0.32rem 0.4rem;
+  border-radius: 6px;
+  border-left: 3px solid var(--wire-faint);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--wire-fg);
+}
+body.webmcp-shop .wire-row .wire-time { color: var(--wire-faint); }
+body.webmcp-shop .wire-row .wire-tag {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+body.webmcp-shop .wire-row .wire-detail { color: color-mix(in srgb, var(--wire-fg) 82%, transparent); word-break: break-word; }
+body.webmcp-shop .wire-row .wire-detail b { color: var(--wire-fg); font-weight: 700; }
+body.webmcp-shop .wire-row.reg    { border-left-color: var(--wire-reg); }
+body.webmcp-shop .wire-row.reg    .wire-tag { color: var(--wire-reg); }
+body.webmcp-shop .wire-row.send   { border-left-color: var(--wire-send); }
+body.webmcp-shop .wire-row.send   .wire-tag { color: var(--wire-send); }
+body.webmcp-shop .wire-row.gate   { border-left-color: var(--wire-gate); }
+body.webmcp-shop .wire-row.gate   .wire-tag { color: var(--wire-gate); }
+body.webmcp-shop .wire-row.exec   { border-left-color: var(--wire-exec); }
+body.webmcp-shop .wire-row.exec   .wire-tag { color: var(--wire-exec); }
+body.webmcp-shop .wire-row.resume { border-left-color: var(--wire-resume); background: color-mix(in srgb, var(--wire-resume) 9%, transparent); }
+body.webmcp-shop .wire-row.resume .wire-tag { color: var(--wire-resume); }
+
+/* Legend under the inspector. */
+body.webmcp-shop .shop-wire-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.7rem;
+  padding: 0.45rem 0.7rem 0.6rem;
+  border-top: 1px solid color-mix(in srgb, #ffffff 8%, transparent);
+}
+body.webmcp-shop .shop-wire-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: var(--font-mono, monospace);
+  font-size: 0.62rem;
+  color: var(--wire-faint);
+}
+body.webmcp-shop .shop-wire-legend i {
+  width: 0.55rem; height: 0.55rem; border-radius: 2px; flex: none;
+}
+
+/* ── Notes (Try-it) tints to brand on this page ────────────────────────── */
+
+body.webmcp-shop .notes-heading { color: var(--shop-faint); }
+body.webmcp-shop .notes-section-title { color: var(--shop-ink); }
+body.webmcp-shop .notes-section > p,
+body.webmcp-shop .notes-section ul,
+body.webmcp-shop .notes-section ol { color: var(--shop-ink-soft); }
+body.webmcp-shop .notes-section code {
+  background: color-mix(in srgb, var(--shop-ink) 7%, transparent);
+  color: var(--shop-ink);
+}
+body.webmcp-shop .notes em { color: var(--shop-brand-strong); font-style: normal; font-weight: 600; }
+
+@media (prefers-color-scheme: dark) {
+  body.webmcp-shop .notes-section code { background: color-mix(in srgb, #ffffff 10%, transparent); }
+}

--- a/examples/embedded-app/src/webmcp-shop.css
+++ b/examples/embedded-app/src/webmcp-shop.css
@@ -114,6 +114,16 @@ body.webmcp-shop .shell-main:has(.stage-widget) .stage-controls {
   border-right-color: var(--shop-line-strong);
 }
 
+/* This page has no gallery shell header, so the full-bleed layout's
+   `padding-top: var(--shell-header)` is just dead space at the top. Drop it on
+   desktop so the widget runs the full viewport height; the rail keeps its own
+   top padding for a little breathing room above the wordmark. */
+@media (min-width: 1101px) {
+  body.webmcp-shop .shell-main:has(.stage-widget) {
+    padding-top: 0;
+  }
+}
+
 /* ── Storefront hero ───────────────────────────────────────────────────── */
 
 body.webmcp-shop .shop-hero {

--- a/examples/embedded-app/src/webmcp-shop.css
+++ b/examples/embedded-app/src/webmcp-shop.css
@@ -81,6 +81,14 @@ body.webmcp-shop {
   }
 }
 
+/* Soften the rail↔widget divider. The gallery's full-bleed desktop layout
+   draws it with the light `--border` token, which is jarringly bright against
+   the dark shop background — retint it to the shop's medium line color (which
+   adapts per scheme). */
+body.webmcp-shop .shell-main:has(.stage-widget) .stage-controls {
+  border-right-color: var(--shop-line-strong);
+}
+
 /* ── Storefront hero ───────────────────────────────────────────────────── */
 
 body.webmcp-shop .shop-hero {

--- a/examples/embedded-app/src/webmcp-shop.css
+++ b/examples/embedded-app/src/webmcp-shop.css
@@ -55,11 +55,14 @@ body.webmcp-shop {
   --stage-controls: minmax(440px, 42%);
 
   background-color: var(--shop-bg);
-  /* Replace the gallery's grey grid with a calm warm wash. */
-  background-image:
-    radial-gradient(circle at 18% -8%, color-mix(in srgb, var(--shop-accent) 8%, transparent), transparent 42%),
-    radial-gradient(circle at 100% 0%, color-mix(in srgb, var(--shop-brand) 5%, transparent), transparent 38%);
-  background-attachment: fixed;
+  /* Subtle low-contrast "switchback" mountain linework. We set background-size
+     and -repeat explicitly: the gallery's base `body` rule declares
+     `background-size: 40px 40px`, which this selector would otherwise inherit
+     and tile any wash into a 40px patchwork. */
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='140'%3E%3Cg fill='none' stroke='%231c1917' stroke-opacity='0.05' stroke-width='1.5' stroke-linejoin='round'%3E%3Cpath d='M0 84 L60 44 L120 84 L180 44 L240 84'/%3E%3Cpath d='M0 106 L40 86 L80 106 L120 86 L160 106 L200 86 L240 106'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: 240px 140px;
+  background-repeat: repeat;
+  background-position: center top;
   color: var(--shop-ink);
 }
 
@@ -83,6 +86,10 @@ body.webmcp-shop {
 
     --shop-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
     --shop-shadow-md: 0 16px 36px -22px rgba(0, 0, 0, 0.7);
+
+    /* Same mountain linework, light stroke for the dark background
+       (size/repeat/position inherit from the base rule). */
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='140'%3E%3Cg fill='none' stroke='%23f5f5f4' stroke-opacity='0.05' stroke-width='1.5' stroke-linejoin='round'%3E%3Cpath d='M0 84 L60 44 L120 84 L180 44 L240 84'/%3E%3Cpath d='M0 106 L40 86 L80 106 L120 86 L160 106 L200 86 L240 106'/%3E%3C/g%3E%3C/svg%3E");
 
     /* Wire-inspector palette — dark scheme (brighter category set). */
     --wire-bg: #211c18;

--- a/examples/embedded-app/webmcp-demo.html
+++ b/examples/embedded-app/webmcp-demo.html
@@ -4,49 +4,65 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="/src/demo-shared.css">
+  <link rel="stylesheet" href="/src/webmcp-shop.css">
   <link rel="icon" href="/favicon.ico" />
-  <title>WebMCP Consumption Demo</title>
+  <title>WebMCP Storefront Demo</title>
 </head>
-<body>
+<body class="webmcp-shop">
   <main class="shell-main">
     <div class="stage">
       <aside class="stage-controls">
-        <header class="demo-meta">
-          <h1>WebMCP — Page tools</h1>
-          <p>
-            This page registers two tools through
-            <code>document.modelContext.registerTool()</code> (via
-            <code>@mcp-b/webmcp-polyfill</code>). Persona snapshots them on
-            every dispatch and ships them as <code>clientTools[]</code>. When the
-            agent calls one, the widget executes it on the page and posts the
-            result back via <code>/resume</code>.
+        <header class="shop-hero">
+          <h1 class="shop-wordmark">
+            <span class="shop-mark" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M4 17l5-9 4 6 2-3 5 6"/></svg>
+            </span>
+            Switchback
+          </h1>
+          <p class="shop-tagline">Trail &amp; road running, outfitted.</p>
+          <p class="shop-explainer">
+            This storefront publishes its own page tools through
+            <code>document.modelContext.registerTool()</code>. Persona snapshots
+            them on every turn, ships them to the agent as
+            <code>clientTools[]</code>, and when the agent calls one the widget
+            runs it <em>here on the page</em> and posts the result back via
+            <code>/resume</code>. Ask the assistant&nbsp;→ and watch the catalog,
+            cart, and the wire log react.
           </p>
           <div class="mount-toolbar" data-mount-toolbar></div>
         </header>
 
-        <section class="notes-section">
-          <h3 class="notes-section-title">Registered tools</h3>
-          <ul>
-            <li>
-              <code>search_products</code> — annotated
-              <code>readOnlyHint: true</code>. Filters a static catalog and
-              returns realistic hits (auto-approved by the demo's gate policy).
-            </li>
-            <li>
-              <code>add_to_cart</code> — mutating operation; gated by Persona's
-              native approval bubble, then updates the cart below.
-            </li>
-          </ul>
+        <section class="shop-section">
+          <div class="shop-section-head">
+            <h2 class="shop-section-title">Catalog</h2>
+            <span class="shop-section-meta" id="shop-catalog-meta"></span>
+          </div>
+          <div id="shop-catalog" class="shop-catalog"></div>
         </section>
 
-        <section class="notes-section">
-          <h3 class="notes-section-title">Cart</h3>
-          <div id="webmcp-cart" class="webmcp-cart"></div>
+        <section class="shop-section">
+          <div class="shop-section-head">
+            <h2 class="shop-section-title">Cart</h2>
+            <span class="shop-section-meta" id="shop-cart-meta"></span>
+          </div>
+          <div id="shop-cart" class="shop-cart"></div>
         </section>
 
-        <section class="notes-section">
-          <h3 class="notes-section-title">Live state</h3>
-          <pre id="webmcp-log" class="webmcp-log"></pre>
+        <section class="shop-section">
+          <details class="shop-wire" id="shop-wire" open>
+            <summary class="shop-wire-head">
+              WebMCP wire log
+              <span class="shop-wire-count" id="shop-wire-count">0 events</span>
+            </summary>
+            <div id="webmcp-wire" class="shop-wire-body"></div>
+            <div class="shop-wire-legend" aria-hidden="true">
+              <span><i style="background: var(--wire-reg)"></i>register</span>
+              <span><i style="background: var(--wire-send)"></i>dispatch · clientTools[]</span>
+              <span><i style="background: var(--wire-gate)"></i>approval gate</span>
+              <span><i style="background: var(--wire-exec)"></i>page exec</span>
+              <span><i style="background: var(--wire-resume)"></i>batched /resume</span>
+            </div>
+          </details>
         </section>
       </aside>
 
@@ -56,14 +72,18 @@
     <section class="notes">
       <h2 class="notes-heading">Try it</h2>
       <ol>
-        <li><strong>Single read:</strong> <em>"search for blue running shoes"</em> — the agent calls <code>search_products</code> against the static catalog. Read-only, so the demo auto-approves it (no bubble).</li>
-        <li><strong>Single write:</strong> <em>"add SHOE-001 to my cart"</em> — the agent calls <code>add_to_cart</code>; Persona's native approval bubble opens, and on Approve the <strong>Cart</strong> panel updates.</li>
-        <li><strong>Continuation:</strong> <em>"find the cheapest blue running shoe and add it to my cart"</em> — the agent searches, then runs a <em>second</em> turn to add the cheapest hit (proving the agent loop continues after a tool result).</li>
-        <li><strong>Parallel:</strong> <em>"add SHOE-001 and SHOE-007 to my cart"</em> — the model emits two <code>add_to_cart</code> calls in one turn. Each opens its <em>own</em> approval bubble; approve both and the widget batches their results into a single <code>/resume</code> (keyed by per-call id, runtypelabs/core#3878), so both items land in the cart.</li>
-        <li>Open DevTools → Network → look for <code>/dispatch</code> requests and confirm the body has a <code>clientTools[]</code> array with the two tools, including <code>origin: "webmcp"</code> and <code>pageOrigin</code>.</li>
+        <li><strong>Browse (read-only):</strong> <em>"find a waterproof trail shoe under $170"</em> — the agent calls <code>search_products</code>. It's annotated <code>readOnlyHint: true</code>, so the gate auto-approves it (no bubble) and matching cards light up.</li>
+        <li><strong>Inspect (read-only):</strong> <em>"tell me about SHOE-005"</em> — the agent calls <code>view_product</code>; the card flashes and scrolls into view. Still read-only → still no bubble.</li>
+        <li><strong>Add (mutating):</strong> <em>"add SHOE-001 to my cart"</em> — <code>add_to_cart</code> is mutating, so Persona's native approval bubble opens; approve it and the <strong>Cart</strong> updates.</li>
+        <li><strong>Parallel (the headline):</strong> <em>"add SHOE-001 and SHOE-007 at the same time"</em> — the model emits two <code>add_to_cart</code> calls in one turn. Each gets its <em>own</em> approval bubble; approve both and the widget batches the two results into a <strong>single <code>/resume</code></strong>, keyed by per-call id (runtypelabs/core#3878). Watch the orange <strong>batched /resume</strong> row in the wire log show both ids at once.</li>
+        <li><strong>Promo &amp; remove (mutating):</strong> <em>"apply code TRAIL10 and drop the socks"</em> — <code>apply_promo</code> + <code>remove_from_cart</code>, both gated. The cart shows the discount line and the item leaves.</li>
       </ol>
       <p>
-        Server-side, the Runtype surface must have
+        The gate policy splits read-only from mutating: the storefront
+        auto-approves its read-only tools (<code>search_products</code>,
+        <code>view_product</code>) so they run with no friction, and routes every
+        mutating call to the approval bubble. The page is the authority on which
+        of its own tools mutate state. Server-side, the Runtype surface must have
         <code>behavior.webmcp.enabled = true</code> for the agent to see these
         tools.
       </p>


### PR DESCRIPTION
## What

Rebuilds the WebMCP demo (`examples/embedded-app/webmcp-demo.html`) into a small running-outfitter storefront — **Switchback** — so the value prop (the agent driving the page's *own* tools) reads clearly and the page looks designed. Examples-only.

## (a) Better WebMCP demonstration
- **Visible storefront** — the catalog renders as a live product grid that highlights `search_products`/`view_product` hits and flashes + badges cards on cart changes; a cart panel shows subtotal/discount/total.
- **Richer tool surface** — adds `view_product` (read-only), `remove_from_cart` and `apply_promo` (mutating) alongside `search_products`/`add_to_cart`, so multi-tool and parallel turns are demonstrable. The gate policy splits read-only (auto-approve) from mutating (approval bubble).
- **Wire inspector** — a `fetch` tap surfaces the *real* round-trip: `clientTools[]` shipped on dispatch (with `origin: webmcp`), the gate decision, page-tool execs, and the **single batched `/resume` keyed by per-call `toolCallId`** — the runtypelabs/core#3878 parallel headline, shown with the actual `toolu_…` ids.

## (b) Theming via Persona's engine
- Sets `theme` / `darkTheme` / `colorScheme: 'auto'` using the nested `palette`/`semantic`/`components` shape, in a warm artisan palette (espresso primary + caramel accent on cream) inspired by the bakery demo.
- Header is pinned to a dark stone bar with a caramel icon in **both** schemes (decoupled from `primary`, which flips to caramel in dark mode) so header text contrast holds.
- A page-scoped `webmcp-shop.css` mirrors the same brand so the widget and host page read as one designed surface — scoped under `body.webmcp-shop` so it never touches the other ~35 gallery demos.

## Notes
- **Polyfill gap:** the gate is keyed by tool *name*, not `annotations.readOnlyHint` — `@mcp-b/webmcp-polyfill@3.0.0`'s `getTools()` drops annotations, so `WebMcpConfirmInfo.annotations` can't be populated by the widget. Worth upstreaming.
- `searchCatalog` now also matches `description` and ignores price words, so "waterproof trail shoe under \$170" returns hits.

## Verification
Browser-verified end-to-end against staging (client-token mode): read-only search/view auto-approve with no bubble; parallel `add_to_cart` of two SKUs → two approval bubbles → both land in cart → **one** batched `/resume` with two `toolu_` ids; `apply_promo` + `remove_from_cart` parallel turn applies the discount and removes the line. No console errors. `tsc` clean for the demo files.

Builds on #214 (WebMCP demo) and #217 (resume session refresh), both merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples-only changes (HTML/CSS/TS in embedded-app); the global fetch wrapper is confined to the demo page and does not affect library or API behavior.
> 
> **Overview**
> Reframes the embedded **WebMCP** example as the **Switchback** trail-running storefront so page tools, UI feedback, and Persona theming read as one product story instead of gallery chrome.
> 
> The left rail now renders a **live catalog grid** and **cart** (subtotal, promo discount, totals) that react to tool calls—search/view highlights cards, cart mutations flash badges and lines. **Five** `document.modelContext` tools replace the old pair: read-only `search_products` / `view_product`, plus mutating `add_to_cart`, `remove_from_cart`, and `apply_promo`. A **wire log** (plus a one-time `fetch` tap) surfaces registration, gate decisions, page execs, `clientTools[]` on dispatch, and **batched `/resume`** with per-call ids for parallel turns.
> 
> **Gate policy** auto-approves read-only tools by **name** (`READ_ONLY_TOOLS`) because the polyfill does not return `readOnlyHint` to the widget. Persona gets matching `theme` / `darkTheme` / `colorScheme: 'auto'` and Switchback copy/chips; styling moves to page-scoped **`webmcp-shop.css`** under `body.webmcp-shop` (shared cart rules removed from `demo-shared.css`).
> 
> `searchCatalog` now matches **description** text and strips price-ish tokens and bare numbers so queries like “waterproof trail shoe under $170” still hit products.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c08b0017dc2eda1b1dfb9e94052363fe859910e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->