### PR TITLE
feat: use nvidia/nemotron-3-ultra-550b-a55b for all agents

### DIFF
--- a/examples/ai-sdk-webmcp/.env.local.example
+++ b/examples/ai-sdk-webmcp/.env.local.example
@@ -1,7 +1,7 @@
 # Copy to `.env.local`.
 #
 # This example routes model calls through the Vercel AI Gateway (the shim uses a
-# bare "anthropic/claude-sonnet-4.6" model id). Auth:
+# bare "nvidia/nemotron-3-ultra-550b-a55b" model id). Auth:
 #
 #   • On Vercel:  nothing to set — the gateway authenticates automatically via
 #                 the deployment's OIDC token.

--- a/examples/ai-sdk-webmcp/README.md
+++ b/examples/ai-sdk-webmcp/README.md
@@ -42,7 +42,7 @@ talking to Runtype.
 ## Run
 
 Model calls route through the **Vercel AI Gateway** (the shim uses a bare
-`anthropic/claude-sonnet-4.6` model id). On Vercel this authenticates
+`nvidia/nemotron-3-ultra-550b-a55b` model id). On Vercel this authenticates
 automatically via the deployment's OIDC token — **no key to set**. For local dev
 you need an `AI_GATEWAY_API_KEY`:
 

--- a/examples/ai-sdk-webmcp/app/api/chat/shim.ts
+++ b/examples/ai-sdk-webmcp/app/api/chat/shim.ts
@@ -42,8 +42,7 @@ const WEBMCP_PREFIX = "webmcp:";
 // Bare "creator/model" id → the AI SDK routes through the Vercel AI Gateway
 // (the default provider when no provider instance is given). On Vercel this
 // authenticates automatically via OIDC; locally it uses AI_GATEWAY_API_KEY.
-// Gateway slugs use dots (claude-sonnet-4.6), unlike the provider SDK (…-4-6).
-const MODEL = "anthropic/claude-sonnet-4.6";
+const MODEL = "nvidia/nemotron-3-ultra-550b-a55b";
 
 const SYSTEM_PROMPT = `You are the Switchback shopping assistant for a trail & road running store.
 You help shoppers using ONLY the page's own tools (search_products, view_product,


### PR DESCRIPTION
Sets every hard-coded agent model in the repo to Nemotron 3 Ultra.

The correct id depends on **who the agent talks to** (confirmed against the core repo's model registry — `packages/shared/src/generated-model-routing.ts` and `packages/model-execution/src/generated-configs.ts`):

- Canonical Runtype API model id: **`nemotron-3-ultra-550b-a55b`** (bare)
- Internal Vercel provider target: `nvidia/nemotron-3-ultra-550b-a55b`

## Changes

**Proxy flows (`packages/proxy`)** → bare `nemotron-3-ultra-550b-a55b` (forwarded to the Runtype API). Was `mercury-2`, plus `claude-sonnet-4-6` for webmcp-storefront:
- `conversational`, `shopping-assistant` (×2), `scheduling`, `bakery-assistant`, `components`, `page-context`, `storefront-assistant`, `webmcp-storefront`, and the `index.ts` default
- Updated the model-rationale comment in `webmcp-storefront.ts`

**Embedded-app demos (`examples/embedded-app`)** → bare `nemotron-3-ultra-550b-a55b` (go through the Runtype proxy): `main.ts` (was `claude-haiku-4-5-...`), `fullscreen-assistant-demo.ts`, `agent-demo.ts`

**AI-SDK example (`examples/ai-sdk-webmcp`)** → keeps `nvidia/nemotron-3-ultra-550b-a55b` — this one calls the **Vercel AI Gateway directly**, not Runtype, so it needs the gateway slug. `shim.ts` + `README.md` + `.env.local.example`.

Test fixtures (`*.test.ts`, `openai:gpt-4o-mini`) left untouched.

Includes a `@runtypelabs/persona-proxy` patch changeset. `pnpm build:proxy` + `pnpm typecheck` pass.