### PR TITLE
feat: set Nemotron 3 Ultra for proxy + embedded-app agents

### DIFF
--- a/.changeset/nemotron-proxy-flows.md
+++ b/.changeset/nemotron-proxy-flows.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Switch all built-in proxy flow agents to the `nvidia/nemotron-3-ultra-550b-a55b` model.

--- a/examples/embedded-app/src/agent-demo.ts
+++ b/examples/embedded-app/src/agent-demo.ts
@@ -41,7 +41,7 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
     ),
     agent: {
       name: "Travel Planner Assistant",
-      model: "mercury-2",
+      model: "nemotron-3-ultra-550b-a55b",
       systemPrompt:
         "You are a travel planning assistant with access to the Exa web search tool. " +
         "For itinerary requests, complete work in exactly 3 iterations: " +

--- a/examples/embedded-app/src/fullscreen-assistant-demo.ts
+++ b/examples/embedded-app/src/fullscreen-assistant-demo.ts
@@ -460,7 +460,7 @@ const config = mergeWithDefaults({
   },
   agent: {
     name: "Chat Assistant",
-    model: "mercury-2",
+    model: "nemotron-3-ultra-550b-a55b",
     systemPrompt: "You are a helpful assistant. Be friendly, concise, and helpful. If you don't know something, say so.",
     artifacts: { enabled: true, types: ["markdown", "component"] },
   },

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -226,7 +226,7 @@ const homeDemoInputPlaceholder =
 const homeDemoSharedAssistant = {
   agent: {
     name: "Persona Documentation Assistant",
-    model: "claude-haiku-4-5-20251001",
+    model: "nemotron-3-ultra-550b-a55b",
     systemPrompt: PERSONA_SYSTEM_PROMPT,
     temperature: 0.5,
     tools: {

--- a/packages/proxy/src/flows/bakery-assistant.ts
+++ b/packages/proxy/src/flows/bakery-assistant.ts
@@ -20,7 +20,7 @@ export const BAKERY_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/components.ts
+++ b/packages/proxy/src/flows/components.ts
@@ -14,7 +14,7 @@ export const COMPONENT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/conversational.ts
+++ b/packages/proxy/src/flows/conversational.ts
@@ -14,7 +14,7 @@ export const CONVERSATIONAL_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/page-context.ts
+++ b/packages/proxy/src/flows/page-context.ts
@@ -31,7 +31,7 @@ export const PAGE_CONTEXT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         responseFormat: "JSON",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/scheduling.ts
+++ b/packages/proxy/src/flows/scheduling.ts
@@ -14,7 +14,7 @@ export const FORM_DIRECTIVE_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/shopping-assistant.ts
+++ b/packages/proxy/src/flows/shopping-assistant.ts
@@ -18,7 +18,7 @@ export const SHOPPING_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",
@@ -97,7 +97,7 @@ export const SHOPPING_ASSISTANT_METADATA_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/storefront-assistant.ts
+++ b/packages/proxy/src/flows/storefront-assistant.ts
@@ -23,7 +23,7 @@ export const STOREFRONT_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-storefront.ts
+++ b/packages/proxy/src/flows/webmcp-storefront.ts
@@ -17,10 +17,9 @@ import type { RuntypeFlowConfig } from "../index.js";
  * needs a tool-capable model and a system prompt that knows how to shop the
  * (page-provided) catalog.
  *
- * Model: `claude-sonnet-4-6`. WebMCP depends on the model emitting **native**
- * tool calls (each surfaces as a `step_await` the widget resumes); a
- * tool-reliable model is required here, so this flow does not use the
- * `mercury-2` default the conversational demos rely on. `responseFormat` is
+ * Model: `nemotron-3-ultra-550b-a55b`. WebMCP depends on the model
+ * emitting **native** tool calls (each surfaces as a `step_await` the widget
+ * resumes), so a tool-reliable model is required here. `responseFormat` is
  * markdown (not JSON) so the model is free to interleave tool calls with a
  * natural-language summary instead of being constrained to a JSON envelope.
  */
@@ -35,7 +34,7 @@ export const WEBMCP_STOREFRONT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "claude-sonnet-4-6",
+        model: "nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -145,7 +145,7 @@ const DEFAULT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "mercury-2",
+        model: "nemotron-3-ultra-550b-a55b",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",


### PR DESCRIPTION
Follow-up to #232 (which only landed the `ai-sdk-webmcp` Vercel-gateway change). Sets the remaining hard-coded agents to **Nemotron 3 Ultra**.

Uses the canonical bare Runtype model id **`nemotron-3-ultra-550b-a55b`** — confirmed against the core repo's model registry (`packages/shared/src/generated-model-routing.ts`, `packages/model-execution/src/generated-configs.ts`), where `nvidia/nemotron-3-ultra-550b-a55b` is the internal Vercel provider target and the bare id is what the Runtype API expects.

## Changes
- **Proxy flows (`packages/proxy`)** — `conversational`, `shopping-assistant` (×2), `scheduling`, `bakery-assistant`, `components`, `page-context`, `storefront-assistant`, `webmcp-storefront`, and the `index.ts` default (was `mercury-2`, plus `claude-sonnet-4-6` for webmcp-storefront). Refreshed the model-rationale comment in `webmcp-storefront.ts`.
- **Embedded-app demos** — `main.ts` (was `claude-haiku-4-5-...`), `fullscreen-assistant-demo.ts`, `agent-demo.ts`.

Includes a `@runtypelabs/persona-proxy` patch changeset. `pnpm typecheck` passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swapping models across JSON-action, MCP, and WebMCP tool flows may change output quality or tool-call reliability in demos without code-path changes.
> 
> **Overview**
> Standardizes remaining hard-coded LLM backends on the Runtype bare model id **`nemotron-3-ultra-550b-a55b`**, completing Nemotron rollout after the ai-sdk-webmcp gateway work.
> 
> **`@runtypelabs/persona-proxy`** — Every built-in flow prompt step and **`DEFAULT_FLOW`** in `index.ts` that previously used **`mercury-2`** now points at Nemotron. **`webmcp-storefront`** also moves off **`claude-sonnet-4-6`**, with the file comment updated to document Nemotron as the tool-capable choice for native WebMCP **`step_await`** / **`/resume`** loops.
> 
> **Embedded-app demos** — Agent-mode widgets in **`main.ts`** (docs assistant), **`fullscreen-assistant-demo.ts`**, and **`agent-demo.ts`** drop Claude/Mercury defaults in favor of the same Nemotron id.
> 
> A **`@runtypelabs/persona-proxy` patch** changeset records the proxy package bump; prompts, routing, and API shapes are unchanged aside from the model string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7259acd6aa22c5f92670d6da0bab868360712b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->