### PR TITLE
fix(examples): polish WebMCP demo dark mode + remove View-as toggle

### DIFF
--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -722,6 +722,23 @@ const shopDarkTheme: NonNullable<AgentWidgetConfig["darkTheme"]> = {
       iconForeground: "#1c1917",
       actionIconForeground: "#d6d3d1",
     },
+    // The widget's component defaults back these surfaces with `gray.50`, which
+    // this dark palette keeps light (#f5f5f4) — so without explicit overrides the
+    // assistant bubbles, composer input, tool-call chrome, and inline code would
+    // render as bright cream cards on the espresso-night panel. Pin them to the
+    // dark surface set (and flip their default dark `gray.900` text to light).
+    message: {
+      assistant: { background: "#292524", text: "#f5f5f4", border: "#3a3530" },
+    },
+    input: { background: "#2c2724", placeholder: "#a8a29e" },
+    collapsibleWidget: {
+      container: "#292524", // tool/reasoning bubble chrome
+      surface: "#141110", // inset args/code box — reads as a dark terminal panel
+      border: "#3a3530",
+    },
+    markdown: {
+      inlineCode: { background: "#44403c", foreground: "#f5f5f4" },
+    },
   },
 };
 

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -3,14 +3,13 @@ import "@runtypelabs/persona/widget.css";
 import {
   createAgentExperience,
   createLocalStorageAdapter,
-  initAgentWidget,
   markdownPostprocessor,
   DEFAULT_WIDGET_CONFIG,
   type AgentWidgetConfig,
   type WebMcpConfirmInfo,
 } from "@runtypelabs/persona";
 import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
-import { setupMountMode, renderInlineMount, renderLauncherScene } from "./mount-mode";
+import { setupMountMode, renderInlineMount } from "./mount-mode";
 import type { Mode } from "./examples-nav";
 import { CATALOG, searchCatalog, findBySku, type CatalogProduct } from "./webmcp-catalog";
 
