### PR TITLE
chore(widget): bundle-size CI guard + minify subpath bundles

### DIFF
--- a/.changeset/minify-subpath-bundles.md
+++ b/.changeset/minify-subpath-bundles.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Minify the subpath build outputs (`theme-editor`, `smart-dom-reader`, `testing`, `animations/*`), which were previously shipped unminified. This cuts `theme-editor.js` from ~1,020 kB to ~538 kB raw (200.8 kB → 143.0 kB gzip) and `smart-dom-reader.js` from ~73 kB to ~37 kB raw, with no API or behavior change.

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,0 +1,37 @@
+name: Bundle Size
+
+on:
+  pull_request:
+    branches: [main, staging]
+  push:
+    branches: [main, staging]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  size-limit:
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build widget
+        run: pnpm build:widget
+
+      - name: Check bundle size against limits
+        run: pnpm --filter @runtypelabs/persona size

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -1,0 +1,44 @@
+[
+  {
+    "name": "⛔ CRITICAL · CDN browser payload (index.global.js)",
+    "path": "dist/index.global.js",
+    "limit": "180 kB",
+    "gzip": true
+  },
+  {
+    "name": "⛔ CRITICAL · browser stylesheet (widget.css)",
+    "path": "dist/widget.css",
+    "limit": "21 kB",
+    "gzip": true
+  },
+  {
+    "name": "⛔ CRITICAL · ESM bundle shipped by consumers (index.js)",
+    "path": "dist/index.js",
+    "limit": "138 kB",
+    "gzip": true
+  },
+  {
+    "name": "CJS bundle (index.cjs)",
+    "path": "dist/index.cjs",
+    "limit": "139 kB",
+    "gzip": true
+  },
+  {
+    "name": "Script installer (install.global.js)",
+    "path": "dist/install.global.js",
+    "limit": "2.5 kB",
+    "gzip": true
+  },
+  {
+    "name": "Opt-in · theme-editor subpath (theme-editor.js)",
+    "path": "dist/theme-editor.js",
+    "limit": "150 kB",
+    "gzip": true
+  },
+  {
+    "name": "Opt-in · smart-dom-reader subpath (smart-dom-reader.js)",
+    "path": "dist/smart-dom-reader.js",
+    "limit": "13 kB",
+    "gzip": true
+  }
+]

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -50,10 +50,10 @@
   ],
   "scripts": {
     "build": "rimraf dist && pnpm run build:styles && pnpm run build:client && pnpm run build:installer && pnpm run build:theme-ref && pnpm run build:theme-editor && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:animations",
-    "build:theme-editor": "tsup src/theme-editor.ts --format esm,cjs --dts --out-dir dist --no-splitting",
-    "build:testing": "tsup src/testing.ts --format esm,cjs --dts --out-dir dist --no-splitting",
-    "build:smart-dom-reader": "tsup src/smart-dom-reader.ts --format esm,cjs --dts --out-dir dist --no-splitting",
-    "build:animations": "tsup src/animations/glyph-cycle.ts src/animations/wipe.ts --format esm,cjs --dts --out-dir dist/animations --no-splitting",
+    "build:theme-editor": "tsup src/theme-editor.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
+    "build:testing": "tsup src/testing.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
+    "build:smart-dom-reader": "tsup src/smart-dom-reader.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
+    "build:animations": "tsup src/animations/glyph-cycle.ts src/animations/wipe.ts --format esm,cjs --minify --dts --out-dir dist/animations --no-splitting",
     "build:theme-ref": "tsup src/theme-reference.ts --format esm,cjs --minify --dts",
     "build:styles": "node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.copyFileSync('src/styles/widget.css','dist/widget.css');\"",
     "build:client": "tsup src/index.ts --format esm,cjs --minify --sourcemap --splitting false --dts --loader \".css=text\" && tsup src/index-global.ts --format iife --global-name AgentWidget --minify --sourcemap --splitting false --out-dir dist --loader \".css=text\" && node -e \"const fs=require('fs');for(const ext of ['.global.js','.global.js.map']){const from='dist/index-global'+ext;if(fs.existsSync(from))fs.renameSync(from,'dist/index'+ext);}\"",
@@ -62,7 +62,8 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:run": "vitest run"
+    "test:run": "vitest run",
+    "size": "size-limit"
   },
   "dependencies": {
     "@mcp-b/webmcp-polyfill": "^3.0.0",
@@ -74,6 +75,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
+    "@size-limit/file": "^12.1.0",
     "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
@@ -82,6 +84,7 @@
     "eslint-config-prettier": "^9.1.0",
     "fake-indexeddb": "^6.2.5",
     "rimraf": "^5.0.5",
+    "size-limit": "^12.1.0",
     "tsup": "^8.0.1",
     "typescript": "^5.4.5",
     "vitest": "^4.0.9"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -154,6 +154,9 @@ importers:
         specifier: ^3.22.4
         version: 3.25.76
     devDependencies:
+      '@size-limit/file':
+        specifier: ^12.1.0
+        version: 12.1.0(size-limit@12.1.0)
       '@types/node':
         specifier: ^20.12.7
         version: 20.19.35
@@ -178,6 +181,9 @@ importers:
       rimraf:
         specifier: ^5.0.5
         version: 5.0.10
+      size-limit:
+        specifier: ^12.1.0
+        version: 12.1.0
       tsup:
         specifier: ^8.0.1
         version: 8.5.1(jiti@1.21.7)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)
