### PR TITLE
feat(examples): WebMCP on a direct AI SDK backend (no Runtype)

### DIFF
--- a/docs/webmcp-without-runtype.md
+++ b/docs/webmcp-without-runtype.md
@@ -1,0 +1,129 @@
+# Using Persona's WebMCP with a direct AI SDK backend (no Runtype)
+
+Persona's WebMCP support lets the agent call **page-defined tools** (registered
+on `document.modelContext`). A common question: can that work against a **direct
+[Vercel AI SDK](https://ai-sdk.dev) backend** instead of the Runtype API?
+
+Yes — and there are two paths depending on whether you keep the Persona widget UI.
+
+---
+
+## The coupling that decides the path
+
+The widget owns the WebMCP loop internally: it snapshots page tools into
+`clientTools[]`, and when the agent calls one it executes the tool on the page
+and posts the result back. That loop is **bound to Runtype's proxy wire
+protocol** — a `step_await` SSE event pauses the run, and the widget POSTs the
+tool output to `${apiUrl}/resume` to continue. The control events
+(`step_await` / `executionId` / `/resume`) are hard-coded to Runtype's field
+names; `parseSSEEvent` / `customFetch` can adapt *content* framing but cannot
+remap them.
+
+So:
+
+- **Keep the Persona widget UI** → your backend must **speak Runtype's proxy
+  protocol**. Build a thin shim over the AI SDK (Path A).
+- **Don't need the widget UI** → reuse just the transport-agnostic
+  `WebMcpBridge` and drive the AI SDK's **native** client-tool loop (Path B).
+
+---
+
+## Path A — keep the widget, shim the protocol (recommended for "drop-in")
+
+A runnable example lives at [`examples/ai-sdk-webmcp/`](../examples/ai-sdk-webmcp/)
+— the Switchback storefront with the real Persona widget, backed by two AI SDK
+route handlers. Point the widget at your own endpoint in **proxy mode**:
+
+```ts
+createAgentExperience(el, {
+  apiUrl: "/api/chat/dispatch", // resume is POSTed to `${apiUrl}/resume`
+  webmcp: { enabled: true, autoApprove: (i) => READ_ONLY.has(i.toolName) },
+  // ...theme, copy, launcher
+});
+```
+
+### The wire contract your shim emits
+
+Each SSE frame is `event: <type>\ndata: <json with matching "type">`.
+
+| Widget expects | JSON |
+| --- | --- |
+| text delta | `step_chunk` → `{type, id, executionId, text}` |
+| text done | `step_complete` → `{type, id, result:{response}}` |
+| **WebMCP call** | `step_await` → `{type, awaitReason:"local_tool_required", toolName:"webmcp:<bare>", toolId, toolCallId, executionId, parameters}` |
+| turn done | `flow_complete` → `{type, success:true, executionId}` |
+| failure | `error` → `{type, message}` |
+
+Two rules that bite if missed:
+
+1. **`toolName` must carry the `webmcp:` prefix.** The widget routes a call to
+   its bridge only when `isWebMcpToolName(toolName)` is true. The bridge strips
+   the prefix to look the tool up on the page.
+2. **Don't emit `flow_complete` when pausing for a tool.** A `step_await` ends
+   the HTTP stream; the widget runs the tool and POSTs to `/resume`. Emitting
+   `flow_complete` would end the turn instead.
+
+### Resume
+
+```
+POST ${apiUrl}/resume
+{ "executionId": "...", "toolOutputs": { "<toolCallId>": <WebMcpToolResult> }, "streamResponse": true }
+```
+
+`toolOutputs` is keyed by the `toolCallId` you emitted in `step_await` (falling
+back to `toolName`). A `WebMcpToolResult` is `{content:[{type:"text",text}], isError?}`.
+The resume response streams the continued turn with the **same** SSE protocol —
+including another `step_await` if the model calls another tool.
+
+### Mapping to `streamText`
+
+The shim ([`app/api/chat/shim.ts`](../examples/ai-sdk-webmcp/app/api/chat/shim.ts))
+is small:
+
+- Build the widget's `clientTools[]` into an AI SDK `ToolSet` with `tool({
+  description, inputSchema: jsonSchema(parametersSchema) })` and **no `execute`**
+  — no-execute tools are client-side, so the model's call streams out and the
+  turn stops.
+- Iterate `result.fullStream`: `text-delta` → `step_chunk`; `tool-call` →
+  `step_await` (prefix the name, reuse the model's `toolCallId`), then pause.
+- Persist the conversation (messages + pending calls + the tool definitions) keyed
+  by a generated `executionId` so `/resume` can continue it.
+- On resume, append a tool-result message (`{role:"tool", content:[{type:"tool-result",
+  toolCallId, toolName, output:{type:"text", value}}]}`) and call `streamText`
+  again, streaming identically until a turn finishes with no tool calls.
+
+State between dispatch and resume must outlive a single request and be reachable
+from a different instance (the two are separate HTTP requests). The example keys
+it by `executionId` in the **Vercel Runtime Cache** (`@vercel/functions`), with an
+in-memory fallback for local dev — but that cache is **ephemeral and
+region-scoped**, so production should use a durable store (Redis/Upstash, Vercel
+KV, a DB, or a Durable Object). The widget's resume request only sends
+`{executionId, toolOutputs}` (not the message history), so server-side shared
+state is required regardless of backend.
+
+---
+
+## Path B — reuse just the bridge (no widget UI)
+
+If you're building your own UI, skip the protocol entirely. `WebMcpBridge` is a
+public export and imports nothing Runtype-specific:
+
+```ts
+import { WebMcpBridge } from "@runtypelabs/persona";
+
+const bridge = new WebMcpBridge({ enabled: true, onConfirm });
+
+// advertise page tools to your AI SDK backend each turn
+const clientTools = await bridge.snapshotForDispatch(); // ClientToolDefinition[]
+
+// in the AI SDK's native client-tool hook
+useChat({
+  async onToolCall({ toolCall }) {
+    return bridge.executeToolCall(toolCall.toolName, toolCall.input);
+  },
+});
+```
+
+Here the AI SDK owns the loop (its auto-resubmission replaces `/resume`) and the
+bridge owns discovery, execution, and the human-approval gate. `parametersSchema`
+is plain JSON Schema, so it maps directly via the AI SDK's `jsonSchema()` helper.

--- a/examples/ai-sdk-webmcp/.env.local.example
+++ b/examples/ai-sdk-webmcp/.env.local.example
@@ -1,0 +1,10 @@
+# Copy to `.env.local`.
+#
+# This example routes model calls through the Vercel AI Gateway (the shim uses a
+# bare "anthropic/claude-sonnet-4.6" model id). Auth:
+#
+#   • On Vercel:  nothing to set — the gateway authenticates automatically via
+#                 the deployment's OIDC token.
+#   • Local dev:  set AI_GATEWAY_API_KEY (create one in the Vercel dashboard →
+#                 AI Gateway → API keys), or run `vercel env pull` to inherit it.
+AI_GATEWAY_API_KEY=vck_...

--- a/examples/ai-sdk-webmcp/.gitignore
+++ b/examples/ai-sdk-webmcp/.gitignore
@@ -1,0 +1,6 @@
+/.next/
+/node_modules
+/out/
+next-env.d.ts
+.env.local
+*.tsbuildinfo

--- a/examples/ai-sdk-webmcp/README.md
+++ b/examples/ai-sdk-webmcp/README.md
@@ -1,0 +1,115 @@
+# ai-sdk-webmcp — Persona + WebMCP on a direct AI SDK backend
+
+A Next.js port of the **Switchback** WebMCP storefront demo that drives the
+**real Persona widget** against a **direct [Vercel AI SDK](https://ai-sdk.dev)
+backend** — **no Runtype**.
+
+The storefront publishes its own page tools via WebMCP
+(`document.modelContext.registerTool`). The Persona widget snapshots them each
+turn, ships them as `clientTools[]`, and when the agent calls one the widget runs
+it here on the page and posts the result back via `/resume`. The catalog, cart,
+and wire log react live. The only difference from the hosted demo is what's
+behind the widget: instead of Runtype, an AI SDK route handler running Claude.
+
+## What this shows / what it costs
+
+The Persona widget's WebMCP loop is **transport-bound to Runtype's proxy wire
+protocol** (a `step_await` SSE pause → `/resume` round-trip). To keep the widget
+UI while talking directly to the AI SDK, this example ships a **protocol shim**:
+two route handlers that emit Runtype's proxy protocol on top of `streamText`
+(`app/api/chat/shim.ts`). The widget is unchanged and never learns it isn't
+talking to Runtype.
+
+- **You keep:** the full Persona widget UI, WebMCP page-tool discovery,
+  per-call approval gating, and parallel/multi-step tool calls.
+- **You add:** the shim (`app/api/chat/shim.ts`). The dispatch pause and the
+  later `/resume` are separate requests that can hit different serverless
+  instances, so the in-flight conversation is held in a small store
+  (`app/api/chat/execution-store.ts`) keyed by `executionId` — backed by the
+  **Vercel Runtime Cache** (`@vercel/functions`), with an in-memory fallback for
+  local dev. ⚠️ The Runtime Cache is an **ephemeral, region-scoped cache** — fine
+  for a demo/preview, but **swap it for a durable store (Redis/Upstash, Vercel
+  KV, a DB, or a Durable Object) in production**. The store interface is one tiny
+  file so the backend is a one-place change.
+
+> Prefer **not** to use the widget UI? You can instead reuse just
+> `WebMcpBridge` from `@runtypelabs/persona` and drive the loop with the AI SDK's
+> native client-tool model (`useChat` + `onToolCall`) — no shim, no `/resume`.
+> See `docs/webmcp-without-runtype.md` at the repo root.
+
+## Run
+
+Model calls route through the **Vercel AI Gateway** (the shim uses a bare
+`anthropic/claude-sonnet-4.6` model id). On Vercel this authenticates
+automatically via the deployment's OIDC token — **no key to set**. For local dev
+you need an `AI_GATEWAY_API_KEY`:
+
+```bash
+# from the repo root — builds the workspace widget the example imports
+pnpm --filter @runtypelabs/persona build
+
+cp examples/ai-sdk-webmcp/.env.local.example examples/ai-sdk-webmcp/.env.local
+# edit .env.local: set AI_GATEWAY_API_KEY=vck_...  (or run `vercel env pull`)
+
+pnpm --filter ai-sdk-webmcp dev
+# open http://localhost:3000
+```
+
+> Want to call Anthropic directly instead of through the gateway? Install
+> `@ai-sdk/anthropic`, and in `app/api/chat/shim.ts` use
+> `model: anthropic("claude-sonnet-4-6")` with `ANTHROPIC_API_KEY`.
+
+## Try it
+
+1. **Browse (read-only):** _"find a waterproof trail shoe under $170"_ →
+   `search_products` auto-approves; matching cards light up.
+2. **Inspect (read-only):** _"tell me about SHOE-005"_ → `view_product`; the card
+   flashes.
+3. **Parallel (the headline):** _"add SHOE-001 and SHOE-007 at the same time"_ →
+   two `add_to_cart` calls in one turn, each with its own approval bubble, batched
+   into a single `/resume`.
+4. **Promo:** _"apply code TRAIL10 and show my cart total"_ → `apply_promo`,
+   gated; the discount line appears.
+
+## How it maps to the wire protocol
+
+`app/lib/widget.ts` mounts the widget in **proxy mode** (`apiUrl:
+"/api/chat/dispatch"`, no `clientToken`); resume is POSTed to `${apiUrl}/resume`.
+
+| Widget expects (SSE `event`) | Shim emits from `streamText` |
+| --- | --- |
+| `step_chunk` `{text}` | `text-delta` parts |
+| `step_await` `{toolName:"webmcp:<bare>", toolCallId, parameters, executionId}` | `tool-call` parts (paused — no `flow_complete`) |
+| `step_complete` + `flow_complete` | end of a turn with no tool calls |
+| POST `/resume` `{executionId, toolOutputs}` | tool-result message appended → `streamText` continues |
+
+## Deploy on Vercel
+
+There's no Vercel project for this example in-repo — to get a PR preview, create
+a Vercel project pointed at this subdirectory:
+
+- **Root Directory:** `examples/ai-sdk-webmcp`
+- **Build Command:** `pnpm --filter @runtypelabs/persona build && next build`
+- **Env:** none required — model calls go through the AI Gateway, authenticated
+  automatically by the deployment's OIDC token. (Locally you set
+  `AI_GATEWAY_API_KEY`; on Vercel you don't.)
+
+Notes that matter for the WebMCP tool loop:
+
+- The paused-execution store uses the **Vercel Runtime Cache**, which is
+  **region-scoped**. Keep the project on a **single function region** so the
+  dispatch pause and the `/resume` that follows share the same cache. The cache
+  is also **ephemeral** — a long delay before resuming (or an eviction) yields an
+  "unknown executionId" error. Fine for a demo; use a durable store for prod
+  (see `app/api/chat/execution-store.ts`).
+
+## Files
+
+- `app/lib/catalog.ts` — product catalog + search (ported verbatim).
+- `app/lib/store.ts` — observable cart/highlight/wire store (React + tools share it).
+- `app/lib/webmcp-tools.ts` — registers the 5 page tools on `document.modelContext`.
+- `app/lib/widget.ts` — Switchback theme + widget config (proxy mode → local shim).
+- `app/page.tsx` — storefront UI + widget mount.
+- `app/api/chat/shim.ts` — the Runtype-proxy-protocol shim over the AI SDK.
+- `app/api/chat/execution-store.ts` — paused-execution store (Runtime Cache; **swap for a durable store in prod**).
+- `app/api/chat/dispatch/route.ts`, `.../resume/route.ts` — the two endpoints.

--- a/examples/ai-sdk-webmcp/app/api/chat/dispatch/resume/route.ts
+++ b/examples/ai-sdk-webmcp/app/api/chat/dispatch/resume/route.ts
@@ -1,0 +1,12 @@
+import { handleResume } from "../../shim";
+
+// Must share the process (and the in-memory execution store) with the dispatch
+// route, so this resume endpoint lives at `${apiUrl}/resume` where the widget
+// POSTs tool outputs.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request): Promise<Response> {
+  const body = await req.json();
+  return handleResume(body);
+}

--- a/examples/ai-sdk-webmcp/app/api/chat/dispatch/route.ts
+++ b/examples/ai-sdk-webmcp/app/api/chat/dispatch/route.ts
@@ -1,0 +1,11 @@
+import { handleDispatch } from "../shim";
+
+// Node runtime: the shim keeps paused executions in an in-memory Map across the
+// dispatch → resume round-trip.
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: Request): Promise<Response> {
+  const body = await req.json();
+  return handleDispatch(body);
+}

--- a/examples/ai-sdk-webmcp/app/api/chat/execution-store.ts
+++ b/examples/ai-sdk-webmcp/app/api/chat/execution-store.ts
@@ -1,0 +1,79 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Paused-execution store for the WebMCP dispatch → /resume round-trip.
+//
+// The widget pauses on a tool call (dispatch) and POSTs the result later
+// (/resume) as a SEPARATE request. On serverless those two requests can land on
+// different function instances, so the in-flight conversation must live in a
+// store both can reach — NOT a module-level Map (which is per-instance).
+//
+// ⚠️  PRODUCTION: SWAP THIS OUT FOR A REAL DATA STORE.  ⚠️
+// This uses the **Vercel Runtime Cache** (`@vercel/functions` getCache), which
+// is an *ephemeral, region-scoped cache*: entries can be evicted at any time and
+// are not guaranteed to persist or to be strongly consistent across regions.
+// That is acceptable for a demo / preview deployment (the pause→resume window is
+// only seconds), but for production you MUST replace it with a durable,
+// strongly-consistent store keyed by executionId — e.g. Redis/Upstash, Vercel
+// KV, a database row, or a Durable Object. The interface below
+// (save/load/delete) is deliberately tiny so swapping the backend is a one-file
+// change.
+//
+// Locally, getCache() transparently falls back to an in-memory cache; we add our
+// own Map fallback too so `next dev` never depends on cache availability.
+// ───────────────────────────────────────────────────────────────────────────
+
+import { getCache } from "@vercel/functions";
+import type { ClientToolDefinition } from "./shim";
+import type { ModelMessage } from "ai";
+
+export interface PausedExecution {
+  messages: ModelMessage[];
+  pending: Array<{ toolCallId: string; toolName: string }>;
+  clientTools: ClientToolDefinition[];
+}
+
+// How long a paused execution may sit before the shopper resumes it.
+const TTL_SECONDS = 600;
+const NAMESPACE = "webmcp-exec";
+
+// Defensive per-instance fallback if getCache() is unavailable for any reason.
+const memory = new Map<string, PausedExecution>();
+
+function cache() {
+  try {
+    return getCache({ namespace: NAMESPACE });
+  } catch {
+    return null;
+  }
+}
+
+export async function savePausedExecution(
+  executionId: string,
+  value: PausedExecution,
+): Promise<void> {
+  const c = cache();
+  if (c) {
+    await c.set(executionId, value, { ttl: TTL_SECONDS });
+    return;
+  }
+  memory.set(executionId, value);
+}
+
+export async function loadPausedExecution(
+  executionId: string,
+): Promise<PausedExecution | undefined> {
+  const c = cache();
+  if (c) {
+    const v = (await c.get(executionId)) as PausedExecution | null;
+    return v ?? undefined;
+  }
+  return memory.get(executionId);
+}
+
+export async function deletePausedExecution(executionId: string): Promise<void> {
+  const c = cache();
+  if (c) {
+    await c.delete(executionId);
+    return;
+  }
+  memory.delete(executionId);
+}

--- a/examples/ai-sdk-webmcp/app/api/chat/shim.ts
+++ b/examples/ai-sdk-webmcp/app/api/chat/shim.ts
@@ -253,8 +253,17 @@ async function runTurn(
     return; // no flow_complete — the widget will /resume with tool outputs
   }
 
-  // No tool calls: the turn is done.
+  // No tool calls: the turn is done. Clean up the stored execution now that it
+  // has completed (a no-op on the initial dispatch path). We deliberately did
+  // NOT delete earlier in handleResume: if the turn errors mid-stream, the
+  // paused state must stay put so the widget can retry /resume with the same
+  // executionId instead of getting an "unknown executionId" error.
   send.send("step_complete", { id: stepId, result: { response: text } });
+  try {
+    await deletePausedExecution(executionId);
+  } catch {
+    /* best-effort cleanup; the cache TTL expires it regardless */
+  }
   send.send("flow_complete", { success: true, executionId });
 }
 
@@ -278,16 +287,30 @@ export function handleResume(body: ResumeBody): Response {
       });
       return;
     }
-    await deletePausedExecution(executionId);
+    // NB: we do NOT delete the paused state here — runTurn cleans it up only
+    // once the continued turn completes, so a mid-stream failure stays retryable.
 
     const outputs = body.toolOutputs ?? {};
-    const toolResults: ToolResultPart[] = paused.pending.map((p) => ({
-      type: "tool-result",
-      toolCallId: p.toolCallId,
-      toolName: p.toolName,
-      // Widget keys outputs by the toolCallId we emitted; fall back to toolName.
-      output: resultToOutput(outputs[p.toolCallId] ?? outputs[p.toolName]),
-    }));
+    const toolResults: ToolResultPart[] = paused.pending.map((p) => {
+      // The widget's batched /resume may omit a call (aborted, deduped, or its
+      // execute() failed), so its output key is absent. Anthropic still requires
+      // a tool_result for every tool_use, so emit an explicit error result for
+      // the missing one rather than a "null" placeholder (which would read as a
+      // real, empty result). The model can then react / re-request as needed.
+      const has = p.toolCallId in outputs || p.toolName in outputs;
+      return {
+        type: "tool-result",
+        toolCallId: p.toolCallId,
+        toolName: p.toolName,
+        output: has
+          ? resultToOutput(outputs[p.toolCallId] ?? outputs[p.toolName])
+          : {
+              type: "error-text",
+              value:
+                "No output was returned for this tool call (it was cancelled or failed on the page).",
+            },
+      };
+    });
 
     const messages: ModelMessage[] = [
       ...paused.messages,

--- a/examples/ai-sdk-webmcp/app/api/chat/shim.ts
+++ b/examples/ai-sdk-webmcp/app/api/chat/shim.ts
@@ -1,0 +1,300 @@
+// ───────────────────────────────────────────────────────────────────────────
+// Runtype proxy-mode wire protocol, implemented on top of the Vercel AI SDK.
+//
+// The Persona widget (proxy mode) POSTs a dispatch request, reads an SSE stream,
+// and — for WebMCP page tools — pauses on a `step_await` event, runs the tool on
+// the page, and POSTs the result to `${apiUrl}/resume`. Runtype normally serves
+// that protocol; here we serve it ourselves, backed by `streamText`. The widget
+// is unchanged and never learns it isn't talking to Runtype.
+//
+// Wire contract (verified against packages/widget/src/{client,session}.ts):
+//   • text delta  → event: step_chunk    {type, id, executionId, text}
+//   • text done   → event: step_complete {type, id, result:{response}}
+//   • WebMCP call → event: step_await     {type, awaitReason:"local_tool_required",
+//                                          toolName:"webmcp:<bare>", toolId,
+//                                          toolCallId, executionId, parameters}
+//   • turn done   → event: flow_complete  {type, success:true, executionId}
+//   • failure     → event: error          {type, message}
+// Resume body: {executionId, toolOutputs: Record<toolCallId, WebMcpToolResult>}.
+// ───────────────────────────────────────────────────────────────────────────
+
+import {
+  generateId,
+  jsonSchema,
+  streamText,
+  tool,
+  type ModelMessage,
+  type ToolCallPart,
+  type ToolResultPart,
+  type ToolSet,
+} from "ai";
+import {
+  deletePausedExecution,
+  loadPausedExecution,
+  savePausedExecution,
+} from "./execution-store";
+
+// Server-applied wire prefix the widget uses to route a call to its WebMCP
+// bridge (isWebMcpToolName checks `startsWith("webmcp:")`). Hard-coded here so
+// the server stays independent of the browser widget bundle.
+const WEBMCP_PREFIX = "webmcp:";
+
+// Bare "creator/model" id → the AI SDK routes through the Vercel AI Gateway
+// (the default provider when no provider instance is given). On Vercel this
+// authenticates automatically via OIDC; locally it uses AI_GATEWAY_API_KEY.
+// Gateway slugs use dots (claude-sonnet-4.6), unlike the provider SDK (…-4-6).
+const MODEL = "anthropic/claude-sonnet-4.6";
+
+const SYSTEM_PROMPT = `You are the Switchback shopping assistant for a trail & road running store.
+You help shoppers using ONLY the page's own tools (search_products, view_product,
+add_to_cart, remove_from_cart, apply_promo). Always call search_products to get
+valid SKUs before adding to the cart. After a cart change, confirm the running
+total from the tool result. When the shopper asks for several actions at once
+(e.g. "add SHOE-001 and SHOE-007"), emit the tool calls together in one turn.
+Be concise and friendly.`;
+
+// ── Widget request payloads ────────────────────────────────────────────────
+
+export interface ClientToolDefinition {
+  name: string;
+  description: string;
+  parametersSchema?: Record<string, unknown>;
+  origin?: string;
+}
+
+interface DispatchBody {
+  messages?: Array<{ role: string; content: unknown }>;
+  clientTools?: ClientToolDefinition[];
+}
+
+interface ResumeBody {
+  executionId?: string;
+  toolOutputs?: Record<string, unknown>;
+}
+
+interface WebMcpToolResult {
+  content?: Array<{ type?: string; text?: string } & Record<string, unknown>>;
+  isError?: boolean;
+}
+
+// Paused conversations live in `execution-store.ts` (Vercel Runtime Cache, so
+// the dispatch pause and the later /resume can land on different serverless
+// instances). The widget's /resume request omits clientTools[], so we persist
+// the full tool surface there too — multi-step prompts call other tools after
+// the first result returns. ⚠️ That store is an ephemeral cache: swap it for a
+// durable data store in production (see execution-store.ts).
+
+// ── SSE plumbing ────────────────────────────────────────────────────────────
+
+const encoder = new TextEncoder();
+
+export interface SSESender {
+  send(event: string, payload: Record<string, unknown>): void;
+}
+
+/** Build a streaming SSE Response and run `handler` against a writer. */
+export function sseResponse(
+  handler: (send: SSESender) => Promise<void>,
+): Response {
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const send: SSESender = {
+        send(event, payload) {
+          controller.enqueue(
+            encoder.encode(
+              `event: ${event}\ndata: ${JSON.stringify({ type: event, ...payload })}\n\n`,
+            ),
+          );
+        },
+      };
+      try {
+        await handler(send);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        send.send("error", { message });
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-transform",
+      connection: "keep-alive",
+    },
+  });
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Map widget messages → AI SDK ModelMessages (the storefront is text-only). */
+function toModelMessages(
+  messages: Array<{ role: string; content: unknown }> = [],
+): ModelMessage[] {
+  return messages
+    .map((m): ModelMessage | null => {
+      const text = flattenContent(m.content);
+      if (m.role === "assistant") return { role: "assistant", content: text };
+      if (m.role === "system") return { role: "system", content: text };
+      return { role: "user", content: text };
+    })
+    .filter((m): m is ModelMessage => m !== null);
+}
+
+function flattenContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((part) =>
+        part && typeof part === "object" && "text" in part
+          ? String((part as { text?: unknown }).text ?? "")
+          : "",
+      )
+      .join("");
+  }
+  return "";
+}
+
+/** Build a no-execute ToolSet from the widget's clientTools[] (client-side). */
+function buildTools(clientTools: ClientToolDefinition[] = []): ToolSet {
+  const set: ToolSet = {};
+  for (const t of clientTools) {
+    set[t.name] = tool({
+      description: t.description,
+      inputSchema: jsonSchema((t.parametersSchema as object) ?? { type: "object" }),
+      // No `execute`: the model's call streams out and the turn pauses; the
+      // widget runs the tool on the page and returns the result via /resume.
+    });
+  }
+  return set;
+}
+
+/** Flatten a WebMcpToolResult to text for the model. */
+function resultToOutput(raw: unknown): ToolResultPart["output"] {
+  const result = raw as WebMcpToolResult | string | undefined;
+  if (typeof result === "string") return { type: "text", value: result };
+  const text =
+    result?.content
+      ?.map((c) => (c?.type === "text" ? (c.text ?? "") : JSON.stringify(c)))
+      .join("\n") ?? JSON.stringify(result ?? null);
+  return result?.isError
+    ? { type: "error-text", value: text }
+    : { type: "text", value: text };
+}
+
+// ── Core turn: stream text, surface tool calls, pause or complete ───────────
+
+/**
+ * Run one model turn over `messages`, streaming text as `step_chunk`. If the
+ * model calls page tools, emit a `step_await` per call and PAUSE (store state,
+ * no `flow_complete`). Otherwise finalize with `step_complete` + `flow_complete`.
+ */
+async function runTurn(
+  send: SSESender,
+  executionId: string,
+  messages: ModelMessage[],
+  clientTools: ClientToolDefinition[],
+): Promise<void> {
+  const stepId = `step_${generateId()}`;
+  let text = "";
+  const toolCalls: ToolCallPart[] = [];
+
+  const result = streamText({
+    model: MODEL, // string id → Vercel AI Gateway (see MODEL above)
+    system: SYSTEM_PROMPT,
+    messages,
+    tools: buildTools(clientTools),
+  });
+
+  for await (const part of result.fullStream) {
+    if (part.type === "text-delta") {
+      text += part.text;
+      send.send("step_chunk", { id: stepId, executionId, text: part.text });
+    } else if (part.type === "tool-call") {
+      toolCalls.push({
+        type: "tool-call",
+        toolCallId: part.toolCallId,
+        toolName: part.toolName,
+        input: part.input,
+      });
+      send.send("step_await", {
+        awaitReason: "local_tool_required",
+        id: stepId,
+        toolId: `runtime_${part.toolName}_${part.toolCallId}`,
+        toolName: `${WEBMCP_PREFIX}${part.toolName}`,
+        toolCallId: part.toolCallId,
+        executionId,
+        parameters: part.input,
+      });
+    } else if (part.type === "error") {
+      const message =
+        part.error instanceof Error ? part.error.message : String(part.error);
+      send.send("error", { message });
+      return;
+    }
+  }
+
+  if (toolCalls.length > 0) {
+    // Pause: persist the assistant turn (incl. tool calls) and the pending set.
+    const assistantContent: Array<{ type: "text"; text: string } | ToolCallPart> = [
+      ...(text ? [{ type: "text" as const, text }] : []),
+      ...toolCalls,
+    ];
+    await savePausedExecution(executionId, {
+      messages: [...messages, { role: "assistant", content: assistantContent }],
+      pending: toolCalls.map((tc) => ({
+        toolCallId: tc.toolCallId,
+        toolName: tc.toolName,
+      })),
+      clientTools,
+    });
+    return; // no flow_complete — the widget will /resume with tool outputs
+  }
+
+  // No tool calls: the turn is done.
+  send.send("step_complete", { id: stepId, result: { response: text } });
+  send.send("flow_complete", { success: true, executionId });
+}
+
+// ── Route entry points ───────────────────────────────────────────────────────
+
+export function handleDispatch(body: DispatchBody): Response {
+  const messages = toModelMessages(body.messages);
+  const clientTools = body.clientTools ?? [];
+  const executionId = `exec_${generateId()}`;
+  return sseResponse((send) => runTurn(send, executionId, messages, clientTools));
+}
+
+export function handleResume(body: ResumeBody): Response {
+  const executionId = body.executionId ?? "";
+
+  return sseResponse(async (send) => {
+    const paused = await loadPausedExecution(executionId);
+    if (!paused) {
+      send.send("error", {
+        message: `Unknown executionId "${executionId}" (expired or evicted from the cache — see execution-store.ts).`,
+      });
+      return;
+    }
+    await deletePausedExecution(executionId);
+
+    const outputs = body.toolOutputs ?? {};
+    const toolResults: ToolResultPart[] = paused.pending.map((p) => ({
+      type: "tool-result",
+      toolCallId: p.toolCallId,
+      toolName: p.toolName,
+      // Widget keys outputs by the toolCallId we emitted; fall back to toolName.
+      output: resultToOutput(outputs[p.toolCallId] ?? outputs[p.toolName]),
+    }));
+
+    const messages: ModelMessage[] = [
+      ...paused.messages,
+      { role: "tool", content: toolResults },
+    ];
+
+    // Reuse the same executionId so a follow-up tool call can /resume again.
+    await runTurn(send, executionId, messages, paused.clientTools);
+  });
+}

--- a/examples/ai-sdk-webmcp/app/globals.css
+++ b/examples/ai-sdk-webmcp/app/globals.css
@@ -1,0 +1,608 @@
+/* ════════════════════════════════════════════════════════════════════════
+   Switchback storefront — Next.js port of the embedded-app WebMCP demo.
+   Ports examples/embedded-app/src/webmcp-shop.css and recreates the two-column
+   "shell" layout that the gallery's demo-shared.css used to provide. The whole
+   app IS the shop, so the original `body.webmcp-shop` scope becomes top-level.
+   ════════════════════════════════════════════════════════════════════════ */
+
+:root {
+  --font-display: Georgia, "Times New Roman", serif;
+  --font-label: system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Brand — warm artisan palette (espresso + caramel). */
+  --shop-brand: #1c1917;
+  --shop-brand-strong: #292524;
+  --shop-brand-ink: #fafaf9;
+  --shop-accent: #b8814b;
+  --shop-accent-strong: #8a5a2b;
+
+  --shop-bg: #f6f4f0;
+  --shop-paper: #ffffff;
+  --shop-card: #ffffff;
+  --shop-ink: #1c1917;
+  --shop-ink-soft: #78716c;
+  --shop-faint: #a8a29e;
+  --shop-line: #e7e5e4;
+  --shop-line-strong: #d6d3d1;
+
+  --wire-bg: #f4f1ea;
+  --wire-fg: #4b4640;
+  --wire-faint: #9a8f80;
+  --wire-line: #e4ddcf;
+  --wire-head-bg: #ece5d8;
+  --wire-row-bg: rgba(28, 25, 23, 0.035);
+  --wire-reg: #15803d;
+  --wire-send: #0369a1;
+  --wire-gate: #a16207;
+  --wire-exec: #6d28d9;
+  --wire-resume: #c2410c;
+
+  --shop-radius: 14px;
+  --shop-radius-sm: 9px;
+  --shop-shadow: 0 1px 2px rgba(28, 25, 23, 0.05);
+  --shop-shadow-md: 0 14px 32px -20px rgba(28, 25, 23, 0.28);
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --shop-brand: #d4a574;
+    --shop-brand-strong: #e0b787;
+    --shop-brand-ink: #1c1917;
+    --shop-accent: #d4a574;
+    --shop-accent-strong: #e0b787;
+
+    --shop-bg: #1c1917;
+    --shop-paper: #292524;
+    --shop-card: #2c2724;
+    --shop-ink: #f5f5f4;
+    --shop-ink-soft: #a8a29e;
+    --shop-faint: #78716c;
+    --shop-line: #3a3530;
+    --shop-line-strong: #44403c;
+
+    --shop-shadow: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --shop-shadow-md: 0 16px 36px -22px rgba(0, 0, 0, 0.7);
+
+    --wire-bg: #211c18;
+    --wire-fg: #e7e0d6;
+    --wire-faint: #9a8f80;
+    --wire-line: rgba(255, 255, 255, 0.08);
+    --wire-head-bg: #2a241f;
+    --wire-row-bg: rgba(255, 255, 255, 0.03);
+    --wire-reg: #86efac;
+    --wire-send: #7dd3fc;
+    --wire-gate: #fcd34d;
+    --wire-exec: #d6bcfa;
+    --wire-resume: #e0a868;
+  }
+}
+
+* { box-sizing: border-box; }
+
+html,
+body {
+  height: 100%;
+  margin: 0;
+}
+
+body {
+  background-color: var(--shop-bg);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='140'%3E%3Cg fill='none' stroke='%231c1917' stroke-opacity='0.05' stroke-width='1.5' stroke-linejoin='round'%3E%3Cpath d='M0 84 L60 44 L120 84 L180 44 L240 84'/%3E%3Cpath d='M0 106 L40 86 L80 106 L120 86 L160 106 L200 86 L240 106'/%3E%3C/g%3E%3C/svg%3E");
+  background-size: 240px 140px;
+  background-repeat: repeat;
+  background-position: center top;
+  color: var(--shop-ink);
+  font-family: var(--font-label);
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='240' height='140'%3E%3Cg fill='none' stroke='%23f5f5f4' stroke-opacity='0.05' stroke-width='1.5' stroke-linejoin='round'%3E%3Cpath d='M0 84 L60 44 L120 84 L180 44 L240 84'/%3E%3Cpath d='M0 106 L40 86 L80 106 L120 86 L160 106 L200 86 L240 106'/%3E%3C/g%3E%3C/svg%3E");
+  }
+}
+
+/* ── Two-column shell (full viewport height) ───────────────────────────── */
+
+.stage {
+  display: grid;
+  grid-template-columns: minmax(440px, 42%) 1fr;
+  min-height: 100vh;
+}
+.stage-controls {
+  max-height: 100vh;
+  overflow-y: auto;
+  padding: 1.6rem 1.5rem;
+  border-right: 1px solid var(--shop-line-strong);
+}
+.stage-widget {
+  height: 100vh;
+  position: sticky;
+  top: 0;
+}
+.stage-widget > div {
+  height: 100%;
+}
+
+@media (max-width: 1100px) {
+  .stage {
+    grid-template-columns: 1fr;
+  }
+  .stage-controls {
+    max-height: none;
+    overflow-y: visible;
+    border-right: 0;
+    border-bottom: 1px solid var(--shop-line-strong);
+  }
+  .stage-widget {
+    height: 80vh;
+    position: static;
+  }
+}
+
+/* ── Storefront hero ───────────────────────────────────────────────────── */
+
+.shop-hero {
+  margin: 0 0 1.25rem 0;
+  padding-bottom: 1.1rem;
+  border-bottom: 1px solid var(--shop-line-strong);
+}
+.shop-wordmark {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  margin: 0 0 0.5rem 0;
+  font-family: var(--font-display);
+  font-size: 1.5rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: var(--shop-ink);
+}
+.shop-mark {
+  display: inline-grid;
+  place-items: center;
+  width: 1.9rem;
+  height: 1.9rem;
+  border-radius: 9px;
+  background: var(--shop-brand);
+  color: var(--shop-brand-ink);
+  flex: none;
+}
+.shop-mark svg {
+  width: 1.05rem;
+  height: 1.05rem;
+}
+.shop-tagline {
+  margin: 0 0 0.7rem 0;
+  font-size: 0.9rem;
+  color: var(--shop-ink-soft);
+}
+.shop-explainer {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--shop-ink-soft);
+}
+.shop-explainer code {
+  background: color-mix(in srgb, var(--shop-ink) 7%, transparent);
+  color: var(--shop-ink);
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  padding: 0.08em 0.38em;
+  border-radius: 5px;
+}
+
+/* ── Section scaffolding ───────────────────────────────────────────────── */
+
+.shop-section {
+  margin-bottom: 1.25rem;
+}
+.shop-section:last-child {
+  margin-bottom: 0;
+}
+.shop-section-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.6rem;
+  margin: 0 0 0.6rem 0;
+}
+.shop-section-title {
+  font-family: var(--font-label);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  color: var(--shop-faint);
+  margin: 0;
+}
+.shop-section-meta {
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  color: var(--shop-faint);
+}
+
+/* ── Catalog grid ──────────────────────────────────────────────────────── */
+
+.shop-catalog {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(186px, 1fr));
+  gap: 0.6rem;
+}
+.shop-product {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  padding: 0.7rem 0.8rem 0.75rem;
+  background: var(--shop-card);
+  border: 1px solid var(--shop-line);
+  border-radius: var(--shop-radius-sm);
+  box-shadow: var(--shop-shadow);
+  transition: border-color 0.18s ease, box-shadow 0.18s ease, transform 0.18s ease;
+}
+.shop-product-top {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+}
+.shop-swatch {
+  width: 0.9rem;
+  height: 0.9rem;
+  border-radius: 50%;
+  flex: none;
+  border: 1px solid color-mix(in srgb, var(--shop-ink) 18%, transparent);
+  box-shadow: inset 0 0 0 2px var(--shop-card);
+}
+.shop-product-cat {
+  font-family: var(--font-label);
+  font-size: 0.62rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--shop-faint);
+}
+.shop-product-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+  line-height: 1.2;
+  color: var(--shop-ink);
+}
+.shop-product-sub {
+  font-size: 0.74rem;
+  color: var(--shop-ink-soft);
+}
+.shop-product-foot {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.4rem;
+  margin-top: auto;
+  padding-top: 0.4rem;
+}
+.shop-product-price {
+  font-weight: 700;
+  font-size: 0.92rem;
+  color: var(--shop-ink);
+  font-variant-numeric: tabular-nums;
+}
+.shop-product-sku {
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  color: var(--shop-faint);
+}
+
+.shop-product.is-hit {
+  border-color: var(--shop-brand);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--shop-brand) 30%, transparent);
+}
+.shop-product.in-cart {
+  border-color: color-mix(in srgb, var(--shop-accent) 45%, var(--shop-line));
+}
+.shop-product .shop-incart-badge {
+  position: absolute;
+  top: -0.5rem;
+  right: -0.5rem;
+  min-width: 1.25rem;
+  height: 1.25rem;
+  padding: 0 0.32rem;
+  display: none;
+  place-items: center;
+  background: var(--shop-accent);
+  color: #1c1917;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  font-weight: 700;
+  border-radius: 999px;
+  box-shadow: var(--shop-shadow-md);
+}
+.shop-product.in-cart .shop-incart-badge {
+  display: grid;
+}
+
+.shop-product.just-changed {
+  animation: shop-flash 0.9s ease;
+}
+@keyframes shop-flash {
+  0% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--shop-accent) 60%, transparent);
+  }
+  30% {
+    box-shadow: 0 0 0 5px color-mix(in srgb, var(--shop-accent) 28%, transparent);
+  }
+  100% {
+    box-shadow: var(--shop-shadow);
+  }
+}
+
+/* ── Cart ──────────────────────────────────────────────────────────────── */
+
+.shop-cart {
+  border: 1px solid var(--shop-line);
+  border-radius: var(--shop-radius);
+  background: var(--shop-paper);
+  box-shadow: var(--shop-shadow);
+  padding: 0.85rem 0.95rem;
+  font-size: 0.85rem;
+  transition: box-shadow 0.2s ease;
+}
+.shop-cart.just-changed {
+  animation: shop-flash 0.9s ease;
+}
+.shop-cart-empty {
+  margin: 0;
+  color: var(--shop-ink-soft);
+  font-style: italic;
+}
+.shop-cart-lines {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+.shop-cart-line {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: baseline;
+  gap: 0.2rem 0.55rem;
+}
+.shop-cart-qty {
+  font-variant-numeric: tabular-nums;
+  font-weight: 700;
+  color: var(--shop-brand);
+}
+.shop-cart-title {
+  font-weight: 600;
+  color: var(--shop-ink);
+}
+.shop-cart-sku {
+  grid-column: 2;
+  font-size: 0.7rem;
+  color: var(--shop-faint);
+  font-family: var(--font-mono);
+}
+.shop-cart-price {
+  grid-row: 1 / span 2;
+  grid-column: 3;
+  align-self: center;
+  font-variant-numeric: tabular-nums;
+  color: var(--shop-ink);
+}
+.shop-cart-foot {
+  margin-top: 0.7rem;
+  padding-top: 0.6rem;
+  border-top: 1px solid var(--shop-line);
+  display: flex;
+  flex-direction: column;
+  gap: 0.28rem;
+}
+.shop-cart-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-variant-numeric: tabular-nums;
+}
+.shop-cart-row.muted {
+  color: var(--shop-ink-soft);
+  font-size: 0.8rem;
+}
+.shop-cart-row.promo {
+  color: var(--shop-accent-strong);
+  font-size: 0.8rem;
+}
+.shop-cart-row.total {
+  font-size: 1rem;
+}
+.shop-cart-row.total strong {
+  color: var(--shop-ink);
+}
+.shop-cart-chip {
+  display: inline-block;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  padding: 0.04rem 0.4rem;
+  border-radius: 5px;
+  background: color-mix(in srgb, var(--shop-accent) 16%, transparent);
+  color: var(--shop-accent-strong);
+}
+
+/* ── Wire inspector ────────────────────────────────────────────────────── */
+
+.shop-wire {
+  border: 1px solid var(--shop-line-strong);
+  border-radius: var(--shop-radius);
+  overflow: hidden;
+  background: var(--wire-bg);
+}
+.shop-wire-head {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  width: 100%;
+  appearance: none;
+  border: 0;
+  cursor: pointer;
+  text-align: left;
+  list-style: none;
+  padding: 0.6rem 0.8rem;
+  background: var(--wire-head-bg);
+  color: var(--wire-fg);
+  font-family: var(--font-label);
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+}
+.shop-wire-head::before {
+  content: "";
+  width: 0;
+  height: 0;
+  border: 4px solid transparent;
+  border-left-color: currentColor;
+  transition: transform 0.15s ease;
+  flex: none;
+}
+.shop-wire-head::-webkit-details-marker {
+  display: none;
+}
+.shop-wire[open] .shop-wire-head::before {
+  transform: rotate(90deg);
+}
+.shop-wire-count {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: 0.66rem;
+  letter-spacing: 0;
+  color: var(--wire-faint);
+  text-transform: none;
+}
+.shop-wire-body {
+  max-height: 290px;
+  overflow-y: auto;
+  padding: 0.5rem 0.6rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+.shop-wire:not([open]) .shop-wire-body {
+  display: none;
+}
+.shop-wire-empty {
+  color: var(--wire-faint);
+  font-family: var(--font-mono);
+  font-size: 0.72rem;
+  padding: 0.4rem 0.2rem;
+}
+.wire-row {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.5rem;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  line-height: 1.5;
+  padding: 0.32rem 0.4rem;
+  border-radius: 6px;
+  border-left: 3px solid var(--wire-faint);
+  background: var(--wire-row-bg);
+  color: var(--wire-fg);
+}
+.wire-row .wire-time {
+  color: var(--wire-faint);
+}
+.wire-row .wire-tag {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.wire-row .wire-detail {
+  color: color-mix(in srgb, var(--wire-fg) 82%, transparent);
+  word-break: break-word;
+}
+.wire-row .wire-detail b {
+  color: var(--wire-fg);
+  font-weight: 700;
+}
+.wire-row.reg {
+  border-left-color: var(--wire-reg);
+}
+.wire-row.reg .wire-tag {
+  color: var(--wire-reg);
+}
+.wire-row.send {
+  border-left-color: var(--wire-send);
+}
+.wire-row.send .wire-tag {
+  color: var(--wire-send);
+}
+.wire-row.gate {
+  border-left-color: var(--wire-gate);
+}
+.wire-row.gate .wire-tag {
+  color: var(--wire-gate);
+}
+.wire-row.exec {
+  border-left-color: var(--wire-exec);
+}
+.wire-row.exec .wire-tag {
+  color: var(--wire-exec);
+}
+.wire-row.resume {
+  border-left-color: var(--wire-resume);
+  background: color-mix(in srgb, var(--wire-resume) 9%, transparent);
+}
+.wire-row.resume .wire-tag {
+  color: var(--wire-resume);
+}
+.shop-wire-legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 0.7rem;
+  padding: 0.45rem 0.7rem 0.6rem;
+  border-top: 1px solid var(--wire-line);
+}
+.shop-wire-legend span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-family: var(--font-mono);
+  font-size: 0.62rem;
+  color: var(--wire-faint);
+}
+.shop-wire-legend i {
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 2px;
+  flex: none;
+}
+
+/* ── Try-it notes ──────────────────────────────────────────────────────── */
+
+.shop-notes {
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: var(--shop-ink-soft);
+}
+.shop-notes ol {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.shop-notes strong {
+  color: var(--shop-ink);
+}
+.shop-notes em {
+  color: var(--shop-brand-strong);
+  font-style: normal;
+  font-weight: 600;
+}
+.shop-notes code {
+  background: color-mix(in srgb, var(--shop-ink) 7%, transparent);
+  color: var(--shop-ink);
+  font-family: var(--font-mono);
+  font-size: 0.82em;
+  padding: 0.08em 0.38em;
+  border-radius: 5px;
+}

--- a/examples/ai-sdk-webmcp/app/layout.tsx
+++ b/examples/ai-sdk-webmcp/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from "next";
+import "@runtypelabs/persona/widget.css";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "Switchback — WebMCP on a direct AI SDK backend",
+  description:
+    "Persona's WebMCP page tools driven by a direct Vercel AI SDK backend, no Runtype.",
+};
+
+export default function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/examples/ai-sdk-webmcp/app/lib/catalog.ts
+++ b/examples/ai-sdk-webmcp/app/lib/catalog.ts
@@ -1,0 +1,187 @@
+// Static product catalog for the WebMCP demo (ported verbatim from the
+// embedded-app Switchback demo). The page's `search_products` tool filters this
+// list; `add_to_cart` looks products up by SKU. Small and fictional (no real
+// trademarks) but varied enough that "blue running shoes", "trail", "jacket", or
+// "cheapest" return distinct results.
+
+export interface CatalogProduct {
+  sku: string;
+  title: string;
+  brand: string;
+  category: string;
+  color: string;
+  price: number;
+  description: string;
+}
+
+export const CATALOG: CatalogProduct[] = [
+  {
+    sku: "SHOE-001",
+    title: "Trailblaze Pro",
+    brand: "V612",
+    category: "running shoes",
+    color: "blue",
+    price: 129,
+    description: "Lightweight daily trainer with a responsive foam midsole.",
+  },
+  {
+    sku: "SHOE-002",
+    title: "Trailblaze Pro",
+    brand: "V612",
+    category: "running shoes",
+    color: "black",
+    price: 129,
+    description: "Lightweight daily trainer with a responsive foam midsole.",
+  },
+  {
+    sku: "SHOE-003",
+    title: "Cloudstrider 5",
+    brand: "Aether",
+    category: "running shoes",
+    color: "white",
+    price: 149,
+    description: "Plush, high-stack cushioning for long easy miles.",
+  },
+  {
+    sku: "SHOE-004",
+    title: "Cloudstrider 5",
+    brand: "Aether",
+    category: "running shoes",
+    color: "blue",
+    price: 149,
+    description: "Plush, high-stack cushioning for long easy miles.",
+  },
+  {
+    sku: "SHOE-005",
+    title: "Marathon Elite",
+    brand: "Aether",
+    category: "running shoes",
+    color: "red",
+    price: 179,
+    description: "Carbon-plated racer tuned for tempo and race day.",
+  },
+  {
+    sku: "SHOE-006",
+    title: "TrailGrip GTX",
+    brand: "Summit",
+    category: "trail running shoes",
+    color: "green",
+    price: 159,
+    description: "Aggressive lugs and a waterproof membrane for wet trails.",
+  },
+  {
+    sku: "SHOE-007",
+    title: "TrailGrip GTX",
+    brand: "Summit",
+    category: "trail running shoes",
+    color: "grey",
+    price: 159,
+    description: "Aggressive lugs and a waterproof membrane for wet trails.",
+  },
+  {
+    sku: "JKT-001",
+    title: "StormShell Jacket",
+    brand: "Summit",
+    category: "jacket",
+    color: "blue",
+    price: 89,
+    description: "Packable, wind- and water-resistant running shell.",
+  },
+  {
+    sku: "JKT-002",
+    title: "StormShell Jacket",
+    brand: "Summit",
+    category: "jacket",
+    color: "black",
+    price: 89,
+    description: "Packable, wind- and water-resistant running shell.",
+  },
+  {
+    sku: "SCK-001",
+    title: "RunDry Socks (3-pack)",
+    brand: "V612",
+    category: "socks",
+    color: "white",
+    price: 18,
+    description: "Moisture-wicking, cushioned crew socks.",
+  },
+  {
+    sku: "SHRT-001",
+    title: "Tempo Shorts",
+    brand: "Aether",
+    category: "shorts",
+    color: "navy",
+    price: 39,
+    description: "5-inch lined shorts with a zip pocket.",
+  },
+];
+
+// Promo codes the storefront honors (apply_promo validates against this).
+export const PROMOS: Record<string, { rate: number; label: string }> = {
+  TRAIL10: { rate: 0.1, label: "10% off — TRAIL10" },
+  TRAILVIP: { rate: 0.15, label: "15% off — TRAILVIP" },
+  SUMMIT20: { rate: 0.2, label: "20% off — SUMMIT20" },
+};
+
+// Named colors → swatch hex for the catalog grid.
+export const COLOR_HEX: Record<string, string> = {
+  blue: "#2563eb",
+  black: "#1f2937",
+  white: "#f3f4f6",
+  red: "#dc2626",
+  green: "#16a34a",
+  grey: "#9ca3af",
+  gray: "#9ca3af",
+  navy: "#1e3a8a",
+};
+
+const STOPWORDS = new Set([
+  "a", "an", "the", "me", "my", "for", "some", "with", "and", "to", "of",
+  "i", "want", "need", "show", "find", "please", "buy", "get",
+]);
+
+// Query tokens that describe price intent rather than the product itself —
+// dropped before matching so "waterproof trail shoe under $170" still matches on
+// "waterproof/trail/shoe" (the agent reasons over the returned prices itself).
+const PRICE_WORDS = new Set([
+  "under", "below", "over", "above", "cheap", "cheapest", "budget", "than",
+  "less", "more", "around", "about", "max", "min", "price", "priced",
+]);
+
+/**
+ * Filter the catalog by a free-text query. A product matches when every
+ * meaningful query token appears somewhere in its searchable text. Results are
+ * sorted cheapest-first so "the cheapest blue running shoe" has a deterministic
+ * top hit. An empty query returns the whole catalog (cheapest-first).
+ */
+export function searchCatalog(query: string): CatalogProduct[] {
+  const tokens = query
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(
+      (t) =>
+        t.length >= 2 &&
+        !STOPWORDS.has(t) &&
+        !PRICE_WORDS.has(t) &&
+        !/^\d+$/.test(t),
+    );
+
+  const byPrice = (a: CatalogProduct, b: CatalogProduct): number =>
+    a.price - b.price;
+
+  if (tokens.length === 0) {
+    return [...CATALOG].sort(byPrice);
+  }
+
+  return CATALOG.filter((p) => {
+    const haystack =
+      `${p.title} ${p.brand} ${p.category} ${p.color} ${p.description}`.toLowerCase();
+    return tokens.every((t) => haystack.includes(t));
+  }).sort(byPrice);
+}
+
+/** Look up a single product by exact SKU (case-insensitive). */
+export function findBySku(sku: string): CatalogProduct | undefined {
+  const needle = sku.trim().toLowerCase();
+  return CATALOG.find((p) => p.sku.toLowerCase() === needle);
+}

--- a/examples/ai-sdk-webmcp/app/lib/store.ts
+++ b/examples/ai-sdk-webmcp/app/lib/store.ts
@@ -1,0 +1,195 @@
+// Shared storefront state for the Switchback demo.
+//
+// In the vanilla embedded-app demo the WebMCP tools mutated the DOM directly.
+// Here the tools live outside React (registered on `document.modelContext`), so
+// they instead mutate this tiny observable store and the React storefront
+// subscribes via `useSyncExternalStore`. This is the only structural change
+// from the original demo — the cart math, promo logic, and search highlighting
+// behave identically.
+
+import {
+  type CatalogProduct,
+  PROMOS,
+} from "./catalog";
+
+export interface CartLine {
+  sku: string;
+  title: string;
+  price: number;
+  quantity: number;
+}
+
+export type WireKind = "reg" | "send" | "gate" | "exec" | "resume";
+
+export interface WireEvent {
+  id: number;
+  kind: WireKind;
+  tag: string;
+  /** Pre-escaped HTML fragment (callers escape dynamic values). */
+  detailHtml: string;
+  time: string;
+}
+
+export interface ShopState {
+  cart: CartLine[];
+  promo: { code: string; rate: number; label: string } | null;
+  /** SKUs highlighted by the last search_products / view_product call. */
+  hits: string[];
+  /** Last single card to change — `nonce` restarts the flash animation. */
+  flash: { sku: string; nonce: number } | null;
+  /** Bumped whenever the cart card should flash. */
+  cartFlashNonce: number;
+  /** Wire-log events, newest first. */
+  wire: WireEvent[];
+}
+
+export interface CartSummary {
+  items: Array<{ sku: string; title: string; quantity: number; lineTotal: number }>;
+  itemCount: number;
+  subtotal: number;
+  discount: number;
+  total: number;
+  promoCode: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Store internals
+// ---------------------------------------------------------------------------
+
+const cart = new Map<string, CartLine>();
+let promo: ShopState["promo"] = null;
+let hits: string[] = [];
+let flash: ShopState["flash"] = null;
+let cartFlashNonce = 0;
+let wire: WireEvent[] = [];
+
+let nonceSeq = 0;
+let wireSeq = 0;
+
+let snapshot: ShopState = buildSnapshot();
+const listeners = new Set<() => void>();
+
+function buildSnapshot(): ShopState {
+  return {
+    cart: [...cart.values()],
+    promo,
+    hits,
+    flash,
+    cartFlashNonce,
+    wire,
+  };
+}
+
+function emit(): void {
+  snapshot = buildSnapshot();
+  listeners.forEach((l) => l());
+}
+
+export const shopStore = {
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot(): ShopState {
+    return snapshot;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Mutations — called by the WebMCP tool execute()s in webmcp-tools.ts
+// ---------------------------------------------------------------------------
+
+export function cartSummary(): CartSummary {
+  const items = [...cart.values()].map((line) => ({
+    sku: line.sku,
+    title: line.title,
+    quantity: line.quantity,
+    lineTotal: Number((line.price * line.quantity).toFixed(2)),
+  }));
+  const subtotal = Number(items.reduce((sum, i) => sum + i.lineTotal, 0).toFixed(2));
+  const discount = promo ? Number((subtotal * promo.rate).toFixed(2)) : 0;
+  return {
+    items,
+    itemCount: items.reduce((n, i) => n + i.quantity, 0),
+    subtotal,
+    discount,
+    total: Number((subtotal - discount).toFixed(2)),
+    promoCode: promo?.code ?? null,
+  };
+}
+
+export function highlightHits(skus: string[]): void {
+  hits = skus;
+  emit();
+}
+
+export function flashCard(sku: string): void {
+  flash = { sku, nonce: ++nonceSeq };
+  emit();
+}
+
+export function flashCart(): void {
+  cartFlashNonce += 1;
+  emit();
+}
+
+export function addToCart(product: CatalogProduct, quantity: number): void {
+  const existing = cart.get(product.sku);
+  if (existing) {
+    existing.quantity += quantity;
+  } else {
+    cart.set(product.sku, {
+      sku: product.sku,
+      title: `${product.title} (${product.color})`,
+      price: product.price,
+      quantity,
+    });
+  }
+  flashCard(product.sku);
+  flashCart();
+}
+
+export function getCartLine(sku: string): CartLine | undefined {
+  return cart.get(sku);
+}
+
+export function setCartLineQuantity(sku: string, quantity: number): void {
+  const line = cart.get(sku);
+  if (line) line.quantity = quantity;
+  emit();
+}
+
+export function deleteCartLine(sku: string): void {
+  cart.delete(sku);
+  emit();
+}
+
+export function applyPromo(code: string): { rate: number; label: string } | null {
+  const key = code.trim().toUpperCase();
+  const match = PROMOS[key];
+  if (!match) return null;
+  promo = { code: key, rate: match.rate, label: match.label };
+  flashCart();
+  return match;
+}
+
+export function logWire(kind: WireKind, tag: string, detailHtml: string): void {
+  const event: WireEvent = {
+    id: ++wireSeq,
+    kind,
+    tag,
+    detailHtml,
+    time: new Date().toLocaleTimeString(),
+  };
+  // newest first, cap to a sane length
+  wire = [event, ...wire].slice(0, 100);
+  emit();
+}
+
+/** Minimal HTML escaper — wire-log details mix static + agent-supplied text. */
+export const esc = (value: unknown): string =>
+  String(value ?? "").replace(/[&<>"']/g, (ch) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[ch] as string,
+  );
+
+export const money = (n: number): string => `$${n.toFixed(2)}`;

--- a/examples/ai-sdk-webmcp/app/lib/webmcp-tools.ts
+++ b/examples/ai-sdk-webmcp/app/lib/webmcp-tools.ts
@@ -1,0 +1,274 @@
+// Register the storefront's page tools on `document.modelContext` via WebMCP.
+//
+// `@mcp-b/webmcp-polyfill` polyfills the strict standard surface
+// (registerTool / getTools / executeTool). We install it explicitly so the
+// global exists before the Persona widget's first dispatch. The widget also
+// lazily installs it from its WebMCP bridge, but the *producer* page should
+// install first so the tools are registered by the time the widget snapshots
+// them.
+//
+// Each tool's execute() mutates the shared observable store (store.ts); the
+// React storefront re-renders off that store. This is the only structural
+// change from the vanilla embedded-app demo — the tool surface and behavior are
+// identical.
+
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+import { findBySku, searchCatalog } from "./catalog";
+import {
+  addToCart,
+  applyPromo,
+  cartSummary,
+  deleteCartLine,
+  esc,
+  flashCard,
+  flashCart,
+  getCartLine,
+  highlightHits,
+  logWire,
+  setCartLineQuantity,
+} from "./store";
+
+interface RegisterableModelContext {
+  registerTool(
+    tool: {
+      name: string;
+      description: string;
+      inputSchema?: object;
+      annotations?: Record<string, unknown>;
+      execute: (
+        args: Record<string, unknown>,
+        client: { requestUserInteraction: (cb: () => unknown) => Promise<unknown> },
+      ) => unknown;
+    },
+    options?: { signal?: AbortSignal },
+  ): void;
+}
+
+let registered = false;
+
+/** Idempotent: safe to call from a React effect (StrictMode double-invoke). */
+export function registerStorefrontTools(): void {
+  if (registered || typeof document === "undefined") return;
+  registered = true;
+
+  initializeWebMCPPolyfill();
+
+  const modelContext = (
+    document as Document & { modelContext?: RegisterableModelContext }
+  ).modelContext;
+
+  if (!modelContext) {
+    logWire("reg", "register", "document.modelContext unavailable — tools NOT registered");
+    return;
+  }
+
+  const ac = new AbortController();
+
+  // -- search_products (read-only) --
+  modelContext.registerTool(
+    {
+      name: "search_products",
+      description:
+        "Search the product catalog by free-text query (e.g. 'waterproof trail shoe', 'blue running', 'jacket'). Returns matching products with SKU, title, brand, color, and price.",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string", description: "Free-text search query." } },
+        required: ["query"],
+      },
+      annotations: { readOnlyHint: true },
+      execute(input): unknown {
+        const { query } = input as { query: string };
+        const hits = searchCatalog(query ?? "");
+        highlightHits(hits.map((p) => p.sku));
+        logWire(
+          "exec",
+          "search_products",
+          `query <b>${esc(query)}</b> → ${hits.length} hit${hits.length === 1 ? "" : "s"}`,
+        );
+        return {
+          query,
+          count: hits.length,
+          hits: hits.map((p) => ({
+            sku: p.sku,
+            title: p.title,
+            brand: p.brand,
+            category: p.category,
+            color: p.color,
+            price: p.price,
+            description: p.description,
+          })),
+        };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  // -- view_product (read-only) --
+  modelContext.registerTool(
+    {
+      name: "view_product",
+      description:
+        "Look at one product in detail by SKU (from search_products results). Highlights it on the page and returns its full description. Read-only.",
+      inputSchema: {
+        type: "object",
+        properties: { sku: { type: "string" } },
+        required: ["sku"],
+      },
+      annotations: { readOnlyHint: true },
+      execute(input): unknown {
+        const { sku } = input as { sku: string };
+        const product = findBySku(sku);
+        if (!product) {
+          logWire("exec", "view_product", `<b>${esc(sku)}</b> → not found`);
+          return { found: false, error: `No product with SKU "${sku}".` };
+        }
+        highlightHits([product.sku]);
+        flashCard(product.sku);
+        logWire("exec", "view_product", `<b>${esc(product.sku)}</b> — ${esc(product.title)}`);
+        return {
+          found: true,
+          sku: product.sku,
+          title: product.title,
+          brand: product.brand,
+          category: product.category,
+          color: product.color,
+          price: product.price,
+          description: product.description,
+        };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  // -- add_to_cart (mutating) --
+  modelContext.registerTool(
+    {
+      name: "add_to_cart",
+      description:
+        "Add a product to the shopper's cart by SKU (from search_products results). Returns the updated cart so you can confirm the running total.",
+      inputSchema: {
+        type: "object",
+        properties: { sku: { type: "string" }, quantity: { type: "integer", minimum: 1 } },
+        required: ["sku"],
+      },
+      annotations: { readOnlyHint: false },
+      execute(input): unknown {
+        const { sku, quantity = 1 } = input as { sku: string; quantity?: number };
+        const product = findBySku(sku);
+        if (!product) {
+          logWire("exec", "add_to_cart", `<b>${esc(sku)}</b> → not found`);
+          return {
+            added: false,
+            error: `No product with SKU "${sku}". Call search_products first to get valid SKUs.`,
+          };
+        }
+        addToCart(product, quantity);
+        logWire("exec", "add_to_cart", `<b>${esc(product.sku)}</b> ×${esc(quantity)} → ${esc(product.title)}`);
+        return {
+          added: true,
+          sku: product.sku,
+          title: product.title,
+          quantity,
+          unitPrice: product.price,
+          cart: cartSummary(),
+        };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  // -- remove_from_cart (mutating) --
+  modelContext.registerTool(
+    {
+      name: "remove_from_cart",
+      description:
+        "Remove a product from the cart by SKU, or reduce its quantity. Omit quantity to remove the line entirely. Returns the updated cart.",
+      inputSchema: {
+        type: "object",
+        properties: { sku: { type: "string" }, quantity: { type: "integer", minimum: 1 } },
+        required: ["sku"],
+      },
+      annotations: { readOnlyHint: false },
+      execute(input): unknown {
+        const { sku, quantity } = input as { sku: string; quantity?: number };
+        // Resolve the SKU canonically (the cart is keyed by product.sku), then
+        // only a positive partial quantity decrements; anything else removes the
+        // whole line — so a negative quantity can't subtract-a-negative.
+        const product = findBySku(sku);
+        if (!product) {
+          logWire("exec", "remove_from_cart", `<b>${esc(sku)}</b> → not found`);
+          return {
+            removed: false,
+            error: `No product with SKU "${sku}". Call search_products first to get valid SKUs.`,
+            cart: cartSummary(),
+          };
+        }
+        const line = getCartLine(product.sku);
+        if (!line) {
+          logWire("exec", "remove_from_cart", `<b>${esc(product.sku)}</b> → not in cart`);
+          return {
+            removed: false,
+            error: `"${product.sku}" is not in the cart.`,
+            cart: cartSummary(),
+          };
+        }
+        const partial =
+          typeof quantity === "number" && quantity >= 1 && quantity < line.quantity;
+        if (partial) {
+          setCartLineQuantity(product.sku, line.quantity - (quantity as number));
+        } else {
+          deleteCartLine(product.sku);
+        }
+        flashCart();
+        logWire(
+          "exec",
+          "remove_from_cart",
+          `<b>${esc(product.sku)}</b>${partial ? ` ×${esc(quantity)}` : ""} → removed`,
+        );
+        return { removed: true, sku: product.sku, cart: cartSummary() };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  // -- apply_promo (mutating) --
+  modelContext.registerTool(
+    {
+      name: "apply_promo",
+      description:
+        "Apply a promo code to the cart (e.g. TRAIL10, TRAILVIP, SUMMIT20). Returns whether it was accepted and the updated cart with the discount applied.",
+      inputSchema: {
+        type: "object",
+        properties: { code: { type: "string" } },
+        required: ["code"],
+      },
+      annotations: { readOnlyHint: false },
+      execute(input): unknown {
+        const { code } = input as { code: string };
+        const match = applyPromo(code ?? "");
+        if (!match) {
+          logWire("exec", "apply_promo", `<b>${esc(code)}</b> → rejected`);
+          return {
+            applied: false,
+            error: `"${code}" is not a valid promo code. Try TRAIL10, TRAILVIP, or SUMMIT20.`,
+            cart: cartSummary(),
+          };
+        }
+        const key = (code ?? "").trim().toUpperCase();
+        logWire("exec", "apply_promo", `<b>${esc(key)}</b> → ${esc(match.label)}`);
+        return { applied: true, code: key, discountRate: match.rate, cart: cartSummary() };
+      },
+    },
+    { signal: ac.signal },
+  );
+
+  logWire(
+    "reg",
+    "register",
+    "5 page tools on <b>document.modelContext</b>: " +
+      "search_products, view_product, add_to_cart, remove_from_cart, apply_promo",
+  );
+}
+
+/** Tools the storefront treats as read-only (safe to auto-approve). */
+export const READ_ONLY_TOOLS = new Set(["search_products", "view_product"]);

--- a/examples/ai-sdk-webmcp/app/lib/widget.ts
+++ b/examples/ai-sdk-webmcp/app/lib/widget.ts
@@ -1,0 +1,183 @@
+// Persona widget configuration for the Switchback storefront, pointed at the
+// local AI-SDK shim instead of Runtype.
+//
+// Proxy mode: `apiUrl` is the full dispatch URL and resume is POSTed to
+// `${apiUrl}/resume`. We point both at this app's own API routes
+// (app/api/chat/dispatch/route.ts + .../resume/route.ts), which speak Runtype's
+// proxy wire protocol on top of the Vercel AI SDK. No clientToken, no Runtype.
+
+import {
+  DEFAULT_WIDGET_CONFIG,
+  markdownPostprocessor,
+  type AgentWidgetConfig,
+  type WebMcpConfirmInfo,
+} from "@runtypelabs/persona";
+import { logWire, esc } from "./store";
+import { READ_ONLY_TOOLS } from "./webmcp-tools";
+
+// --- Switchback brand theme (ported from the embedded-app demo; mirrors
+//     globals.css). Warm artisan palette: espresso primary + caramel accent on
+//     cream; both follow the OS light/dark preference via colorScheme:'auto'. ---
+const shopTheme: NonNullable<AgentWidgetConfig["theme"]> = {
+  palette: {
+    colors: {
+      primary: { 500: "#1c1917", 600: "#292524", 700: "#44403c" },
+      accent: { 500: "#b8814b", 600: "#8a5a2b" },
+      gray: {
+        50: "#ffffff",
+        100: "#f6f4f0",
+        200: "#e7e5e4",
+        500: "#78716c",
+        900: "#1c1917",
+      },
+    },
+    radius: { md: "0.5rem", lg: "0.75rem", xl: "1rem" },
+  },
+  semantic: {
+    colors: {
+      primary: "#1c1917",
+      accent: "#b8814b",
+      surface: "#ffffff",
+      background: "#ffffff",
+      container: "#f6f4f0",
+      text: "#1c1917",
+      textMuted: "#78716c",
+      border: "#e7e5e4",
+      divider: "#e7e5e4",
+      interactive: {
+        default: "#1c1917",
+        hover: "#292524",
+        focus: "#44403c",
+        active: "#0c0a09",
+      },
+      feedback: { info: "#1c1917" },
+    },
+  },
+  components: {
+    panel: { borderRadius: "0" },
+    header: {
+      borderRadius: "0",
+      background: "#1c1917",
+      titleForeground: "#fafaf9",
+      subtitleForeground: "#d6d3d1",
+      iconBackground: "#b8814b",
+      iconForeground: "#1c1917",
+      actionIconForeground: "#e7e5e4",
+    },
+  },
+};
+
+const shopDarkTheme: NonNullable<AgentWidgetConfig["darkTheme"]> = {
+  palette: {
+    colors: {
+      primary: { 500: "#d4a574", 600: "#e0b787", 700: "#ecd3b0" },
+      accent: { 500: "#d4a574", 600: "#e0b787" },
+      gray: {
+        50: "#f5f5f4",
+        100: "#292524",
+        200: "#44403c",
+        500: "#a8a29e",
+        900: "#1c1917",
+        950: "#141110",
+      },
+    },
+  },
+  semantic: {
+    colors: {
+      primary: "#d4a574",
+      accent: "#d4a574",
+      surface: "#292524",
+      background: "#1c1917",
+      container: "#2c2724",
+      text: "#f5f5f4",
+      textMuted: "#a8a29e",
+      textInverse: "#1c1917",
+      border: "#44403c",
+      divider: "#44403c",
+      interactive: {
+        default: "#d4a574",
+        hover: "#e0b787",
+        focus: "#ecd3b0",
+        active: "#f0e0c8",
+        disabled: "#57534e",
+      },
+      feedback: { info: "#d4a574" },
+    },
+  },
+  components: {
+    panel: { borderRadius: "0" },
+    header: {
+      borderRadius: "0",
+      background: "#292524",
+      titleForeground: "#f5f5f4",
+      subtitleForeground: "#a8a29e",
+      iconBackground: "#d4a574",
+      iconForeground: "#1c1917",
+      actionIconForeground: "#d6d3d1",
+    },
+    message: {
+      assistant: { background: "#292524", text: "#f5f5f4", border: "#3a3530" },
+    },
+    input: { background: "#2c2724", placeholder: "#a8a29e" },
+    collapsibleWidget: {
+      container: "#292524",
+      surface: "#141110",
+      border: "#3a3530",
+    },
+    markdown: {
+      inlineCode: { background: "#44403c", foreground: "#f5f5f4" },
+    },
+  },
+};
+
+export function buildWidgetConfig(): AgentWidgetConfig {
+  return {
+    ...DEFAULT_WIDGET_CONFIG,
+    // Proxy mode → our own Next.js route. resume hits `${apiUrl}/resume`.
+    apiUrl: "/api/chat/dispatch",
+    features: {
+      ...DEFAULT_WIDGET_CONFIG.features,
+      showEventStreamToggle: true,
+    },
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+    theme: shopTheme,
+    darkTheme: shopDarkTheme,
+    colorScheme: "auto",
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Switchback Assistant",
+      welcomeSubtitle:
+        "I can search the catalog, pull up a product, and manage your cart — using this page's own tools. Try one of the prompts below.",
+      inputPlaceholder: "Find me a trail shoe…",
+    },
+    suggestionChips: [
+      "Find a waterproof trail shoe under $170",
+      "Tell me about SHOE-005",
+      "Add SHOE-001 and SHOE-007 at the same time",
+      "Apply code TRAIL10 and show my cart total",
+    ],
+    webmcp: {
+      enabled: true,
+      // Auto-approve the storefront's read-only tools; route mutating calls to
+      // Persona's native in-panel approval bubble. Name-based because the
+      // polyfill's getTools() does not echo annotations to consumers.
+      autoApprove: (info: WebMcpConfirmInfo): boolean => {
+        const readOnly = READ_ONLY_TOOLS.has(info.toolName);
+        logWire(
+          "gate",
+          "gate",
+          `${esc(info.toolName)} — ${readOnly ? "read-only → <b>auto-approve</b>" : "mutating → <b>approval bubble</b>"}`,
+        );
+        return readOnly;
+      },
+    },
+    launcher: {
+      title: "Switchback",
+      subtitle: "Trail & road running assistant",
+      enabled: false,
+      autoExpand: true,
+      width: "100%",
+      fullHeight: true,
+    },
+  };
+}

--- a/examples/ai-sdk-webmcp/app/page.tsx
+++ b/examples/ai-sdk-webmcp/app/page.tsx
@@ -1,0 +1,303 @@
+"use client";
+
+import {
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+import { createAgentExperience } from "@runtypelabs/persona";
+import { CATALOG, COLOR_HEX, type CatalogProduct } from "./lib/catalog";
+import {
+  cartSummary,
+  money,
+  shopStore,
+  type ShopState,
+} from "./lib/store";
+import { registerStorefrontTools } from "./lib/webmcp-tools";
+import { buildWidgetConfig } from "./lib/widget";
+
+const EMPTY_STATE: ShopState = {
+  cart: [],
+  promo: null,
+  hits: [],
+  flash: null,
+  cartFlashNonce: 0,
+  wire: [],
+};
+
+function useShop(): ShopState {
+  return useSyncExternalStore(
+    shopStore.subscribe,
+    shopStore.getSnapshot,
+    () => EMPTY_STATE, // server snapshot (storefront is client-driven)
+  );
+}
+
+// Restart a CSS flash animation each time `nonce` changes.
+function useFlash(nonce: number): boolean {
+  const [flashing, setFlashing] = useState(false);
+  useEffect(() => {
+    if (!nonce) return;
+    setFlashing(true);
+    const t = setTimeout(() => setFlashing(false), 900);
+    return () => clearTimeout(t);
+  }, [nonce]);
+  return flashing;
+}
+
+function ProductCard({
+  product,
+  isHit,
+  quantity,
+  flashNonce,
+}: {
+  product: CatalogProduct;
+  isHit: boolean;
+  quantity: number;
+  flashNonce: number;
+}) {
+  const flashing = useFlash(flashNonce);
+  const swatch = COLOR_HEX[product.color.toLowerCase()] ?? "#9ca3af";
+  const classes = [
+    "shop-product",
+    isHit ? "is-hit" : "",
+    quantity > 0 ? "in-cart" : "",
+    flashing ? "just-changed" : "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+  return (
+    <article className={classes} data-sku={product.sku}>
+      <span className="shop-incart-badge">{quantity > 0 ? quantity : ""}</span>
+      <div className="shop-product-top">
+        <span className="shop-swatch" style={{ background: swatch }} />
+        <span className="shop-product-cat">{product.category}</span>
+      </div>
+      <div className="shop-product-title">{product.title}</div>
+      <div className="shop-product-sub">
+        {product.brand} · {product.color}
+      </div>
+      <div className="shop-product-foot">
+        <span className="shop-product-price">{money(product.price)}</span>
+        <span className="shop-product-sku">{product.sku}</span>
+      </div>
+    </article>
+  );
+}
+
+function Cart({ state }: { state: ShopState }) {
+  const flashing = useFlash(state.cartFlashNonce);
+  const summary = cartSummary();
+  const className = `shop-cart${flashing ? " just-changed" : ""}`;
+
+  if (summary.items.length === 0) {
+    return (
+      <div className={className}>
+        <p className="shop-cart-empty">
+          Your cart is empty — ask the assistant to add something.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <ul className="shop-cart-lines">
+        {state.cart.map((line) => (
+          <li className="shop-cart-line" key={line.sku}>
+            <span className="shop-cart-qty">{line.quantity}×</span>
+            <span className="shop-cart-title">{line.title}</span>
+            <span className="shop-cart-sku">{line.sku}</span>
+            <span className="shop-cart-price">
+              {money(line.price * line.quantity)}
+            </span>
+          </li>
+        ))}
+      </ul>
+      <div className="shop-cart-foot">
+        <div className="shop-cart-row muted">
+          <span>Subtotal</span>
+          <span>{money(summary.subtotal)}</span>
+        </div>
+        {state.promo && (
+          <div className="shop-cart-row promo">
+            <span>
+              <span className="shop-cart-chip">{state.promo.code}</span>{" "}
+              {state.promo.label}
+            </span>
+            <span>−{money(summary.discount)}</span>
+          </div>
+        )}
+        <div className="shop-cart-row total">
+          <span>
+            {summary.itemCount} item{summary.itemCount === 1 ? "" : "s"}
+          </span>
+          <strong>{money(summary.total)}</strong>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const WIRE_LEGEND: Array<{ varName: string; label: string }> = [
+  { varName: "--wire-reg", label: "register" },
+  { varName: "--wire-send", label: "dispatch · clientTools[]" },
+  { varName: "--wire-gate", label: "approval gate" },
+  { varName: "--wire-exec", label: "page exec" },
+  { varName: "--wire-resume", label: "batched /resume" },
+];
+
+export default function Home() {
+  const state = useShop();
+  const cartQty = new Map(state.cart.map((l) => [l.sku, l.quantity]));
+  const widgetRef = useRef<HTMLDivElement | null>(null);
+
+  // Register page tools + mount the Persona widget once on the client.
+  useEffect(() => {
+    registerStorefrontTools();
+    if (!widgetRef.current) return;
+    const controller = createAgentExperience(widgetRef.current, buildWidgetConfig());
+    return () => controller.destroy();
+  }, []);
+
+  return (
+    <main className="stage">
+      <aside className="stage-controls">
+        <header className="shop-hero">
+          <h1 className="shop-wordmark">
+            <span className="shop-mark" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M4 17l5-9 4 6 2-3 5 6" />
+              </svg>
+            </span>
+            Switchback
+          </h1>
+          <p className="shop-tagline">Trail &amp; road running, outfitted.</p>
+          <p className="shop-explainer">
+            This storefront publishes its own page tools through{" "}
+            <code>document.modelContext.registerTool()</code>. Persona snapshots
+            them on every turn, ships them as <code>clientTools[]</code> to a{" "}
+            <strong>direct Vercel AI SDK backend</strong> (no Runtype), and when
+            the agent calls one the widget runs it <em>here on the page</em> and
+            posts the result back via <code>/resume</code>. Ask the assistant →
+            and watch the catalog, cart, and wire log react.
+          </p>
+        </header>
+
+        <section className="shop-section">
+          <div className="shop-section-head">
+            <h2 className="shop-section-title">Catalog</h2>
+            <span className="shop-section-meta">{CATALOG.length} products</span>
+          </div>
+          <div className="shop-catalog">
+            {CATALOG.map((product) => (
+              <ProductCard
+                key={product.sku}
+                product={product}
+                isHit={state.hits.includes(product.sku)}
+                quantity={cartQty.get(product.sku) ?? 0}
+                flashNonce={
+                  state.flash?.sku === product.sku ? state.flash.nonce : 0
+                }
+              />
+            ))}
+          </div>
+        </section>
+
+        <section className="shop-section">
+          <div className="shop-section-head">
+            <h2 className="shop-section-title">Cart</h2>
+            <span className="shop-section-meta">
+              {(() => {
+                const s = cartSummary();
+                return s.itemCount > 0
+                  ? `${s.itemCount} item${s.itemCount === 1 ? "" : "s"}`
+                  : "";
+              })()}
+            </span>
+          </div>
+          <Cart state={state} />
+        </section>
+
+        <section className="shop-section">
+          <details className="shop-wire" open>
+            <summary className="shop-wire-head">
+              WebMCP wire log
+              <span className="shop-wire-count">
+                {state.wire.length} event{state.wire.length === 1 ? "" : "s"}
+              </span>
+            </summary>
+            <div className="shop-wire-body">
+              {state.wire.length === 0 ? (
+                <div className="shop-wire-empty">
+                  No events yet — ask the assistant something.
+                </div>
+              ) : (
+                state.wire.map((ev) => (
+                  <div className={`wire-row ${ev.kind}`} key={ev.id}>
+                    <span className="wire-time">{ev.time}</span>
+                    <span className="wire-detail">
+                      <span className="wire-tag">{ev.tag}</span>{" "}
+                      <span
+                        dangerouslySetInnerHTML={{ __html: ev.detailHtml }}
+                      />
+                    </span>
+                  </div>
+                ))
+              )}
+            </div>
+            <div className="shop-wire-legend" aria-hidden="true">
+              {WIRE_LEGEND.map((l) => (
+                <span key={l.label}>
+                  <i style={{ background: `var(${l.varName})` }} />
+                  {l.label}
+                </span>
+              ))}
+            </div>
+          </details>
+        </section>
+
+        <section className="shop-section shop-notes">
+          <div className="shop-section-head">
+            <h2 className="shop-section-title">Try it</h2>
+          </div>
+          <ol>
+            <li>
+              <strong>Browse (read-only):</strong>{" "}
+              <em>“find a waterproof trail shoe under $170”</em> →{" "}
+              <code>search_products</code> auto-approves; matching cards light up.
+            </li>
+            <li>
+              <strong>Inspect (read-only):</strong>{" "}
+              <em>“tell me about SHOE-005”</em> → <code>view_product</code>; the
+              card flashes.
+            </li>
+            <li>
+              <strong>Parallel (the headline):</strong>{" "}
+              <em>“add SHOE-001 and SHOE-007 at the same time”</em> → two{" "}
+              <code>add_to_cart</code> calls, each with its own approval bubble,
+              batched into a single <code>/resume</code>.
+            </li>
+            <li>
+              <strong>Promo:</strong>{" "}
+              <em>“apply code TRAIL10 and show my cart total”</em> →{" "}
+              <code>apply_promo</code>, gated; the discount line appears.
+            </li>
+          </ol>
+        </section>
+      </aside>
+
+      <div className="stage-widget">
+        <div ref={widgetRef} />
+      </div>
+    </main>
+  );
+}

--- a/examples/ai-sdk-webmcp/next.config.mjs
+++ b/examples/ai-sdk-webmcp/next.config.mjs
@@ -1,5 +1,15 @@
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+// This example lives in a pnpm monorepo. Next 16's Turbopack otherwise infers
+// the workspace root ambiguously (multiple lockfiles) and fails to resolve
+// `next`; pin the root to the repo root so both the app and the workspace
+// `@runtypelabs/persona` package sit inside the compilable root.
+const repoRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  turbopack: { root: repoRoot },
   // The widget ships ESM + its own CSS; transpile it so Next can consume the
   // workspace package (and its `@runtypelabs/persona/widget.css` subpath) directly.
   transpilePackages: ["@runtypelabs/persona"],

--- a/examples/ai-sdk-webmcp/next.config.mjs
+++ b/examples/ai-sdk-webmcp/next.config.mjs
@@ -1,0 +1,10 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  // The widget ships ESM + its own CSS; transpile it so Next can consume the
+  // workspace package (and its `@runtypelabs/persona/widget.css` subpath) directly.
+  transpilePackages: ["@runtypelabs/persona"],
+  // This example has no ESLint config of its own; type-checking still runs.
+  eslint: { ignoreDuringBuilds: true },
+};
+
+export default nextConfig;

--- a/examples/ai-sdk-webmcp/package.json
+++ b/examples/ai-sdk-webmcp/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "ai-sdk-webmcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "pnpm --filter @runtypelabs/persona build && next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@mcp-b/webmcp-polyfill": "^3.0.0",
+    "@runtypelabs/persona": "workspace:^",
+    "@vercel/functions": "^3.6.2",
+    "ai": "^6.0.197",
+    "next": "^16.2.7",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.2",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/examples/ai-sdk-webmcp/tsconfig.json
+++ b/examples/ai-sdk-webmcp/tsconfig.json
@@ -1,0 +1,41 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "ES2022"
+    ],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ],
+    "paths": {
+      "@/*": [
+        "./*"
+      ]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}

--- a/examples/ai-sdk-webmcp/vercel.json
+++ b/examples/ai-sdk-webmcp/vercel.json
@@ -2,6 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "installCommand": "pnpm install --frozen-lockfile",
-  "buildCommand": "pnpm --filter @runtypelabs/persona build && next build",
+  "buildCommand": "pnpm --filter @runtypelabs/persona build && next build --webpack",
   "regions": ["iad1"]
 }

--- a/examples/ai-sdk-webmcp/vercel.json
+++ b/examples/ai-sdk-webmcp/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "installCommand": "pnpm install --frozen-lockfile",
+  "buildCommand": "pnpm --filter @runtypelabs/persona build && next build",
+  "regions": ["iad1"]
+}

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -525,6 +525,31 @@ inside the subtree is still pierced.
 > provenance and update steps. Once upstream republishes correctly this can revert to a
 > normal optional peer dependency.
 
+### WebMCP page tools
+
+When `webmcp: { enabled: true }` is set, the widget consumes tools the page
+registers on `document.modelContext` (the [WebMCP](https://github.com/webmachinelearning/webmcp)
+producer surface), snapshots them into each request as `clientTools[]`, runs the
+agent's calls on the page, and gates each behind a confirm bubble (override with
+`autoApprove` / `onConfirm`).
+
+```ts
+initAgentWidget({
+  // ...config
+  webmcp: {
+    enabled: true,
+    autoApprove: (info) => READ_ONLY_TOOLS.has(info.toolName),
+  },
+});
+```
+
+**Using WebMCP against a non-Runtype backend (e.g. the Vercel AI SDK)?** The
+widget's WebMCP loop expects Runtype's proxy wire protocol (a `step_await` pause
+→ `/resume` round-trip). See
+[`docs/webmcp-without-runtype.md`](../../docs/webmcp-without-runtype.md) for the
+exact contract and two integration paths, with a runnable Next.js example at
+[`examples/ai-sdk-webmcp/`](../../examples/ai-sdk-webmcp/).
+
 ### DOM Events
 
 The widget dispatches custom DOM events that you can listen to for integration with your application:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,47 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.7
-        version: 2.29.8(@types/node@20.19.35)
+        version: 2.29.8(@types/node@25.9.2)
       concurrently:
         specifier: ^8.2.2
         version: 8.2.2
+
+  examples/ai-sdk-webmcp:
+    dependencies:
+      '@mcp-b/webmcp-polyfill':
+        specifier: ^3.0.0
+        version: 3.0.0
+      '@runtypelabs/persona':
+        specifier: workspace:^
+        version: link:../../packages/widget
+      '@vercel/functions':
+        specifier: ^3.6.2
+        version: 3.6.2
+      ai:
+        specifier: ^6.0.197
+        version: 6.0.197(zod@4.1.11)
+      next:
+        specifier: ^16.2.7
+        version: 16.2.7(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.9.2
+        version: 25.9.2
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
 
   examples/cloudflare-workers:
     dependencies:
@@ -60,10 +97,10 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^5.4.1
-        version: 5.4.21(@types/node@20.19.35)
+        version: 5.4.21(@types/node@25.9.2)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0)
 
   examples/vercel-edge:
     dependencies:
@@ -128,7 +165,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.0
-        version: 4.1.0(@types/node@20.19.35)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))
+        version: 4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))
 
   packages/widget:
     dependencies:
@@ -192,12 +229,28 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.9
-        version: 4.0.18(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jsdom@28.1.0)(tsx@4.21.0)
 
 packages:
 
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
+
+  '@ai-sdk/gateway@3.0.125':
+    resolution: {integrity: sha512-tocl7cUDoTpmhZqeW8XVKMMznZQwwQAEunF0VyNKmf64qt8NbMIAEiet/vRMzh7Jr9WcFeb6EZjmhLTP4Qx2Og==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
 
   '@asamuzakjp/css-color@5.0.1':
     resolution: {integrity: sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==}
@@ -894,6 +947,61 @@ packages:
   '@mcp-b/webmcp-types@3.0.0':
     resolution: {integrity: sha512-MmKHNAtlyZoK5khz5GnmgEj/ehk5esoUbgOaFndrlZvpjq3ppmIY3BDrwCv6xaihuuIMOoLLDlf0E65wUd4q7A==}
 
+  '@next/env@16.2.7':
+    resolution: {integrity: sha512-tMJizPlj6ZYpBMMdK8S0LJufrP4QTdR6pcv9KQ/bVETPAmg0j1mlHE9G2c38UyGHxoBapgwuj7XjbGJ2RcDFOg==}
+
+  '@next/swc-darwin-arm64@16.2.7':
+    resolution: {integrity: sha512-vm1EDI/pVaBNNiychmxk3fft+OhQPVD9cIM/tReLZIQ3TfQ4kqI9DwKk00dzuS1ulC7icbrzCFrmRRlk9PfNdw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.2.7':
+    resolution: {integrity: sha512-O3IRSv1ZBL1zs0WrIgefTEcTKFVn+ryxBNe54erJ6KsD+2f/Mmt7g2jOYh8PSBdUwPtKQJuCsTMlZ7tIu2AcsQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.2.7':
+    resolution: {integrity: sha512-Re6PZtjBDd0aMU+VcZcC/PrIvj4WhrjDYtMhhCVQamWN4L90EVP0pcEOBQD25prSlw7OzNw5QpHLWMilRLsRNw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.2.7':
+    resolution: {integrity: sha512-qyogG9QtBzWxgJfeGBvOEHI3851gTfCF3wLZ5RDLTBJGAmE9p1qDwKCOdrBrvBzRvYDT+gUDp72pzlSEfAXgNA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.2.7':
+    resolution: {integrity: sha512-Vhe4ZDuBpmMogrGi5D4R2Kq4JAQlj6+wvgaFYy31zfES0zPmt6TLA+cuYpM/OLrPZjo2MYQTHVqNUSCR6+fDZQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.2.7':
+    resolution: {integrity: sha512-srvian89JahFLw1YLBEuhvPJ0DO5lpUeJQMXy4xYo7g628ZlNgXdNkqoxSAv9OYrBfByh6vxISMwW/mRbzCY+g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.2.7':
+    resolution: {integrity: sha512-GX3wvLpULFuRFJzwHaKfm7QZJ18F4ZSuxlPJ96BoBglCzBmdSjyeBKF+ZhWhvL/ckxNfLnNa7bsObO2ipYpszw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.7':
+    resolution: {integrity: sha512-J4WlM72NMk076Qsg0jTdK3SNXatlSdnjW7L7oNGLst1tAGjHrJh/FYi+pw9wyIjEtGRKDNzD0zuiY16oWYWVaw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -905,6 +1013,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.1':
+    resolution: {integrity: sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==}
+    engines: {node: '>=8.0.0'}
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1076,6 +1188,9 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -1090,6 +1205,17 @@ packages:
 
   '@types/node@20.19.35':
     resolution: {integrity: sha512-Uarfe6J91b9HAUXxjvSOdiO2UPOKLm07Q1oh0JHxoZ1y8HoqxDAu3gVrsrOHeiio0kSsoVBt4wFrKOm0dKxVPQ==}
+
+  '@types/node@25.9.2':
+    resolution: {integrity: sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
 
   '@types/trusted-types@2.0.7':
     resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
@@ -1154,6 +1280,30 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@0.1.1':
+    resolution: {integrity: sha512-LMRMEai3Z+BODyxGcU9+KiWrS/UElNiOLKiNRfGNt2Vu3NTEmXgFeXG9wBfocAnTe5yJCX/DY6k3k7S/LkPp/g==}
+    engines: {node: '>= 18'}
+
+  '@vercel/functions@3.6.2':
+    resolution: {integrity: sha512-AeWUppTKlHoeJ4zttStwAJ1PsSqucSK7NPy27wrb5cSBBo4VbRo7j6rFCcJrGg4jcV9Cv5Qmk4Dc2dHe6/1g5A==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/oidc@3.6.0':
+    resolution: {integrity: sha512-a2HjItW75qSZfyyDbZ2XDFTQAfNKM93uloZABPgx6t8IrdbCgf+EQBeSypQVP2jHrZ3LHApDgLFCf1frRgPwLg==}
+    engines: {node: '>= 20'}
 
   '@vitest/expect@4.0.18':
     resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
@@ -1232,6 +1382,12 @@ packages:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
+  ai@6.0.197:
+    resolution: {integrity: sha512-U3KsjkqwQXGHC0u0VeUDqUaNaBS/uQc7v4Vj92Cjv5lPx5DIyRBQYk4Hipy5vwD9AQKIG8uRvdaN9R+pAvrtcQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
@@ -1275,6 +1431,11 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  baseline-browser-mapping@2.10.34:
+    resolution: {integrity: sha512-IMDedajPifLnHNY0X9n8hKxRTQ6/eTHwr5bDo04WnuqxyKw6LYtQywCuuqPZwhl3aBXMvQpJov42GLCwRRdQzw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -1313,6 +1474,9 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
+  caniuse-lite@1.0.30001797:
+    resolution: {integrity: sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
@@ -1331,6 +1495,9 @@ packages:
   ci-info@3.9.0:
     resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
     engines: {node: '>=8'}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
@@ -1380,6 +1547,9 @@ packages:
   cssstyle@6.2.0:
     resolution: {integrity: sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==}
     engines: {node: '>=20'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -1519,6 +1689,14 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1612,6 +1790,10 @@ packages:
     resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
     engines: {node: '>=16'}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
   get-tsconfig@4.13.6:
     resolution: {integrity: sha512-shZT/QMiSHc/YBLxxOkMtgSid5HFoauqCE3/exfsEcwg1WkeqjG+V40yBbBrsD+jW2HDXcs28xOfcbm2jI8Ddw==}
 
@@ -1675,6 +1857,10 @@ packages:
     resolution: {integrity: sha512-tsYlhAYpjCKa//8rXZ9DqKEawhPoSytweBC2eNvcaDK+57RZLHGqNs3PZTQO6yekLFSuvA6AlnAfrw1uBvtb+Q==}
     hasBin: true
 
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -1724,6 +1910,10 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   is-subdir@1.2.0:
     resolution: {integrity: sha512-2AT6j+gXe/1ueqbW6fLZJiIw3F8iXGJtt0yDrZaBhAZEG1raiTxKWU+IPqMCzQAXOUCKdA4UDMgacKH25XG2Cw==}
     engines: {node: '>=4'}
@@ -1768,6 +1958,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -1835,6 +2028,9 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1842,6 +2038,10 @@ packages:
   micromatch@4.0.8:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   miniflare@4.20260305.0:
     resolution: {integrity: sha512-jVhtKJtiwaZa3rI+WgoLvSJmEazDsoUmAPYRUmEe2VO6VSbvkhbnDRm+dsPbYRatgNIExwrpqG1rv96jHiSb0w==}
@@ -1893,6 +2093,31 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  next@16.2.7:
+    resolution: {integrity: sha512-eMJxgjRzBaj3olkP4cBamHDXL79A8FC6u1GcsO1D1Tsx8bw/LLXUJCaoajVxtnhD3A1IJqIT8IcRJjgBIPJq4w==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1903,9 +2128,17 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   outdent@0.5.0:
     resolution: {integrity: sha512-/jHxFIzoMXdqPzTaCpFzAAWhpkSjZPF4Vsn6jAfNpmbH/ymsmd7Qc6VE9BGn0L6YMj6uwpQLxCECpus4ukKS9Q==}
@@ -2024,6 +2257,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -2046,6 +2283,15 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
 
   read-yaml-file@1.1.0:
     resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
@@ -2105,6 +2351,9 @@ packages:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -2128,6 +2377,9 @@ packages:
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
@@ -2201,9 +2453,26 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   sucrase@3.35.1:
     resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
@@ -2337,6 +2606,11 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
 
@@ -2347,6 +2621,9 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.18.2:
     resolution: {integrity: sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==}
@@ -2577,6 +2854,14 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
   xml-name-validator@5.0.0:
     resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
     engines: {node: '>=18'}
@@ -2609,9 +2894,30 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
 snapshots:
 
   '@acemir/cssom@0.9.31': {}
+
+  '@ai-sdk/gateway@3.0.125(zod@4.1.11)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.1.11)
+      '@vercel/oidc': 3.2.0
+      zod: 4.1.11
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.1.11)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.1.0
+      zod: 4.1.11
+
+  '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
 
   '@asamuzakjp/css-color@5.0.1':
     dependencies:
@@ -2668,7 +2974,7 @@ snapshots:
     dependencies:
       '@changesets/types': 6.1.0
 
-  '@changesets/cli@2.29.8(@types/node@20.19.35)':
+  '@changesets/cli@2.29.8(@types/node@25.9.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.0.14
       '@changesets/assemble-release-plan': 6.0.9
@@ -2684,7 +2990,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@20.19.35)
+      '@inquirer/external-editor': 1.0.3(@types/node@25.9.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       ci-info: 3.9.0
@@ -3123,12 +3429,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@20.19.35)':
+  '@inquirer/external-editor@1.0.3(@types/node@25.9.2)':
     dependencies:
       chardet: 2.1.1
       iconv-lite: 0.7.2
     optionalDependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.9.2
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -3182,6 +3488,32 @@ snapshots:
 
   '@mcp-b/webmcp-types@3.0.0': {}
 
+  '@next/env@16.2.7': {}
+
+  '@next/swc-darwin-arm64@16.2.7':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.7':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.2.7':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.7':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.2.7':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.7':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.2.7':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.7':
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3193,6 +3525,8 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@opentelemetry/api@1.9.1': {}
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -3296,6 +3630,10 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -3310,6 +3648,18 @@ snapshots:
   '@types/node@20.19.35':
     dependencies:
       undici-types: 6.21.0
+
+  '@types/node@25.9.2':
+    dependencies:
+      undici-types: 7.24.6
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/trusted-types@2.0.7':
     optional: true
@@ -3397,6 +3747,26 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@0.1.1':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/functions@3.6.2':
+    dependencies:
+      '@vercel/oidc': 3.6.0
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/oidc@3.6.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 0.1.1
+
   '@vitest/expect@4.0.18':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -3415,13 +3785,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.35)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)
+
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@25.9.2)(jiti@1.21.7)(tsx@4.21.0))':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1(@types/node@25.9.2)(jiti@1.21.7)(tsx@4.21.0)
 
   '@vitest/mocker@4.1.0(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))':
     dependencies:
@@ -3475,7 +3853,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -3495,6 +3873,14 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ai@6.0.197(zod@4.1.11):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.125(zod@4.1.11)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.1.11)
+      '@opentelemetry/api': 1.9.1
+      zod: 4.1.11
 
   ajv@6.14.0:
     dependencies:
@@ -3528,6 +3914,8 @@ snapshots:
   assertion-error@2.0.1: {}
 
   balanced-match@1.0.2: {}
+
+  baseline-browser-mapping@2.10.34: {}
 
   better-path-resolve@1.0.0:
     dependencies:
@@ -3563,6 +3951,8 @@ snapshots:
 
   callsites@3.1.0: {}
 
+  caniuse-lite@1.0.30001797: {}
+
   chai@6.2.2: {}
 
   chalk@4.1.2:
@@ -3577,6 +3967,8 @@ snapshots:
       readdirp: 4.1.2
 
   ci-info@3.9.0: {}
+
+  client-only@0.0.1: {}
 
   cliui@8.0.1:
     dependencies:
@@ -3631,6 +4023,8 @@ snapshots:
       '@csstools/css-syntax-patches-for-csstree': 1.1.0
       css-tree: 3.2.1
       lru-cache: 11.2.6
+
+  csstype@3.2.3: {}
 
   data-urls@7.0.0:
     dependencies:
@@ -3825,6 +4219,20 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventsource-parser@3.1.0: {}
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   expect-type@1.3.0: {}
 
   extendable-error@0.1.7: {}
@@ -3917,6 +4325,8 @@ snapshots:
 
   get-port@7.1.0: {}
 
+  get-stream@6.0.1: {}
+
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
@@ -3999,6 +4409,8 @@ snapshots:
 
   human-id@4.1.3: {}
 
+  human-signals@2.1.0: {}
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -4034,6 +4446,8 @@ snapshots:
   is-path-inside@3.0.3: {}
 
   is-potential-custom-element-name@1.0.1: {}
+
+  is-stream@2.0.1: {}
 
   is-subdir@1.2.0:
     dependencies:
@@ -4094,6 +4508,8 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
+  json-schema@0.4.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
 
   jsonfile@4.0.0:
@@ -4145,12 +4561,16 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  merge-stream@2.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mimic-fn@2.1.0: {}
 
   miniflare@4.20260305.0:
     dependencies:
@@ -4205,6 +4625,35 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  next@16.2.7(@opentelemetry/api@1.9.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@next/env': 16.2.7
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.34
+      caniuse-lite: 1.0.30001797
+      postcss: 8.4.31
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      styled-jsx: 5.1.6(react@19.2.7)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.7
+      '@next/swc-darwin-x64': 16.2.7
+      '@next/swc-linux-arm64-gnu': 16.2.7
+      '@next/swc-linux-arm64-musl': 16.2.7
+      '@next/swc-linux-x64-gnu': 16.2.7
+      '@next/swc-linux-x64-musl': 16.2.7
+      '@next/swc-win32-arm64-msvc': 16.2.7
+      '@next/swc-win32-x64-msvc': 16.2.7
+      '@opentelemetry/api': 1.9.1
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   object-assign@4.1.1: {}
 
   obug@2.1.1: {}
@@ -4212,6 +4661,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -4221,6 +4674,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  os-paths@4.4.0: {}
 
   outdent@0.5.0: {}
 
@@ -4307,6 +4762,12 @@ snapshots:
       postcss: 8.5.6
       tsx: 4.21.0
 
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
   postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
@@ -4322,6 +4783,13 @@ snapshots:
   quansync@0.2.11: {}
 
   queue-microtask@1.2.3: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react@19.2.7: {}
 
   read-yaml-file@1.1.0:
     dependencies:
@@ -4397,6 +4865,8 @@ snapshots:
     dependencies:
       xmlchars: 2.2.0
 
+  scheduler@0.27.0: {}
+
   semver@7.7.4: {}
 
   sharp@0.34.5:
@@ -4439,6 +4909,8 @@ snapshots:
   shell-quote@1.8.3: {}
 
   siginfo@2.0.0: {}
+
+  signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
 
@@ -4501,7 +4973,14 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-final-newline@2.0.0: {}
+
   strip-json-comments@3.1.1: {}
+
+  styled-jsx@5.1.6(react@19.2.7):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.7
 
   sucrase@3.35.1:
     dependencies:
@@ -4628,12 +5107,16 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  typescript@6.0.3: {}
+
   ufo@1.6.3: {}
 
   uglify-js@3.19.3:
     optional: true
 
   undici-types@6.21.0: {}
+
+  undici-types@7.24.6: {}
 
   undici@7.18.2: {}
 
@@ -4649,13 +5132,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite@5.4.21(@types/node@20.19.35):
+  vite@5.4.21(@types/node@25.9.2):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.5.6
       rollup: 4.59.0
     optionalDependencies:
-      '@types/node': 20.19.35
+      '@types/node': 25.9.2
       fsevents: 2.3.3
 
   vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0):
@@ -4672,10 +5155,24 @@ snapshots:
       jiti: 1.21.7
       tsx: 4.21.0
 
-  vitest@4.0.18(@types/node@20.19.35)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0):
+  vite@7.3.1(@types/node@25.9.2)(jiti@1.21.7)(tsx@4.21.0):
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.59.0
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 25.9.2
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      tsx: 4.21.0
+
+  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jsdom@28.1.0)(tsx@4.21.0):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.35)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -4695,6 +5192,7 @@ snapshots:
       vite: 7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.35
       '@vitest/ui': 4.0.18(vitest@4.0.18)
       jsdom: 28.1.0
@@ -4711,7 +5209,47 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.0(@types/node@20.19.35)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)):
+  vitest@4.0.18(@opentelemetry/api@1.9.1)(@types/node@25.9.2)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(tsx@4.21.0):
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@25.9.2)(jiti@1.21.7)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1(@types/node@25.9.2)(jiti@1.21.7)(tsx@4.21.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@types/node': 25.9.2
+      '@vitest/ui': 4.0.18(vitest@4.0.18)
+      jsdom: 28.1.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  vitest@4.1.0(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)):
     dependencies:
       '@vitest/expect': 4.1.0
       '@vitest/mocker': 4.1.0(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0))
@@ -4734,6 +5272,7 @@ snapshots:
       vite: 7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.1
       '@types/node': 20.19.35
       jsdom: 28.1.0
     transitivePeerDependencies:
@@ -4809,6 +5348,15 @@ snapshots:
 
   ws@8.18.0: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
@@ -4843,3 +5391,5 @@ snapshots:
       youch-core: 0.3.3
 
   zod@3.25.76: {}
+
+  zod@4.1.11: {}


### PR DESCRIPTION
## What

A new Next.js example, `examples/ai-sdk-webmcp/` — a port of the **Switchback** WebMCP storefront demo that drives the **real Persona widget** against a **direct Vercel AI SDK v6 backend, with no Runtype**.

The storefront publishes its own page tools via WebMCP (`document.modelContext.registerTool`); the widget snapshots them into `clientTools[]`, runs the agent's calls on the page, and posts results back via `/resume`. The only difference from the hosted demo is what's behind the widget.

## How it works

The widget's WebMCP loop is bound to Runtype's **proxy wire protocol** (a `step_await` SSE pause → `/resume` round-trip), so the example ships a **protocol shim** (`app/api/chat/shim.ts`) that emits that protocol on top of `streamText`:

- `clientTools[]` → AI SDK `tool()`s with **no `execute`** (client-side); the model's call streams out as `step_await` and the turn pauses.
- text → `step_chunk`; turn end → `step_complete` + `flow_complete`.
- `/resume` appends the tool results and continues `streamText` (handles parallel + multi-step tool calls).

Model calls route through the **Vercel AI Gateway** (bare `anthropic/claude-sonnet-4.6` id) — OIDC on Vercel (no key), `AI_GATEWAY_API_KEY` locally.

Paused executions live in the **Vercel Runtime Cache** (`app/api/chat/execution-store.ts`) so dispatch and `/resume` survive across serverless instances. ⚠️ It's an ephemeral, region-scoped cache — flagged in code to **swap for a durable store in production**.

## Docs

- `docs/webmcp-without-runtype.md` — the exact wire contract + both integration paths (this shim, vs. reusing just `WebMcpBridge` with the AI SDK's native client-tool loop).
- Cross-linked from a new **WebMCP page tools** section in the widget README.

## Notes

- **Examples + docs only — no changeset.** (The one `packages/widget` change is README.)
- Built clean on the latest majors: Next 16, TypeScript 6, React 19.2, `ai` 6, `@vercel/functions` 3.6.
- A Vercel preview needs a project with **Root Directory = `examples/ai-sdk-webmcp`** (build: `pnpm --filter @runtypelabs/persona build && next build`); single region for the Runtime Cache. See the example README's "Deploy on Vercel".

## Verification

`next build` passes; storefront renders; dispatch routes through the gateway; `/resume` exercises the execution store. The live model→tool→pause→resume loop needs an AI Gateway-enabled deploy (or local `AI_GATEWAY_API_KEY`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples and documentation only; the widget package change is README cross-links with no runtime or API changes.
> 
> **Overview**
> Adds **`examples/ai-sdk-webmcp/`**, a Next.js Switchback storefront that keeps the **unchanged Persona widget** in proxy mode while backing it with **Vercel AI SDK `streamText`** (via AI Gateway) instead of Runtype.
> 
> The core addition is a **Runtype proxy-protocol shim** (`shim.ts`): dispatch/resume routes emit `step_chunk`, `step_await` (with `webmcp:` tool names), and `flow_complete`, mapping AI SDK client-side tools (no `execute`) to the widget’s pause → page tool run → **`POST …/resume`** loop. Paused turns are stored in **`execution-store.ts`** (Vercel Runtime Cache + local Map fallback), with explicit warnings to use a durable store in production.
> 
> Also adds **`docs/webmcp-without-runtype.md`** (wire contract, shim path vs. standalone `WebMcpBridge` + `useChat`), a **WebMCP section** in `packages/widget/README.md` linking to both, and **`pnpm-lock.yaml`** entries for the new example workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee19bcfd5c0cb061990525587a9a0f7d475436cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->