### PR TITLE
feat(widget): output throughput (tok/s) in Events diagnostics screen

### DIFF
--- a/.changeset/output-throughput-events.md
+++ b/.changeset/output-throughput-events.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add an output throughput (tok/s) metric to the Events diagnostics screen. Throughput is derived passively from the existing SSE event stream — estimated live from visible text deltas and finalized from exact provider usage on terminal `flow_complete` / `agent_complete` events — and shown as a compact "Output throughput" summary row: the tok/s value is the headline, with the supporting breakdown (output tokens, duration, and source — usage vs estimate) revealed on hover.

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -732,6 +732,12 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
     ...(usingClientToken
       ? { clientToken, ...(clientApiBase ? { apiUrl: clientApiBase } : {}) }
       : { apiUrl: proxyApiUrl }),
+    // Surface the widget's Events diagnostics screen (header toggle) so the new
+    // "Output throughput" (tok/s) row is visible for live testing.
+    features: {
+      ...DEFAULT_WIDGET_CONFIG.features,
+      showEventStreamToggle: true,
+    },
     storageAdapter: createLocalStorageAdapter(`persona-state-webmcp-${mode}`),
     postprocessMessage: ({ text }) => markdownPostprocessor(text),
     theme: shopTheme,

--- a/packages/widget/src/components/event-stream-view.ts
+++ b/packages/widget/src/components/event-stream-view.ts
@@ -7,6 +7,7 @@ import {
   resolveFollowStateFromWheel
 } from "../utils/auto-follow";
 import type { EventStreamBuffer } from "../utils/event-stream-buffer";
+import type { ThroughputMetric } from "../utils/throughput-tracker";
 import type {
   SSEEventRecord,
   AgentWidgetConfig,
@@ -149,6 +150,36 @@ function formatEventForCopy(event: SSEEventRecord): string {
     null,
     2
   );
+}
+
+// ============================================================================
+// Output Throughput Summary
+// ============================================================================
+
+/** Format the headline value, e.g. `23.9 tok/s` or `-- tok/s` when unavailable. */
+function formatThroughputValue(metric: ThroughputMetric): string {
+  if (
+    metric.tokensPerSecond === undefined ||
+    !Number.isFinite(metric.tokensPerSecond)
+  ) {
+    return "-- tok/s";
+  }
+  return `${metric.tokensPerSecond.toFixed(1)} tok/s`;
+}
+
+/** Compact supporting details: output tokens, duration, and usage/estimate source. */
+function formatThroughputMeta(metric: ThroughputMetric): string {
+  const parts: string[] = [];
+  if (metric.outputTokens !== undefined) {
+    parts.push(`${metric.outputTokens.toLocaleString()} tok`);
+  }
+  if (metric.durationMs !== undefined) {
+    parts.push(`${(metric.durationMs / 1000).toFixed(2)}s`);
+  }
+  if (metric.source) {
+    parts.push(metric.source);
+  }
+  return parts.join(" · ");
 }
 
 // ============================================================================