@@ -1058,6 +1064,12 @@ packages:
     resolution: {integrity: sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==}
     engines: {node: '>=18'}
 
+  '@size-limit/file@12.1.0':
+    resolution: {integrity: sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    peerDependencies:
+      size-limit: 12.1.0
+
   '@speed-highlight/core@1.2.14':
     resolution: {integrity: sha512-G4ewlBNhUtlLvrJTb88d2mdy2KRijzs4UhnlrOSRT4bmjh/IqNElZa3zkrZ+TC47TwtlDWzVLFADljF1Ijp5hA==}
 
@@ -1288,6 +1300,10 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     peerDependencies:
       esbuild: '>=0.18'
+
+  bytes-iec@3.1.1:
+    resolution: {integrity: sha512-fey6+4jDK7TFtFg/klGSvNKJctyU7n2aQdnM+CO0ruLPbqqMOM8Tio0Pc+deqUeVKX1tL5DQep1zQ7+37aTAsA==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -1868,6 +1884,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanospinner@1.2.2:
+    resolution: {integrity: sha512-Zt/AmG6qRU3e+WnzGGLuMCEAO/dAu45stNbHY223tUxldaDAeE+FxSPsd9Q+j+paejmm0ZbrNVs5Sraqy3dRxA==}
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -1970,6 +1989,10 @@ packages:
 
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
   pify@4.0.1:
@@ -2114,6 +2137,16 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  size-limit@12.1.0:
+    resolution: {integrity: sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      jiti: ^2.0.0
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
@@ -2218,6 +2251,10 @@ packages:
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
   tinyrainbow@3.0.3:
@@ -3251,6 +3288,10 @@ snapshots:
 
   '@sindresorhus/is@7.2.0': {}
 
+  '@size-limit/file@12.1.0(size-limit@12.1.0)':
+    dependencies:
+      size-limit: 12.1.0
+
   '@speed-highlight/core@1.2.14': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -3515,6 +3556,8 @@ snapshots:
     dependencies:
       esbuild: 0.27.3
       load-tsconfig: 0.2.5
+
+  bytes-iec@3.1.1: {}
 
   cac@6.7.14: {}
 
@@ -3809,6 +3852,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fflate@0.8.2: {}
 
@@ -4150,6 +4197,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanospinner@1.2.2:
+    dependencies:
+      picocolors: 1.1.1
+
   natural-compare@1.4.0: {}
 
   neo-async@2.6.2: {}
@@ -4235,6 +4286,8 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  picomatch@4.0.4: {}
 
   pify@4.0.1: {}
 
@@ -4395,6 +4448,14 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  size-limit@12.1.0:
+    dependencies:
+      bytes-iec: 3.1.1
+      lilconfig: 3.1.3
+      nanospinner: 1.2.2
+      picocolors: 1.1.1
+      tinyglobby: 0.2.17
+
   slash@3.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -4486,6 +4547,11 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
 
   tinyrainbow@3.0.3: {}
 


### PR DESCRIPTION
## What

Adds a **Bundle Size** GitHub Action that enforces gzip size limits on the widget's built artifacts, and fixes the subpath builds that were shipping unminified.

### Bundle-size CI guard
- New workflow `.github/workflows/bundle-size.yml` runs on PRs/pushes to `main`/`staging`: install → `pnpm build:widget` → `size-limit`. Fails CI if any artifact exceeds its budget.
- `size-limit` + `@size-limit/file` measure the **real built `dist/` files** (gzipped), not a re-bundle — so the numbers match what consumers actually download.
- Budgets in `packages/widget/.size-limit.json`. The tightest, `⛔ CRITICAL` limits guard the **end-user browser payload**:

  | Artifact | Gzip | Limit |
  |---|---:|---:|
  | `index.global.js` (CDN `<script>`) | 175.5 kB | 180 kB |
  | `widget.css` | 19.8 kB | 21 kB |
  | `index.js` (what bundler consumers ship) | 134.0 kB | 138 kB |

  Opt-in subpaths (`theme-editor`, `smart-dom-reader`) get looser regression-guard limits since no end user loads them on the widget path.

  Run locally: `pnpm build:widget && pnpm --filter @runtypelabs/persona size`

### Optimization: minify subpath builds
`theme-editor`, `smart-dom-reader`, `testing`, and `animations/*` were missing the `--minify` flag the main bundles already use. Adding it (no API/behavior change):
- `theme-editor.js`: **1,020 kB → 538 kB** raw (200.8 → **143.0 kB gzip, −57 kB**)
- `smart-dom-reader.js`: **73 kB → 37 kB** raw (16.1 → 11.7 kB gzip)

## Follow-ups (not in this PR)
- `utils/code-generators.ts` (~39 kB) and `components/demo-carousel.ts` (~11 kB) are authoring/demo helpers re-exported from the root, so they ship in the CDN bundle every end user downloads. Moving them to dedicated subpaths would strip ~50 kB raw — but it's a breaking public-API move.
- A careful `sideEffects` allowlist would let downstream bundlers drop unused root exports.

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm --filter @runtypelabs/persona size` passes (all under budget)
- [x] `pnpm --filter @runtypelabs/persona lint` + `typecheck` pass
- [x] Patch changeset included

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build and CI tooling only; minification affects published bytes but not public API or runtime behavior per the changeset.
> 
> **Overview**
> Adds **bundle-size enforcement** for `@runtypelabs/persona` and **minifies opt-in subpath builds** that were previously shipped without `--minify`.
> 
> A new **Bundle Size** workflow on `main`/`staging` runs `pnpm build:widget` then `pnpm --filter @runtypelabs/persona size`, failing CI when gzipped `dist/` artifacts exceed budgets in `packages/widget/.size-limit.json` (critical caps on `index.global.js`, `widget.css`, and `index.js`, plus looser limits for installer and subpaths). The widget package gains `size-limit` / `@size-limit/file` and a `size` script.
> 
> **Build change:** `tsup` for `theme-editor`, `testing`, `smart-dom-reader`, and `animations/*` now passes `--minify`, aligning with main bundles and shrinking published subpath JS (notably `theme-editor.js` and `smart-dom-reader.js`) with no intended API change. A patch changeset documents the minification release note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3011a944a8a368f98f274f98c5389f9b592fb0f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->