### PR TITLE
feat(widget): add server-safe @runtypelabs/persona/codegen subpath

### DIFF
--- a/.changeset/codegen-subpath.md
+++ b/.changeset/codegen-subpath.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add a server/Worker-safe `@runtypelabs/persona/codegen` subpath export that exposes `generateCodeSnippet` (and its `CodeFormat` / `CodeGeneratorHooks` / `CodeGeneratorOptions` types) without pulling in the browser widget runtime. Snippet generation is pure string-templating, so consumers that only need to emit embed code (server-side renderers, Cloudflare Workers, CLIs) can import it without dragging in idiomorph/marked/DOM code. The main barrel export is unchanged.

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -46,5 +46,11 @@
     "path": "dist/smart-dom-reader.js",
     "limit": "13 kB",
     "gzip": true
+  },
+  {
+    "name": "Server-safe · codegen subpath (codegen.js)",
+    "path": "dist/codegen.js",
+    "limit": "12 kB",
+    "gzip": true
   }
 ]

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -17,6 +17,11 @@
       "import": "./dist/theme-reference.js",
       "require": "./dist/theme-reference.cjs"
     },
+    "./codegen": {
+      "types": "./dist/codegen.d.ts",
+      "import": "./dist/codegen.js",
+      "require": "./dist/codegen.cjs"
+    },
     "./theme-editor": {
       "types": "./dist/theme-editor.d.ts",
       "import": "./dist/theme-editor.js",
@@ -49,12 +54,13 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && pnpm run build:styles && pnpm run build:client && pnpm run build:installer && pnpm run build:launcher && pnpm run build:theme-ref && pnpm run build:theme-editor && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:animations",
+    "build": "rimraf dist && pnpm run build:styles && pnpm run build:client && pnpm run build:installer && pnpm run build:launcher && pnpm run build:theme-ref && pnpm run build:codegen && pnpm run build:theme-editor && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:animations",
     "build:theme-editor": "tsup src/theme-editor.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:testing": "tsup src/testing.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:smart-dom-reader": "tsup src/smart-dom-reader.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:animations": "tsup src/animations/glyph-cycle.ts src/animations/wipe.ts --format esm,cjs --minify --dts --out-dir dist/animations --no-splitting",
     "build:theme-ref": "tsup src/theme-reference.ts --format esm,cjs --minify --dts",
+    "build:codegen": "tsup src/codegen.ts --format esm,cjs --minify --dts",
     "build:styles": "node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.copyFileSync('src/styles/widget.css','dist/widget.css');\"",
     "build:client": "tsup src/index.ts --format esm,cjs --minify --sourcemap --splitting false --dts --loader \".css=text\" && tsup src/index-global.ts --format iife --global-name AgentWidget --minify --sourcemap --splitting false --out-dir dist --loader \".css=text\" && node -e \"const fs=require('fs');for(const ext of ['.global.js','.global.js.map']){const from='dist/index-global'+ext;if(fs.existsSync(from))fs.renameSync(from,'dist/index'+ext);}\"",
     "build:installer": "tsup src/install.ts --format iife --global-name SiteAgentInstaller --out-dir dist --minify --sourcemap --no-splitting",

--- a/packages/widget/src/codegen.test.ts
+++ b/packages/widget/src/codegen.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { generateCodeSnippet as fromSubpath } from "./codegen";
+import { generateCodeSnippet as fromInternal } from "./utils/code-generators";
+import { VERSION } from "./version";
+
+// The `@runtypelabs/persona/codegen` subpath is the server/Worker-safe entry for
+// snippet generation. It must expose the exact same generator as the internal
+// module (and, transitively, the main barrel) — no fork, no drift.
+describe("codegen subpath", () => {
+  const config = {
+    apiUrl: "https://api.example.com/chat",
+    clientToken: "ct_test_123",
+    launcher: { enabled: true, title: "Chat" },
+  };
+
+  it("re-exports the same generateCodeSnippet implementation", () => {
+    expect(fromSubpath).toBe(fromInternal);
+  });
+
+  it("produces identical output via the subpath for every format", () => {
+    const formats = [
+      "esm",
+      "script-installer",
+      "script-manual",
+      "script-advanced",
+      "react-component",
+      "react-advanced",
+    ] as const;
+    for (const format of formats) {
+      expect(fromSubpath(config, format)).toBe(fromInternal(config, format));
+    }
+  });
+
+  it("pins the installer CDN url to the package version (not @latest)", () => {
+    const code = fromSubpath(config, "script-installer");
+    expect(code).toContain(`@runtypelabs/persona@${VERSION}/dist/install.global.js`);
+    expect(code).not.toContain("@latest");
+  });
+});

--- a/packages/widget/src/codegen.ts
+++ b/packages/widget/src/codegen.ts
@@ -1,0 +1,20 @@
+/**
+ * Pure code-snippet generation entry (`@runtypelabs/persona/codegen`).
+ *
+ * `generateCodeSnippet` is pure string-templating — it builds install snippets
+ * from a widget config and depends only on a type import + the `VERSION`
+ * constant. The main `index.ts` barrel re-exports it too, but that barrel pulls
+ * in the full widget runtime (`index-core` → idiomorph / marked / DOM), which is
+ * unacceptable for server/Worker consumers that only need snippet strings.
+ *
+ * This subpath exposes the generator on its own (mirroring `theme-reference`) so
+ * those consumers import it without dragging in the browser runtime. Existing
+ * npm consumers keep using the barrel export unchanged.
+ */
+
+export { generateCodeSnippet } from "./utils/code-generators";
+export type {
+  CodeFormat,
+  CodeGeneratorHooks,
+  CodeGeneratorOptions
+} from "./utils/code-generators";


### PR DESCRIPTION
## What

Adds a new `@runtypelabs/persona/codegen` subpath export that exposes `generateCodeSnippet` (and its `CodeFormat` / `CodeGeneratorHooks` / `CodeGeneratorOptions` types) **without** pulling in the browser widget runtime.

## Why

Snippet generation (`utils/code-generators.ts`) is pure string-templating — its only deps are a type import and the `VERSION` constant. But it's only reachable through the main barrel, which drags in `index-core` (idiomorph / marked / DOM). Server-side renderers, Cloudflare Workers, and CLIs that just want to emit embed code currently can't import it cheaply.

Downstream (`runtypelabs/core`) had to hand-roll a `persona-lite.ts` fork wired in via a wrangler alias to keep the widget runtime out of the API Worker startup bundle. That fork has already drifted (pins `@latest` instead of `@${VERSION}`, 5-key config whitelist, no-op `markdownPostprocessor`). This subpath lets core delete the fork and consume the single source of truth.

Mirrors the existing `theme-reference` subpath pattern exactly.

## Changes

- New `src/codegen.ts` entry (thin re-export of `generateCodeSnippet` + types).
- `./codegen` export + `build:codegen` tsup script in `package.json`.
- `.size-limit.json` guard (9.35 kB gzip, limit 12 kB) so the entry can't silently absorb a widget-runtime import.
- `src/codegen.test.ts`: asserts the subpath export is identical to the internal generator across all formats and pins the version-pinned CDN URL.
- Changeset (minor — new public subpath, no breaking change).

## Verification

- `pnpm --filter @runtypelabs/persona build` → `dist/codegen.{js,cjs,d.ts}` emitted; verified no `import`/`require` of idiomorph/marked/dompurify.
- `test:run` 1046 tests pass; `typecheck`, `lint`, `size` all clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New opt-in public subpath and build/tests only; no changes to the main export or generator behavior.
> 
> **Overview**
> Adds **`@runtypelabs/persona/codegen`**, a server/Worker-safe subpath that re-exports **`generateCodeSnippet`** and related types from `utils/code-generators` without the main barrel’s browser runtime (idiomorph, marked, DOM).
> 
> **Build & packaging:** `./codegen` in `package.json` exports, a **`build:codegen`** tsup step in the main build, and a **12 kB gzip** size-limit on `dist/codegen.js` so the entry can’t accidentally pull in widget code. Minor changeset; the main barrel is unchanged.
> 
> **Tests:** `codegen.test.ts` asserts the subpath is the same function as the internal module, identical output for all formats, and installer snippets pin the CDN URL to **`@runtypelabs/persona@${VERSION}`** (not `@latest`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e0bcdd6642eb71a8ef331b6c5bfcb2e526e1bfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->