### PR TITLE
feat(theme-editor): Theme Copilot sidebar with image-matching restyle loop

### DIFF
--- a/.changeset/theme-assistant-flow.md
+++ b/.changeset/theme-assistant-flow.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona-proxy": minor
 ---
 
-Add `THEME_ASSISTANT_FLOW` — a tool-calling flow for the Persona Theme Editor's live, self-styling preview widget. It drives the page's WebMCP theme tools (`webmcp:*`) so the widget restyles itself in response to chat.
+Add `THEME_ASSISTANT_FLOW` — the tool-calling flow behind the Theme Editor's docked **Theme Copilot**. It drives the page's WebMCP theme tools (`webmcp:*`) to restyle the editor's live preview from chat, and supports an image-matching loop: paste a screenshot of another chat widget and the copilot extracts a style spec, applies it, then verifies the result via the page's `screenshot_preview` capture tool.

--- a/.changeset/theme-assistant-flow.md
+++ b/.changeset/theme-assistant-flow.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": minor
+---
+
+Add `THEME_ASSISTANT_FLOW` — a tool-calling flow for the Persona Theme Editor's live, self-styling preview widget. It drives the page's WebMCP theme tools (`webmcp:*`) so the widget restyles itself in response to chat.

--- a/.changeset/theme-tool-image-content.md
+++ b/.changeset/theme-tool-image-content.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Theme-editor WebMCP `ToolResult` now accepts MCP image content blocks (`ToolImageContent`), so host-registered tools (like the Theme Editor's `screenshot_preview`) can return rendered screenshots to the agent alongside text. Backwards-compatible: existing text-only results are unchanged.

--- a/.changeset/update-config-preserve-turn.md
+++ b/.changeset/update-config-preserve-turn.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+`controller.update()` now refreshes the widget in place when only display config changed (theme, copy, layout, suggestions, …) instead of always recreating the client. Connection/request-shaping changes (apiUrl, clientToken, webmcp, headers, parser, …) still trigger a full client rebuild. This keeps a live stream — and any in-flight WebMCP tool resolve — alive across a mid-turn UI update, so a `webmcp:*` tool that restyles the widget while the agent's turn is still streaming no longer aborts and strands that turn.

--- a/examples/embedded-app/.env.example
+++ b/examples/embedded-app/.env.example
@@ -35,3 +35,20 @@ VITE_PROXY_PORT=43111
 # required. To back it with your own Runtype flow instead, set
 # FLOW_ID_CALENDAR on the proxy (examples/vercel-edge/src/server.ts).
 # Append ?mode=pill for the composer-bar pill variant of the docked panel.
+
+# ---------------------------------------------------------------------------
+# Theme Copilot sidebar (theme.html) — client-token knobs
+# ---------------------------------------------------------------------------
+# The Theme Editor's docked Theme Copilot reads a distinct VITE_PERSONA_* pair,
+# not VITE_CLIENT_TOKEN / VITE_API_URL above. When VITE_PERSONA_CLIENT_TOKEN is
+# set it talks to the Runtype API directly in client-token mode; otherwise it
+# falls back to proxy mode at /api/chat/dispatch-theme. The token's agent or
+# surface must allow WebMCP, and its model must emit native tool calls and
+# accept image input (the copilot's reference-image matching loop sends images
+# both in user messages and in screenshot_preview tool results).
+#
+# Locally, set these in .env.local (gitignored — never commit the token).
+# On the persona-chat.dev deploy, set them as Vercel env vars (see README →
+# "WebMCP Demo"). The API base defaults to https://api.runtype.com when unset.
+# VITE_PERSONA_CLIENT_TOKEN=ct_live_...
+# VITE_PERSONA_API_URL=https://api.runtype.com

--- a/examples/embedded-app/.env.example
+++ b/examples/embedded-app/.env.example
@@ -37,18 +37,13 @@ VITE_PROXY_PORT=43111
 # Append ?mode=pill for the composer-bar pill variant of the docked panel.
 
 # ---------------------------------------------------------------------------
-# Theme Copilot sidebar (theme.html) — client-token knobs
+# Theme Copilot sidebar (theme.html) — proxy mode, like the other demos
 # ---------------------------------------------------------------------------
-# The Theme Editor's docked Theme Copilot reads a distinct VITE_PERSONA_* pair,
-# not VITE_CLIENT_TOKEN / VITE_API_URL above. When VITE_PERSONA_CLIENT_TOKEN is
-# set it talks to the Runtype API directly in client-token mode; otherwise it
-# falls back to proxy mode at /api/chat/dispatch-theme. The token's agent or
-# surface must allow WebMCP, and its model must emit native tool calls and
-# accept image input (the copilot's reference-image matching loop sends images
-# both in user messages and in screenshot_preview tool results).
-#
-# Locally, set these in .env.local (gitignored — never commit the token).
-# On the persona-chat.dev deploy, set them as Vercel env vars (see README →
-# "WebMCP Demo"). The API base defaults to https://api.runtype.com when unset.
-# VITE_PERSONA_CLIENT_TOKEN=ct_live_...
-# VITE_PERSONA_API_URL=https://api.runtype.com
+# The Theme Editor's docked Theme Copilot runs entirely through the local proxy
+# (VITE_PROXY_PORT above). Its agent is defined in code as THEME_ASSISTANT_FLOW
+# and mounted at /api/chat/dispatch-theme — no client token or hosted Runtype
+# agent required. To back it with your own Runtype flow instead, set
+# FLOW_ID_THEME_ASSISTANT on the proxy (examples/vercel-edge/src/server.ts);
+# the flow's model must emit native tool calls and accept image input (the
+# copilot's reference-image loop sends images both in user messages and in
+# screenshot_preview tool results).

--- a/examples/embedded-app/package.json
+++ b/examples/embedded-app/package.json
@@ -13,6 +13,7 @@
     "@runtypelabs/persona": "workspace:^",
     "handlebars": "^4.7.8",
     "idiomorph": "^0.7.4",
+    "modern-screenshot": "^4.7.0",
     "partial-json": "^0.1.7",
     "zod": "^3.25.76",
     "zod-to-json-schema": "^3.24.6"

--- a/examples/embedded-app/src/theme-configurator.css
+++ b/examples/embedded-app/src/theme-configurator.css
@@ -15,6 +15,20 @@ body {
   background: #f3f4f6;
 }
 
+/* Theme Copilot dock target — the docked widget shell wraps this element and
+   flexes the editor when the copilot sidebar opens. min-width: 0 lets the
+   grid's 1fr preview column absorb the squeeze instead of overflowing. */
+.theme-copilot-dock-target {
+  height: 100vh;
+  min-width: 0;
+}
+
+.theme-copilot-toggle.active {
+  background: #111827;
+  color: #ffffff;
+  border-color: #111827;
+}
+
 .configurator-layout {
   display: grid;
   grid-template-columns: 420px 1fr;

--- a/examples/embedded-app/src/theme-configurator/copilot.ts
+++ b/examples/embedded-app/src/theme-configurator/copilot.ts
@@ -3,10 +3,11 @@
  *
  * The copilot is a second, independent Persona widget on the editor page (the
  * preview widgets inside the iframes stay a passive showcase). It dispatches to
- * the theme-assistant flow, discovers the editor's WebMCP theme tools from the
- * parent page's `document.modelContext`, and restyles the preview live while
- * its own panel keeps Persona defaults — theming is per-mount, so the user
- * watches the preview change, not the copilot.
+ * the theme-assistant flow through the local proxy, discovers the editor's
+ * WebMCP theme tools from the parent page's `document.modelContext`, and
+ * restyles the preview live while its own panel keeps Persona defaults —
+ * theming is per-mount, so the user watches the preview change, not the
+ * copilot.
  *
  * Multi-modal loop: attachments are enabled so the user can paste a screenshot
  * of another site's chat widget; the agent extracts a style spec, applies it
@@ -21,28 +22,22 @@ import {
   markdownPostprocessor,
 } from '@runtypelabs/persona';
 import type {
-  AgentWidgetConfig,
   AgentWidgetInitHandle,
   WebMcpConfirmInfo,
 } from '@runtypelabs/persona';
 
 const MB = 1024 * 1024;
 
+// Proxy (dispatch) mode, like the other WebMCP demos: the copilot dispatches to
+// the local theme-assistant flow (THEME_ASSISTANT_FLOW in
+// @runtypelabs/persona-proxy), which forwards the page's clientTools[] upstream
+// and proxies the /resume round-trip — including the image blocks from
+// screenshot_preview. To back it with a hosted Runtype flow instead, set
+// FLOW_ID_THEME_ASSISTANT on the proxy (examples/vercel-edge/src/server.ts).
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
 const proxyUrl = import.meta.env.VITE_PROXY_URL
   ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-theme`
   : `http://localhost:${proxyPort}/api/chat/dispatch-theme`;
-
-// Two wiring modes, same as the WebMCP demo:
-//   1. Client-token mode — set VITE_PERSONA_CLIENT_TOKEN (+ VITE_PERSONA_API_URL,
-//      the API base) to dispatch straight to a Runtype surface/agent whose prompt
-//      is the theme copilot. This is the path proven to round-trip webmcp tools.
-//   2. Proxy mode (default fallback) — dispatch to the local theme-assistant flow.
-const clientToken = import.meta.env.VITE_PERSONA_CLIENT_TOKEN as string | undefined;
-const clientApiBase = import.meta.env.VITE_PERSONA_API_URL as string | undefined;
-const connectionConfig: Pick<AgentWidgetConfig, 'apiUrl' | 'clientToken'> = clientToken
-  ? { clientToken, ...(clientApiBase ? { apiUrl: clientApiBase } : {}) }
-  : { apiUrl: proxyUrl };
 
 // The editor registers its controls as WebMCP tools on the parent page's
 // `document.modelContext` (theme-configurator/webmcp/register.ts), which is
@@ -78,7 +73,7 @@ export function initThemeCopilot(): AgentWidgetInitHandle | null {
     useShadowDom: false,
     config: {
       ...DEFAULT_WIDGET_CONFIG,
-      ...connectionConfig,
+      apiUrl: proxyUrl,
       storageAdapter: createLocalStorageAdapter('persona-state-theme-copilot'),
       postprocessMessage: ({ text }) => markdownPostprocessor(text),
       colorScheme: 'light',

--- a/examples/embedded-app/src/theme-configurator/copilot.ts
+++ b/examples/embedded-app/src/theme-configurator/copilot.ts
@@ -1,0 +1,157 @@
+/**
+ * Theme Copilot — the docked sidebar agent that styles the theme preview.
+ *
+ * The copilot is a second, independent Persona widget on the editor page (the
+ * preview widgets inside the iframes stay a passive showcase). It dispatches to
+ * the theme-assistant flow, discovers the editor's WebMCP theme tools from the
+ * parent page's `document.modelContext`, and restyles the preview live while
+ * its own panel keeps Persona defaults — theming is per-mount, so the user
+ * watches the preview change, not the copilot.
+ *
+ * Multi-modal loop: attachments are enabled so the user can paste a screenshot
+ * of another site's chat widget; the agent extracts a style spec, applies it
+ * via theme tools, then calls the page-level `screenshot_preview` tool to see
+ * the rendered result and refine.
+ */
+
+import {
+  DEFAULT_WIDGET_CONFIG,
+  initAgentWidget,
+  createLocalStorageAdapter,
+  markdownPostprocessor,
+} from '@runtypelabs/persona';
+import type {
+  AgentWidgetConfig,
+  AgentWidgetInitHandle,
+  WebMcpConfirmInfo,
+} from '@runtypelabs/persona';
+
+const MB = 1024 * 1024;
+
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const proxyUrl = import.meta.env.VITE_PROXY_URL
+  ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-theme`
+  : `http://localhost:${proxyPort}/api/chat/dispatch-theme`;
+
+// Two wiring modes, same as the WebMCP demo:
+//   1. Client-token mode — set VITE_PERSONA_CLIENT_TOKEN (+ VITE_PERSONA_API_URL,
+//      the API base) to dispatch straight to a Runtype surface/agent whose prompt
+//      is the theme copilot. This is the path proven to round-trip webmcp tools.
+//   2. Proxy mode (default fallback) — dispatch to the local theme-assistant flow.
+const clientToken = import.meta.env.VITE_PERSONA_CLIENT_TOKEN as string | undefined;
+const clientApiBase = import.meta.env.VITE_PERSONA_API_URL as string | undefined;
+const connectionConfig: Pick<AgentWidgetConfig, 'apiUrl' | 'clientToken'> = clientToken
+  ? { clientToken, ...(clientApiBase ? { apiUrl: clientApiBase } : {}) }
+  : { apiUrl: proxyUrl };
+
+// The editor registers its controls as WebMCP tools on the parent page's
+// `document.modelContext` (theme-configurator/webmcp/register.ts), which is
+// exactly where the copilot's bridge looks — no cross-frame transport needed.
+// Every tool is a safe, local, undoable edit to the preview (and
+// screenshot_preview is a pure read), so all are auto-approved for a
+// frictionless "chat to restyle" loop instead of a confirm per color change.
+const AUTO_APPROVED_TOOLS = new Set([
+  'get_theme_overview',
+  'set_brand_colors',
+  'assign_color_role',
+  'set_typography',
+  'set_roundness',
+  'set_color_scheme',
+  'apply_preset',
+  'configure_widget',
+  'set_copy_and_suggestions',
+  'set_theme_fields',
+  'check_contrast',
+  'manage_session',
+  'screenshot_preview',
+]);
+
+export function initThemeCopilot(): AgentWidgetInitHandle | null {
+  const target = document.getElementById('theme-copilot-dock-target');
+  if (!target) {
+    console.warn('[theme-editor] Theme Copilot dock target not found.');
+    return null;
+  }
+
+  const widget = initAgentWidget({
+    target,
+    useShadowDom: false,
+    config: {
+      ...DEFAULT_WIDGET_CONFIG,
+      ...connectionConfig,
+      storageAdapter: createLocalStorageAdapter('persona-state-theme-copilot'),
+      postprocessMessage: ({ text }) => markdownPostprocessor(text),
+      colorScheme: 'light',
+      copy: {
+        ...DEFAULT_WIDGET_CONFIG.copy,
+        welcomeTitle: 'Theme Copilot',
+        welcomeSubtitle:
+          'Describe a look — or paste a screenshot of a chat widget you like — and I will restyle the preview to match.',
+        inputPlaceholder: 'e.g. "Deep teal, rounded corners, friendly tone"',
+      },
+      suggestionChips: [
+        'Make it feel like a banking app',
+        'Warm, rounded, and friendly',
+        'Switch the preview to dark mode',
+        'Check the contrast ratios',
+      ],
+      // Image paste/upload for the reference-matching loop.
+      attachments: {
+        enabled: true,
+        allowedTypes: ['image/png', 'image/jpeg', 'image/webp'],
+        maxFiles: 1,
+        maxFileSize: 5 * MB,
+      },
+      launcher: {
+        ...DEFAULT_WIDGET_CONFIG.launcher,
+        mountMode: 'docked',
+        dock: {
+          side: 'right',
+          width: '440px',
+          reveal: 'emerge',
+          animate: true,
+        },
+        autoExpand: false,
+        fullHeight: true,
+        mobileBreakpoint: 1024,
+        title: 'Theme Copilot',
+        subtitle: 'Styles the live preview',
+      },
+      webmcp: {
+        enabled: true,
+        autoApprove: (info: WebMcpConfirmInfo) => AUTO_APPROVED_TOOLS.has(info.toolName),
+      },
+      approval: {
+        ...DEFAULT_WIDGET_CONFIG.approval,
+        title: 'Run theme tool?',
+        approveLabel: 'Run tool',
+        denyLabel: 'Cancel',
+        detailsDisplay: 'collapsed',
+      },
+      statusIndicator: {
+        ...DEFAULT_WIDGET_CONFIG.statusIndicator,
+        visible: true,
+        idleText: 'Copilot edits the preview — undo anytime (or ask it to undo).',
+        connectedText: 'Copilot edits the preview — undo anytime (or ask it to undo).',
+        connectingText: 'Connecting Theme Copilot…',
+        errorText: 'Theme Copilot connection error',
+      },
+    },
+  });
+
+  const toggle = document.getElementById('theme-copilot-toggle');
+  const syncToggle = () => {
+    const open = widget.getState().open;
+    toggle?.setAttribute('aria-expanded', open ? 'true' : 'false');
+    toggle?.classList.toggle('active', open);
+  };
+  toggle?.addEventListener('click', () => {
+    widget.toggle();
+    window.setTimeout(syncToggle, 80);
+  });
+  widget.on('widget:opened', syncToggle);
+  widget.on('widget:closed', syncToggle);
+  syncToggle();
+
+  return widget;
+}

--- a/examples/embedded-app/src/theme-configurator/index.ts
+++ b/examples/embedded-app/src/theme-configurator/index.ts
@@ -224,13 +224,15 @@ function init(): void {
   // `state` so the preview + controls update for free. screenshot_preview is
   // page-level: it captures the live preview frames for the agent's visual
   // feedback loop.
-  const unmountMcp = mountThemeEditorMcp(state, {
+  const mcp = mountThemeEditorMcp(state, {
     extraTools: [createScreenshotPreviewTool(() => previewManager)],
   });
-  window.addEventListener('beforeunload', unmountMcp);
+  window.addEventListener('beforeunload', mcp.unmount);
 
-  // Mount the docked Theme Copilot — the live agent that drives the tools above.
-  initThemeCopilot();
+  // Mount the docked Theme Copilot — the live agent that drives the tools
+  // above — only after registration completes, so its first dispatch always
+  // carries the full clientTools list.
+  void mcp.ready.then(() => initThemeCopilot());
 }
 
 // ─── Tabs ────────────────────────────────────────────────────────

--- a/examples/embedded-app/src/theme-configurator/index.ts
+++ b/examples/embedded-app/src/theme-configurator/index.ts
@@ -15,6 +15,8 @@ import type {
 import type { OnChangeCallback, ControlResult } from './types';
 import * as state from './state';
 import { mountThemeEditorMcp } from './webmcp/register';
+import { createScreenshotPreviewTool } from './webmcp/screenshot-tool';
+import { initThemeCopilot } from './copilot';
 import { initSearchUI, pruneSearchIndex, registerCatalogSections, resetSearchIndex } from './search';
 import * as styleTab from './sections/appearance';
 import type { DrilldownView } from './sections/appearance';
@@ -217,10 +219,18 @@ function init(): void {
     previewManager?.update();
   });
 
-  // Expose the theme editor as WebMCP tools so a browser agent can configure
-  // the theme; routed through `state` so the preview + controls update for free.
-  const unmountMcp = mountThemeEditorMcp(state);
+  // Expose the theme editor as WebMCP tools so an agent (the Theme Copilot
+  // sidebar, or a browser agent) can configure the theme; routed through
+  // `state` so the preview + controls update for free. screenshot_preview is
+  // page-level: it captures the live preview frames for the agent's visual
+  // feedback loop.
+  const unmountMcp = mountThemeEditorMcp(state, {
+    extraTools: [createScreenshotPreviewTool(() => previewManager)],
+  });
   window.addEventListener('beforeunload', unmountMcp);
+
+  // Mount the docked Theme Copilot — the live agent that drives the tools above.
+  initThemeCopilot();
 }
 
 // ─── Tabs ────────────────────────────────────────────────────────

--- a/examples/embedded-app/src/theme-configurator/preview-manager.ts
+++ b/examples/embedded-app/src/theme-configurator/preview-manager.ts
@@ -1338,12 +1338,18 @@ export function createPreviewManager(
       // dimensions and downscale via the library's `scale` option. Nested
       // iframes (the cross-origin background preview) are excluded via a
       // tagName check — NOT instanceof, which always fails across realms.
+      //
+      // Backfill the (JPEG, no-alpha) canvas with the frame's own body
+      // background so dark previews aren't captured against white where the
+      // canvas shows through — e.g. behind the excluded background iframe.
+      const bodyBg = doc.defaultView?.getComputedStyle(doc.body).backgroundColor;
+      const bodyBgTransparent = !bodyBg || bodyBg === 'transparent' || bodyBg === 'rgba(0, 0, 0, 0)';
       const dataUrl = await domToJpeg(doc.body, {
         width: dims.w,
         height: dims.h,
         scale,
         quality: CAPTURE_JPEG_QUALITY,
-        backgroundColor: '#ffffff',
+        backgroundColor: bodyBgTransparent ? '#ffffff' : bodyBg,
         filter: (node) => (node as Element).tagName?.toUpperCase?.() !== 'IFRAME',
       });
 

--- a/examples/embedded-app/src/theme-configurator/preview-manager.ts
+++ b/examples/embedded-app/src/theme-configurator/preview-manager.ts
@@ -113,6 +113,18 @@ const STREAM_CHUNK_SIZE = 6;
 const STREAM_CHUNK_DELAY_MS = 80;
 const STREAM_INITIAL_DELAY_MS = 600;
 
+// Screenshot capture (screenshot_preview WebMCP tool). Downscaled JPEG keeps a
+// two-frame capture comfortably inside the tool-result payload budget the
+// /resume round-trip can carry (~150KB of base64).
+const CAPTURE_TARGET_WIDTH = 600;
+const CAPTURE_JPEG_QUALITY = 0.7;
+const CAPTURE_FRAME_LABELS: Record<string, string> = {
+  'preview-current': 'Current',
+  'preview-baseline': 'Baseline',
+  'preview-light': 'Light',
+  'preview-dark': 'Dark',
+};
+
 // ─── Test Helpers (re-exported) ─────────────────────────────────
 
 /**
@@ -282,6 +294,17 @@ const _embedCheckReasonCache = new Map<string, string>();
 
 export { CompareMode };
 
+export type PreviewCaptureFrame = {
+  mountId: string;
+  /** Human label matching the on-screen frame caption ('Current', 'Dark', …). */
+  label: string;
+  /** JPEG data URL (`data:image/jpeg;base64,...`). */
+  dataUrl: string;
+  /** Post-downscale pixel dimensions. */
+  width: number;
+  height: number;
+};
+
 export interface PreviewManager {
   /** Full mount / remount of the preview (initial or after structural change). */
   mount(): void;
@@ -303,6 +326,8 @@ export interface PreviewManager {
   highlightZone(zone: string): void;
   /** Remove any active zone highlight from all iframes. */
   clearHighlight(): void;
+  /** Capture each visible preview frame as a downscaled JPEG data URL. */
+  capturePreview(): Promise<PreviewCaptureFrame[]>;
   /** Clean up all resources. */
   destroy(): void;
 }
@@ -1280,6 +1305,59 @@ export function createPreviewManager(
     }
   }
 
+  async function capturePreviewFrames(): Promise<PreviewCaptureFrame[]> {
+    // Lazy import keeps the screenshot library off the editor's load path.
+    const { domToJpeg } = await import('modern-screenshot');
+
+    const iframes = (
+      Array.from(container.querySelectorAll('iframe[data-mount-id]')) as HTMLIFrameElement[]
+    )
+      .sort(
+        (a, b) =>
+          (a.dataset.mountId === 'preview-current' ? 0 : 1) -
+          (b.dataset.mountId === 'preview-current' ? 0 : 1)
+      )
+      .slice(0, 2);
+
+    const frames: PreviewCaptureFrame[] = [];
+    for (const iframe of iframes) {
+      const mountId = iframe.dataset.mountId;
+      const doc = iframe.contentDocument;
+      if (!mountId || !doc?.body) continue;
+
+      const wrapper = iframe.closest('.preview-iframe-wrapper') as HTMLElement | null;
+      const device = wrapper?.dataset.device ?? stateModule.getPreviewDevice();
+      const dims = DEVICE_DIMENSIONS[device] ?? DEVICE_DIMENSIONS.desktop;
+      const scale = Math.min(1, CAPTURE_TARGET_WIDTH / dims.w);
+
+      // Capture the iframe's body, not the widget mount: in floating/minimized
+      // scenes the widget is position:fixed in the body (the mount box is
+      // empty), and the body shows the widget in situ — shell, placement,
+      // launcher. The CSS scale() on the iframe element lives in the parent
+      // document and doesn't affect the inner DOM, so render at device
+      // dimensions and downscale via the library's `scale` option. Nested
+      // iframes (the cross-origin background preview) are excluded via a
+      // tagName check — NOT instanceof, which always fails across realms.
+      const dataUrl = await domToJpeg(doc.body, {
+        width: dims.w,
+        height: dims.h,
+        scale,
+        quality: CAPTURE_JPEG_QUALITY,
+        backgroundColor: '#ffffff',
+        filter: (node) => (node as Element).tagName?.toUpperCase?.() !== 'IFRAME',
+      });
+
+      frames.push({
+        mountId,
+        label: CAPTURE_FRAME_LABELS[mountId] ?? mountId,
+        dataUrl,
+        width: Math.round(dims.w * scale),
+        height: Math.round(dims.h * scale),
+      });
+    }
+    return frames;
+  }
+
   function doMount(preserveBackgroundStates = false): void {
     destroyPreviewControllers();
     lastMountedScene = stateModule.getPreviewScene();
@@ -1781,6 +1859,10 @@ export function createPreviewManager(
 
     clearHighlight(): void {
       applyHighlightZone(null);
+    },
+
+    capturePreview(): Promise<PreviewCaptureFrame[]> {
+      return capturePreviewFrames();
     },
 
     destroy(): void {

--- a/examples/embedded-app/src/theme-configurator/state.ts
+++ b/examples/embedded-app/src/theme-configurator/state.ts
@@ -3,7 +3,7 @@
  *  adds widget controller integration, localStorage persistence, and editor UI state.
  */
 
-import type { AgentWidgetConfig } from '@runtypelabs/persona';
+import type { AgentWidgetConfig, WebMcpConfirmInfo } from '@runtypelabs/persona';
 import type { PersonaTheme } from '@runtypelabs/persona';
 import {
   createAgentExperience,
@@ -31,10 +31,51 @@ const STORAGE_KEY = 'persona-widget-config-v2';
 const EDITOR_UI_STORAGE_KEY = 'persona-theme-editor-ui';
 
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+// The theme editor's preview widget is a *live* agent: it dispatches to the
+// theme-assistant flow (THEME_ASSISTANT_FLOW in @runtypelabs/persona-proxy),
+// which tool-calls the page's WebMCP theme tools to restyle the widget itself.
 const proxyUrl =
   import.meta.env.VITE_PROXY_URL
-    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
-    : `http://localhost:${proxyPort}/api/chat/dispatch`;
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-theme`
+    : `http://localhost:${proxyPort}/api/chat/dispatch-theme`;
+
+// Two wiring modes, same as the WebMCP demo:
+//   1. Client-token mode — set VITE_PERSONA_CLIENT_TOKEN (+ VITE_PERSONA_API_URL,
+//      the API base) to dispatch straight to a Runtype surface/agent whose prompt
+//      is the theme assistant. This is the path proven to round-trip webmcp tools.
+//   2. Proxy mode (default fallback) — dispatch to the local theme-assistant flow.
+const clientToken = import.meta.env.VITE_PERSONA_CLIENT_TOKEN as string | undefined;
+const clientApiBase = import.meta.env.VITE_PERSONA_API_URL as string | undefined;
+const connectionConfig: Pick<AgentWidgetConfig, 'apiUrl' | 'clientToken'> = clientToken
+  ? { clientToken, ...(clientApiBase ? { apiUrl: clientApiBase } : {}) }
+  : { apiUrl: proxyUrl };
+
+// The Theme Editor registers its controls as WebMCP tools on the page's
+// `document.modelContext` (see theme-configurator/webmcp/register.ts). Because the
+// preview widget is mounted by parent-realm code (its WebMCP bridge reads the
+// parent's global `document`, not the preview iframe's), it discovers those tools
+// directly — no cross-frame transport needed. Every theme tool is a safe, local
+// edit to the preview, so we auto-approve them all for a frictionless
+// "chat to restyle" loop instead of gating each color change behind a confirm.
+const THEME_TOOL_NAMES = new Set([
+  'get_theme_overview',
+  'set_brand_colors',
+  'assign_color_role',
+  'set_typography',
+  'set_roundness',
+  'set_color_scheme',
+  'apply_preset',
+  'configure_widget',
+  'set_copy_and_suggestions',
+  'set_theme_fields',
+  'check_contrast',
+  'manage_session',
+]);
+
+const THEME_WEBMCP_CONFIG: NonNullable<AgentWidgetConfig['webmcp']> = {
+  enabled: true,
+  autoApprove: (info: WebMcpConfirmInfo): boolean => THEME_TOOL_NAMES.has(info.toolName),
+};
 
 export type ParserType = 'plain' | 'json' | 'regex-json' | 'xml';
 const MB = 1024 * 1024;
@@ -42,7 +83,7 @@ const MB = 1024 * 1024;
 // ─── Default config builder ────────────────────────────────────────
 export const getDefaultConfig = (): AgentWidgetConfig => ({
   ...DEFAULT_WIDGET_CONFIG,
-  apiUrl: proxyUrl,
+  ...connectionConfig,
   parserType: 'plain',
   initialMessages: [
     {
@@ -260,6 +301,10 @@ export function buildPreviewConfig(
       suggestionChips: sanitizedSuggestionChips,
       theme: snapshot.theme,
       colorScheme,
+      // Live, self-styling preview: discover + call the page's theme tools.
+      // Injected here (not in core/persisted config) so the autoApprove function
+      // survives — functions can't round-trip through localStorage.
+      webmcp: THEME_WEBMCP_CONFIG,
     },
     scene
   );

--- a/examples/embedded-app/src/theme-configurator/state.ts
+++ b/examples/embedded-app/src/theme-configurator/state.ts
@@ -3,7 +3,7 @@
  *  adds widget controller integration, localStorage persistence, and editor UI state.
  */
 
-import type { AgentWidgetConfig, WebMcpConfirmInfo } from '@runtypelabs/persona';
+import type { AgentWidgetConfig } from '@runtypelabs/persona';
 import type { PersonaTheme } from '@runtypelabs/persona';
 import {
   createAgentExperience,
@@ -31,51 +31,10 @@ const STORAGE_KEY = 'persona-widget-config-v2';
 const EDITOR_UI_STORAGE_KEY = 'persona-theme-editor-ui';
 
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
-// The theme editor's preview widget is a *live* agent: it dispatches to the
-// theme-assistant flow (THEME_ASSISTANT_FLOW in @runtypelabs/persona-proxy),
-// which tool-calls the page's WebMCP theme tools to restyle the widget itself.
 const proxyUrl =
   import.meta.env.VITE_PROXY_URL
-    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-theme`
-    : `http://localhost:${proxyPort}/api/chat/dispatch-theme`;
-
-// Two wiring modes, same as the WebMCP demo:
-//   1. Client-token mode — set VITE_PERSONA_CLIENT_TOKEN (+ VITE_PERSONA_API_URL,
-//      the API base) to dispatch straight to a Runtype surface/agent whose prompt
-//      is the theme assistant. This is the path proven to round-trip webmcp tools.
-//   2. Proxy mode (default fallback) — dispatch to the local theme-assistant flow.
-const clientToken = import.meta.env.VITE_PERSONA_CLIENT_TOKEN as string | undefined;
-const clientApiBase = import.meta.env.VITE_PERSONA_API_URL as string | undefined;
-const connectionConfig: Pick<AgentWidgetConfig, 'apiUrl' | 'clientToken'> = clientToken
-  ? { clientToken, ...(clientApiBase ? { apiUrl: clientApiBase } : {}) }
-  : { apiUrl: proxyUrl };
-
-// The Theme Editor registers its controls as WebMCP tools on the page's
-// `document.modelContext` (see theme-configurator/webmcp/register.ts). Because the
-// preview widget is mounted by parent-realm code (its WebMCP bridge reads the
-// parent's global `document`, not the preview iframe's), it discovers those tools
-// directly — no cross-frame transport needed. Every theme tool is a safe, local
-// edit to the preview, so we auto-approve them all for a frictionless
-// "chat to restyle" loop instead of gating each color change behind a confirm.
-const THEME_TOOL_NAMES = new Set([
-  'get_theme_overview',
-  'set_brand_colors',
-  'assign_color_role',
-  'set_typography',
-  'set_roundness',
-  'set_color_scheme',
-  'apply_preset',
-  'configure_widget',
-  'set_copy_and_suggestions',
-  'set_theme_fields',
-  'check_contrast',
-  'manage_session',
-]);
-
-const THEME_WEBMCP_CONFIG: NonNullable<AgentWidgetConfig['webmcp']> = {
-  enabled: true,
-  autoApprove: (info: WebMcpConfirmInfo): boolean => THEME_TOOL_NAMES.has(info.toolName),
-};
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
+    : `http://localhost:${proxyPort}/api/chat/dispatch`;
 
 export type ParserType = 'plain' | 'json' | 'regex-json' | 'xml';
 const MB = 1024 * 1024;
@@ -83,7 +42,7 @@ const MB = 1024 * 1024;
 // ─── Default config builder ────────────────────────────────────────
 export const getDefaultConfig = (): AgentWidgetConfig => ({
   ...DEFAULT_WIDGET_CONFIG,
-  ...connectionConfig,
+  apiUrl: proxyUrl,
   parserType: 'plain',
   initialMessages: [
     {
@@ -301,10 +260,6 @@ export function buildPreviewConfig(
       suggestionChips: sanitizedSuggestionChips,
       theme: snapshot.theme,
       colorScheme,
-      // Live, self-styling preview: discover + call the page's theme tools.
-      // Injected here (not in core/persisted config) so the autoApprove function
-      // survives — functions can't round-trip through localStorage.
-      webmcp: THEME_WEBMCP_CONFIG,
     },
     scene
   );

--- a/examples/embedded-app/src/theme-configurator/webmcp/register.ts
+++ b/examples/embedded-app/src/theme-configurator/webmcp/register.ts
@@ -8,17 +8,25 @@
  */
 
 import { createThemeEditorTools } from '@runtypelabs/persona/theme-editor';
-import type { ThemeEditorLike } from '@runtypelabs/persona/theme-editor';
+import type { ThemeEditorLike, WebMcpTool } from '@runtypelabs/persona/theme-editor';
 import { ensureModelContext } from './install';
 
-export function mountThemeEditorMcp(state: ThemeEditorLike): () => void {
+export interface MountThemeEditorMcpOptions {
+  /** Page-level tools registered alongside the theme tools (e.g. screenshot_preview). */
+  extraTools?: WebMcpTool[];
+}
+
+export function mountThemeEditorMcp(
+  state: ThemeEditorLike,
+  options?: MountThemeEditorMcpOptions
+): () => void {
   const controller = new AbortController();
 
   void (async () => {
     const modelContext = await ensureModelContext();
     if (!modelContext || controller.signal.aborted) return;
 
-    const tools = createThemeEditorTools(state);
+    const tools = [...createThemeEditorTools(state), ...(options?.extraTools ?? [])];
     for (const tool of tools) {
       modelContext.registerTool(tool, { signal: controller.signal });
     }

--- a/examples/embedded-app/src/theme-configurator/webmcp/register.ts
+++ b/examples/embedded-app/src/theme-configurator/webmcp/register.ts
@@ -16,13 +16,25 @@ export interface MountThemeEditorMcpOptions {
   extraTools?: WebMcpTool[];
 }
 
+export interface ThemeEditorMcpHandle {
+  /**
+   * Resolves once every tool is registered on `document.modelContext` (or
+   * registration was skipped — no model context / already unmounted). Gate
+   * agent mounting on this so a first dispatch never races the registration
+   * and ships an empty clientTools list.
+   */
+  ready: Promise<void>;
+  /** Abort the registration signal, unregistering all tools. */
+  unmount: () => void;
+}
+
 export function mountThemeEditorMcp(
   state: ThemeEditorLike,
   options?: MountThemeEditorMcpOptions
-): () => void {
+): ThemeEditorMcpHandle {
   const controller = new AbortController();
 
-  void (async () => {
+  const ready = (async () => {
     const modelContext = await ensureModelContext();
     if (!modelContext || controller.signal.aborted) return;
 
@@ -33,5 +45,5 @@ export function mountThemeEditorMcp(
     console.info(`[persona] Registered ${tools.length} theme-editor WebMCP tools.`);
   })();
 
-  return () => controller.abort();
+  return { ready, unmount: () => controller.abort() };
 }

--- a/examples/embedded-app/src/theme-configurator/webmcp/screenshot-tool.ts
+++ b/examples/embedded-app/src/theme-configurator/webmcp/screenshot-tool.ts
@@ -1,0 +1,61 @@
+/**
+ * `screenshot_preview` — example-local WebMCP tool that captures the rendered
+ * theme preview and returns it to the agent as MCP image content blocks.
+ *
+ * Lives in the example (not the widget package's tool factory) on purpose: the
+ * factory is headless and DOM-free, while this tool needs the live preview
+ * manager and the `modern-screenshot` dependency. It closes the visual loop
+ * for the Theme Copilot — apply theme tools, screenshot, compare against the
+ * user's reference image, refine.
+ */
+
+import type { WebMcpTool, ToolContent } from '@runtypelabs/persona/theme-editor';
+import type { PreviewManager } from '../preview-manager';
+
+export function createScreenshotPreviewTool(
+  getPreviewManager: () => PreviewManager | null
+): WebMcpTool {
+  return {
+    name: 'screenshot_preview',
+    title: 'Screenshot the preview',
+    description:
+      'Capture the current rendered state of the theme preview as an image — exactly what the user sees. ' +
+      'Returns one JPEG per visible preview frame (two when a compare mode is active, labeled e.g. Light/Dark). ' +
+      'Call after applying a batch of theme changes to verify the visual result, especially when matching a reference image.',
+    inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+    annotations: { readOnlyHint: true },
+    async execute() {
+      const previewManager = getPreviewManager();
+      if (!previewManager) {
+        return {
+          isError: true,
+          content: [{ type: 'text' as const, text: 'Preview is not mounted; nothing to capture.' }],
+        };
+      }
+
+      const frames = await previewManager.capturePreview();
+      if (frames.length === 0) {
+        return {
+          isError: true,
+          content: [{ type: 'text' as const, text: 'No preview frames available to capture.' }],
+        };
+      }
+
+      // Built by hand rather than via the `toolResult()` helper: that helper
+      // mirrors the payload into `structuredContent`, which would double
+      // ~100KB of base64 in the /resume round-trip.
+      const content: ToolContent[] = [
+        {
+          type: 'text',
+          text: `Captured ${frames.map((f) => `${f.label} (${f.width}x${f.height})`).join(', ')}.`,
+        },
+        ...frames.map((f) => ({
+          type: 'image' as const,
+          data: f.dataUrl.slice(f.dataUrl.indexOf(',') + 1),
+          mimeType: 'image/jpeg',
+        })),
+      ];
+      return { content };
+    },
+  };
+}

--- a/examples/embedded-app/theme.html
+++ b/examples/embedded-app/theme.html
@@ -14,6 +14,10 @@
       class="config-drawer-backdrop"
       aria-hidden="true"
     ></div>
+    <!-- Dock target for the Theme Copilot sidebar: the docked widget shell
+         wraps this element's children and squeezes the editor layout when the
+         copilot opens (reveal: emerge). -->
+    <div id="theme-copilot-dock-target" class="theme-copilot-dock-target">
     <main class="configurator-layout">
       <header class="mobile-editor-toolbar" aria-label="Theme editor">
         <div class="mobile-editor-toolbar-start">
@@ -153,6 +157,18 @@
             </button>
           </div>
           <div class="preview-toolbar-trail">
+            <button
+              type="button"
+              id="theme-copilot-toggle"
+              class="preview-pill-btn theme-copilot-toggle"
+              aria-expanded="false"
+              title="Open Theme Copilot — chat to restyle the preview"
+            >
+              <span class="preview-pill-theme-icon" aria-hidden="true">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9.937 15.5A2 2 0 0 0 8.5 14.063l-6.135-1.582a.5.5 0 0 1 0-.962L8.5 9.936A2 2 0 0 0 9.937 8.5l1.582-6.135a.5.5 0 0 1 .963 0L14.063 8.5A2 2 0 0 0 15.5 9.937l6.135 1.581a.5.5 0 0 1 0 .964L15.5 14.063a2 2 0 0 0-1.437 1.437l-1.582 6.135a.5.5 0 0 1-.963 0z"/></svg>
+              </span>
+              Copilot
+            </button>
             <div class="preview-pill-wrapper">
               <button id="preview-pill-btn" class="preview-pill-btn" type="button">
                 <span id="preview-pill-scene">Conversation</span>
@@ -300,6 +316,7 @@
         </div>
       </section>
     </main>
+    </div>
 
     <div id="wizard-overlay" class="wizard-overlay hidden">
       <div class="wizard-dialog">

--- a/examples/vercel-edge/.env.example
+++ b/examples/vercel-edge/.env.example
@@ -1,11 +1,21 @@
 # Copy this file to .env and fill in your actual values
 # .env is gitignored and used for local development
 
+# Required: Runtype API key the proxy uses to authenticate upstream dispatch.
+RUNTYPE_API_KEY=rt_your_api_key_here
+
 # Optional: Port for the server (defaults to 43111)
 # PORT=43111
 
-# Optional: Port for the server (defaults to https://api.runtype.com/v1/dispatch)
-# UPSTREAM_URL=https://api.myserver.com/v1/dispatch
+# Optional: upstream dispatch endpoint (defaults to https://api.runtype.com/v1/dispatch).
+# The theme-editor WebMCP tool-calling round-trip (dispatch clientTools[] → step_await
+# → /resume) is currently proven against staging — point here if prod virtual-flow
+# dispatch doesn't yet tool-call clientTools:
+# UPSTREAM_URL=https://api.runtype-staging.com/v1/dispatch
+
+# Optional: pin the theme assistant to an existing Runtype flow id instead of the
+# bundled THEME_ASSISTANT_FLOW config.
+# FLOW_ID_THEME_ASSISTANT=flow_your_theme_assistant_flow_id_here
 
 # Optional: Flow IDs for specific chat endpoints
 # If set, these will be used instead of the hardcoded flow configurations

--- a/examples/vercel-edge/.env.example
+++ b/examples/vercel-edge/.env.example
@@ -8,13 +8,11 @@ RUNTYPE_API_KEY=rt_your_api_key_here
 # PORT=43111
 
 # Optional: upstream dispatch endpoint (defaults to https://api.runtype.com/v1/dispatch).
-# The theme-editor WebMCP tool-calling round-trip (dispatch clientTools[] → step_await
-# → /resume) is currently proven against staging — point here if prod virtual-flow
-# dispatch doesn't yet tool-call clientTools:
 # UPSTREAM_URL=https://api.runtype-staging.com/v1/dispatch
 
-# Optional: pin the theme assistant to an existing Runtype flow id instead of the
-# bundled THEME_ASSISTANT_FLOW config.
+# Optional: pin the Theme Copilot to an existing Runtype flow id instead of the
+# bundled THEME_ASSISTANT_FLOW config. The flow's model must emit native tool
+# calls and accept image input (reference images + screenshot_preview results).
 # FLOW_ID_THEME_ASSISTANT=flow_your_theme_assistant_flow_id_here
 
 # Optional: Flow IDs for specific chat endpoints

--- a/examples/vercel-edge/api/index.ts
+++ b/examples/vercel-edge/api/index.ts
@@ -11,6 +11,7 @@ import {
   WEBMCP_SLIDES_FLOW,
   WEBMCP_DOCKED_FLOW,
   PAGE_CONTEXT_FLOW,
+  THEME_ASSISTANT_FLOW,
   createCheckoutSession,
 } from "@runtypelabs/persona-proxy";
 
@@ -116,6 +117,15 @@ const pageContextApp = createChatProxyApp({
   upstreamUrl,
 });
 
+// Theme Copilot proxy - for the Theme Editor's docked styling copilot.
+const themeAssistantApp = createChatProxyApp({
+  path: "/api/chat/dispatch-theme",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_THEME_ASSISTANT || undefined,
+  flowConfig: process.env.FLOW_ID_THEME_ASSISTANT ? undefined : THEME_ASSISTANT_FLOW,
+  upstreamUrl,
+});
+
 app.route("/", directiveApp);
 app.route("/", actionApp);
 app.route("/", componentApp);
@@ -126,6 +136,7 @@ app.route("/", webmcpCalendarApp);
 app.route("/", webmcpSlidesApp);
 app.route("/", webmcpDockedApp);
 app.route("/", pageContextApp);
+app.route("/", themeAssistantApp);
 
 app.post("/api/checkout", async (c) => {
   const origin = c.req.header("origin");

--- a/examples/vercel-edge/src/server.ts
+++ b/examples/vercel-edge/src/server.ts
@@ -13,6 +13,7 @@ import {
   WEBMCP_SLIDES_FLOW,
   WEBMCP_DOCKED_FLOW,
   PAGE_CONTEXT_FLOW,
+  THEME_ASSISTANT_FLOW,
   createCheckoutSession
 } from "@runtypelabs/persona-proxy";
 
@@ -148,6 +149,19 @@ const pageContextApp = createChatProxyApp({
   upstreamUrl
 });
 
+// Theme-assistant proxy — for the Persona Theme Editor's live, self-styling widget.
+// The Theme Editor registers its controls as WebMCP tools on document.modelContext;
+// the widget ships them as clientTools[] and the agent calls them (webmcp:*) to
+// restyle the very widget the user is chatting with. Tool-calling flow (not an
+// action envelope), so it relies on clientTools forwarding + /resume.
+const themeAssistantApp = createChatProxyApp({
+  path: "/api/chat/dispatch-theme",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_THEME_ASSISTANT || undefined,
+  flowConfig: process.env.FLOW_ID_THEME_ASSISTANT ? undefined : THEME_ASSISTANT_FLOW,
+  upstreamUrl
+});
+
 // Mount all apps
 app.route("/", directiveApp);
 app.route("/", actionApp);
@@ -159,6 +173,7 @@ app.route("/", webmcpCalendarApp);
 app.route("/", webmcpSlidesApp);
 app.route("/", webmcpDockedApp);
 app.route("/", pageContextApp);
+app.route("/", themeAssistantApp);
 
 // Stripe checkout endpoint
 // Uses the shared createCheckoutSession helper from @runtypelabs/persona-proxy

--- a/examples/vercel-edge/src/server.ts
+++ b/examples/vercel-edge/src/server.ts
@@ -149,11 +149,12 @@ const pageContextApp = createChatProxyApp({
   upstreamUrl
 });
 
-// Theme-assistant proxy — for the Persona Theme Editor's live, self-styling widget.
-// The Theme Editor registers its controls as WebMCP tools on document.modelContext;
-// the widget ships them as clientTools[] and the agent calls them (webmcp:*) to
-// restyle the very widget the user is chatting with. Tool-calling flow (not an
-// action envelope), so it relies on clientTools forwarding + /resume.
+// Theme-assistant proxy — for the Theme Editor's docked Theme Copilot.
+// The Theme Editor registers its controls (plus screenshot_preview) as WebMCP
+// tools on document.modelContext; the copilot widget ships them as clientTools[]
+// and the agent calls them (webmcp:*) to restyle the live theme preview.
+// Tool-calling flow (not an action envelope), so it relies on clientTools
+// forwarding + /resume — including image blocks in screenshot tool results.
 const themeAssistantApp = createChatProxyApp({
   path: "/api/chat/dispatch-theme",
   allowedOrigins,

--- a/packages/proxy/src/flows/index.ts
+++ b/packages/proxy/src/flows/index.ts
@@ -16,3 +16,4 @@ export { WEBMCP_CALENDAR_FLOW } from "./webmcp-calendar.js";
 export { WEBMCP_SLIDES_FLOW } from "./webmcp-slides.js";
 export { WEBMCP_DOCKED_FLOW } from "./webmcp-docked.js";
 export { PAGE_CONTEXT_FLOW } from "./page-context.js";
+export { THEME_ASSISTANT_FLOW } from "./theme-assistant.js";

--- a/packages/proxy/src/flows/theme-assistant.ts
+++ b/packages/proxy/src/flows/theme-assistant.ts
@@ -1,15 +1,19 @@
 import type { RuntypeFlowConfig } from "../index.js";
 
 /**
- * Theme-assistant flow for the Persona Theme Editor's live, self-styling widget.
+ * Theme-assistant flow for the Persona Theme Editor's docked **Theme Copilot**.
  *
  * Unlike the storefront / page-context flows (which emit an action *envelope*
  * the host interprets), this flow is a real tool-calling agent: the Theme Editor
- * page registers its theme-editor controls as WebMCP tools on
- * `document.modelContext`, the widget snapshots them onto `dispatch.clientTools[]`,
- * and the upstream agent calls them as `webmcp:<name>`. Each call mutates the
- * editor's live state, which re-themes the very widget the user is chatting with
- * — so the assistant visibly restyles *itself* as the conversation goes.
+ * page registers its theme controls (plus a `screenshot_preview` capture tool)
+ * as WebMCP tools on `document.modelContext`, the copilot widget snapshots them
+ * onto `dispatch.clientTools[]`, and the upstream agent calls them as
+ * `webmcp:<name>`. Each call mutates the editor's live state, restyling the
+ * theme **preview** on the page while the copilot's own panel stays unchanged.
+ *
+ * Multi-modal: the copilot accepts pasted reference images (a screenshot of
+ * another site's chat widget) and closes the loop visually — apply theme tools,
+ * call `screenshot_preview` to see the rendered preview, compare, refine.
  *
  * The agent never renders JSON or describes the tooling to the user; it just
  * chats and calls tools. Responses are short, conversational markdown.
@@ -17,7 +21,7 @@ import type { RuntypeFlowConfig } from "../index.js";
 export const THEME_ASSISTANT_FLOW: RuntypeFlowConfig = {
   name: "Theme Assistant Flow",
   description:
-    "Self-styling Persona assistant — restyles the live widget by calling the Theme Editor's WebMCP tools.",
+    "Theme Copilot — restyles the Theme Editor's live preview by calling the page's WebMCP theme tools, with image-reference matching.",
   steps: [
     {
       id: "theme_assistant_prompt",
@@ -25,24 +29,25 @@ export const THEME_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        // The model MUST emit *native* structured tool calls for the
-        // page-discovered `clientTools[]` — otherwise the WebMCP round-trip never
-        // fires. Verified live (client-token → agent, staging): `minimax-m2.7`
-        // calls them natively and restyles the widget; `claude-sonnet-4-6`
-        // emitted the calls as plain `<function_calls>` text that never executed.
-        // If you swap models, confirm native tool-calling first.
-        model: "general-compute/minimax-m2.7",
+        // Needs BOTH native structured tool calls (for the page-discovered
+        // `clientTools[]` — text-emitted calls never execute) AND vision (the
+        // user pastes reference images; screenshot_preview returns image
+        // blocks). This is why it diverges from the other flows'
+        // `nemotron-3-ultra-550b-a55b`: the platform catalog tags nemotron
+        // ultra as tool-use but NOT vision, which would silently break the
+        // reference-image loop. If you swap models, confirm both first.
+        model: "gemini-3.5-flash",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",
-        systemPrompt: `You are the **Persona Theme Assistant** — a chat widget embedded inside the Persona Theme Editor. The catch: the widget the user is chatting with *is* the widget being themed. When you change the theme, you visibly restyle **yourself** in real time.
+        systemPrompt: `You are the **Theme Copilot** — a sidebar assistant docked inside the Persona Theme Editor. The widget being styled is the **preview on the page beside you**, not you: your own panel never changes. Every tool call you make restyles that preview instantly, and the user is watching it as you work. There is no separate "save" — each change takes effect immediately and lands on the editor's undo stack.
 
-This page exposes its theme controls to you as tools (discovered live from the page — you'll see them as \`webmcp:*\` tools). Calling them edits the editor's state, updates the preview, and re-skins this very conversation. There is no separate "save" — every tool call takes effect immediately.
+The page exposes its theme controls to you as tools (discovered live — you'll see them as \`webmcp:*\` tools). Always use the tools to read or change the theme; never claim a change you did not make with a tool this turn.
 
 ## How to work
 
-1. **Look before you leap.** On your first styling request in a session, call \`get_theme_overview\` to read the current colors, role assignments, typography, roundness, color scheme, and the list of presets. It also tells you which tools are available and what each does.
+1. **Look before you leap.** On your first styling request in a session, call \`get_theme_overview\` to read the current colors, role assignments, typography, roundness, color scheme, and the list of presets. Mutating tools return updated summaries and contrast warnings — chain on those instead of re-reading after every call.
 2. **Pick the most specific tool** for what the user asked, then call it. Prefer one well-aimed call over many:
    - Recolor the brand → \`set_brand_colors\` (primary / secondary / accent; each auto-expands to a full shade scale). Accepts hex, rgb(), or CSS color names.
    - Recolor one region (header, user messages, assistant messages, primary actions, input, links, borders, surfaces, scroll-to-bottom) → \`assign_color_role\` with a family (primary/secondary/accent/neutral) and intensity (solid/soft).
@@ -52,16 +57,53 @@ This page exposes its theme controls to you as tools (discovered live from the p
    - Launcher position, features, layout → \`configure_widget\`.
    - Welcome copy, input placeholder, suggestion chips → \`set_copy_and_suggestions\`.
    - Anything not covered above → \`set_theme_fields\` (escape hatch: set fields by id or dot-path; call \`get_theme_overview\` with verbosity "full" first to get the field index).
+   - See the preview exactly as the user does → \`screenshot_preview\`.
    - Audit legibility → \`check_contrast\`. Undo / redo / reset / export → \`manage_session\`.
-3. **Mind contrast.** The color tools return WCAG contrast warnings in their result. If a change risks unreadable text (e.g. light text on a light surface), fix it (adjust the role or intensity) or tell the user and offer a fix. Run \`check_contrast\` when you make a sweeping color change.
-4. **Confirm briefly.** After a tool succeeds, reply in one or two short sentences describing what changed ("Done — switched the brand to ocean blue and softened the header."). Don't dump the tool result, don't restate the whole theme.
+3. **Mind contrast.** The color tools return WCAG contrast warnings in their result. If a change risks unreadable text (e.g. light text on a light surface), fix it (adjust the role or intensity) or tell the user and offer a fix. Run \`check_contrast\` after a sweeping color change.
+4. **Confirm briefly.** After your tool calls resolve, reply in one or two short sentences describing what changed ("Done — switched the brand to ocean blue and softened the header."). The user can see the preview, so don't re-describe it in detail, don't dump tool results, don't restate the whole theme.
+
+## Matching a reference image
+
+When the user pastes or attaches a screenshot of a chat widget (or site) they want the preview to match:
+
+1. **Extract a spec first.** Read the image and commit to concrete values: primary / secondary / accent colors as hex, the neutral/surface tone, corner radius tier (sharp / default / rounded / pill), typography vibe (sans/serif/mono, weight), and whether it's a light or dark design. State the spec in one sentence so the user can correct you.
+2. **Apply it as one batch:** \`set_brand_colors\`, then \`assign_color_role\` for regions that need explicit treatment (header, user messages, primary actions), then \`set_roundness\` and \`set_typography\`, and \`set_color_scheme\` if the reference is dark.
+3. **Verify visually.** Call \`screenshot_preview\` once and compare the result against the reference: palette, corner radii, message-bubble treatment, overall weight.
+4. **Refine within budget.** At most TWO refinement rounds, each at most 3 targeted mutations followed by one \`screenshot_preview\`. Then STOP and report: what matches, what intentionally differs (Persona's layout is its own — you are matching style, not cloning the widget), and one offer to push further. Never loop silently past the budget.
+
+## Screenshot etiquette
+
+- Call \`screenshot_preview\` after a meaningful batch of changes, when the user asks how it looks, or to verify a reference match — not after every single tool call, and never twice in a row without an intervening edit.
+- The screenshot is ground truth over your assumptions about how tokens render. If it contradicts what you expected, trust the screenshot.
+- It captures the preview (both frames when the editor is in a compare mode), never your own panel.
+
+## Style passes ("make it pop", "more modern", "warmer")
+
+Vague restyle requests mean a SMALL, focused pass — not a rebuild and not a decoration spree:
+
+- Read the theme with \`get_theme_overview\`, then budget yourself: at most 4-5 mutations total for the whole request.
+- Prefer adjusting what's already there — strengthen the accent, soften the corners, rebalance one or two color roles — over re-assigning every region.
+- Then STOP and summarize the change in a sentence, offering one direction to push further (e.g. "Want it bolder? I can darken the header and sharpen the corners.").
+
+If you catch yourself queueing mutation after mutation, stop and check in instead — the runtime cuts the turn off mid-tool-call and the user is left with a half-finished restyle and no explanation.
+
+## Acting vs. claiming (critical)
+
+- You can only change the preview by calling a tool. Text alone changes nothing.
+- Never say you recolored, restyled, or reconfigured anything unless a tool call you made IN THIS TURN returned a success result. If you have not called the tool yet, call it now instead of replying.
+- Earlier "Done — …" messages in this conversation report past turns' tool results — they are not a template to imitate. Every new styling request requires fresh tool calls this turn.
+- If the user sends a bare confirmation ("do it", "yes", "go ahead"):
+  - If your last reply proposed a change you did NOT execute, execute it now with tools.
+  - If the change already completed last turn, verify with \`get_theme_overview\` (or \`screenshot_preview\`) and say it is already applied — do not re-announce it as a new action.
+- When unsure whether a change landed, check with a read tool before confirming.
 
 ## Style
 
 - Calm, concise, design-literate. No hype, minimal exclamation points.
 - Never explain JSON, tools, WebMCP, or "the editor state" to the user — just do the work and describe the visible result.
-- If a request is ambiguous (e.g. "make it pop"), make a tasteful concrete choice and say what you did; offer to adjust. Don't stall with clarifying questions for simple aesthetic asks.
-- If the user asks something unrelated to theming the widget, answer briefly but steer back to what you can restyle.`,
+- If a request is ambiguous, make a tasteful concrete choice and say what you did; offer to adjust. Don't stall with clarifying questions for simple aesthetic asks.
+- Every change is undoable (\`manage_session\`, or the editor's own undo) — don't be precious about edits.
+- If the user asks something unrelated to theming the preview, answer briefly but steer back to what you can restyle.`,
         previousMessages: "{{messages}}",
       },
     },

--- a/packages/proxy/src/flows/theme-assistant.ts
+++ b/packages/proxy/src/flows/theme-assistant.ts
@@ -1,0 +1,69 @@
+import type { RuntypeFlowConfig } from "../index.js";
+
+/**
+ * Theme-assistant flow for the Persona Theme Editor's live, self-styling widget.
+ *
+ * Unlike the storefront / page-context flows (which emit an action *envelope*
+ * the host interprets), this flow is a real tool-calling agent: the Theme Editor
+ * page registers its theme-editor controls as WebMCP tools on
+ * `document.modelContext`, the widget snapshots them onto `dispatch.clientTools[]`,
+ * and the upstream agent calls them as `webmcp:<name>`. Each call mutates the
+ * editor's live state, which re-themes the very widget the user is chatting with
+ * — so the assistant visibly restyles *itself* as the conversation goes.
+ *
+ * The agent never renders JSON or describes the tooling to the user; it just
+ * chats and calls tools. Responses are short, conversational markdown.
+ */
+export const THEME_ASSISTANT_FLOW: RuntypeFlowConfig = {
+  name: "Theme Assistant Flow",
+  description:
+    "Self-styling Persona assistant — restyles the live widget by calling the Theme Editor's WebMCP tools.",
+  steps: [
+    {
+      id: "theme_assistant_prompt",
+      name: "Theme Assistant Prompt",
+      type: "prompt",
+      enabled: true,
+      config: {
+        // The model MUST emit *native* structured tool calls for the
+        // page-discovered `clientTools[]` — otherwise the WebMCP round-trip never
+        // fires. Verified live (client-token → agent, staging): `minimax-m2.7`
+        // calls them natively and restyles the widget; `claude-sonnet-4-6`
+        // emitted the calls as plain `<function_calls>` text that never executed.
+        // If you swap models, confirm native tool-calling first.
+        model: "general-compute/minimax-m2.7",
+        reasoning: false,
+        responseFormat: "markdown",
+        outputVariable: "prompt_result",
+        userPrompt: "{{user_message}}",
+        systemPrompt: `You are the **Persona Theme Assistant** — a chat widget embedded inside the Persona Theme Editor. The catch: the widget the user is chatting with *is* the widget being themed. When you change the theme, you visibly restyle **yourself** in real time.
+
+This page exposes its theme controls to you as tools (discovered live from the page — you'll see them as \`webmcp:*\` tools). Calling them edits the editor's state, updates the preview, and re-skins this very conversation. There is no separate "save" — every tool call takes effect immediately.
+
+## How to work
+
+1. **Look before you leap.** On your first styling request in a session, call \`get_theme_overview\` to read the current colors, role assignments, typography, roundness, color scheme, and the list of presets. It also tells you which tools are available and what each does.
+2. **Pick the most specific tool** for what the user asked, then call it. Prefer one well-aimed call over many:
+   - Recolor the brand → \`set_brand_colors\` (primary / secondary / accent; each auto-expands to a full shade scale). Accepts hex, rgb(), or CSS color names.
+   - Recolor one region (header, user messages, assistant messages, primary actions, input, links, borders, surfaces, scroll-to-bottom) → \`assign_color_role\` with a family (primary/secondary/accent/neutral) and intensity (solid/soft).
+   - Fonts → \`set_typography\`. Corners → \`set_roundness\` (sharp/default/rounded/pill, or granular radii).
+   - Light vs dark, or which variant your edits target → \`set_color_scheme\`.
+   - "Make it look like X" / a full restyle → \`apply_preset\` (use a preset id from \`get_theme_overview\`).
+   - Launcher position, features, layout → \`configure_widget\`.
+   - Welcome copy, input placeholder, suggestion chips → \`set_copy_and_suggestions\`.
+   - Anything not covered above → \`set_theme_fields\` (escape hatch: set fields by id or dot-path; call \`get_theme_overview\` with verbosity "full" first to get the field index).
+   - Audit legibility → \`check_contrast\`. Undo / redo / reset / export → \`manage_session\`.
+3. **Mind contrast.** The color tools return WCAG contrast warnings in their result. If a change risks unreadable text (e.g. light text on a light surface), fix it (adjust the role or intensity) or tell the user and offer a fix. Run \`check_contrast\` when you make a sweeping color change.
+4. **Confirm briefly.** After a tool succeeds, reply in one or two short sentences describing what changed ("Done — switched the brand to ocean blue and softened the header."). Don't dump the tool result, don't restate the whole theme.
+
+## Style
+
+- Calm, concise, design-literate. No hype, minimal exclamation points.
+- Never explain JSON, tools, WebMCP, or "the editor state" to the user — just do the work and describe the visible result.
+- If a request is ambiguous (e.g. "make it pop"), make a tasteful concrete choice and say what you did; offer to adjust. Don't stall with clarifying questions for simple aesthetic asks.
+- If the user asks something unrelated to theming the widget, answer briefly but steer back to what you can restyle.`,
+        previousMessages: "{{messages}}",
+      },
+    },
+  ],
+};

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -202,6 +202,28 @@ export class AgentWidgetClient {
   }
 
   /**
+   * Refresh config in place WITHOUT tearing down the live connection or the
+   * WebMCP bridge. `AgentWidgetSession.updateConfig` calls this when only
+   * connection-irrelevant fields changed (theme, copy, layout, suggestions, …),
+   * so a UI update that lands mid-turn — e.g. a `webmcp:*` tool restyling the
+   * widget while the agent's turn is still streaming — doesn't abandon the
+   * in-flight stream/resume. Connection or request-shaping changes (apiUrl,
+   * clientToken, webmcp, headers, parser, …) take the full client rebuild path
+   * in the session instead, which is the only place the bridge is recreated.
+   *
+   * Only the live-read `config` is refreshed (e.g. `iterationDisplay`); the
+   * constructor-derived request-shaping fields (apiUrl, headers, parser,
+   * contextProviders, middleware, …) are left untouched because the session
+   * routes any change to those down the full-rebuild path instead — so they are
+   * guaranteed unchanged here. The `webMcpBridge` instance and its
+   * installed-polyfill memo are deliberately preserved, which keeps any
+   * in-flight resolve alive.
+   */
+  public updateConfig(next: AgentWidgetConfig): void {
+    this.config = next;
+  }
+
+  /**
    * Set callback for capturing raw SSE events
    */
   public setSSEEventCallback(callback: SSEEventCallback): void {

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -40,6 +40,49 @@ export type AgentWidgetSessionStatus =
   | "connected"
   | "error";
 
+/**
+ * Config fields the `AgentWidgetClient` reads to shape the connection and each
+ * request. When NONE of these change, `updateConfig` can refresh the live
+ * client in place (preserving the WebMCP bridge and any in-flight stream/resume)
+ * instead of swapping in a fresh client and tearing down WebMCP state. Fields
+ * outside this list (theme, copy, layout, suggestionChips, iterationDisplay,
+ * postprocessMessage, feature display toggles, …) are display-only and safe to
+ * apply mid-turn — which is what a self-styling widget needs when a `webmcp:*`
+ * theme tool re-renders the widget while the agent's turn is still streaming.
+ *
+ * Compared by identity (`!==`): primitives by value, functions/objects by
+ * reference. A consumer that rebuilds these objects on every render simply
+ * takes the (still-correct) full-rebuild path. The default is therefore safe:
+ * anything not explicitly listed here can never strand a paused turn.
+ */
+const CONNECTION_CONFIG_KEYS = [
+  "apiUrl",
+  "clientToken",
+  "flowId",
+  "agent",
+  "agentOptions",
+  "headers",
+  "getHeaders",
+  "webmcp",
+  "streamParser",
+  "parserType",
+  "contextProviders",
+  "requestMiddleware",
+  "customFetch",
+  "parseSSEEvent",
+  "onSessionInit",
+  "onSessionExpired",
+  "getStoredSessionId",
+  "setStoredSessionId",
+] as const satisfies ReadonlyArray<keyof AgentWidgetConfig>;
+
+function connectionConfigChanged(
+  prev: AgentWidgetConfig,
+  next: AgentWidgetConfig,
+): boolean {
+  return CONNECTION_CONFIG_KEYS.some((key) => prev[key] !== next[key]);
+}
+
 type SessionCallbacks = {
   onMessagesChanged: (messages: AgentWidgetMessage[]) => void;
   onStatusChanged: (status: AgentWidgetSessionStatus) => void;
@@ -615,6 +658,21 @@ export class AgentWidgetSession {
   }
 
   public updateConfig(next: AgentWidgetConfig) {
+    const merged = { ...this.config, ...next };
+
+    // Connection/request-shaping change (apiUrl, clientToken, webmcp, headers,
+    // parser, agent, …) → full client rebuild. UI-only change (theme, copy,
+    // layout, suggestions, …) → refresh in place so the live stream, WebMCP
+    // bridge, and any in-flight resolve survive. The latter is what makes a
+    // self-styling widget work: a `webmcp:*` theme tool mutates config and
+    // re-renders mid-turn; recreating the client there would abort the very
+    // turn that's restyling the widget and strand the paused execution.
+    if (!connectionConfigChanged(this.config, merged)) {
+      this.config = merged;
+      this.client.updateConfig(merged);
+      return;
+    }
+
     // Replacing the client invalidates every in-flight WebMCP resolve, buffered
     // parallel-await batch, and pending approval bubble tied to the OLD client/
     // session. Tear them down BEFORE the swap (the new client has no session
@@ -626,7 +684,7 @@ export class AgentWidgetSession {
     this.webMcpInflightKeys.clear();
     this.webMcpResolvedKeys.clear();
     const prevSSECallback = this.client.getSSEEventCallback();
-    this.config = { ...this.config, ...next };
+    this.config = merged;
     this.client = new AgentWidgetClient(this.config);
     this.wireDefaultWebMcpConfirm();
     if (prevSSECallback) {

--- a/packages/widget/src/session.webmcp.test.ts
+++ b/packages/widget/src/session.webmcp.test.ts
@@ -1075,6 +1075,54 @@ describe("AgentWidgetSession — WebMCP parallel batched resume (core#3878)", ()
     expect(s.webMcpApprovalResolvers.size).toBe(0);
   });
 
+  it("a UI-only updateConfig preserves the client, bridge, and in-flight WebMCP state", async () => {
+    // Self-styling widget: a `webmcp:*` theme tool mutates config and re-renders
+    // mid-turn. updateConfig must NOT swap the client when only display fields
+    // (theme/copy/…) change — doing so would abort the very turn that's
+    // restyling the widget and strand the paused execution. (Inverse of the
+    // teardown test above.)
+    const { session } = makeSession();
+    const s = session as unknown as {
+      client: unknown;
+      config: { copy?: { welcomeTitle?: string } };
+      webMcpAwaitBatches: Map<string, unknown>;
+      webMcpApprovalResolvers: Map<string, unknown>;
+    };
+    const clientBefore = s.client;
+    feed(session, parallelAwait("toolu_A", "SHOE-001"));
+    feed(session, parallelAwait("toolu_B", "SHOE-007"));
+    session.requestWebMcpApproval({
+      toolName: "add_to_cart",
+      args: { sku: "SHOE-001" },
+    } as WebMcpConfirmInfo);
+    expect(s.webMcpAwaitBatches.size).toBe(1);
+    expect(s.webMcpApprovalResolvers.size).toBe(1);
+
+    // No apiUrl / webmcp in the patch → connection unchanged → in-place refresh.
+    session.updateConfig({ copy: { welcomeTitle: "Recolored" } });
+
+    expect(s.client).toBe(clientBefore); // same client instance, not swapped
+    expect(s.config.copy?.welcomeTitle).toBe("Recolored"); // display change applied
+    expect(s.webMcpAwaitBatches.size).toBe(1); // batch survives
+    expect(s.webMcpApprovalResolvers.size).toBe(1); // approval still pending
+  });
+
+  it("a connection change (apiUrl) still swaps the client and tears down WebMCP state", () => {
+    const { session } = makeSession();
+    const s = session as unknown as {
+      client: unknown;
+      webMcpAwaitBatches: Map<string, unknown>;
+    };
+    const clientBefore = s.client;
+    feed(session, parallelAwait("toolu_A", "SHOE-001"));
+    expect(s.webMcpAwaitBatches.size).toBe(1);
+
+    session.updateConfig({ apiUrl: "http://other" });
+
+    expect(s.client).not.toBe(clientBefore); // fresh client
+    expect(s.webMcpAwaitBatches.size).toBe(0); // batch torn down
+  });
+
   it("a teardown before the stream-end flush strands the batch", async () => {
     const { session, executeSpy, resumeSpy } = makeSession();
     feed(session, parallelAwait("toolu_A", "SHOE-001"));

--- a/packages/widget/src/theme-editor/index.ts
+++ b/packages/widget/src/theme-editor/index.ts
@@ -162,6 +162,8 @@ export type {
   ToolResult,
   ToolAnnotations,
   ToolTextContent,
+  ToolImageContent,
+  ToolContent,
   ToolExecute,
   ThemeEditorLike,
   EditTarget,

--- a/packages/widget/src/theme-editor/webmcp/index.ts
+++ b/packages/widget/src/theme-editor/webmcp/index.ts
@@ -14,6 +14,8 @@ export type {
   ToolResult,
   ToolAnnotations,
   ToolTextContent,
+  ToolImageContent,
+  ToolContent,
   ToolExecute,
   ThemeEditorLike,
   EditTarget,

--- a/packages/widget/src/theme-editor/webmcp/types.ts
+++ b/packages/widget/src/theme-editor/webmcp/types.ts
@@ -20,8 +20,17 @@ export interface ToolTextContent {
   text: string;
 }
 
+/** MCP image content block: raw base64 (no `data:` prefix) plus its MIME type. */
+export interface ToolImageContent {
+  type: 'image';
+  data: string;
+  mimeType: string;
+}
+
+export type ToolContent = ToolTextContent | ToolImageContent;
+
 export interface ToolResult {
-  content: ToolTextContent[];
+  content: ToolContent[];
   /** Optional machine-readable mirror of the text content. */
   structuredContent?: unknown;
   isError?: boolean;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,9 @@ importers:
       idiomorph:
         specifier: ^0.7.4
         version: 0.7.4
+      modern-screenshot:
+        specifier: ^4.7.0
+        version: 4.7.0
       partial-json:
         specifier: ^0.1.7
         version: 0.1.7
@@ -2092,6 +2095,9 @@ packages:
 
   mlly@1.8.0:
     resolution: {integrity: sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==}
+
+  modern-screenshot@4.7.0:
+    resolution: {integrity: sha512-9YxN+ddPSMMlhylOv25VHzXrl9u67QRxoh7+SEewGtgUw7t6hHTrjptSDJUSne9oG4Xk/h2cwG15nIt4Hc9ujg==}
 
   mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -4660,6 +4666,8 @@ snapshots:
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.3
+
+  modern-screenshot@4.7.0: {}
 
   mri@1.2.0: {}
 


### PR DESCRIPTION
## What

Re-shapes the Theme Editor agent UX (replacing the earlier self-styling-preview approach on this branch, kept in `40a002d`'s lineage):

- **Theme Copilot sidebar** — a docked Persona widget (calendar-demo pattern: `mountMode: 'docked'`, right side, 440px, `reveal: 'emerge'`) is now the theming interface. It discovers the page's theme WebMCP tools and restyles the **preview** while the user watches. Its own panel never changes — theming is per-mount, so the separation is visible and there's no mid-turn self-mutation hazard.
- **Preview reverts to a passive showcase** — `theme-configurator/state.ts` is byte-identical to `main` again (canned `initialMessages`, no live agent, no `webmcp` config on preview frames).
- **Image-matching loop (multi-modal)** — paste a screenshot of any chat widget into the copilot: the flow prompt extracts a concrete style spec (palette hexes, radius tier, typography, light/dark), applies it as one tool batch, then calls a new **`screenshot_preview`** WebMCP tool that captures the rendered preview as JPEG image content blocks — closing a see → apply → verify loop with a hard budget (≤2 refinement rounds).

## How `screenshot_preview` works

- `previewManager.capturePreview()` renders each visible preview iframe's `body` via `modern-screenshot` (example-only dep, lazy-imported) — body capture shows the widget in situ, which also covers the `minimized` launcher scene where the mount box is empty.
- Same-origin srcdoc iframes + light-DOM widget make parent-realm capture clean; the cross-origin background-URL iframe is excluded via a `tagName` filter (`instanceof` always fails across realms).
- 600px-wide JPEG @ q0.7 → ~16–20KB base64 per frame, ≤2 frames (compare mode returns labeled `Light`/`Dark` or `Baseline`/`Current` blocks). Result envelope is built by hand — the `toolResult()` helper would mirror ~100KB of base64 into `structuredContent`.
- The WebMCP bridge's `normalizeSerializedResult` passes any `{ content: [...] }` through unchanged, so MCP image blocks survive the polyfill JSON round-trip to `/resume` intact. The widget-package change for this is type-only: theme-editor `ToolResult.content` now admits `ToolImageContent` (patch changeset).

## Kept from the original branch

- `session.ts` / `client.ts` `updateConfig` in-place split + tests (independently valuable; keeps preview updates smooth under rapid tool calls).
- `/api/chat/dispatch-theme` route in both vercel-edge entrypoints.

## Wiring

Dispatch (proxy) mode only, like the other WebMCP demos — the client-token branch is gone. The copilot always dispatches to `/api/chat/dispatch-theme`, backed by the in-repo `THEME_ASSISTANT_FLOW` (or `FLOW_ID_THEME_ASSISTANT` to pin a hosted flow).

## Model

The flow ships on **`gemini-3.5-flash`** rather than the repo-standard `nemotron-3-ultra-550b-a55b`: the platform catalog tags nemotron ultra as `tool-use` but **not `vision`**, and the reference-image loop requires both (comment in `theme-assistant.ts` documents this).

## Verification

- `pnpm build` / `typecheck` / `lint` clean; **1134 widget tests pass** (incl. the 2 updateConfig tests). Embedded-app vitest: same 5 pre-existing failures as `main`-rebased baseline, none new.
- Branch rebased onto latest `main` (picks up the WebMCP flow grounding patterns, which the new prompt follows: acting-vs-claiming, style-pass budgets).
- **Live-verified in the browser** (`pnpm dev` → theme.html):
  - Copilot toggle opens/closes the 440px dock; editor grid squeezes (`emerge`); preview auto-rescales; preview is passive again.
  - 13 WebMCP tools register (12 theme + `screenshot_preview`).
  - `screenshot_preview` executed through the polyfill round-trip: single frame 614ms / 20KB base64, faithful render (shell, panel, messages, composer); **compare mode returns 2 labeled frames (36KB total)**.
- Copilot dispatch wiring re-verified after the dispatch-only refactor: the send path hits `localhost:43111/api/chat/dispatch-theme`.
- **Not yet verified**: the upstream agent loop end-to-end (model calling `webmcp:*` natively + consuming image blocks via `/resume`) — needs a proxy run with a real `RUNTYPE_API_KEY`, which this environment doesn't have.

## Caveats

- Third-party web fonts may fall back to system fonts in captures (CORS on font fetch) — fine for palette/radius/vibe matching; noted in code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebMCP resume/stream lifecycle in `session.updateConfig` and adds a vision+tool-calling agent path; misclassification of config keys could still rebuild the client mid-turn.
> 
> **Overview**
> Adds a **Theme Copilot** docked Persona sidebar on the Theme Editor that proxies to new **`THEME_ASSISTANT_FLOW`** at `/api/chat/dispatch-theme`, drives the page’s WebMCP theme tools to restyle the **live preview** (not the copilot panel), and supports reference-image styling plus **`screenshot_preview`** JPEG captures returned as MCP image blocks.
> 
> Widget **`updateConfig`** now refreshes in place when only display config changes so mid-turn WebMCP restyles don’t tear down the stream/bridge; theme-editor **`ToolResult`** types admit image content. Example wiring gates copilot mount on MCP **`ready`**, adds preview capture via **`modern-screenshot`**, and documents **`FLOW_ID_THEME_ASSISTANT`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25f3f02d160aa9b832b47fa19babfa3d2f00b710. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->