### PR TITLE
Hide blank leading tool bubbles

### DIFF
--- a/.changeset/hide-blank-tool-bubbles.md
+++ b/.changeset/hide-blank-tool-bubbles.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Suppress whitespace-only assistant bubbles emitted before leading tool calls.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1633,6 +1633,55 @@ describe('AgentWidgetClient - partId Text/Tool Interleaving', () => {
     expect(seqTool).toBeLessThan(seq1);
   });
 
+  it('should not emit a whitespace-only assistant bubble before a leading tool call', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    const encoder = new TextEncoder();
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const stream = new ReadableStream({
+        start(controller) {
+          const e = (eventType: string, data: Record<string, unknown>) =>
+            controller.enqueue(encoder.encode(`event: ${eventType}\ndata: ${JSON.stringify({ type: eventType, ...data })}\n\n`));
+
+          e('flow_start', { flowId: 'f1', flowName: 'Test', totalSteps: 1 });
+          e('step_start', { id: 's1', name: 'Prompt', stepType: 'prompt', index: 1, totalSteps: 1 });
+          // Tool UI is the first meaningful output. Some providers still emit
+          // newline-only text lifecycle events around the tool boundary; those
+          // must not become an empty assistant message bubble.
+          e('tool_start', { toolId: 'tc_1', name: 'add_to_cart', toolType: 'local', sequenceIndex: 4 });
+          e('text_start', { partId: 'text_0', messageId: 'msg_s1', seq: 1 });
+          e('step_delta', { id: 's1', text: '\n', partId: 'text_0', messageId: 'msg_s1', seq: 2 });
+          e('text_end', { partId: 'text_0', messageId: 'msg_s1', seq: 3 });
+          e('tool_complete', { toolId: 'tc_1', name: 'add_to_cart', success: true, completedAt: new Date().toISOString(), executionTime: 20, sequenceIndex: 5 });
+          e('flow_complete', { success: true });
+          controller.close();
+        }
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'Add to cart', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const messageEvents = events.filter(e => e.type === 'message');
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of messageEvents) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+
+    const allMessages = Array.from(messagesById.values());
+    const assistantTexts = allMessages.filter(m => m.role === 'assistant' && !m.variant);
+    const toolMsgs = allMessages.filter(m => m.variant === 'tool');
+
+    expect(assistantTexts).toHaveLength(0);
+    expect(toolMsgs).toHaveLength(1);
+    expect(toolMsgs[0].toolCall?.name).toBe('add_to_cart');
+    expect(toolMsgs[0].toolCall?.status).toBe('complete');
+  });
+
   it('should not split when partId is absent (backward compatible)', async () => {
     const events: AgentWidgetEvent[] = [];
 

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1297,7 +1297,25 @@ export class AgentWidgetClient {
       };
     };
 
+    const shouldEmitMessage = (msg: AgentWidgetMessage): boolean => {
+      if (msg.role !== "assistant" || msg.variant) return true;
+
+      const hasContentParts =
+        Array.isArray(msg.contentParts) && msg.contentParts.length > 0;
+      const hasRawContent =
+        typeof msg.rawContent === "string" && msg.rawContent.trim() !== "";
+      const hasVisibleText =
+        typeof msg.content === "string" && msg.content.trim() !== "";
+
+      // Do not surface assistant text bubbles that only contain whitespace.
+      // Some providers emit newline-only text parts around a leading tool call;
+      // rendering those as normal messages creates an empty bubble above the
+      // tool card. Keep media/component/stop-reason messages renderable.
+      return hasVisibleText || hasContentParts || hasRawContent || Boolean(msg.stopReason);
+    };
+
     const emitMessage = (msg: AgentWidgetMessage) => {
+      if (!shouldEmitMessage(msg)) return;
       onEvent({
         type: "message",
         message: cloneMessage(msg)


### PR DESCRIPTION
## Summary
- Suppress assistant text messages that only contain whitespace before they reach the transcript
- Preserve assistant messages that carry visible text, content parts, raw component/artifact content, or stop-reason notices
- Add a regression test for newline-only text lifecycle events around a leading tool call
- Add a patch changeset for `@runtypelabs/persona`

## Root cause
Some streams emit newline-only `text_start` / `step_delta` / `text_end` lifecycle events around a tool call that is the first meaningful assistant output. Persona treated that whitespace-only assistant segment as a normal message, so the UI rendered an empty assistant bubble above the tool card.

## Validation
- `pnpm --filter @runtypelabs/persona test:run -- client.test.ts`
- `pnpm --filter @runtypelabs/persona lint`
- `pnpm --filter @runtypelabs/persona typecheck`
- `pnpm --filter @runtypelabs/persona build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering at message emit time with explicit carve-outs for content parts, raw content, and stop reasons; covered by a targeted regression test.
> 
> **Overview**
> Fixes empty assistant bubbles when the first model output is a tool call but the stream still emits **newline-only** `text_start` / `step_delta` / `text_end` around that boundary.
> 
> **`AgentWidgetClient`** now gates outgoing `message` events: plain assistant text is dropped unless it has trimmed visible `content`, `contentParts`, non-blank `rawContent`, or a `stopReason`; tool/reasoning variants and non-assistant messages are unchanged. A regression test covers tool-first streams with `\n`-only text lifecycle events. **`@runtypelabs/persona`** gets a patch changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fb7d2f60eeae1ea2a05f767220d71c70294522f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->