### PR TITLE
docs: list ai-sdk-webmcp example + link its live demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Persona works with any SSE-capable backend. It's pre-integrated with [Runtype](h
 | Example | Platform | Description |
 |---------|----------|-------------|
 | [`examples/embedded-app`](./examples/embedded-app) | Vite | Vanilla JS demo with runtime configuration ([live](https://persona-chat.dev)) |
+| [`examples/ai-sdk-webmcp`](./examples/ai-sdk-webmcp) | Next.js | WebMCP page tools on a direct Vercel AI SDK backend, no Runtype ([live](https://ai-sdk-webmcp.persona-chat.dev)) |
 | [`examples/vercel-edge`](./examples/vercel-edge) | Vercel / Railway / Fly.io | Node.js proxy server |
 | [`examples/cloudflare-workers`](./examples/cloudflare-workers) | Cloudflare Workers | Edge proxy server |
 

--- a/docs/webmcp-without-runtype.md
+++ b/docs/webmcp-without-runtype.md
@@ -31,6 +31,7 @@ So:
 ## Path A — keep the widget, shim the protocol (recommended for "drop-in")
 
 A runnable example lives at [`examples/ai-sdk-webmcp/`](../examples/ai-sdk-webmcp/)
+(live at [ai-sdk-webmcp.persona-chat.dev](https://ai-sdk-webmcp.persona-chat.dev))
 — the Switchback storefront with the real Persona widget, backed by two AI SDK
 route handlers. Point the widget at your own endpoint in **proxy mode**:
 

--- a/examples/ai-sdk-webmcp/README.md
+++ b/examples/ai-sdk-webmcp/README.md
@@ -4,6 +4,8 @@ A Next.js port of the **Switchback** WebMCP storefront demo that drives the
 **real Persona widget** against a **direct [Vercel AI SDK](https://ai-sdk.dev)
 backend** — **no Runtype**.
 
+**Live demo:** [ai-sdk-webmcp.persona-chat.dev](https://ai-sdk-webmcp.persona-chat.dev)
+
 The storefront publishes its own page tools via WebMCP
 (`document.modelContext.registerTool`). The Persona widget snapshots them each
 turn, ships them as `clientTools[]`, and when the agent calls one the widget runs


### PR DESCRIPTION
Follow-up to #229.

- Adds the **ai-sdk-webmcp** example to the root README **Examples** table (it was missing — #229 added the directory and docs but not this row).
- Links the public live demo — **https://ai-sdk-webmcp.persona-chat.dev** — from the example README and `docs/webmcp-without-runtype.md`.

Docs-only; no changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime, API, or dependency changes.
> 
> **Overview**
> Documents the **ai-sdk-webmcp** example in the root **Examples** table (Next.js, WebMCP + direct Vercel AI SDK, no Runtype) with a **[live](https://ai-sdk-webmcp.persona-chat.dev)** link, matching how other examples are listed.
> 
> Adds the same public demo URL to **`examples/ai-sdk-webmcp/README.md`** and **`docs/webmcp-without-runtype.md`** (Path A section) so readers can open the hosted Switchback storefront without hunting for the deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a43703d2266fdccb01c607ec754b5003d4b2551. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->