### PR TITLE
Really cut down launcher bundle size

### DIFF
--- a/.changeset/launcher-critical-bundle.md
+++ b/.changeset/launcher-critical-bundle.md
@@ -1,0 +1,9 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Faster script-tag installs: the launcher now loads from a standalone ~14 KB brotli `launcher.global.js` critical bundle (vs ~134 KB for the full `index.global.js`), and the heavy conversation panel is deferred until the launcher is first clicked.
+
+The installer (`install.global.js`) automatically takes this path for the common floating-launcher case and renders the real launcher — full theme and Lucide icon fidelity, no placeholder or flash. On first click it loads the full widget and opens the panel via the existing controller API, then removes the critical launcher. Any configuration that starts open or renders differently eager-loads the full bundle exactly as before — inline embeds, docked / composer-bar modes, `launcher.autoExpand`, a persisted "was open" state restored on reload, and `onStateLoaded` hooks — as do custom `jsUrl` overrides that don't mirror the published `dist` layout. Also adds a public `window.AgentWidgetLauncher.mount()` API for advanced/standalone use.
+
+Clearer install lifecycle hooks, so deferral never makes a "loaded" handler fire at the wrong time: `onScriptLoad` (the embed script executed), `onLauncherShown` (the launcher painted on the page — page-load time, for "widget appeared" analytics), `onChatReady` (the full widget is initialized and its controller API is callable — after first open in deferred installs), and `onError` (a load step failed, so ad-blocked / timed-out installs no longer fail silently). Matching DOM events are dispatched too: `persona:script-load`, `persona:launcher-shown`, `persona:chat-ready`, `persona:error`. `onReady` is **deprecated** in favor of `onChatReady`: it keeps working as an alias (and still dispatches `persona:ready`) but logs a one-time console warning and will be removed in the next major. The same `onReady` → `onChatReady` rename applies to the programmatic `initAgentWidget({ … })` option.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,7 @@ The widget uses a layered architecture:
    - `install.ts` - Script tag installer for CDN usage
    - `runtime/init.ts` - Widget initialization (Shadow DOM setup)
    - `runtime/host-layout.ts` - Layout management for docked mode
+   - `launcher-global.ts` - Critical-path launcher entry (`launcher.global.js`); ships only the collapsed launcher + theme system so the installer can paint the real launcher from a tiny bundle and defer the full widget. See "Deferred Launcher Loading" under Key Patterns.
 
 2. **Core Layer**
    - `client.ts` - HTTP client handling SSE streaming, message dispatch, and API communication
@@ -129,6 +130,8 @@ The widget uses a layered architecture:
 
 **HTML Sanitization:** All rendered markdown is sanitized via DOMPurify by default (`utils/sanitize.ts`). Configurable per-widget via the `sanitize` option: `true` (default), `false`, or a custom `(html: string) => string` function. When writing sanitization hooks, always compare URI schemes case-insensitively (e.g. `val.toLowerCase().startsWith("data:")`) per RFC 3986.
 
+**Deferred Launcher Loading:** For the common floating-launcher case, `install.ts` paints the real launcher from the tiny `launcher.global.js` (~13 KB brotli) at page load and defers the full `index.global.js` (~134 KB) until the user's first click. `shouldDeferPanel()` gates this — floating launcher, not auto-expanded, no restored/`onStateLoaded` open state, derivable launcher URL — and everything else eager-loads unchanged. The critical launcher is mount-then-destroyed at handoff and renders pixel-identically to the full widget's, so the swap is invisible. Installer lifecycle hooks (`onScriptLoad` / `onLauncherShown` / `onChatReady` / `onError`) and matching `persona:*` DOM events expose each stage; `onChatReady` (formerly `onReady`, now a deprecated alias) fires after first open in a deferred install. See the header comment in `launcher-global.ts` and the gate/handoff comments in `install.ts` for the invariants.
+
 ### Proxy Package (`packages/proxy/src/`)
 
 Hono-based server that proxies requests to the Runtype API:
@@ -162,6 +165,8 @@ The widget builds to multiple formats via tsup:
 - `dist/index.js` - ESM (primary)
 - `dist/index.cjs` - CommonJS
 - `dist/index.global.js` - IIFE (for script tag / CDN usage)
+- `dist/install.global.js` - IIFE installer bootstrap (reads `window.siteAgentConfig`; the script-tag entry point)
+- `dist/launcher.global.js` - IIFE critical launcher bundle (deferred-loading fast path; see "Deferred Launcher Loading")
 - `dist/index.d.ts` - TypeScript declarations
 - `dist/widget.css` - Prefixed Tailwind CSS (for consumers who import styles separately)
 