@@ -743,7 +742,6 @@ const shopDarkTheme: NonNullable<AgentWidgetConfig["darkTheme"]> = {
 };
 
 const buildConfig = (mode: Mode): AgentWidgetConfig => {
-  const showLauncherChrome = mode === "launcher";
   return {
     ...DEFAULT_WIDGET_CONFIG,
     ...(usingClientToken
@@ -792,23 +790,20 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
     launcher: {
       title: "Switchback",
       subtitle: "Trail & road running assistant",
-      ...(showLauncherChrome
-        ? { enabled: true, autoExpand: false, width: "420px", fullHeight: true }
-        : { enabled: false, autoExpand: true, width: "100%", fullHeight: true }),
+      enabled: false,
+      autoExpand: true,
+      width: "100%",
+      fullHeight: true,
     },
   };
 };
 
+// Inline-only: the widget mounts flush in the storefront's right-hand stage.
+// A single mode means setupMountMode renders no "View as" toggle.
 setupMountMode({
   slug: "webmcp-demo",
-  modes: ["inline", "launcher", "fullscreen"],
+  modes: ["inline"],
   mount: (mode, { stage }) => {
-    if (mode === "launcher") {
-      const { mountEl } = renderLauncherScene(stage);
-      const handle = initAgentWidget({ target: mountEl, config: buildConfig("launcher") });
-      return () => handle.destroy();
-    }
-
     const mount = renderInlineMount(stage);
     mount.style.height = "100%";
     const controller = createAgentExperience(mount, buildConfig(mode));

--- a/examples/embedded-app/src/webmcp-shop.css
+++ b/examples/embedded-app/src/webmcp-shop.css
@@ -173,6 +173,27 @@ body.webmcp-shop .shop-explainer code {
 }
 body.webmcp-shop .shop-hero .mount-toolbar { justify-content: flex-start; margin: 0.85rem 0 0; min-height: 0; }
 
+/* "View as" mode toggle — the gallery styles this with the shared neutral
+   tokens (`--paper`/`--background`/`--foreground`), which have no dark variant,
+   so the pill group glares bright white on the espresso-night page. Retint it to
+   the shop palette; `--shop-*` adapt per scheme, so this fixes both light + dark. */
+body.webmcp-shop .mount-toggle-label { color: var(--shop-faint); }
+body.webmcp-shop .mount-toggle-group {
+  background: var(--shop-bg);
+  border-color: var(--shop-line);
+}
+body.webmcp-shop .mount-toggle-button { color: var(--shop-ink-soft); }
+body.webmcp-shop .mount-toggle-button:hover {
+  color: var(--shop-ink);
+  background: color-mix(in srgb, var(--shop-ink) 7%, transparent);
+}
+body.webmcp-shop .mount-toggle-button[aria-pressed="true"] {
+  background: var(--shop-paper);
+  color: var(--shop-ink);
+  box-shadow: var(--shop-shadow), 0 0 0 1px var(--shop-line);
+}
+body.webmcp-shop .mount-toggle-button:focus-visible { outline-color: var(--shop-accent); }
+
 /* ── Section scaffolding ───────────────────────────────────────────────── */
 
 body.webmcp-shop .shop-section { margin-bottom: 1.25rem; }

--- a/examples/embedded-app/src/webmcp-shop.css
+++ b/examples/embedded-app/src/webmcp-shop.css
@@ -171,29 +171,6 @@ body.webmcp-shop .shop-explainer code {
   padding: 0.08em 0.38em;
   border-radius: 5px;
 }
-body.webmcp-shop .shop-hero .mount-toolbar { justify-content: flex-start; margin: 0.85rem 0 0; min-height: 0; }
-
-/* "View as" mode toggle — the gallery styles this with the shared neutral
-   tokens (`--paper`/`--background`/`--foreground`), which have no dark variant,
-   so the pill group glares bright white on the espresso-night page. Retint it to
-   the shop palette; `--shop-*` adapt per scheme, so this fixes both light + dark. */
-body.webmcp-shop .mount-toggle-label { color: var(--shop-faint); }
-body.webmcp-shop .mount-toggle-group {
-  background: var(--shop-bg);
-  border-color: var(--shop-line);
-}
-body.webmcp-shop .mount-toggle-button { color: var(--shop-ink-soft); }
-body.webmcp-shop .mount-toggle-button:hover {
-  color: var(--shop-ink);
-  background: color-mix(in srgb, var(--shop-ink) 7%, transparent);
-}
-body.webmcp-shop .mount-toggle-button[aria-pressed="true"] {
-  background: var(--shop-paper);
-  color: var(--shop-ink);
-  box-shadow: var(--shop-shadow), 0 0 0 1px var(--shop-line);
-}
-body.webmcp-shop .mount-toggle-button:focus-visible { outline-color: var(--shop-accent); }
-
 /* ── Section scaffolding ───────────────────────────────────────────────── */
 
 body.webmcp-shop .shop-section { margin-bottom: 1.25rem; }


### PR DESCRIPTION
## What

Polishes the dark-mode appearance of the WebMCP "Switchback" storefront demo. Four surfaces rendered as bright cream cards on the dark espresso-night panel:

1. **Assistant message bubbles**
2. **Composer input box**
3. **Expanded tool-call chrome** (the "Used tool for…" header + Arguments area)
4. **"View as" mode selector** (gallery toggle on the left rail) — now removed entirely

## Root cause (1–3)

`colorScheme: 'auto'` does **not** auto-invert colors — the dark palette must be fully specified. `shopDarkTheme` correctly inverted the *semantic* surfaces (`surface`/`background`/`container` → dark), but the widget's component defaults (`packages/widget/src/utils/tokens.ts`) back several backgrounds with **`palette.colors.gray.50`**, not with `semantic.colors.surface`:

- `message.assistant.background` (and `.text` → `gray.900`)
- `input.background`
- `collapsibleWidget.container`
- `markdown.inlineCode.background`

`shopDarkTheme` kept `gray.50 = #f5f5f4` (light cream), so all four resolved light even though `--persona-surface` was correctly `#292524`. Confirmed live via `getComputedStyle`.

## Changes (examples-only — no changeset)

- **`webmcp-demo.ts`**
  - Added explicit `components` overrides to `shopDarkTheme`:
    - assistant bubbles → `#292524` bg / `#f5f5f4` text / `#3a3530` border
    - composer input → `#2c2724`
    - tool/reasoning bubbles → `#292524` chrome + `#141110` inset code box
    - inline code → `#44403c` bg / `#f5f5f4` text
  - Made the demo **inline-only** (`modes: ["inline"]`), which removes the "View as" toggle entirely (`setupMountMode` hides the toolbar for a single mode). Dropped the dead launcher mount branch and the now-unused `initAgentWidget` / `renderLauncherScene` imports.
- **`webmcp-shop.css`** — no toggle styling needed anymore.

## Verification

- All four widget tokens resolve to dark values via `getComputedStyle` after reload.
- Screenshotted in a system-dark browser: input is dark, tool/assistant chrome is dark, and the "View as" section is gone — the header flows straight into the Catalog section while the widget still mounts inline.
- `tsc` clean for `webmcp-demo.ts`.