@@ -381,6 +412,12 @@ export type EventStreamViewOptions = {
   onClose?: () => void;
   config?: AgentWidgetConfig;
   plugins?: AgentWidgetPlugin[];
+  /**
+   * Optional accessor for the current output-throughput metric, derived from
+   * the same SSE event stream. When provided, a compact "Output throughput"
+   * summary row is rendered and refreshed on each update.
+   */
+  getThroughput?: () => ThroughputMetric;
 };
 
 export function createEventStreamView(
@@ -396,6 +433,7 @@ export function createEventStreamView(
     onClose,
     config,
     plugins = [],
+    getThroughput,
   } = options;
   const scrollToBottomConfig = config?.features?.scrollToBottom;
   const scrollToBottomEnabled = scrollToBottomConfig?.enabled !== false;
@@ -474,11 +512,17 @@ export function createEventStreamView(
     let copyAllBtn!: HTMLButtonElement;
     let searchInput!: HTMLInputElement;
     let searchClearBtn!: HTMLButtonElement;
+    // Inline "Throughput <tok/s>" group, rendered into the header bar next to
+    // the "Events" count when getThroughput is provided. The detailed
+    // breakdown is revealed on hover via the native title tooltip.
+    let throughputValueEl: HTMLElement | null = null;
+    let throughputContainer: HTMLElement | null = null;
+    let throughputTooltipEl: HTMLElement | null = null;
 
     function buildDefaultToolbar(): HTMLElement {
       const toolbarOuter = createElement(
         "div",
-        "persona-flex persona-flex-col persona-flex-shrink-0"
+        "persona-relative persona-flex persona-flex-col persona-flex-shrink-0"
       );
 
       // --- Header bar ---
@@ -501,6 +545,58 @@ export function createEventStreamView(
         "persona-text-[11px] persona-font-mono persona-bg-persona-container persona-text-persona-muted persona-px-2 persona-py-0.5 persona-rounded persona-border persona-border-persona-border"
       );
       countBadge.textContent = "0";
+
+      // Inline throughput group: "Throughput  146.3 tok/s", grouped with the
+      // Events count. Hover reveals tokens · duration · source via a custom
+      // tooltip (shown instantly, unlike the slow native `title` delay).
+      if (getThroughput) {
+        throughputContainer = createElement(
+          "div",
+          "persona-relative persona-flex persona-items-center persona-gap-1.5 persona-whitespace-nowrap persona-ml-1"
+        );
+        throughputContainer.style.cursor = "help";
+        // Label styled to match the "Events" title.
+        const throughputLabel = createElement(
+          "span",
+          "persona-text-sm persona-font-medium persona-text-persona-primary persona-whitespace-nowrap"
+        );
+        throughputLabel.textContent = "Throughput";
+        // Same bounding box + styling as the Events count badge.
+        throughputValueEl = createElement(
+          "span",
+          "persona-text-[11px] persona-font-mono persona-bg-persona-container persona-text-persona-muted persona-px-2 persona-py-0.5 persona-rounded persona-border persona-border-persona-border persona-tabular-nums"
+        );
+        throughputValueEl.textContent = "-- tok/s";
+
+        // Custom hover tooltip — appears instantly (no native title delay).
+        // Appended to the (non-clipping) toolbar wrapper rather than the header
+        // bar, which has overflow-hidden and would clip a dropdown. Position is
+        // measured on hover so it sits just under the throughput group.
+        throughputTooltipEl = createElement(
+          "div",
+          "persona-absolute persona-z-50 persona-whitespace-nowrap persona-rounded persona-border persona-border-persona-border persona-bg-persona-container persona-text-persona-primary persona-text-[11px] persona-font-mono persona-px-2 persona-py-1 persona-shadow"
+        );
+        throughputTooltipEl.style.display = "none";
+        throughputTooltipEl.style.pointerEvents = "none";
+        const group = throughputContainer;
+        const tooltip = throughputTooltipEl;
+        const showTooltip = () => {
+          if (!tooltip.textContent) return;
+          const gRect = group.getBoundingClientRect();
+          const pRect = toolbarOuter.getBoundingClientRect();
+          tooltip.style.left = `${gRect.left - pRect.left}px`;
+          tooltip.style.top = `${gRect.bottom - pRect.top + 4}px`;
+          tooltip.style.display = "block";
+        };
+        const hideTooltip = () => {
+          tooltip.style.display = "none";
+        };
+        throughputContainer.addEventListener("mouseenter", showTooltip);
+        throughputContainer.addEventListener("mouseleave", hideTooltip);
+
+        throughputContainer.appendChild(throughputLabel);
+        throughputContainer.appendChild(throughputValueEl);
+      }
 
       const headerSpacer = createElement("div", "persona-flex-1");
 
@@ -540,6 +636,7 @@ export function createEventStreamView(
 
       headerBar.appendChild(title);
       headerBar.appendChild(countBadge);
+      if (throughputContainer) headerBar.appendChild(throughputContainer);
       headerBar.appendChild(headerSpacer);
       headerBar.appendChild(filterSelect);
       headerBar.appendChild(copyAllBtn);
@@ -592,6 +689,7 @@ export function createEventStreamView(
 
       toolbarOuter.appendChild(headerBar);
       toolbarOuter.appendChild(searchBar);
+      if (throughputTooltipEl) toolbarOuter.appendChild(throughputTooltipEl);
       return toolbarOuter;
     }
 
@@ -629,6 +727,28 @@ export function createEventStreamView(
       "persona-text-xs persona-text-persona-muted persona-text-center persona-py-0.5 persona-px-4 persona-bg-persona-container persona-border-b persona-border-persona-divider persona-italic persona-flex-shrink-0"
     );
     truncationBanner.style.display = "none";
+
+    // Refresh the inline header throughput value + hover tooltip. The elements
+    // live in the header bar (built by buildDefaultToolbar); this is a no-op
+    // when getThroughput is absent or a plugin replaced the toolbar.
+    function updateThroughputSummary(): void {
+      if (!getThroughput || !throughputValueEl || !throughputContainer) return;
+      const metric = getThroughput();
+      throughputValueEl.textContent = formatThroughputValue(metric);
+      // Detailed breakdown is revealed on hover via the custom tooltip; mirror
+      // it into aria-label for assistive tech. When there's nothing to show,
+      // hide the tooltip so an empty box never flashes on hover.
+      const meta = formatThroughputMeta(metric);
+      if (throughputTooltipEl) {
+        throughputTooltipEl.textContent = meta;
+        if (!meta) throughputTooltipEl.style.display = "none";
+      }
+      if (meta) {
+        throughputContainer.setAttribute("aria-label", meta);
+      } else {
+        throughputContainer.removeAttribute("aria-label");
+      }
+    }
 
     // ========================================================================
     // Events List (simple DOM, no virtual scroller)
@@ -804,6 +924,7 @@ export function createEventStreamView(
       lastRenderTime = Date.now();
       pendingUpdate = false;
 
+      updateThroughputSummary();
       updateFilterOptions();
 
       // Truncation banner

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -89,6 +89,7 @@ import { createApprovalBubble } from "./components/approval-bubble";
 import { createSuggestions } from "./components/suggestions";
 import { EventStreamBuffer } from "./utils/event-stream-buffer";
 import { EventStreamStore } from "./utils/event-stream-store";
+import { ThroughputTracker } from "./utils/throughput-tracker";
 import { createEventStreamView } from "./components/event-stream-view";
 import { createArtifactPane, type ArtifactPaneApi } from "./components/artifact-pane";
 import {
@@ -669,6 +670,8 @@ export const createAgentExperience = (
   let eventStreamStore = showEventStreamToggle ? new EventStreamStore(eventStreamDbName) : null;
   const eventStreamMaxEvents = config.features?.eventStream?.maxEvents ?? 2000;
   let eventStreamBuffer = showEventStreamToggle ? new EventStreamBuffer(eventStreamMaxEvents, eventStreamStore) : null;
+  // Passive output-throughput tracker, fed from the same SSE tap as the buffer.
+  let throughputTracker = showEventStreamToggle ? new ThroughputTracker() : null;
   let eventStreamView: ReturnType<typeof createEventStreamView> | null = null;
   let eventStreamVisible = false;
   let eventStreamRAF: number | null = null;
@@ -858,6 +861,8 @@ export const createAgentExperience = (
         onClose: () => toggleEventStreamOff(),
         config,
         plugins,
+        getThroughput: () =>
+          throughputTracker?.getMetric() ?? { status: "idle" },
       });
     }
     if (eventStreamView) {
@@ -4508,6 +4513,7 @@ export const createAgentExperience = (
   if (eventStreamBuffer || config.onSSEEvent) {
     session.setSSEEventCallback((type: string, payload: unknown) => {
       config.onSSEEvent?.(type, payload);
+      throughputTracker?.processEvent(type, payload);
       eventStreamBuffer?.push({
         id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
         type,
@@ -4563,6 +4569,10 @@ export const createAgentExperience = (
     // intact so the user can edit and resend without retyping.
     if (session.isStreaming()) {
       session.cancel();
+      // Cancelling emits no terminal/error SSE frame, so reset the throughput
+      // tracker (as clear-chat does) to avoid a stale `running` row lingering.
+      throughputTracker?.reset();
+      eventStreamView?.update();
       return;
     }
 
@@ -4697,6 +4707,10 @@ export const createAgentExperience = (
     if (!session.isStreaming()) return;
     if (!event.composedPath().includes(container)) return;
     session.cancel();
+    // Cancelling emits no terminal/error SSE frame — reset throughput so the
+    // Events row doesn't keep showing a live rate from the stopped stream.
+    throughputTracker?.reset();
+    eventStreamView?.update();
     resetHistoryNavigation();
     event.preventDefault();
     event.stopImmediatePropagation();
@@ -5562,8 +5576,9 @@ export const createAgentExperience = (
       persistentMetadata = {};
       actionManager.syncFromMetadata();
 
-      // Clear event stream buffer and store
+      // Clear event stream buffer and store, and reset throughput tracking
       eventStreamBuffer?.clear();
+      throughputTracker?.reset();
       eventStreamView?.update();
     });
   };
@@ -5732,10 +5747,12 @@ export const createAgentExperience = (
         if (!eventStreamBuffer) {
           eventStreamStore = new EventStreamStore(eventStreamDbName);
           eventStreamBuffer = new EventStreamBuffer(eventStreamMaxEvents, eventStreamStore);
+          throughputTracker = throughputTracker ?? new ThroughputTracker();
           eventStreamStore.open().then(() => eventStreamBuffer?.restore()).catch(() => {});
-          // Register the SSE event callback (host tap + buffer)
+          // Register the SSE event callback (host tap + buffer + throughput)
           session.setSSEEventCallback((type: string, payload: unknown) => {
             config.onSSEEvent?.(type, payload);
+            throughputTracker?.processEvent(type, payload);
             eventStreamBuffer!.push({
               id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
               type,
@@ -5784,6 +5801,8 @@ export const createAgentExperience = (
         eventStreamStore?.destroy();
         eventStreamBuffer = null;
         eventStreamStore = null;
+        throughputTracker?.reset();
+        throughputTracker = null;
       }
 
       if (config.launcher?.enabled === false && launcherButtonInstance) {
@@ -7024,8 +7043,9 @@ export const createAgentExperience = (
       persistentMetadata = {};
       actionManager.syncFromMetadata();
 
-      // Clear event stream buffer and store
+      // Clear event stream buffer and store, and reset throughput tracking
       eventStreamBuffer?.clear();
+      throughputTracker?.reset();
       eventStreamView?.update();
     },
     setMessage(message: string): boolean {
@@ -7179,6 +7199,7 @@ export const createAgentExperience = (
     /** Push a raw event into the event stream buffer (for testing/debugging) */
     __pushEventStreamEvent(event: { type: string; payload: unknown }): void {
       if (eventStreamBuffer) {
+        throughputTracker?.processEvent(event.type, event.payload);
         eventStreamBuffer.push({
           id: `evt-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
           type: event.type,

--- a/packages/widget/src/utils/throughput-tracker.test.ts
+++ b/packages/widget/src/utils/throughput-tracker.test.ts
@@ -1,0 +1,366 @@
+import { describe, it, expect } from "vitest";
+import {
+  ThroughputTracker,
+  estimateOutputTokens,
+  type ThroughputMetric,
+} from "./throughput-tracker";
+
+/**
+ * Builds a tracker with a manually-advanced clock so durations are
+ * deterministic. Call `clock.set(ms)` before feeding an event.
+ */
+function makeTracker() {
+  let nowMs = 0;
+  const tracker = new ThroughputTracker(() => nowMs);
+  return {
+    tracker,
+    at(ms: number) {
+      nowMs = ms;
+      return tracker;
+    },
+    metric(): ThroughputMetric {
+      return tracker.getMetric();
+    },
+  };
+}
+
+const text = (n: number) => "a".repeat(n);
+
+describe("estimateOutputTokens", () => {
+  it("uses the ~4 chars/token heuristic with a floor of 1", () => {
+    expect(estimateOutputTokens("")).toBe(0);
+    expect(estimateOutputTokens("   ")).toBe(0);
+    expect(estimateOutputTokens("a")).toBe(1);
+    expect(estimateOutputTokens(text(40))).toBe(10);
+  });
+});
+
+describe("ThroughputTracker — live estimate", () => {
+  it("estimates output tokens live from visible text deltas", () => {
+    const h = makeTracker();
+
+    // First delta: lazily starts the run. Duration is 0 so no rate yet.
+    h.at(1000).processEvent("step_delta", {
+      type: "step_delta",
+      text: text(40),
+    });
+    let m = h.metric();
+    expect(m.status).toBe("running");
+    expect(m.outputTokens).toBe(10);
+    expect(m.source).toBe("estimate");
+    expect(m.tokensPerSecond).toBeUndefined();
+
+    // Second delta 1s later via a different visible event type.
+    h.at(2000).processEvent("chunk", { type: "chunk", text: text(40) });
+    m = h.metric();
+    expect(m.outputTokens).toBe(20);
+    expect(m.durationMs).toBe(1000);
+    expect(m.source).toBe("estimate");
+    expect(m.tokensPerSecond).toBeCloseTo(20);
+  });
+
+  it("counts agent_turn_delta text deltas as visible output", () => {
+    const h = makeTracker();
+    h.at(0).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "text",
+      text: text(40),
+    });
+    h.at(1000).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "text",
+      text: text(40),
+    });
+    const m = h.metric();
+    expect(m.status).toBe("running");
+    expect(m.outputTokens).toBe(20);
+    expect(m.tokensPerSecond).toBeCloseTo(20);
+  });
+
+  it("ignores agent_turn_delta with a missing contentType (matches client)", () => {
+    const h = makeTracker();
+    // The client only renders agent text when contentType === "text"; a delta
+    // without a contentType is not visible output, so it must not be counted.
+    h.at(0).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      text: text(400),
+    });
+    expect(h.metric().status).toBe("idle");
+
+    // An explicit text delta is still counted.
+    h.at(1000).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "text",
+      text: text(40),
+    });
+    expect(h.metric().outputTokens).toBe(10);
+  });
+});
+
+describe("ThroughputTracker — exact usage finalization", () => {
+  it("prefers exact output tokens from the terminal event over the estimate", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    h.at(2000).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "text",
+      text: text(40),
+    });
+
+    // estimate so far would be 20 tokens; terminal usage overrides it.
+    h.at(2000).processEvent("flow_complete", {
+      type: "flow_complete",
+      usage: { outputTokens: 123 },
+    });
+
+    const m = h.metric();
+    expect(m.status).toBe("complete");
+    expect(m.outputTokens).toBe(123);
+    expect(m.source).toBe("usage");
+    expect(m.durationMs).toBe(1000); // streamed window 1000ms
+    expect(m.tokensPerSecond).toBeCloseTo(123);
+  });
+
+  it("accumulates exact usage from intermediate completes and uses it on terminal", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    h.at(1500).processEvent("step_complete", {
+      type: "step_complete",
+      result: { tokens: { output: 50 } },
+    });
+    h.at(2000).processEvent("agent_turn_complete", {
+      type: "agent_turn_complete",
+      usage: { outputTokens: 30 },
+    });
+
+    // Terminal carries no usage of its own → fall back to accumulated 80.
+    h.at(2000).processEvent("agent_complete", { type: "agent_complete" });
+
+    const m = h.metric();
+    expect(m.status).toBe("complete");
+    expect(m.outputTokens).toBe(80);
+    expect(m.source).toBe("usage");
+  });
+
+  it("falls back to provider execution time when the streamed window is too short", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("flow_start", { type: "flow_start" });
+    h.at(1100).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    // streamed window = 50ms (< 250ms threshold) → use executionTime.
+    h.at(1150).processEvent("flow_complete", {
+      type: "flow_complete",
+      executionTime: 5000,
+    });
+
+    const m = h.metric();
+    expect(m.status).toBe("complete");
+    expect(m.outputTokens).toBe(10);
+    expect(m.durationMs).toBe(5000);
+    expect(m.tokensPerSecond).toBeCloseTo(2);
+  });
+});
+
+describe("ThroughputTracker — non-visible deltas ignored", () => {
+  it("ignores agent thinking and tool_input deltas", () => {
+    const h = makeTracker();
+
+    h.at(1000).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "thinking",
+      text: text(400),
+    });
+    expect(h.metric().status).toBe("idle");
+
+    h.at(1000).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "tool_input",
+      text: text(400),
+    });
+    expect(h.metric().status).toBe("idle");
+
+    // Only the visible text delta is counted.
+    h.at(1000).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "text",
+      text: text(40),
+    });
+    h.at(2000).processEvent("agent_turn_delta", {
+      type: "agent_turn_delta",
+      contentType: "thinking",
+      text: text(400),
+    });
+
+    const m = h.metric();
+    expect(m.status).toBe("running");
+    expect(m.outputTokens).toBe(10); // thinking text excluded
+  });
+
+  it("ignores tool and context step deltas", () => {
+    const h = makeTracker();
+
+    h.at(1000).processEvent("step_delta", {
+      type: "step_delta",
+      stepType: "tool",
+      text: text(400),
+    });
+    expect(h.metric().status).toBe("idle");
+
+    h.at(1000).processEvent("step_delta", {
+      type: "step_delta",
+      executionType: "context",
+      text: text(400),
+    });
+    expect(h.metric().status).toBe("idle");
+
+    // A prompt-step delta is counted.
+    h.at(1000).processEvent("step_delta", {
+      type: "step_delta",
+      stepType: "prompt",
+      text: text(40),
+    });
+    expect(h.metric().status).toBe("running");
+    expect(h.metric().outputTokens).toBe(10);
+  });
+});
+
+describe("ThroughputTracker — intermediate completes do not finalize", () => {
+  it("keeps the run running across step_complete / agent_turn_complete", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+
+    h.at(1500).processEvent("step_complete", {
+      type: "step_complete",
+      result: { tokens: { output: 10 } },
+    });
+    expect(h.metric().status).toBe("running");
+
+    h.at(1800).processEvent("agent_turn_complete", {
+      type: "agent_turn_complete",
+      usage: { outputTokens: 5 },
+    });
+    expect(h.metric().status).toBe("running");
+
+    h.at(2000).processEvent("flow_complete", { type: "flow_complete" });
+    expect(h.metric().status).toBe("complete");
+  });
+});
+
+describe("ThroughputTracker — error handling", () => {
+  it.each(["step_error", "flow_error", "agent_error", "error"])(
+    "marks the metric unavailable on %s",
+    (errorType: string) => {
+      const h = makeTracker();
+      h.at(1000).processEvent("step_delta", {
+        type: "step_delta",
+        text: text(40),
+      });
+      expect(h.metric().status).toBe("running");
+
+      h.at(1500).processEvent(errorType, { type: errorType });
+      expect(h.metric().status).toBe("error");
+      expect(h.metric().tokensPerSecond).toBeUndefined();
+    }
+  );
+
+  it("treats a bare non-object error payload as an error", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    h.at(1500).processEvent("error", "boom");
+    expect(h.metric().status).toBe("error");
+  });
+
+  it("ignores terminal/error events when no run is active", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("flow_complete", { type: "flow_complete" });
+    expect(h.metric().status).toBe("idle");
+    h.at(1000).processEvent("flow_error", { type: "flow_error" });
+    expect(h.metric().status).toBe("idle");
+  });
+});
+
+describe("ThroughputTracker — reset & re-run", () => {
+  it("reset() returns to idle", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    h.tracker.reset();
+    expect(h.metric()).toEqual({ status: "idle" });
+  });
+
+  it("starts a fresh run after a completed one", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(80) });
+    h.at(2000).processEvent("flow_complete", { type: "flow_complete" });
+    expect(h.metric().status).toBe("complete");
+
+    // New stream → accumulation resets, does not carry the prior 20 tokens.
+    h.at(3000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    const m = h.metric();
+    expect(m.status).toBe("running");
+    expect(m.outputTokens).toBe(10);
+  });
+
+  it("resets a stale run on the next request's start event (no bleed)", () => {
+    const h = makeTracker();
+    // First request streams visible output but never terminates (e.g. the
+    // user cancels mid-stream — no flow_complete / error frame is emitted).
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(120) });
+    expect(h.metric().outputTokens).toBe(30);
+    expect(h.metric().status).toBe("running");
+
+    // Next request begins. Its flow_start must discard the stale run so the
+    // prior request's 30 tokens don't bleed into this one.
+    h.at(5000).processEvent("flow_start", { type: "flow_start" });
+    h.at(5200).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    const m = h.metric();
+    expect(m.status).toBe("running");
+    expect(m.outputTokens).toBe(10); // only the new request's text
+  });
+
+  it("does not reset between per-step starts within one request", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("flow_start", { type: "flow_start" });
+    h.at(1100).processEvent("step_start", { type: "step_start" });
+    h.at(1200).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    // A second step within the same request must not restart accumulation.
+    h.at(1300).processEvent("step_start", { type: "step_start" });
+    h.at(1400).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    expect(h.metric().outputTokens).toBe(20);
+  });
+});
+
+describe("ThroughputTracker — exact usage never drops mid-run", () => {
+  it("keeps exact tokens as a floor when later steps stream more text", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+
+    // Step 1 reports exact usage; the running total switches to it.
+    h.at(1500).processEvent("step_complete", {
+      type: "step_complete",
+      result: { tokens: { output: 50 } },
+    });
+    let m = h.metric();
+    expect(m.outputTokens).toBe(50);
+    expect(m.source).toBe("usage");
+
+    // Step 2 streams more visible text — the total must grow from 50, not
+    // collapse back to a bare 10-token estimate of the new text.
+    h.at(2000).processEvent("step_delta", { type: "step_delta", text: text(40) });
+    m = h.metric();
+    expect(m.outputTokens).toBe(60); // 50 exact + 10 estimated
+    expect(m.source).toBe("usage");
+  });
+});
+
+describe("ThroughputTracker — live rate decays while paused", () => {
+  it("recomputes duration/tok-s from the clock between events", () => {
+    const h = makeTracker();
+    h.at(1000).processEvent("step_delta", { type: "step_delta", text: text(400) });
+    // 100 tokens over a 1s window read at t=2000 → ~100 tok/s.
+    h.at(2000);
+    expect(h.metric().tokensPerSecond).toBeCloseTo(100);
+    // Same tokens, but the model has paused — reading at t=5000 (4s window)
+    // must decay the displayed rate even though no new event arrived.
+    h.at(5000);
+    expect(h.metric().tokensPerSecond).toBeCloseTo(25);
+  });
+});

--- a/packages/widget/src/utils/throughput-tracker.ts
+++ b/packages/widget/src/utils/throughput-tracker.ts
@@ -1,0 +1,427 @@
+// ============================================================================
+// Output Throughput Tracker
+// ============================================================================
+//
+// Derives an output tokens-per-second metric from the widget's existing SSE
+// event stream, for display in the Events diagnostics screen. This is a passive
+// consumer: it never mutates dispatch payloads, never forces debug mode, and
+// never changes the wire contract — it only inspects the `(type, payload)`
+// events that already flow through the SSE tap.
+//
+// Throughput is estimated live from visible text deltas while a run streams,
+// then prefers exact provider usage (output tokens) when terminal events carry
+// it. A run starts when the stream starts (or lazily on the first visible
+// delta), stays "running" across intermediate step/turn completions, and only
+// finalizes on terminal `flow_complete` / `agent_complete`. Stream errors mark
+// the metric unavailable rather than leaving it stuck "running".
+
+export type ThroughputMetricStatus = "idle" | "running" | "complete" | "error";
+
+export type ThroughputMetricSource = "usage" | "estimate";
+
+export interface ThroughputMetric {
+  status: ThroughputMetricStatus;
+  /** Output tokens per second, when computable. */
+  tokensPerSecond?: number;
+  /** Output tokens counted/estimated for the run. */
+  outputTokens?: number;
+  /** Duration window the rate was computed over (ms). */
+  durationMs?: number;
+  /** Whether `outputTokens` came from provider usage or a text estimate. */
+  source?: ThroughputMetricSource;
+}
+
+interface ThroughputRunStats {
+  startedAt: number;
+  firstDeltaAt?: number;
+  /**
+   * Running character count of accumulated visible text, estimated via the
+   * ~4 chars/token heuristic. Tracked as a counter (not the concatenated
+   * string) so the estimate stays O(1) per delta over a long stream.
+   */
+  visibleCharCount: number;
+  exactOutputTokens: number;
+}
+
+// Below this streamed window we don't trust the rate; fall back to provider
+// execution time or whole-request duration instead.
+const THROUGHPUT_MIN_DURATION_MS = 250;
+
+// Request-level lifecycle events: each marks the beginning of a NEW request.
+// The SSE tap fires for every payload type regardless of whether the client has
+// a handler for it, so any of these that the server emits starts the run with
+// an accurate `startedAt` (capturing time-to-first-token). These RESET any run
+// already in progress, so a prior stream that ended without a terminal/error
+// frame (e.g. `session.cancel()`) doesn't bleed its tokens into the next one.
+const REQUEST_START_EVENTS = new Set([
+  "flow_start",
+  "flow_run_start",
+  "agent_start",
+  "dispatch_start",
+  "run_start",
+]);
+
+// Per-step markers that fire repeatedly WITHIN a single request (a flow emits
+// one per step). These only lazily begin a run — they must never reset, or a
+// multi-step response would restart the metric between steps. If no request- or
+// step-start event is emitted, the first visible delta lazily starts the run.
+const STEP_START_EVENTS = new Set(["step_start", "execution_start"]);
+
+const VISIBLE_DELTA_EVENTS = new Set([
+  "step_delta",
+  "step_chunk",
+  "chunk",
+  "agent_turn_delta",
+]);
+
+const INTERMEDIATE_COMPLETE_EVENTS = new Set([
+  "step_complete",
+  "agent_turn_complete",
+]);
+
+const TERMINAL_COMPLETE_EVENTS = new Set(["flow_complete", "agent_complete"]);
+
+const ERROR_EVENTS = new Set([
+  "step_error",
+  "flow_error",
+  "agent_error",
+  "dispatch_error",
+  "error",
+]);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+const toFiniteNumber = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
+
+const getRecord = (
+  value: Record<string, unknown>,
+  key: string
+): Record<string, unknown> | undefined => {
+  const nested = value[key];
+  return isRecord(nested) ? nested : undefined;
+};
+
+/** Token estimate from a character count: ~4 chars/token, floor of 1. */
+function estimateTokensFromCharCount(charCount: number): number {
+  return charCount > 0 ? Math.max(1, Math.ceil(charCount / 4)) : 0;
+}
+
+/** Simple token estimate matching the dashboard heuristic: ~4 chars/token. */
+export function estimateOutputTokens(text: string): number {
+  return estimateTokensFromCharCount(text.trim().length);
+}
+
+function calculateTokensPerSecond(
+  outputTokens: number,
+  durationMs: number | undefined
+): number | undefined {
+  if (
+    outputTokens <= 0 ||
+    durationMs === undefined ||
+    durationMs < THROUGHPUT_MIN_DURATION_MS
+  ) {
+    return undefined;
+  }
+  return outputTokens / (durationMs / 1000);
+}
+
+function resolveEventType(
+  eventType: string,
+  payload: Record<string, unknown>
+): string {
+  return typeof payload.type === "string" ? payload.type : eventType;
+}
+
+function getTextDelta(payload: Record<string, unknown>): string {
+  if (typeof payload.text === "string") return payload.text;
+  if (typeof payload.delta === "string") return payload.delta;
+  if (typeof payload.content === "string") return payload.content;
+  if (typeof payload.chunk === "string") return payload.chunk;
+  return "";
+}
+
+/**
+ * Only count visible model output.
+ *
+ * For `agent_turn_delta`, count only a contentType of exactly `text` as
+ * visible, matching the client renderer (which appends streaming assistant
+ * text only when `contentType === "text"`); `thinking`, `tool_input`, any
+ * other value, and a missing contentType are ignored so throughput never
+ * includes deltas the chat UI doesn't render.
+ *
+ * For `step_delta` / `step_chunk`, skip tool and context steps — those carry
+ * tool I/O, not model-visible text — mirroring the widget's own renderer.
+ */
+function isVisibleTextDelta(
+  type: string,
+  payload: Record<string, unknown>
+): boolean {
+  if (type === "step_delta" || type === "step_chunk") {
+    return payload.stepType !== "tool" && payload.executionType !== "context";
+  }
+
+  if (type !== "agent_turn_delta") return true;
+
+  const contentType =
+    typeof payload.contentType === "string"
+      ? payload.contentType
+      : typeof payload.content_type === "string"
+        ? payload.content_type
+        : undefined;
+
+  return contentType === "text";
+}
+
+/** Extract exact output tokens from a variety of usage payload shapes. */
+function getOutputTokens(payload: Record<string, unknown>): number | undefined {
+  const result = getRecord(payload, "result");
+  const candidates = [
+    getRecord(payload, "tokens"),
+    getRecord(payload, "totalTokens"),
+    result ? getRecord(result, "tokens") : undefined,
+    getRecord(payload, "usage"),
+    result ? getRecord(result, "usage") : undefined,
+  ];
+
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    const outputTokens =
+      toFiniteNumber(candidate.output) ??
+      toFiniteNumber(candidate.outputTokens) ??
+      toFiniteNumber(candidate.completionTokens);
+    if (outputTokens !== undefined) return outputTokens;
+  }
+
+  return (
+    toFiniteNumber(payload.outputTokens) ??
+    toFiniteNumber(payload.completionTokens) ??
+    (result
+      ? (toFiniteNumber(result.outputTokens) ??
+        toFiniteNumber(result.completionTokens))
+      : undefined)
+  );
+}
+
+/** Extract provider execution time (ms) from a variety of payload shapes. */
+function getExecutionTimeMs(
+  payload: Record<string, unknown>
+): number | undefined {
+  const result = getRecord(payload, "result");
+  return (
+    toFiniteNumber(payload.executionTime) ??
+    toFiniteNumber(payload.executionTimeMs) ??
+    toFiniteNumber(payload.execution_time) ??
+    toFiniteNumber(payload.duration) ??
+    (result
+      ? (toFiniteNumber(result.executionTime) ??
+        toFiniteNumber(result.executionTimeMs))
+      : undefined)
+  );
+}
+
+function defaultClock(): number {
+  if (
+    typeof performance !== "undefined" &&
+    typeof performance.now === "function"
+  ) {
+    return performance.now();
+  }
+  return Date.now();
+}
+
+/**
+ * Tracks output throughput across one streamed run at a time. Feed it every SSE
+ * event via {@link processEvent}; read the current state via {@link getMetric}.
+ */
+export class ThroughputTracker {
+  private metric: ThroughputMetric = { status: "idle" };
+  private run: ThroughputRunStats | null = null;
+  private readonly now: () => number;
+
+  constructor(now: () => number = defaultClock) {
+    this.now = now;
+  }
+
+  getMetric(): ThroughputMetric {
+    // While a run is streaming, recompute the elapsed window (and rate) from the
+    // clock on each read. The view polls this every ~200ms, so without this a
+    // pause between deltas would keep showing the stale rate from the last
+    // event; recomputing lets the displayed tok/s decay as time passes.
+    const run = this.run;
+    if (
+      run &&
+      this.metric.status === "running" &&
+      run.firstDeltaAt !== undefined &&
+      this.metric.outputTokens !== undefined
+    ) {
+      const durationMs = this.now() - run.firstDeltaAt;
+      return {
+        ...this.metric,
+        durationMs,
+        tokensPerSecond: calculateTokensPerSecond(
+          this.metric.outputTokens,
+          durationMs
+        ),
+      };
+    }
+    return this.metric;
+  }
+
+  /** Reset back to idle (e.g. when the chat is cleared). */
+  reset(): void {
+    this.run = null;
+    this.metric = { status: "idle" };
+  }
+
+  private startRun(now: number): void {
+    this.run = {
+      startedAt: now,
+      visibleCharCount: 0,
+      exactOutputTokens: 0,
+    };
+    this.metric = { status: "running" };
+  }
+
+  processEvent(eventType: string, payload: unknown): void {
+    if (!isRecord(payload)) {
+      // Non-object payloads can still signal lifecycle (e.g. bare "error").
+      if (ERROR_EVENTS.has(eventType) && this.run) {
+        this.run = null;
+        this.metric = { status: "error" };
+      }
+      return;
+    }
+
+    const type = resolveEventType(eventType, payload);
+    const now = this.now();
+
+    if (REQUEST_START_EVENTS.has(type)) {
+      // New request — start fresh, discarding any incomplete prior run.
+      this.startRun(now);
+      return;
+    }
+
+    if (STEP_START_EVENTS.has(type)) {
+      // Mid-request step marker — only begin a run if none is active.
+      if (!this.run) this.startRun(now);
+      return;
+    }
+
+    if (VISIBLE_DELTA_EVENTS.has(type)) {
+      if (!isVisibleTextDelta(type, payload)) return;
+      const text = getTextDelta(payload);
+      if (!text) return;
+
+      // Lazily start a run if the stream began without a recognized start event.
+      if (!this.run) this.startRun(now);
+      const stats = this.run!;
+
+      stats.firstDeltaAt ??= now;
+      stats.visibleCharCount += text.length;
+
+      // Add the live char estimate of the CURRENT (not-yet-completed) step on
+      // top of any exact usage already booked from completed steps, so the
+      // count only grows — it never drops back to a bare estimate mid-run.
+      const outputTokens =
+        stats.exactOutputTokens +
+        estimateTokensFromCharCount(stats.visibleCharCount);
+      const durationMs = now - stats.firstDeltaAt;
+      this.metric = {
+        status: "running",
+        tokensPerSecond: calculateTokensPerSecond(outputTokens, durationMs),
+        outputTokens,
+        durationMs,
+        source: stats.exactOutputTokens > 0 ? "usage" : "estimate",
+      };
+      return;
+    }
+
+    if (INTERMEDIATE_COMPLETE_EVENTS.has(type)) {
+      // Accumulate exact usage but keep the run going — these fire per
+      // step/turn, not at the end of the whole run.
+      if (!this.run) return;
+      const stats = this.run;
+      const exact = getOutputTokens(payload);
+      if (exact !== undefined) {
+        stats.exactOutputTokens += exact;
+        // This step's visible text is now represented exactly by provider
+        // usage — drop it from the running char estimate so the two don't
+        // double-count once the next step starts streaming.
+        stats.visibleCharCount = 0;
+      }
+
+      const usingExact = stats.exactOutputTokens > 0;
+      const outputTokens =
+        stats.exactOutputTokens +
+        estimateTokensFromCharCount(stats.visibleCharCount);
+      const durationMs = this.resolveDuration(stats, payload, now);
+      this.metric = {
+        status: "running",
+        tokensPerSecond: calculateTokensPerSecond(outputTokens, durationMs),
+        outputTokens,
+        durationMs,
+        source: usingExact ? "usage" : "estimate",
+      };
+      return;
+    }
+
+    if (TERMINAL_COMPLETE_EVENTS.has(type)) {
+      if (!this.run) return;
+      const stats = this.run;
+      // Prefer exact output tokens from this terminal event, else accumulated
+      // usage from intermediate completes, else the text estimate.
+      const terminalExact = getOutputTokens(payload);
+      // Prefer a total from the terminal event; otherwise sum exact usage booked
+      // from intermediate completes plus the estimate of any still-streamed text
+      // not yet covered by a usage report.
+      const outputTokens =
+        terminalExact ??
+        stats.exactOutputTokens +
+          estimateTokensFromCharCount(stats.visibleCharCount);
+      const source: ThroughputMetricSource =
+        terminalExact !== undefined || stats.exactOutputTokens > 0
+          ? "usage"
+          : "estimate";
+      const durationMs = this.resolveDuration(stats, payload, now);
+      this.metric = {
+        status: "complete",
+        tokensPerSecond: calculateTokensPerSecond(outputTokens, durationMs),
+        outputTokens,
+        durationMs,
+        source,
+      };
+      this.run = null;
+      return;
+    }
+
+    if (ERROR_EVENTS.has(type)) {
+      if (!this.run) return;
+      this.run = null;
+      this.metric = { status: "error" };
+    }
+  }
+
+  /**
+   * Prefer the streamed visible-output window when it clears the minimum
+   * threshold; otherwise fall back to provider execution time, then to the
+   * whole-request duration.
+   */
+  private resolveDuration(
+    stats: ThroughputRunStats,
+    payload: Record<string, unknown>,
+    now: number
+  ): number {
+    const streamedDurationMs =
+      stats.firstDeltaAt !== undefined ? now - stats.firstDeltaAt : undefined;
+    if (
+      streamedDurationMs !== undefined &&
+      streamedDurationMs >= THROUGHPUT_MIN_DURATION_MS
+    ) {
+      return streamedDurationMs;
+    }
+    const executionTimeMs = getExecutionTimeMs(payload);
+    return executionTimeMs ?? now - stats.startedAt;
+  }
+}


### PR DESCRIPTION
## What
Adds an **Output throughput** (tok/s) metric to the widget's Events diagnostics screen,
derived passively from the existing SSE event stream. Reworks core PR #3877 (playground-only
chip) so the metric ships inside `@runtypelabs/persona`; the dashboard playground picks it up
through the widget's Events screen instead of owning custom metric state.

## How
- New `utils/throughput-tracker.ts`: estimates output tokens live from visible text deltas
  (`step_delta`/`step_chunk`/`chunk`/`agent_turn_delta`), ignores `thinking`/`tool_input` and
  tool/context step deltas, accumulates exact provider usage on intermediate
  `step_complete`/`agent_turn_complete` (stays *running*), finalizes only on terminal
  `flow_complete`/`agent_complete` (usage > accumulated > estimate). Errors mark it unavailable.
  Duration prefers the streamed window, then provider `executionTime`, then whole-request time.
- `event-stream-view.ts` renders/refreshes an "Output throughput" summary row.
- `ui.ts` feeds the tracker from the same SSE tap as the buffer; resets on clear-chat / feature
  disable. Stays passive: no dispatch-payload mutation, no forced debug mode, no wire-contract change.
- 17 unit tests; changeset (minor). Demo: `webmcp-demo.ts` enables the Events toggle.

## Testing
`pnpm --filter @runtypelabs/persona test:run` (997 pass). Manual: run the embedded-app dev server,
open webmcp-demo.html, toggle the Events (activity) icon, send a message → the Output throughput
row updates live (estimate while streaming, switches to `usage` on completion when the provider
returns token counts).

## Related
Core PR #3877 (a different repo, `runtypelabs/core`) should be reduced to just deleting the
playground-only throughput state (`TokenRateMetric`/`TokenRateChip`/`metric-aware-fetch` in
`apps/dashboard`), since the widget now provides throughput natively via the Events screen.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Diagnostics-only UI and passive SSE observation; gated behind the existing Events toggle with no API or streaming contract changes.
> 
> **Overview**
> Adds **output throughput (tok/s)** to the widget Events diagnostics screen in `@runtypelabs/persona`, computed passively from the same SSE tap as the event buffer—no wire or dispatch changes.
> 
> A new **`ThroughputTracker`** estimates rate from visible text deltas (`step_delta`, `chunk`, `agent_turn_delta` with `contentType: text`, etc.), ignores thinking/tool/context noise, accumulates provider usage on intermediate completes, and finalizes on `flow_complete` / `agent_complete`. **`event-stream-view`** shows a compact **Throughput** badge in the header with token count, duration, and usage vs estimate on hover. **`ui.ts`** wires the tracker into the SSE callback and resets it on clear chat, stream cancel, and when the Events toggle is disabled.
> 
> Ships with a minor changeset and unit tests; the embedded **webmcp** demo turns on `showEventStreamToggle` for manual verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b5c531a7ce04237cb63e622aab6270cc1b44178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->