--- a/examples/embedded-app/llms.txt
+++ b/examples/embedded-app/llms.txt
@@ -88,7 +88,7 @@ initAgentWidget({
 
 Two entry points:
 
-- `initAgentWidget({ target, config, useShadowDom?, onReady?, windowKey? })` — floating launcher or docked panel. Returns a controller.
+- `initAgentWidget({ target, config, useShadowDom?, onChatReady?, windowKey? })` — floating launcher or docked panel. Returns a controller.
 - `createAgentExperience(element, config)` — inline embed with no launcher. Returns a controller.
 
 ### Controller API

--- a/examples/embedded-app/src/action-middleware-demo.ts
+++ b/examples/embedded-app/src/action-middleware-demo.ts
@@ -508,14 +508,14 @@ reportDemoConfig(configInspector, {
 });
 
 // Initialize widget
-// Note: We use a separate variable to avoid reference error in onReady callback
+// Note: We use a separate variable to avoid reference error in onChatReady callback
 let widgetControllerRef: ReturnType<typeof initAgentWidget> | null = null;
 
 const widgetController = initAgentWidget({
   target: "#launcher-root",
   useShadowDom: false,
   config,
-  onReady: () => {
+  onChatReady: () => {
     // Handle auto-open for navigation message or checkout return
     // Use setTimeout to ensure widgetControllerRef is assigned
     if (shouldAutoOpen) {

--- a/examples/embedded-app/src/standalone-nav.ts
+++ b/examples/embedded-app/src/standalone-nav.ts
@@ -48,6 +48,12 @@ export const STANDALONE_EXAMPLES: readonly StandaloneExample[] = [
     title: "Preview Mode",
     blurb: "Gate widget load behind a URL preview parameter",
   },
+  {
+    slug: "lifecycle-events",
+    href: "/standalone/lifecycle-events.html",
+    title: "Lifecycle Events",
+    blurb: "Deferred launcher + onScriptLoad/onLauncherShown/onChatReady events",
+  },
 ];
 
 const escapeHtml = (s: string): string =>

--- a/examples/embedded-app/standalone/example-shop-installer-voice-metadata.html
+++ b/examples/embedded-app/standalone/example-shop-installer-voice-metadata.html
@@ -535,7 +535,7 @@
           ],
           storageAdapter: createStorageAdapter(STORAGE_KEY),
           voiceRecognition: userConfig.voiceRecognition,
-          onReady: () => {
+          onChatReady: () => {
             const controller = window.chatController;
             handleDeferredNavigation(controller);
             exposeHelpers(controller);

--- a/examples/embedded-app/standalone/example-shop-metadata.html
+++ b/examples/embedded-app/standalone/example-shop-metadata.html
@@ -747,7 +747,7 @@
             target: 'body',
             config: widgetConfig,
             useShadowDom: false,
-            onReady: function() {
+            onChatReady: function() {
               if (navMessage && shouldAutoOpen) {
                 setTimeout(() => {
                   widgetController.open();

--- a/examples/embedded-app/standalone/example-shop.html
+++ b/examples/embedded-app/standalone/example-shop.html
@@ -860,7 +860,7 @@
           const widgetController = window.AgentWidget.initAgentWidget({
             target: '#shopping-assistant-root',
             config: widgetConfig,
-            onReady: function() {
+            onChatReady: function() {
               if (navMessage && shouldAutoOpen) {
                 setTimeout(() => {
                   widgetController.open();

--- a/examples/embedded-app/standalone/lifecycle-events.html
+++ b/examples/embedded-app/standalone/lifecycle-events.html
@@ -1,0 +1,343 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="icon" href="/favicon.ico" />
+  <title>Installer Lifecycle Events Demo</title>
+  <style>
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+      background: #f1f5f9;
+      color: #1e293b;
+      line-height: 1.6;
+    }
+    header {
+      background: white;
+      padding: 1.5rem 2rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    }
+    h1 { margin: 0; font-size: 1.6rem; color: #0f172a; }
+    .subtitle { margin-top: 0.4rem; color: #64748b; font-size: 0.95rem; }
+    .container { max-width: 860px; margin: 0 auto; padding: 2rem; }
+    .grid {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr);
+      gap: 1.5rem;
+      align-items: start;
+    }
+    .card {
+      background: white;
+      border-radius: 10px;
+      padding: 1.5rem;
+      box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+    }
+    .card h2 { margin-top: 0; font-size: 1.1rem; color: #0f172a; }
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.5rem;
+      padding: 0.4rem 0.85rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+      background: #fef9c3;
+      color: #854d0e;
+      transition: background 0.2s, color 0.2s;
+    }
+    .status-badge.ready { background: #dcfce7; color: #166534; }
+    .step-list { margin: 0.5rem 0 0; padding-left: 1.1rem; color: #475569; font-size: 0.92rem; }
+    .step-list li { margin-bottom: 0.4rem; }
+    .step-list code { background: #f1f5f9; padding: 0.1rem 0.35rem; border-radius: 4px; font-size: 0.85em; }
+    .log {
+      font-family: "SFMono-Regular", ui-monospace, "Cascadia Code", Menlo, Consolas, monospace;
+      font-size: 0.8rem;
+      background: #0f172a;
+      color: #e2e8f0;
+      border-radius: 8px;
+      padding: 1rem;
+      min-height: 260px;
+      max-height: 420px;
+      overflow-y: auto;
+    }
+    .log:empty::after { content: "Waiting for the installer to run…"; color: #64748b; }
+    .log-row { padding: 0.45rem 0; border-bottom: 1px solid rgba(255, 255, 255, 0.05); }
+    .log-line { display: flex; flex-wrap: wrap; align-items: baseline; column-gap: 0.6rem; row-gap: 0.15rem; }
+    .log-sub { color: #64748b; padding-left: 90px; margin-top: 0.25rem; font-size: 0.72rem; line-height: 1.4; overflow-wrap: anywhere; }
+    .log-time { color: #64748b; flex: none; width: 64px; text-align: right; }
+    .log-dot { flex: none; width: 8px; height: 8px; border-radius: 50%; align-self: center; }
+    .log-name { font-weight: 600; flex: none; }
+    .log-detail { color: #94a3b8; flex: 1 1 auto; min-width: 0; overflow-wrap: anywhere; }
+    .dot-script { background: #94a3b8; }
+    .dot-launcher { background: #38bdf8; }
+    .dot-chat { background: #4ade80; }
+    .dot-error { background: #f87171; }
+    .name-script { color: #cbd5e1; }
+    .name-launcher { color: #7dd3fc; }
+    .name-chat { color: #86efac; }
+    .name-error { color: #fca5a5; }
+    .source-tag {
+      font-size: 0.62rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: #64748b;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      border-radius: 4px;
+      padding: 0 0.3rem;
+      align-self: center;
+      flex: none;
+      margin-left: auto;
+    }
+    pre {
+      background: #f8fafc;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 1rem;
+      overflow-x: auto;
+      font-size: 0.78rem;
+      line-height: 1.5;
+      margin: 0.5rem 0 0;
+    }
+    .toolbar { margin-bottom: 1rem; display: flex; gap: 0.6rem; flex-wrap: wrap; }
+    .btn {
+      padding: 0.45rem 0.9rem;
+      border-radius: 6px;
+      border: 1px solid #cbd5e1;
+      background: white;
+      color: #1e293b;
+      font-size: 0.85rem;
+      cursor: pointer;
+    }
+    .btn:hover { background: #f8fafc; }
+    .hint { color: #64748b; font-size: 0.85rem; margin-top: 0.75rem; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>⚡ Installer Lifecycle Events</h1>
+    <p class="subtitle">
+      Watch the deferred-launcher optimization in action: the real launcher paints from a tiny
+      critical bundle on load, and the full widget only initializes on your first click.
+    </p>
+  </header>
+
+  <div class="container">
+    <div class="toolbar">
+      <button class="btn" id="reload-btn">Reload page</button>
+      <span class="status-badge" id="status">⏳ waiting for first open…</span>
+    </div>
+
+    <div class="grid">
+      <div class="card">
+        <h2>Live event log</h2>
+        <div class="log" id="log" aria-live="polite"></div>
+        <p class="hint">
+          Each lifecycle moment is logged <strong>twice on purpose</strong> — to show both ways to
+          subscribe. Line one names the subscription: the <code>onX()</code> config
+          <strong>callback</strong> vs the <code>persona:*</code> <strong>DOM event</strong> on
+          <code>window</code>. The grey sub-line explains what that moment means.
+        </p>
+      </div>
+
+      <div class="card">
+        <h2>What you're seeing</h2>
+        <ol class="step-list">
+          <li>
+            <strong><code>persona:script-load</code></strong> fires immediately — the installer ran.
+          </li>
+          <li>
+            <strong><code>persona:launcher-shown</code></strong> (<code>deferred: true</code>) fires at
+            page load: the real launcher is painted from the ~13&nbsp;KB critical bundle.
+          </li>
+          <li>
+            Nothing else fires yet. The heavy conversation panel is <em>not</em> downloaded.
+          </li>
+          <li>
+            Click the launcher (bottom-right). The full bundle loads, then
+            <strong><code>persona:chat-ready</code></strong> fires and the panel opens.
+          </li>
+        </ol>
+        <p class="hint">
+          Each row is timestamped with <code>performance.now()</code> (ms since navigation), so the gap
+          between launcher-shown and chat-ready is the deferral you saved on initial load.
+        </p>
+
+        <h2 style="margin-top:1.5rem">The config powering this page</h2>
+        <pre id="config-snippet"></pre>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── Lifecycle wiring ─────────────────────────────────────────────────────
+       Define the logger and configure the installer BEFORE the installer script
+       loads, so the very first callback (onScriptLoad) is captured. -->
+  <script>
+    (function () {
+      "use strict";
+
+      var logEl = document.getElementById("log");
+      var statusEl = document.getElementById("status");
+
+      var META = {
+        "script-load": { dot: "dot-script", name: "name-script", label: "persona:script-load", cb: "onScriptLoad", meaning: "the installer script executed — fires before any loading or gating" },
+        "launcher-shown": { dot: "dot-launcher", name: "name-launcher", label: "persona:launcher-shown", cb: "onLauncherShown", meaning: "the real launcher was painted (deferred: true = from the ~13 KB critical bundle)" },
+        "chat-ready": { dot: "dot-chat", name: "name-chat", label: "persona:chat-ready", cb: "onChatReady", meaning: "the full widget is initialized and its controller API is now callable" },
+        "error": { dot: "dot-error", name: "name-error", label: "persona:error", cb: "onError", meaning: "a load step failed (css / bundle / init)" }
+      };
+
+      function logEvent(kind, detail, source) {
+        var meta = META[kind] || META["script-load"];
+        var isDom = source === "dom";
+
+        var row = document.createElement("div");
+        row.className = "log-row";
+
+        // ── Top line: time · dot · event name · payload · channel badge ──
+        var line = document.createElement("div");
+        line.className = "log-line";
+
+        var time = document.createElement("span");
+        time.className = "log-time";
+        time.textContent = "+" + Math.round(performance.now()) + "ms";
+
+        var dot = document.createElement("span");
+        dot.className = "log-dot " + meta.dot;
+
+        var name = document.createElement("span");
+        name.className = "log-name " + meta.name;
+        // Line-one label reflects the *subscription*, not just the event: the
+        // callback shows its function signature, the DOM row shows the event name.
+        name.textContent = isDom ? meta.label : meta.cb + "()";
+
+        var det = document.createElement("span");
+        det.className = "log-detail";
+        det.textContent = detail || "";
+
+        var tag = document.createElement("span");
+        tag.className = "source-tag";
+        tag.textContent = isDom ? "DOM event" : "callback";
+
+        line.appendChild(time);
+        line.appendChild(dot);
+        line.appendChild(name);
+        if (detail) line.appendChild(det);
+        line.appendChild(tag);
+
+        // ── Sub line: which subscription fired + what the event means, so a
+        //    callback row and its DOM-event twin are each self-explanatory. ──
+        var sub = document.createElement("div");
+        sub.className = "log-sub";
+        sub.textContent = isDom
+          ? 'same moment — any code can subscribe via window.addEventListener("' + meta.label + '")'
+          : meta.meaning;
+
+        row.appendChild(line);
+        row.appendChild(sub);
+        logEl.appendChild(row);
+        logEl.scrollTop = logEl.scrollHeight;
+      }
+
+      // On localhost, point the installer at the LOCAL widget build so the
+      // deferred launcher (launcher.global.js) actually loads. The published CDN
+      // @latest does not ship launcher.global.js yet, so without this its fetch
+      // 404s and the installer silently falls back to the eager path — you'd see
+      // `deferred: false` and launcher-shown + chat-ready at the same timestamp.
+      // Setting cssUrl/jsUrl is also exactly how a self-hosted deploy opts into
+      // the optimization: the installer derives the sibling launcher.global.js
+      // URL from jsUrl.
+      var isLocal = window.location.hostname === "localhost";
+
+      // Configure the installer. A plain floating launcher with no autoExpand /
+      // persisted-open / onStateLoaded → the installer takes the deferred path.
+      window.siteAgentConfig = {
+        target: "body",
+        cssUrl: isLocal ? "/widget-dist/widget.css" : undefined,
+        jsUrl: isLocal ? "/widget-dist/index.global.js" : undefined,
+        config: {
+          apiUrl: "http://localhost:43111/api/chat/dispatch",
+          launcher: {
+            enabled: true,
+            title: "Lifecycle Demo",
+            subtitle: "Click me to load the full widget",
+            iconText: "💬"
+          },
+          suggestionChips: ["Hello!", "What can you do?"]
+        },
+
+        // ── The lifecycle callbacks (recommended API) ──
+        onScriptLoad: function (info) {
+          logEvent("script-load", "version: " + JSON.stringify(info.version));
+        },
+        onLauncherShown: function (info) {
+          logEvent("launcher-shown", "deferred: " + info.deferred);
+        },
+        onChatReady: function (handle) {
+          logEvent("chat-ready", "handle.open is " + typeof handle.open);
+          statusEl.textContent = "✅ chat ready";
+          statusEl.classList.add("ready");
+        },
+        onError: function (info) {
+          logEvent("error", "phase: " + info.phase + " — " + (info.error && info.error.message || info.error));
+        }
+      };
+
+      // ── The same lifecycle as DOM events (tagged "dom" in the log) ──
+      window.addEventListener("persona:script-load", function (e) {
+        logEvent("script-load", "version: " + JSON.stringify(e.detail && e.detail.version), "dom");
+      });
+      window.addEventListener("persona:launcher-shown", function (e) {
+        logEvent("launcher-shown", "deferred: " + (e.detail && e.detail.deferred), "dom");
+      });
+      window.addEventListener("persona:chat-ready", function () {
+        logEvent("chat-ready", "event.detail = handle", "dom");
+      });
+      window.addEventListener("persona:error", function (e) {
+        logEvent("error", "phase: " + (e.detail && e.detail.phase), "dom");
+      });
+
+      // Reload button → re-run the whole lifecycle from a clean load.
+      document.getElementById("reload-btn").addEventListener("click", function () {
+        window.location.reload();
+      });
+
+      // Show the config that drives the page (kept in sync by hand for clarity).
+      document.getElementById("config-snippet").textContent =
+        "window.siteAgentConfig = {\n" +
+        "  target: \"body\",\n" +
+        "  // localhost only — load the unreleased launcher bundle from the local\n" +
+        "  // build; in production omit these two and the CDN is used:\n" +
+        "  cssUrl: \"/widget-dist/widget.css\",\n" +
+        "  jsUrl:  \"/widget-dist/index.global.js\",\n" +
+        "  config: {\n" +
+        "    apiUrl: \"…/api/chat/dispatch\",\n" +
+        "    launcher: { enabled: true, title: \"Lifecycle Demo\" }\n" +
+        "  },\n" +
+        "  onScriptLoad:    (info)   => { /* info.version */ },\n" +
+        "  onLauncherShown: (info)   => { /* info.deferred, info.element */ },\n" +
+        "  onChatReady:     (handle) => { /* handle.open(), handle.on(…) */ },\n" +
+        "  onError:         (info)   => { /* info.phase: css|bundle|init */ }\n" +
+        "};";
+    })();
+  </script>
+
+  <!-- Load Widget Installer (local build on localhost, CDN in production) -->
+  <!-- Run `pnpm build:widget` to refresh the local /widget-dist build. -->
+  <script>
+    (function () {
+      var base = window.location.hostname === "localhost"
+        ? "/widget-dist"
+        : "https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist";
+      var s = document.createElement("script");
+      s.src = base + "/install.global.js";
+      document.currentScript.parentNode.insertBefore(s, document.currentScript.nextSibling);
+    })();
+  </script>
+
+  <script type="module">
+    import { renderStandaloneNav } from "/src/standalone-nav.ts";
+    renderStandaloneNav("lifecycle-events");
+  </script>
+</body>
+</html>

--- a/examples/embedded-app/standalone/shopify.html
+++ b/examples/embedded-app/standalone/shopify.html
@@ -823,7 +823,7 @@
         config: widgetConfig,
         useShadowDom: false,
         windowKey: 'chatController',
-        onReady: function() {
+        onChatReady: function() {
           console.log('[Shopping Assistant] Widget ready');
           
           const shouldRestoreVoice = loadVoiceState();

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -427,6 +427,7 @@ export default defineConfig({
         'standalone/example-shop-installer-voice-metadata': path.resolve(__dirname, 'standalone/example-shop-installer-voice-metadata.html'),
         'standalone/sample': path.resolve(__dirname, 'standalone/sample.html'),
         'standalone/preview-mode': path.resolve(__dirname, 'standalone/preview-mode.html'),
+        'standalone/lifecycle-events': path.resolve(__dirname, 'standalone/lifecycle-events.html'),
       }).filter(([, entryPath]) => fs.existsSync(entryPath))
       )
     }

--- a/examples/embedded-app/voice-integration-demo.html
+++ b/examples/embedded-app/voice-integration-demo.html
@@ -807,7 +807,7 @@
             target: mountPoint,
             useShadowDom: false,
             config: activeMountMode === "launcher" ? config : squareInlinePanel(config),
-            onReady: () => {
+            onChatReady: () => {
               console.log("Widget ready, setting up voice...");
               setupVoiceInterface();
             },

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -6,6 +6,12 @@
     "gzip": true
   },
   {
+    "name": "⛔ CRITICAL · launcher critical bundle (launcher.global.js)",
+    "path": "dist/launcher.global.js",
+    "limit": "18.5 kB",
+    "gzip": true
+  },
+  {
     "name": "⛔ CRITICAL · browser stylesheet (widget.css)",
     "path": "dist/widget.css",
     "limit": "21 kB",
@@ -26,7 +32,7 @@
   {
     "name": "Script installer (install.global.js)",
     "path": "dist/install.global.js",
-    "limit": "2.5 kB",
+    "limit": "2.8 kB",
     "gzip": true
   },
   {

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -92,7 +92,8 @@ const docked = initAgentWidget({
 | `target` | `string \| HTMLElement` | CSS selector or element where widget mounts. |
 | `config` | `AgentWidgetConfig` | Widget configuration object (see [Configuration reference](#configuration-reference) below). |
 | `useShadowDom` | `boolean` | Use Shadow DOM for style isolation (default: `true`). |
-| `onReady` | `() => void` | Callback fired when widget is initialized. |
+| `onChatReady` | `() => void` | Callback fired when the widget is initialized and its API is callable. |
+| `onReady` | `() => void` | **Deprecated** alias of `onChatReady`; still works, removed in the next major. |
 | `windowKey` | `string` | If provided, stores the controller on `window[windowKey]` for global access. Automatically cleaned up on `destroy()`. |
 
 When `config.launcher.mountMode` is `'docked'`, `target` is treated as the page container that Persona should wrap. Use a concrete element such as `#workspace-main`; `body` and `html` are rejected.
@@ -354,7 +355,7 @@ window.chatController.submitMessage("Test message")
 window.chatController.startVoiceRecognition()
 ```
 
-When using the automatic installer script (`install.global.js`), see [Programmatic access with the installer](#programmatic-access-with-the-installer) for additional approaches including the `onReady` callback and `persona:ready` event.
+When using the automatic installer script (`install.global.js`), see [Programmatic access with the installer](#programmatic-access-with-the-installer) for additional approaches including the `onChatReady` callback and `persona:chat-ready` event.
 
 #### Message Types
 
@@ -619,19 +620,30 @@ window.dispatchEvent(new CustomEvent('persona:focusInput', {
 
 **Instance scoping:** Same as `persona:showEventStream` — use `detail.instanceId` to target a specific widget. Without `instanceId`, all instances receive the event.
 
-#### `persona:ready`
+#### `persona:chat-ready`
 
-Dispatched on `window` by the automatic installer script (`install.global.js`) after the widget is initialized. The `event.detail` contains the `AgentWidgetInitHandle` (the same object returned by `initAgentWidget()`).
+Dispatched on `window` by the automatic installer script (`install.global.js`) when the widget is initialized and its controller API is callable. The `event.detail` contains the `AgentWidgetInitHandle` (the same object returned by `initAgentWidget()`). In a deferred install (the default floating-launcher case) this fires after the user first opens the panel; in an eager install it fires on page load.
 
 ```ts
-window.addEventListener('persona:ready', (e) => {
+window.addEventListener('persona:chat-ready', (e) => {
   const handle = e.detail;
   handle.on('message:sent', (msg) => console.log(msg));
   handle.open();
 });
 ```
 
-> **Note:** This event is only dispatched by the automatic installer script. Direct calls to `initAgentWidget()` return the handle synchronously and do not fire this event.
+The installer also dispatches sibling lifecycle events for diagnostics and analytics:
+
+| Event | `detail` | Fires |
+| --- | --- | --- |
+| `persona:script-load` | `{ version }` | the installer script executed (before any loading) |
+| `persona:launcher-shown` | `{ deferred, element? }` | the floating launcher painted on the page (page-load time) |
+| `persona:chat-ready` | the widget handle | the widget is initialized and its API is callable |
+| `persona:error` | `{ phase, error }` | a load step (`css` / `bundle` / `init`) failed |
+
+> **Note:** These events are only dispatched by the automatic installer script. Direct calls to `initAgentWidget()` return the handle synchronously and do not fire them.
+>
+> `persona:ready` is still dispatched as a **deprecated** alias of `persona:chat-ready` and will be removed in the next major.
 
 ### Controller Events
 
@@ -1553,7 +1565,11 @@ The easiest way is to use the automatic installer script. It handles loading CSS
 - `previewQueryParam` - Query parameter key that gates widget loading; widget only loads when the parameter is present and truthy
 - `useShadowDom` - Use Shadow DOM for style isolation (default: `false`)
 - `windowKey` - If provided, stores the widget handle on `window[windowKey]` for programmatic access
-- `onReady` - Callback fired with the widget handle after initialization; signature: `(handle) => void`
+- `onScriptLoad` - Fired as soon as the installer script executes, before it loads or gates anything (diagnostics / timing); signature: `({ version }) => void`
+- `onLauncherShown` - Fired when the floating launcher is painted on the page (page-load time — for "widget appeared" analytics); signature: `({ deferred, element? }) => void`
+- `onChatReady` - Fired when the widget is initialized and its controller API is callable (after first open in a deferred install); signature: `(handle) => void`
+- `onError` - Fired when a load step fails (`css` / `bundle` / `init`), so ad-blocked / timed-out installs don't fail silently; signature: `({ phase, error }) => void`
+- `onReady` - **Deprecated** alias of `onChatReady`; still works, removed in the next major; signature: `(handle) => void`
 
 **Example with version pinning:**
 
@@ -1574,14 +1590,14 @@ The easiest way is to use the automatic installer script. It handles loading CSS
 
 The installer is fully asynchronous (it waits for framework hydration, then loads CSS and JS). To interact with the widget after it initializes, use one of these approaches:
 
-**`onReady` callback** — best when config and access logic live in the same script:
+**`onChatReady` callback** — best when config and access logic live in the same script:
 
 ```html
 <script>
   window.siteAgentConfig = {
     clientToken: 'YOUR_TOKEN',
     windowKey: 'myChat',
-    onReady(handle) {
+    onChatReady(handle) {
       handle.on('message:sent', (e) => console.log('sent:', e));
       handle.on('message:received', (e) => console.log('received:', e));
     }
@@ -1590,11 +1606,11 @@ The installer is fully asynchronous (it waits for framework hydration, then load
 <script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"></script>
 ```
 
-**`persona:ready` event** — best for decoupled integration (e.g. tag managers, separate scripts):
+**`persona:chat-ready` event** — best for decoupled integration (e.g. tag managers, separate scripts):
 
 ```html
 <script>
-  window.addEventListener('persona:ready', (e) => {
+  window.addEventListener('persona:chat-ready', (e) => {
     const handle = e.detail;
     handle.on('message:sent', (e) => console.log('sent:', e));
   });
@@ -1607,7 +1623,7 @@ The installer is fully asynchronous (it waits for framework hydration, then load
 <script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"></script>
 ```
 
-**`windowKey`** — stores the handle on `window[windowKey]` for persistent global access. Combine with `onReady` or `persona:ready` to know when it's available:
+**`windowKey`** — stores the handle on `window[windowKey]` for persistent global access. Combine with `onChatReady` or `persona:chat-ready` to know when it's available:
 
 ```html
 <script>
@@ -1619,7 +1635,7 @@ The installer is fully asynchronous (it waits for framework hydration, then load
 <script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"></script>
 
 <script>
-  window.addEventListener('persona:ready', () => {
+  window.addEventListener('persona:chat-ready', () => {
     // window.myChat is now available and persists until destroy()
     window.myChat.open();
   });

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -49,7 +49,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && pnpm run build:styles && pnpm run build:client && pnpm run build:installer && pnpm run build:theme-ref && pnpm run build:theme-editor && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:animations",
+    "build": "rimraf dist && pnpm run build:styles && pnpm run build:client && pnpm run build:installer && pnpm run build:launcher && pnpm run build:theme-ref && pnpm run build:theme-editor && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:animations",
     "build:theme-editor": "tsup src/theme-editor.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:testing": "tsup src/testing.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:smart-dom-reader": "tsup src/smart-dom-reader.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
@@ -58,6 +58,7 @@
     "build:styles": "node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.copyFileSync('src/styles/widget.css','dist/widget.css');\"",
     "build:client": "tsup src/index.ts --format esm,cjs --minify --sourcemap --splitting false --dts --loader \".css=text\" && tsup src/index-global.ts --format iife --global-name AgentWidget --minify --sourcemap --splitting false --out-dir dist --loader \".css=text\" && node -e \"const fs=require('fs');for(const ext of ['.global.js','.global.js.map']){const from='dist/index-global'+ext;if(fs.existsSync(from))fs.renameSync(from,'dist/index'+ext);}\"",
     "build:installer": "tsup src/install.ts --format iife --global-name SiteAgentInstaller --out-dir dist --minify --sourcemap --no-splitting",
+    "build:launcher": "tsup src/launcher-global.ts --format iife --global-name AgentWidgetLauncher --minify --sourcemap --splitting false --out-dir dist && node -e \"const fs=require('fs');for(const ext of ['.global.js','.global.js.map']){const from='dist/launcher-global'+ext;if(fs.existsSync(from))fs.renameSync(from,'dist/launcher'+ext);}\"",
     "lint": "eslint . --ext .ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest",

--- a/packages/widget/scripts/measure-size.mjs
+++ b/packages/widget/scripts/measure-size.mjs
@@ -1,0 +1,44 @@
+// Throwaway measurement helper for the launcher-critical-bundle Phase 0 spike.
+// Reports raw / gzip / brotli sizes for the given files.
+import { readFileSync, statSync } from "node:fs";
+import { gzipSync, brotliCompressSync, constants } from "node:zlib";
+
+const files = process.argv.slice(2);
+if (files.length === 0) {
+  console.error("usage: node measure-size.mjs <file> [file...]");
+  process.exit(1);
+}
+
+const kb = (n) => (n / 1024).toFixed(1).padStart(7) + " kB";
+
+const rows = [];
+for (const f of files) {
+  let buf;
+  try {
+    buf = readFileSync(f);
+  } catch {
+    rows.push({ f, raw: NaN, gz: NaN, br: NaN });
+    continue;
+  }
+  const raw = statSync(f).size;
+  const gz = gzipSync(buf, { level: 9 }).length;
+  const br = brotliCompressSync(buf, {
+    params: { [constants.BROTLI_PARAM_QUALITY]: 11 },
+  }).length;
+  rows.push({ f, raw, gz, br });
+}
+
+console.log("");
+console.log(
+  "file".padEnd(40) + "raw".padStart(10) + "gzip".padStart(10) + "brotli".padStart(10)
+);
+console.log("-".repeat(70));
+for (const r of rows) {
+  const name = r.f.split("/").slice(-1)[0];
+  if (Number.isNaN(r.raw)) {
+    console.log(name.padEnd(40) + "  (missing)".padStart(30));
+    continue;
+  }
+  console.log(name.padEnd(40) + kb(r.raw) + kb(r.gz) + kb(r.br));
+}
+console.log("");

--- a/packages/widget/src/install.test.ts
+++ b/packages/widget/src/install.test.ts
@@ -1,0 +1,442 @@
+// @vitest-environment jsdom
+//
+// Integration tests for the installer IIFE (`install.ts`). These import the real
+// module so the self-executing installer runs in jsdom, then assert behavior by
+// observing the mocked global bundles (`window.AgentWidget` /
+// `window.AgentWidgetLauncher`) and the lifecycle callbacks / DOM events.
+//
+// The installer defers loading to `setTimeout` (via `waitForHydration`, since
+// jsdom has no `requestIdleCallback`), so tests use fake timers and
+// `vi.runAllTimersAsync()` to drive it forward deterministically.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const PERSONA_EVENTS = [
+  "persona:script-load",
+  "persona:launcher-shown",
+  "persona:chat-ready",
+  "persona:ready",
+  "persona:error",
+] as const;
+
+type FakeHandle = { open: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn>; on: ReturnType<typeof vi.fn> };
+
+// Captured across a single installer run.
+let capturedOnOpen: (() => void) | null;
+let launcherMount: ReturnType<typeof vi.fn>;
+let launcherDestroy: ReturnType<typeof vi.fn>;
+let launcherElement: HTMLButtonElement;
+let initAgentWidget: ReturnType<typeof vi.fn>;
+let fakeHandle: FakeHandle;
+let warnSpy: ReturnType<typeof vi.spyOn>;
+let errorSpy: ReturnType<typeof vi.spyOn>;
+
+/** Subscribe to every persona:* event and record dispatch order + detail. */
+function recordEvents() {
+  const log: Array<{ type: string; detail: any }> = [];
+  const handlers: Array<[string, (e: Event) => void]> = [];
+  for (const type of PERSONA_EVENTS) {
+    const handler = (e: Event) => log.push({ type, detail: (e as CustomEvent).detail });
+    window.addEventListener(type, handler);
+    handlers.push([type, handler]);
+  }
+  return {
+    log,
+    types: () => log.map((entry) => entry.type),
+    stop() {
+      handlers.forEach(([type, handler]) => window.removeEventListener(type, handler));
+    },
+  };
+}
+
+/** Make `isCssLoaded()` return true so `loadCSS()` resolves without a network. */
+function markCssLoaded() {
+  const link = document.createElement("link");
+  link.rel = "stylesheet";
+  link.setAttribute("data-persona", "true");
+  document.head.appendChild(link);
+}
+
+/** Provide the full bundle global so `loadJS()` short-circuits to resolved. */
+function provideFullBundle() {
+  (window as any).AgentWidget = { initAgentWidget };
+}
+
+/** Provide the critical launcher global so `loadLauncher()` short-circuits. */
+function provideLauncherBundle() {
+  (window as any).AgentWidgetLauncher = { mount: launcherMount };
+}
+
+/**
+ * Force the next dynamically-inserted <script> to error. jsdom never fires
+ * load/error on injected scripts, so we trigger `onerror` on a fake timer that
+ * `runAllTimersAsync()` flushes — deterministic under fake timers.
+ */
+function failNextScriptLoad() {
+  const head = document.head;
+  const original = head.appendChild.bind(head);
+  vi.spyOn(head, "appendChild").mockImplementation(((node: any) => {
+    const result = original(node);
+    if (node && node.tagName === "SCRIPT") {
+      setTimeout(() => node.onerror && node.onerror(new Event("error")), 0);
+    }
+    return result;
+  }) as any);
+}
+
+async function install(config: any) {
+  (window as any).siteAgentConfig = config;
+  await import("./install");
+}
+
+/** Flush waitForHydration's timer, the deferred init setTimeout(0), prefetch, etc. */
+async function flush() {
+  await vi.runAllTimersAsync();
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.useFakeTimers();
+
+  document.head.innerHTML = "";
+  document.body.innerHTML = "";
+  try {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+  } catch {
+    /* storage unavailable */
+  }
+
+  delete (window as any).__siteAgentInstallerLoaded;
+  delete (window as any).siteAgentConfig;
+  delete (window as any).AgentWidget;
+  delete (window as any).AgentWidgetLauncher;
+  capturedOnOpen = null;
+
+  launcherElement = document.createElement("button");
+  launcherDestroy = vi.fn();
+  launcherMount = vi.fn((opts: any) => {
+    capturedOnOpen = opts.onOpen;
+    return {
+      root: document.createElement("div"),
+      element: launcherElement,
+      update: vi.fn(),
+      destroy: launcherDestroy,
+    };
+  });
+
+  fakeHandle = { open: vi.fn(), close: vi.fn(), on: vi.fn() };
+  initAgentWidget = vi.fn(() => fakeHandle);
+
+  warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("install.ts — onScriptLoad beacon", () => {
+  it("fires synchronously on script execution, before any loading or gating", async () => {
+    const events = recordEvents();
+    const onScriptLoad = vi.fn();
+
+    // No config at all — the beacon must still fire (diagnostics: "did my embed run").
+    await install({ onScriptLoad });
+
+    // Fired during module evaluation — no timer flush needed.
+    expect(onScriptLoad).toHaveBeenCalledTimes(1);
+    expect(onScriptLoad).toHaveBeenCalledWith({ version: "latest" });
+    expect(events.types()[0]).toBe("persona:script-load");
+    expect(events.log[0]?.detail).toEqual({ version: "latest" });
+    events.stop();
+  });
+
+  it("reports the configured version in the beacon", async () => {
+    const onScriptLoad = vi.fn();
+    await install({ version: "1.2.3", onScriptLoad });
+    expect(onScriptLoad).toHaveBeenCalledWith({ version: "1.2.3" });
+  });
+});
+
+describe("install.ts — deferred launcher path", () => {
+  it("mounts the critical launcher, fires onLauncherShown, and defers onChatReady until open", async () => {
+    markCssLoaded();
+    provideFullBundle(); // so loadJS resolves instantly when the user opens
+    provideLauncherBundle();
+    const events = recordEvents();
+    const onScriptLoad = vi.fn();
+    const onLauncherShown = vi.fn();
+    const onChatReady = vi.fn();
+
+    await install({
+      config: { apiUrl: "/api", launcher: { enabled: true } },
+      onScriptLoad,
+      onLauncherShown,
+      onChatReady,
+    });
+
+    // script-load fires before hydration.
+    expect(onScriptLoad).toHaveBeenCalledTimes(1);
+
+    await flush();
+
+    // The real launcher is painted at page-load time from the critical bundle.
+    expect(launcherMount).toHaveBeenCalledTimes(1);
+    expect(onLauncherShown).toHaveBeenCalledTimes(1);
+    expect(onLauncherShown).toHaveBeenCalledWith({ deferred: true, element: launcherElement });
+    // The full widget has NOT been initialized yet — that waits for first open.
+    expect(initAgentWidget).not.toHaveBeenCalled();
+    expect(onChatReady).not.toHaveBeenCalled();
+
+    // Simulate the user clicking the launcher.
+    expect(capturedOnOpen).toBeTypeOf("function");
+    capturedOnOpen!();
+    await flush();
+
+    // Full widget mounts, the click carries through (panel opens), and the
+    // critical launcher is removed (handoff).
+    expect(initAgentWidget).toHaveBeenCalledTimes(1);
+    expect(fakeHandle.open).toHaveBeenCalledTimes(1);
+    expect(onChatReady).toHaveBeenCalledTimes(1);
+    expect(onChatReady).toHaveBeenCalledWith(fakeHandle);
+    expect(launcherDestroy).toHaveBeenCalledTimes(1);
+
+    // DOM event parity: script-load → launcher-shown (deferred) → chat-ready.
+    const types = events.types();
+    expect(types).toContain("persona:script-load");
+    const launcherShown = events.log.find((e) => e.type === "persona:launcher-shown");
+    expect(launcherShown?.detail).toMatchObject({ deferred: true });
+    const chatReady = events.log.find((e) => e.type === "persona:chat-ready");
+    expect(chatReady?.detail).toBe(fakeHandle);
+    // launcher-shown precedes chat-ready.
+    expect(types.indexOf("persona:launcher-shown")).toBeLessThan(types.indexOf("persona:chat-ready"));
+    events.stop();
+  });
+
+  it("a second click while loading does not initialize the widget twice", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    provideLauncherBundle();
+    await install({ config: { apiUrl: "/api", launcher: { enabled: true } } });
+    await flush();
+
+    capturedOnOpen!();
+    capturedOnOpen!(); // re-entrant click before the first finishes
+    await flush();
+
+    expect(initAgentWidget).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("install.ts — eager path", () => {
+  it("non-floating (launcher disabled) eager-loads, fires onChatReady, and does NOT fire onLauncherShown", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    provideLauncherBundle(); // available, but must NOT be used for an inline embed
+    const onLauncherShown = vi.fn();
+    const onChatReady = vi.fn();
+
+    await install({
+      config: { apiUrl: "/api", launcher: { enabled: false } },
+      onLauncherShown,
+      onChatReady,
+    });
+    await flush();
+
+    expect(launcherMount).not.toHaveBeenCalled();
+    expect(initAgentWidget).toHaveBeenCalledTimes(1);
+    expect(onChatReady).toHaveBeenCalledWith(fakeHandle);
+    // No floating launcher → onLauncherShown must stay silent (name-honest).
+    expect(onLauncherShown).not.toHaveBeenCalled();
+  });
+
+  it("eager floating install fires onLauncherShown with deferred:false", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    provideLauncherBundle();
+    const onLauncherShown = vi.fn();
+
+    // autoExpand starts the panel open → deferral is disabled → eager floating.
+    await install({
+      config: { apiUrl: "/api", launcher: { enabled: true, autoExpand: true } },
+      onLauncherShown,
+    });
+    await flush();
+
+    expect(launcherMount).not.toHaveBeenCalled(); // deferral off
+    expect(initAgentWidget).toHaveBeenCalledTimes(1);
+    expect(onLauncherShown).toHaveBeenCalledTimes(1);
+    expect(onLauncherShown).toHaveBeenCalledWith({ deferred: false });
+  });
+});
+
+describe("install.ts — deferral gate", () => {
+  async function expectDecision(config: any, { defers }: { defers: boolean }) {
+    markCssLoaded();
+    provideFullBundle();
+    provideLauncherBundle();
+    await install({ config });
+    await flush();
+    if (defers) {
+      expect(launcherMount).toHaveBeenCalledTimes(1);
+      expect(initAgentWidget).not.toHaveBeenCalled();
+    } else {
+      expect(launcherMount).not.toHaveBeenCalled();
+      expect(initAgentWidget).toHaveBeenCalledTimes(1);
+    }
+  }
+
+  it("defers for a plain floating launcher", async () => {
+    await expectDecision({ apiUrl: "/api", launcher: { enabled: true } }, { defers: true });
+  });
+
+  it("defers when launcher.mountMode is omitted (defaults to floating)", async () => {
+    await expectDecision({ apiUrl: "/api", launcher: { title: "Help" } }, { defers: true });
+  });
+
+  it("does NOT defer for a docked launcher", async () => {
+    await expectDecision({ apiUrl: "/api", launcher: { enabled: true, mountMode: "docked" } }, { defers: false });
+  });
+
+  it("does NOT defer when an onStateLoaded hook is present (it may request open)", async () => {
+    await expectDecision(
+      { apiUrl: "/api", launcher: { enabled: true }, onStateLoaded: () => ({ open: true }) },
+      { defers: false }
+    );
+  });
+
+  it("does NOT defer when a persisted open state is restored from storage", async () => {
+    window.sessionStorage.setItem("persona-widget-open", "true");
+    await expectDecision({ apiUrl: "/api", launcher: { enabled: true }, persistState: true }, { defers: false });
+  });
+
+  it("STILL defers when persistState is on but no open state is stored", async () => {
+    // Distinguishes the real storage read from a blanket "persistState disables deferral".
+    await expectDecision({ apiUrl: "/api", launcher: { enabled: true }, persistState: true }, { defers: true });
+  });
+
+  it("honors a custom keyPrefix + local storage when checking persisted open state", async () => {
+    window.localStorage.setItem("shop-widget-open", "true");
+    await expectDecision(
+      {
+        apiUrl: "/api",
+        launcher: { enabled: true },
+        persistState: { keyPrefix: "shop-", storage: "local" },
+      },
+      { defers: false }
+    );
+  });
+
+  it("does NOT defer when a custom jsUrl override has no derivable launcher URL", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    provideLauncherBundle();
+    // Non-standard jsUrl → getCdnBase() yields launcherUrl: null → eager.
+    await install({
+      cssUrl: "https://cdn.example.com/persona.css",
+      jsUrl: "https://cdn.example.com/persona.bundle.js",
+      config: { apiUrl: "/api", launcher: { enabled: true } },
+    });
+    await flush();
+    expect(launcherMount).not.toHaveBeenCalled();
+    expect(initAgentWidget).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("install.ts — onReady deprecation alias", () => {
+  it("still calls the deprecated onReady and warns once", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    const onReady = vi.fn();
+
+    await install({ config: { apiUrl: "/api", launcher: { enabled: false } }, onReady });
+    await flush();
+
+    expect(onReady).toHaveBeenCalledTimes(1);
+    expect(onReady).toHaveBeenCalledWith(fakeHandle);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("`onReady` is deprecated");
+  });
+
+  it("prefers onChatReady over onReady and does not warn", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    const onReady = vi.fn();
+    const onChatReady = vi.fn();
+
+    await install({ config: { apiUrl: "/api", launcher: { enabled: false } }, onReady, onChatReady });
+    await flush();
+
+    expect(onChatReady).toHaveBeenCalledTimes(1);
+    expect(onChatReady).toHaveBeenCalledWith(fakeHandle);
+    expect(onReady).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("install.ts — onError", () => {
+  it("fires onError with phase 'init' and dispatches persona:error when initialization throws", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    const boom = new Error("init boom");
+    initAgentWidget.mockImplementation(() => {
+      throw boom;
+    });
+    const events = recordEvents();
+    const onError = vi.fn();
+
+    await install({ config: { apiUrl: "/api", launcher: { enabled: false } }, onError });
+    await flush();
+
+    expect(onError).toHaveBeenCalledWith({ phase: "init", error: boom });
+    const errorEvent = events.log.find((e) => e.type === "persona:error");
+    expect(errorEvent?.detail).toMatchObject({ phase: "init" });
+    events.stop();
+  });
+
+  it("fires onError with phase 'bundle' when the full bundle fails to load on open", async () => {
+    markCssLoaded();
+    provideLauncherBundle();
+    // AgentWidget intentionally NOT provided → loadJS() creates a real <script>...
+    failNextScriptLoad(); // ...which we force to error.
+    const events = recordEvents();
+    const onError = vi.fn();
+
+    await install({ config: { apiUrl: "/api", launcher: { enabled: true } }, onError });
+    await flush();
+
+    expect(launcherMount).toHaveBeenCalledTimes(1);
+    expect(capturedOnOpen).toBeTypeOf("function");
+    capturedOnOpen!(); // user clicks → loadJS → <script> error
+    await flush();
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toMatchObject({ phase: "bundle" });
+    const errorEvent = events.log.find((e) => e.type === "persona:error");
+    expect(errorEvent?.detail).toMatchObject({ phase: "bundle" });
+    events.stop();
+  });
+});
+
+describe("install.ts — lifecycle callback safety", () => {
+  it("a throwing onScriptLoad callback does not break the rest of installation", async () => {
+    markCssLoaded();
+    provideFullBundle();
+    const onChatReady = vi.fn();
+
+    await install({
+      config: { apiUrl: "/api", launcher: { enabled: false } },
+      onScriptLoad: () => {
+        throw new Error("user callback blew up");
+      },
+      onChatReady,
+    });
+    await flush();
+
+    // The throw was swallowed (logged) and init still completed.
+    expect(onChatReady).toHaveBeenCalledWith(fakeHandle);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+});

--- a/packages/widget/src/install.ts
+++ b/packages/widget/src/install.ts
@@ -24,14 +24,42 @@ interface SiteAgentInstallConfig {
   useShadowDom?: boolean;
   // Expose the widget handle on window[windowKey] for programmatic access
   windowKey?: string;
-  // Called when the widget is initialized and ready for interaction
+  /**
+   * Fired as soon as the installer script executes, before it loads or gates
+   * anything. For diagnostics / load-timing baselines ("did my embed run").
+   */
+  onScriptLoad?: (info: { version: string }) => void;
+  /**
+   * Fired when the floating launcher is painted on the page — at page-load time.
+   * Deferred installs: the critical launcher mounts. Eager floating installs:
+   * the full widget's launcher mounts. Use this for "widget appeared" analytics.
+   * Does NOT fire for inline / docked / composer-bar installs (no floating
+   * launcher) — use `onChatReady` there.
+   */
+  onLauncherShown?: (info: { deferred: boolean; element?: HTMLElement }) => void;
+  /**
+   * Fired when the full widget is initialized and its controller API is
+   * callable. Deferred installs: after the user first opens the panel. Eager
+   * installs: on page load.
+   */
+  onChatReady?: (handle: any) => void;
+  /**
+   * @deprecated Use `onChatReady`. Retained as a working alias; it will be
+   * removed in the next major version.
+   */
   onReady?: (handle: any) => void;
+  /**
+   * Fired when a load step fails (stylesheet, full bundle, or init), so you can
+   * detect ad-blocked / timed-out installs instead of failing silently.
+   */
+  onError?: (info: { phase: "css" | "bundle" | "init"; error: unknown }) => void;
 }
 
 declare global {
   interface Window {
     siteAgentConfig?: SiteAgentInstallConfig;
     AgentWidget?: any;
+    AgentWidgetLauncher?: any;
   }
 }
 
@@ -111,6 +139,56 @@ declare global {
   const windowConfig: SiteAgentInstallConfig = window.siteAgentConfig || {};
   const config: SiteAgentInstallConfig = { ...windowConfig, ...scriptConfig };
 
+  // --- Lifecycle helpers -----------------------------------------------------
+  // A throwing user callback must never break the installer.
+  const safeCall = <T>(fn: ((arg: T) => void) | undefined, arg: T): void => {
+    try {
+      fn?.(arg);
+    } catch (e) {
+      console.error("[Persona] lifecycle callback threw:", e);
+    }
+  };
+  const dispatchLifecycle = (name: string, detail: unknown): void => {
+    try {
+      window.dispatchEvent(new CustomEvent(name, { detail }));
+    } catch {
+      /* CustomEvent unsupported — ignore */
+    }
+  };
+  const fail = (phase: "css" | "bundle" | "init", error: unknown): void => {
+    console.error("Failed to install AgentWidget:", error);
+    safeCall(config.onError, { phase, error });
+    dispatchLifecycle("persona:error", { phase, error });
+  };
+  // `onReady` is the deprecated alias of `onChatReady`; warn once if it's used.
+  let warnedOnReadyDeprecated = false;
+  const resolveChatReady = (): ((handle: any) => void) | undefined => {
+    if (config.onChatReady) return config.onChatReady;
+    if (config.onReady) {
+      if (!warnedOnReadyDeprecated) {
+        warnedOnReadyDeprecated = true;
+        console.warn(
+          "[Persona] `onReady` is deprecated — use `onChatReady`. `onReady` still works but is removed in the next major."
+        );
+      }
+      return config.onReady;
+    }
+    return undefined;
+  };
+  // True when the config renders a standard floating launcher button — the only
+  // case that paints a clickable launcher at load. Shared by the deferral gate
+  // and the eager-path `onLauncherShown` so the event name stays honest.
+  const hasFloatingLauncher = (widgetConfig: any): boolean => {
+    const launcher = widgetConfig.launcher ?? {};
+    if (launcher.enabled === false) return false;             // inline embed
+    return (launcher.mountMode ?? "floating") === "floating"; // not docked / composer-bar
+  };
+
+  // Earliest signal: the installer has executed. Fire before any loading or
+  // preview-gating so it's a reliable "did my embed run" beacon for diagnostics.
+  safeCall(config.onScriptLoad, { version: config.version || "latest" });
+  dispatchLifecycle("persona:script-load", { version: config.version || "latest" });
+
   const isPreviewModeEnabled = (): boolean => {
     if (!config.previewQueryParam) {
       return true;
@@ -131,27 +209,31 @@ declare global {
 
   // Determine CDN base URL
   const getCdnBase = () => {
+    // For a custom URL override, derive the sibling launcher URL when the
+    // override mirrors the dist layout (…/index.global.js → …/launcher.global.js)
+    // so self-hosted deployments still get the optimization. A non-standard
+    // jsUrl yields null → eager-load fallback.
     if (config.cssUrl && config.jsUrl) {
-      return { cssUrl: config.cssUrl, jsUrl: config.jsUrl };
+      const derivedLauncherUrl = config.jsUrl.replace(/index\.global\.js($|\?)/, "launcher.global.js$1");
+      return {
+        cssUrl: config.cssUrl,
+        jsUrl: config.jsUrl,
+        launcherUrl: (derivedLauncherUrl !== config.jsUrl ? derivedLauncherUrl : null) as string | null,
+      };
     }
-    
+
     const packageName = "@runtypelabs/persona";
     const basePath = `/npm/${packageName}@${version}/dist`;
-    
-    if (cdn === "unpkg") {
-      return {
-        cssUrl: `https://unpkg.com${basePath}/widget.css`,
-        jsUrl: `https://unpkg.com${basePath}/index.global.js`
-      };
-    } else {
-      return {
-        cssUrl: `https://cdn.jsdelivr.net${basePath}/widget.css`,
-        jsUrl: `https://cdn.jsdelivr.net${basePath}/index.global.js`
-      };
-    }
+    const host = cdn === "unpkg" ? "https://unpkg.com" : "https://cdn.jsdelivr.net";
+
+    return {
+      cssUrl: `${host}${basePath}/widget.css`,
+      jsUrl: `${host}${basePath}/index.global.js`,
+      launcherUrl: `${host}${basePath}/launcher.global.js` as string | null,
+    };
   };
 
-  const { cssUrl, jsUrl } = getCdnBase();
+  const { cssUrl, jsUrl, launcherUrl } = getCdnBase();
 
   // Check if CSS is already loaded
   const isCssLoaded = () => {
@@ -238,41 +320,76 @@ declare global {
     });
   };
 
-  // Initialize widget
-  const initWidget = () => {
+  // Load the tiny launcher-only critical bundle (launcher.global.js)
+  const isLauncherLoaded = () => !!window.AgentWidgetLauncher;
+
+  const loadLauncher = (): Promise<void> => {
+    return new Promise((resolve, reject) => {
+      if (isLauncherLoaded() || !launcherUrl) {
+        resolve();
+        return;
+      }
+
+      const script = document.createElement("script");
+      script.src = launcherUrl;
+      script.async = true;
+      script.onload = () => resolve();
+      script.onerror = () => reject(new Error(`Failed to load launcher from ${launcherUrl}`));
+      document.head.appendChild(script);
+    });
+  };
+
+  // Warm the full bundle in the background (download-only, not executed) so the
+  // first open is quick. Runs at idle so it never competes with the launcher.
+  const prefetchFullBundle = (): void => {
+    const addPrefetch = () => {
+      if (isJsLoaded()) return;
+      const link = document.createElement("link");
+      link.rel = "prefetch";
+      link.as = "script";
+      link.href = jsUrl;
+      document.head.appendChild(link);
+    };
+    if (typeof requestIdleCallback !== "undefined") {
+      requestIdleCallback(addPrefetch, { timeout: 4000 });
+    } else {
+      setTimeout(addPrefetch, 1200);
+    }
+  };
+
+  // Merge top-level installer options into the widget config. Shared by the
+  // eager init path and the deferred-launcher path.
+  const buildWidgetInit = (): { target: string | HTMLElement; widgetConfig: any; hasApiConfig: boolean } => {
+    const target = config.target || "body";
+    const widgetConfig: any = { ...config.config };
+
+    if (config.apiUrl && !widgetConfig.apiUrl) widgetConfig.apiUrl = config.apiUrl;
+    if (config.clientToken && !widgetConfig.clientToken) widgetConfig.clientToken = config.clientToken;
+    if (config.flowId && !widgetConfig.flowId) widgetConfig.flowId = config.flowId;
+
+    const hasApiConfig = !!(widgetConfig.apiUrl || widgetConfig.clientToken);
+    return { target, widgetConfig, hasApiConfig };
+  };
+
+  // Initialize the full widget. When `openAfter` is true (the deferred-launcher
+  // handoff), open the panel immediately via the public controller API so the
+  // user's click on the critical launcher carries through.
+  const initWidget = (openAfter = false): any => {
     if (!window.AgentWidget || !window.AgentWidget.initAgentWidget) {
       console.warn("AgentWidget not available. Make sure the script loaded successfully.");
       return;
     }
 
-    const target = config.target || "body";
-    // Merge top-level config options into widget config
-    const widgetConfig = { ...config.config };
-    
-    // Merge apiUrl from top-level config into widget config if present
-    if (config.apiUrl && !widgetConfig.apiUrl) {
-      widgetConfig.apiUrl = config.apiUrl;
-    }
-    
-    // Merge clientToken from top-level config into widget config if present
-    if (config.clientToken && !widgetConfig.clientToken) {
-      widgetConfig.clientToken = config.clientToken;
-    }
-    
-    // Merge flowId from top-level config into widget config if present
-    if (config.flowId && !widgetConfig.flowId) {
-      widgetConfig.flowId = config.flowId;
-    }
+    const { target, widgetConfig, hasApiConfig } = buildWidgetInit();
 
     // Only initialize if we have either apiUrl OR clientToken (or other config)
-    const hasApiConfig = widgetConfig.apiUrl || widgetConfig.clientToken;
     if (!hasApiConfig && Object.keys(widgetConfig).length === 0) {
       return;
     }
 
     // Auto-apply markdown postprocessor if not explicitly set and available
     if (!widgetConfig.postprocessMessage && window.AgentWidget.markdownPostprocessor) {
-      widgetConfig.postprocessMessage = ({ text }: { text: string }) => 
+      widgetConfig.postprocessMessage = ({ text }: { text: string }) =>
         window.AgentWidget.markdownPostprocessor(text);
     }
 
@@ -285,32 +402,149 @@ declare global {
         windowKey: config.windowKey
       });
 
-      config.onReady?.(handle);
-      window.dispatchEvent(new CustomEvent("persona:ready", { detail: handle }));
+      // Handoff from the critical launcher: the user already clicked, so open
+      // the panel via the existing public controller method.
+      if (openAfter && handle && typeof handle.open === "function") {
+        handle.open();
+      }
+
+      // Eager floating installs paint their launcher at load time too — emit the
+      // same page-load "appeared" signal as the deferred path. The deferred
+      // handoff (openAfter) already fired it at launcher mount, and non-floating
+      // modes have no launcher, so guard on both.
+      if (!openAfter && hasFloatingLauncher(widgetConfig)) {
+        safeCall(config.onLauncherShown, { deferred: false });
+        dispatchLifecycle("persona:launcher-shown", { deferred: false });
+      }
+
+      // The full widget is initialized and its controller API is callable.
+      safeCall(resolveChatReady(), handle);
+      dispatchLifecycle("persona:chat-ready", handle);
+      dispatchLifecycle("persona:ready", handle); // deprecated alias — removed next major
+      return handle;
     } catch (error) {
-      console.error("Failed to initialize AgentWidget:", error);
+      fail("init", error);
     }
+  };
+
+  // A persisted "open" state reopens the panel on reload with no click
+  // (ui.ts:7513). The installer can't see that from config, so it reads the very
+  // same storage key the widget writes. Mirrors normalizePersistStateConfig
+  // (ui.ts:213): openState persistence defaults on, storage to sessionStorage,
+  // key prefix to "persona-".
+  const hasPersistedOpenState = (widgetConfig: any): boolean => {
+    const persistState = widgetConfig.persistState;
+    if (!persistState) return false; // persistence off → nothing to restore
+    const asObject = typeof persistState === "object" ? persistState : null;
+    if (asObject && asObject.persist?.openState === false) return false; // open-state persistence opted out
+    const keyPrefix = (asObject && asObject.keyPrefix) || "persona-";
+    const storageType = (asObject && asObject.storage) || "session";
+    try {
+      const storage = storageType === "local" ? window.localStorage : window.sessionStorage;
+      return storage.getItem(`${keyPrefix}widget-open`) === "true";
+    } catch {
+      return false; // storage blocked (private mode) → the widget can't restore either
+    }
+  };
+
+  // The deferred-launcher optimization only applies to the common floating case
+  // that paints a collapsed launcher and waits for a click. Anything that starts
+  // open or renders differently eager-loads the full bundle exactly as before —
+  // including the two open triggers config alone can't express: a host
+  // onStateLoaded hook that may request open, and a restored "was open" state.
+  const shouldDeferPanel = (widgetConfig: any): boolean => {
+    if (!launcherUrl) return false;                                      // custom bundle URL override — can't derive launcher URL
+    if (!hasFloatingLauncher(widgetConfig)) return false;                // inline / docked / composer-bar
+    const launcher = widgetConfig.launcher ?? {};
+    if (launcher.autoExpand === true) return false;                      // starts open
+    if (typeof widgetConfig.onStateLoaded === "function") return false;  // hook may request open
+    if (hasPersistedOpenState(widgetConfig)) return false;               // restored "was open"
+    return true;
+  };
+
+  // Render the real launcher from the tiny critical bundle; load + mount the
+  // full widget on first click, then remove the critical launcher.
+  const mountDeferredLauncher = (target: string | HTMLElement, widgetConfig: any): void => {
+    let phase: "idle" | "loading" | "done" = "idle";
+    let launcherHandle: { destroy: () => void } | undefined;
+
+    const onOpen = () => {
+      if (phase !== "idle") return; // already loading or handed off
+      phase = "loading";
+      loadJS()
+        .then(() => {
+          initWidget(true);          // mount the full widget + open the panel
+          launcherHandle?.destroy();  // remove the critical launcher (same component → invisible)
+          phase = "done";
+        })
+        .catch((error) => {
+          phase = "idle";            // allow the click to be retried
+          console.error("Failed to load AgentWidget on open:", error);
+          safeCall(config.onError, { phase: "bundle", error });
+          dispatchLifecycle("persona:error", { phase: "bundle", error });
+        });
+    };
+
+    const mounted = window.AgentWidgetLauncher.mount({ target, config: widgetConfig, onOpen });
+    launcherHandle = mounted;
+
+    // The real launcher is now painted at page-load time — emit the page-load
+    // "appeared" signal (distinct from `onChatReady`, which waits for first open).
+    safeCall(config.onLauncherShown, { deferred: true, element: mounted.element });
+    dispatchLifecycle("persona:launcher-shown", { deferred: true, element: mounted.element });
+
+    // Warm the full bundle so the first open is quick.
+    prefetchFullBundle();
   };
 
   // Main installation flow (called after hydration completes)
   const install = async () => {
     try {
-      await loadCSS();
-      await loadJS();
-      
       // Auto-init if we have config OR apiUrl OR clientToken
       const shouldAutoInit = autoInit && (
-        config.config || 
-        config.apiUrl || 
+        config.config ||
+        config.apiUrl ||
         config.clientToken
       );
-      
+
+      // Fast path: render the real launcher from the ~13 KB critical bundle and
+      // defer the full widget until first open. Only for the common floating
+      // case; everything else falls through to the eager path below.
+      if (shouldAutoInit) {
+        const { target, widgetConfig } = buildWidgetInit();
+        if (shouldDeferPanel(widgetConfig)) {
+          try {
+            // CSS + launcher in parallel so the launcher paints correctly styled.
+            await Promise.all([loadCSS(), loadLauncher()]);
+            if (window.AgentWidgetLauncher && window.AgentWidgetLauncher.mount) {
+              mountDeferredLauncher(target, widgetConfig);
+              return;
+            }
+          } catch (error) {
+            console.warn("Deferred launcher failed; falling back to eager load.", error);
+          }
+          // Fall through to the eager path on any failure.
+        }
+      }
+
+      // Eager path (unchanged behavior): load the full bundle, then init.
+      try {
+        await loadCSS();
+      } catch (error) {
+        return fail("css", error);
+      }
+      try {
+        await loadJS();
+      } catch (error) {
+        return fail("bundle", error);
+      }
       if (shouldAutoInit) {
         // Wait a tick to ensure AgentWidget is fully initialized
-        setTimeout(initWidget, 0);
+        setTimeout(() => initWidget(false), 0);
       }
     } catch (error) {
-      console.error("Failed to install AgentWidget:", error);
+      // Safety net for anything unexpected before the eager loads above.
+      fail("init", error);
     }
   };
 

--- a/packages/widget/src/launcher-global.ts
+++ b/packages/widget/src/launcher-global.ts
@@ -9,7 +9,7 @@
  * The full Lucide icon registry is kept on purpose: any *supported* icon a site
  * configures (`launcher.agentIconName` / `callToActionIconName`) must render at
  * first paint with no flash, and the only synchronously-available source is this
- * bundle. See `.planning/launcher-critical-bundle-plan.md` §11.
+ * bundle. See the "Deferred Launcher Loading" pattern in CLAUDE.md.
  *
  * Public global (via tsup `--global-name AgentWidgetLauncher`):
  *

--- a/packages/widget/src/launcher-global.ts
+++ b/packages/widget/src/launcher-global.ts
@@ -1,0 +1,115 @@
+/**
+ * Critical-path launcher entry — built to `launcher.global.js` (IIFE).
+ *
+ * Ships ONLY the real collapsed launcher (`createLauncherButton`) plus the full
+ * theme system, so the launcher paints pixel-identically to the full widget from
+ * a tiny bundle (~13 KB brotli vs ~134 KB for `index.global.js`). The heavy
+ * conversation panel is deferred until first open by the installer (Phase 2).
+ *
+ * The full Lucide icon registry is kept on purpose: any *supported* icon a site
+ * configures (`launcher.agentIconName` / `callToActionIconName`) must render at
+ * first paint with no flash, and the only synchronously-available source is this
+ * bundle. See `.planning/launcher-critical-bundle-plan.md` §11.
+ *
+ * Public global (via tsup `--global-name AgentWidgetLauncher`):
+ *
+ *   window.AgentWidgetLauncher.mount({ target, config, onOpen })
+ *     → { root, element, update, destroy }
+ */
+import { createLauncherButton } from "./components/launcher";
+import { applyThemeVariables } from "./utils/theme";
+import { mergeWithDefaults } from "./defaults";
+import type { AgentWidgetConfig } from "./types";
+
+export interface AgentWidgetLauncherMountOptions {
+  /** Where to mount. Defaults to `document.body` (the floating launcher is `position: fixed`). */
+  target?: string | HTMLElement;
+  /** The same widget config the full widget will receive — drives theme, icons, position, copy. */
+  config?: AgentWidgetConfig;
+  /** Called when the launcher is clicked; the installer loads the full widget and opens the panel. */
+  onOpen: () => void;
+}
+
+export interface AgentWidgetLauncherHandle {
+  /** The `[data-persona-root]` wrapper that carries the theme CSS variables. */
+  root: HTMLElement;
+  /** The launcher button element itself. */
+  element: HTMLButtonElement;
+  /** Re-apply theme + re-render the launcher with new config. */
+  update: (config: AgentWidgetConfig) => void;
+  /** Remove the critical launcher (called at handoff once the full widget is mounted). */
+  destroy: () => void;
+}
+
+/**
+ * Marks the critical launcher's wrapper so the installer can find/remove it at
+ * handoff without disturbing the full widget's own `[data-persona-root]`.
+ */
+export const CRITICAL_LAUNCHER_ATTR = "data-persona-launcher-critical";
+
+const resolveTarget = (target?: string | HTMLElement): HTMLElement => {
+  if (target instanceof HTMLElement) return target;
+  if (typeof target === "string") {
+    const el = document.querySelector<HTMLElement>(target);
+    if (el) return el;
+  }
+  return document.body;
+};
+
+/**
+ * Mount the real collapsed launcher from the critical bundle.
+ *
+ * Mirrors the full widget's DOM exactly (`runtime/init.ts` + `ui.ts`): a
+ * `[data-persona-root]` wrapper carries the theme CSS variables and the launcher
+ * button is its child. Keeping the theme vars on the wrapper (not the button)
+ * leaves the button's own inline style byte-identical to the full widget's, so
+ * the eventual mount-then-remove handoff is invisible.
+ */
+export const mount = (
+  options: AgentWidgetLauncherMountOptions
+): AgentWidgetLauncherHandle => {
+  if (typeof window === "undefined" || typeof document === "undefined") {
+    throw new Error(
+      "AgentWidgetLauncher can only be mounted in a browser environment"
+    );
+  }
+
+  const { onOpen } = options;
+  const target = resolveTarget(options.target);
+
+  // Render from the SAME effective config the full widget uses: `ui.ts` runs
+  // `mergeWithDefaults(config)` before building the launcher (ui.ts:495). Without
+  // this, the critical launcher misses launcher defaults like
+  // `callToActionIconPadding` and `agentIconName`, so it looks subtly different
+  // from the full widget that replaces it on open.
+  const config = mergeWithDefaults(options.config) as AgentWidgetConfig;
+
+  const root = document.createElement("div");
+  root.setAttribute("data-persona-root", "true");
+  root.setAttribute(CRITICAL_LAUNCHER_ATTR, "true");
+  applyThemeVariables(root, config);
+
+  const launcher = createLauncherButton(config, onOpen);
+  root.appendChild(launcher.element);
+  target.appendChild(root);
+
+  return {
+    root,
+    element: launcher.element,
+    update: (next: AgentWidgetConfig) => {
+      const merged = mergeWithDefaults(next) as AgentWidgetConfig;
+      applyThemeVariables(root, merged);
+      launcher.update(merged);
+    },
+    destroy: () => {
+      launcher.destroy();
+      root.remove();
+    },
+  };
+};
+
+// Note: the `window.AgentWidgetLauncher` global is created by tsup's
+// `--global-name AgentWidgetLauncher` at build time. The installer
+// (`install.ts`) declares the `Window` augmentation it needs; this entry never
+// reads the global, so re-declaring it here would only create a cross-file type
+// conflict.

--- a/packages/widget/src/runtime/init.test.ts
+++ b/packages/widget/src/runtime/init.test.ts
@@ -159,6 +159,77 @@ describe("initAgentWidget windowKey and ready notifications", () => {
   });
 });
 
+describe("initAgentWidget onChatReady / onReady deprecation", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    createAgentExperienceMock.mockReset();
+    createAgentExperienceMock.mockImplementation((_mount, config) => createMockController(config));
+  });
+
+  it("calls onChatReady after initialization without a deprecation warning", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const onChatReady = vi.fn();
+    const handle = initAgentWidget({
+      target: "#target",
+      onChatReady,
+      config: { launcher: { enabled: false } },
+    });
+
+    expect(onChatReady).toHaveBeenCalledOnce();
+    expect(warn).not.toHaveBeenCalled();
+
+    handle.destroy();
+    warn.mockRestore();
+  });
+
+  it("prefers onChatReady over the deprecated onReady (onReady never fires, no warning)", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const onChatReady = vi.fn();
+    const onReady = vi.fn();
+    const handle = initAgentWidget({
+      target: "#target",
+      onChatReady,
+      onReady,
+      config: { launcher: { enabled: false } },
+    });
+
+    expect(onChatReady).toHaveBeenCalledOnce();
+    expect(onReady).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+
+    handle.destroy();
+    warn.mockRestore();
+  });
+
+  it("still calls the deprecated onReady but warns at most once across multiple widgets", async () => {
+    // Fresh module so the once-per-page warn flag starts unset.
+    vi.resetModules();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="a"></div><div id="b"></div>`;
+
+    const onReadyA = vi.fn();
+    const onReadyB = vi.fn();
+    const a = initAgentWidget({ target: "#a", onReady: onReadyA, config: { launcher: { enabled: false } } });
+    const b = initAgentWidget({ target: "#b", onReady: onReadyB, config: { launcher: { enabled: false } } });
+
+    expect(onReadyA).toHaveBeenCalledOnce();
+    expect(onReadyB).toHaveBeenCalledOnce();
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0]?.[0])).toContain("`onReady` is deprecated");
+
+    a.destroy();
+    b.destroy();
+    warn.mockRestore();
+  });
+});
+
 describe("install script onReady and persona:ready event", () => {
   beforeEach(() => {
     document.body.innerHTML = "";

--- a/packages/widget/src/runtime/init.ts
+++ b/packages/widget/src/runtime/init.ts
@@ -3,6 +3,9 @@ import { AgentWidgetConfig as _AgentWidgetConfig, AgentWidgetInitOptions, AgentW
 import { isComposerBarMountMode, isDockedMountMode } from "../utils/dock";
 import { createWidgetHostLayout } from "./host-layout";
 
+// Warn at most once per page when the deprecated `onReady` alias is used.
+let warnedOnReadyDeprecated = false;
+
 const ensureTarget = (target: string | HTMLElement): HTMLElement => {
   if (typeof window === "undefined" || typeof document === "undefined") {
     throw new Error("Chat widget can only be mounted in a browser environment");
@@ -157,7 +160,20 @@ export const initAgentWidget = (
   };
 
   mountController();
-  options.onReady?.();
+  // Fired when the controller is mounted and its API is callable. `onReady` is
+  // the deprecated alias of `onChatReady` (removed next major) — warn once.
+  if (options.onChatReady) {
+    options.onChatReady();
+  } else if (options.onReady) {
+    if (!warnedOnReadyDeprecated) {
+      warnedOnReadyDeprecated = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[Persona] `onReady` is deprecated — use `onChatReady`. `onReady` still works but is removed in the next major."
+      );
+    }
+    options.onReady();
+  }
 
   const rebuildLayout = (nextConfig?: _AgentWidgetConfig) => {
     destroyCurrentController();

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -4136,6 +4136,9 @@ export type AgentWidgetInitOptions = {
   target: string | HTMLElement;
   config?: AgentWidgetConfig;
   useShadowDom?: boolean;
+  /** Fired when the widget controller is mounted and its API is callable. */
+  onChatReady?: () => void;
+  /** @deprecated Use `onChatReady`. Retained as an alias; removed in the next major. */
   onReady?: () => void;
   windowKey?: string; // If provided, stores the controller on window[windowKey] for global access
   debugTools?: boolean;


### PR DESCRIPTION
## Summary
  Script-tag installs now render the launcher from a standalone **~14 KB brotli `launcher.global.js`** (vs ~134 KB for the full `index.global.js`) and defer the heavy conversation panel until the launcher is first clicked.

## Deferred launcher
  - `install.global.js` takes this path automatically for the common floating-launcher case, rendering the **real** launcher (the full theme + Lucide-icon fidelity, no placeholder or flash)
  - First click loads the full widget, opens the panel via the existing controller API, then removes the critical launcher.
  - Configs that start open or render differently **eager-load exactly as before**: inline embeds, docked / composer-bar modes, `launcher.autoExpand`, a restored "was open" state,
  `onStateLoaded` hooks, and custom `jsUrl` overrides that don't mirror the published `dist` layout.
  - Adds a public **`window.AgentWidgetLauncher.mount()`** for advanced / standalone use.

## Install lifecycle hooks

  | Callback | DOM event | Fires when |
  |---|---|---|
  | `onScriptLoad` | `persona:script-load` | the embed script executed |
  | `onLauncherShown` | `persona:launcher-shown` | launcher painted (page-load; "widget appeared" analytics) |
  | `onChatReady` | `persona:chat-ready` | widget initialized + controller callable (after first open when deferred) |
  | `onError` | `persona:error` | a load step failed (no more silent ad-blocked / timed-out installs) |

  **`onReady` → `onChatReady`:** `onReady` is deprecated but keeps working as an alias (still dispatches `persona:ready`), logs a one-time console warning. Will remove in the next major version