### PR TITLE
Fix WebMCP tool duration timing

### DIFF
--- a/.changeset/webmcp-tool-duration.md
+++ b/.changeset/webmcp-tool-duration.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Measure WebMCP tool bubbles through browser-side async execution instead of completing them at the local-tool pause.

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -62,11 +62,11 @@ const esc = (value: unknown): string =>
 const money = (n: number): string => `$${n.toFixed(2)}`;
 
 const DEMO_TOOL_LATENCY_MS = {
-  search_products: [900, 1400],
-  view_product: [650, 1100],
-  add_to_cart: [1100, 1800],
-  remove_from_cart: [800, 1300],
-  apply_promo: [750, 1200],
+  search_products: [450, 700],
+  view_product: [325, 550],
+  add_to_cart: [550, 900],
+  remove_from_cart: [400, 650],
+  apply_promo: [375, 600],
 } as const;
 
 type DemoToolName = keyof typeof DEMO_TOOL_LATENCY_MS;

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -61,6 +61,28 @@ const esc = (value: unknown): string =>
 
 const money = (n: number): string => `$${n.toFixed(2)}`;
 
+const DEMO_TOOL_LATENCY_MS = {
+  search_products: [900, 1400],
+  view_product: [650, 1100],
+  add_to_cart: [1100, 1800],
+  remove_from_cart: [800, 1300],
+  apply_promo: [750, 1200],
+} as const;
+
+type DemoToolName = keyof typeof DEMO_TOOL_LATENCY_MS;
+
+const wait = (ms: number): Promise<void> =>
+  new Promise((resolve) => window.setTimeout(resolve, ms));
+
+const simulateToolLatency = async (toolName: DemoToolName): Promise<number> => {
+  const [min, max] = DEMO_TOOL_LATENCY_MS[toolName];
+  const delay = Math.round(min + Math.random() * (max - min));
+  await wait(delay);
+  return delay;
+};
+
+const formatLatency = (ms: number): string => `${(ms / 1000).toFixed(1)}s`;
+
 // ===========================================================================
 // 2. Wire log — make the round-trip legible.
 //
@@ -377,14 +399,15 @@ if (!modelContext) {
         required: ["query"],
       },
       annotations: { readOnlyHint: true },
-      execute(input): unknown {
+      async execute(input): Promise<unknown> {
+        const latency = await simulateToolLatency("search_products");
         const { query } = input as { query: string };
         const hits = searchCatalog(query ?? "");
         highlightHits(hits.map((p) => p.sku));
         logWire(
           "exec",
           "search_products",
-          `query <b>${esc(query)}</b> → ${hits.length} hit${hits.length === 1 ? "" : "s"}`,
+          `query <b>${esc(query)}</b> → ${hits.length} hit${hits.length === 1 ? "" : "s"} <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
         );
         return {
           query,
@@ -416,16 +439,25 @@ if (!modelContext) {
         required: ["sku"],
       },
       annotations: { readOnlyHint: true },
-      execute(input): unknown {
+      async execute(input): Promise<unknown> {
+        const latency = await simulateToolLatency("view_product");
         const { sku } = input as { sku: string };
         const product = findBySku(sku);
         if (!product) {
-          logWire("exec", "view_product", `<b>${esc(sku)}</b> → not found`);
+          logWire(
+            "exec",
+            "view_product",
+            `<b>${esc(sku)}</b> → not found <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+          );
           return { found: false, error: `No product with SKU "${sku}".` };
         }
         highlightHits([product.sku]);
         flashCard(product.sku);
-        logWire("exec", "view_product", `<b>${esc(product.sku)}</b> — ${esc(product.title)}`);
+        logWire(
+          "exec",
+          "view_product",
+          `<b>${esc(product.sku)}</b> — ${esc(product.title)} <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+        );
         return {
           found: true,
           sku: product.sku,
@@ -453,18 +485,27 @@ if (!modelContext) {
         required: ["sku"],
       },
       annotations: { readOnlyHint: false },
-      execute(input): unknown {
+      async execute(input): Promise<unknown> {
+        const latency = await simulateToolLatency("add_to_cart");
         const { sku, quantity = 1 } = input as { sku: string; quantity?: number };
         const product = findBySku(sku);
         if (!product) {
-          logWire("exec", "add_to_cart", `<b>${esc(sku)}</b> → not found`);
+          logWire(
+            "exec",
+            "add_to_cart",
+            `<b>${esc(sku)}</b> → not found <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+          );
           return {
             added: false,
             error: `No product with SKU "${sku}". Call search_products first to get valid SKUs.`,
           };
         }
         addToCart(product, quantity);
-        logWire("exec", "add_to_cart", `<b>${esc(product.sku)}</b> ×${esc(quantity)} → ${esc(product.title)}`);
+        logWire(
+          "exec",
+          "add_to_cart",
+          `<b>${esc(product.sku)}</b> ×${esc(quantity)} → ${esc(product.title)} <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+        );
         return {
           added: true,
           sku: product.sku,
@@ -490,14 +531,19 @@ if (!modelContext) {
         required: ["sku"],
       },
       annotations: { readOnlyHint: false },
-      execute(input): unknown {
+      async execute(input): Promise<unknown> {
+        const latency = await simulateToolLatency("remove_from_cart");
         const { sku, quantity } = input as { sku: string; quantity?: number };
         // Resolve the SKU the same way add_to_cart/view_product do (trimmed,
         // case-insensitive) — the cart is keyed by the canonical product.sku, so
         // a raw `cart.get(sku)` would miss on different casing/spacing.
         const product = findBySku(sku);
         if (!product) {
-          logWire("exec", "remove_from_cart", `<b>${esc(sku)}</b> → not found`);
+          logWire(
+            "exec",
+            "remove_from_cart",
+            `<b>${esc(sku)}</b> → not found <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+          );
           return {
             removed: false,
             error: `No product with SKU "${sku}". Call search_products first to get valid SKUs.`,
@@ -506,7 +552,11 @@ if (!modelContext) {
         }
         const line = cart.get(product.sku);
         if (!line) {
-          logWire("exec", "remove_from_cart", `<b>${esc(product.sku)}</b> → not in cart`);
+          logWire(
+            "exec",
+            "remove_from_cart",
+            `<b>${esc(product.sku)}</b> → not in cart <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+          );
           return {
             removed: false,
             error: `"${product.sku}" is not in the cart.`,
@@ -528,7 +578,7 @@ if (!modelContext) {
         logWire(
           "exec",
           "remove_from_cart",
-          `<b>${esc(product.sku)}</b>${partial ? ` ×${esc(quantity)}` : ""} → removed`,
+          `<b>${esc(product.sku)}</b>${partial ? ` ×${esc(quantity)}` : ""} → removed <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
         );
         return { removed: true, sku: product.sku, cart: cartSummary() };
       },
@@ -548,12 +598,17 @@ if (!modelContext) {
         required: ["code"],
       },
       annotations: { readOnlyHint: false },
-      execute(input): unknown {
+      async execute(input): Promise<unknown> {
+        const latency = await simulateToolLatency("apply_promo");
         const { code } = input as { code: string };
         const key = (code ?? "").trim().toUpperCase();
         const match = PROMOS[key];
         if (!match) {
-          logWire("exec", "apply_promo", `<b>${esc(code)}</b> → rejected`);
+          logWire(
+            "exec",
+            "apply_promo",
+            `<b>${esc(code)}</b> → rejected <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+          );
           return {
             applied: false,
             error: `"${code}" is not a valid promo code. Try TRAIL10, TRAILVIP, or SUMMIT20.`,
@@ -563,7 +618,11 @@ if (!modelContext) {
         promo = { code: key, rate: match.rate, label: match.label };
         renderCart();
         flashCart();
-        logWire("exec", "apply_promo", `<b>${esc(key)}</b> → ${esc(match.label)}`);
+        logWire(
+          "exec",
+          "apply_promo",
+          `<b>${esc(key)}</b> → ${esc(match.label)} <span class="wire-time">(+${esc(formatLatency(latency))})</span>`,
+        );
         return { applied: true, code: key, discountRate: match.rate, cart: cartSummary() };
       },
     },

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -3056,6 +3056,46 @@ describe('AgentWidgetClient — step_await parsing', () => {
     expect(toolMsg!.agentMetadata?.awaitingLocalTool).toBe(true);
   });
 
+  it('emits a running tool message for WebMCP local_tool_required until the browser tool resolves', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      body: buildStepAwaitStream({
+        awaitReason: 'local_tool_required',
+        id: 'step-1',
+        name: 'Test Step',
+        stepType: 'prompt',
+        index: 0,
+        toolCallId: 'tc_webmcp_1',
+        toolName: 'webmcp:get_product_by_url',
+        executionId: 'exec_abc',
+        startedAt: 1234,
+        parameters: { path: '/jade/' },
+      }),
+    });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const toolMsg = events
+      .filter((e) => e.type === 'message')
+      .map((e) => (e as { message: AgentWidgetMessage }).message)
+      .find((m) => m.variant === 'tool' && m.toolCall?.name === 'webmcp:get_product_by_url');
+
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg!.toolCall!.id).toBe('tc_webmcp_1');
+    expect(toolMsg!.toolCall!.status).toBe('running');
+    expect(toolMsg!.toolCall!.startedAt).toBe(1234);
+    expect(toolMsg!.toolCall!.completedAt).toBeUndefined();
+    expect(toolMsg!.toolCall!.durationMs).toBeUndefined();
+    expect(toolMsg!.toolCall!.args).toEqual({ path: '/jade/' });
+    expect(toolMsg!.agentMetadata?.executionId).toBe('exec_abc');
+    expect(toolMsg!.agentMetadata?.awaitingLocalTool).toBe(true);
+  });
+
   it('ignores step_await events whose awaitReason is not local_tool_required', async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -23,7 +23,7 @@ import {
   ContentPart,
   WebMcpConfirmHandler
 } from "./types";
-import { WebMcpBridge, computeClientToolsFingerprint } from "./webmcp-bridge";
+import { WebMcpBridge, computeClientToolsFingerprint, isWebMcpToolName } from "./webmcp-bridge";
 import {
   extractTextFromJson,
   createPlainTextParser,
@@ -2026,14 +2026,28 @@ export class AgentWidgetClient {
           const toolId =
             toolCallId ?? (payload.toolId as string) ?? `local-${nextSequence()}`;
           const toolMessage = ensureToolMessage(toolId);
+          const toolName = payload.toolName as string;
+          const webMcpTool = isWebMcpToolName(toolName);
           const tool = toolMessage.toolCall ?? { id: toolId, status: "pending" as const };
-          tool.name = payload.toolName as string;
+          tool.name = toolName;
           tool.args = payload.parameters;
-          tool.status = "complete";
+          // WebMCP tools are executed asynchronously by the browser AFTER this
+          // `step_await` arrives. Keep them running until session.ts resolves
+          // the page tool and records its actual elapsed time. Other local
+          // tools (for example ask_user_question) keep the existing complete
+          // state because they are waiting for a user interaction, not an
+          // automatic page-tool execution.
+          tool.status = webMcpTool ? "running" : "complete";
           tool.chunks = tool.chunks ?? [];
           tool.startedAt =
             tool.startedAt ?? resolveTimestamp(payload.startedAt ?? payload.timestamp);
-          tool.completedAt = tool.completedAt ?? tool.startedAt;
+          if (webMcpTool) {
+            tool.completedAt = undefined;
+            tool.duration = undefined;
+            tool.durationMs = undefined;
+          } else {
+            tool.completedAt = tool.completedAt ?? tool.startedAt;
+          }
           toolMessage.toolCall = tool;
           toolMessage.streaming = false;
           toolMessage.agentMetadata = {

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -206,6 +206,7 @@ export type RuntypeAgentSSEEvent = {
   iteration: number;
   reflection?: string;
   seq: number;
+  timestamp?: string;
   type: "agent_reflection";
 } | {
   activatedCapabilities: Array<string>;
@@ -213,6 +214,7 @@ export type RuntypeAgentSSEEvent = {
   iteration: number;
   seq: number;
   skill: string;
+  timestamp?: string;
   toolCallId: string;
   type: "agent_skill_loaded";
 } | ({
@@ -222,6 +224,7 @@ export type RuntypeAgentSSEEvent = {
   proposalId?: string;
   seq: number;
   skill: string;
+  timestamp?: string;
   toolCallId: string;
   type: "agent_skill_proposed";
 }) | ({
@@ -255,6 +258,7 @@ export type RuntypeAgentSSEEvent = {
   iteration?: number;
   recoverable: boolean;
   seq: number;
+  timestamp?: string;
   type: "agent_error";
 } | {
   executionId: string;
@@ -289,6 +293,7 @@ export type RuntypeFlowSSEEvent = {
   failedSteps?: number;
   finalOutput?: string;
   flowId?: string;
+  flowName?: string;
   output?: unknown;
   seq?: number;
   source?: string;
@@ -340,6 +345,7 @@ export type RuntypeFlowSSEEvent = {
   id?: string;
   index?: number;
   name?: string;
+  outputVariable?: string;
   seq?: number;
   startedAt: string;
   stepId?: string;
@@ -751,6 +757,7 @@ export type RuntypeDispatchSSEEvent = {
   iteration: number;
   reflection?: string;
   seq: number;
+  timestamp?: string;
   type: "agent_reflection";
 } | {
   activatedCapabilities: Array<string>;
@@ -758,6 +765,7 @@ export type RuntypeDispatchSSEEvent = {
   iteration: number;
   seq: number;
   skill: string;
+  timestamp?: string;
   toolCallId: string;
   type: "agent_skill_loaded";
 } | ({
@@ -767,6 +775,7 @@ export type RuntypeDispatchSSEEvent = {
   proposalId?: string;
   seq: number;
   skill: string;
+  timestamp?: string;
   toolCallId: string;
   type: "agent_skill_proposed";
 }) | ({
@@ -800,6 +809,7 @@ export type RuntypeDispatchSSEEvent = {
   iteration?: number;
   recoverable: boolean;
   seq: number;
+  timestamp?: string;
   type: "agent_error";
 } | {
   executionId: string;
@@ -832,6 +842,7 @@ export type RuntypeDispatchSSEEvent = {
   failedSteps?: number;
   finalOutput?: string;
   flowId?: string;
+  flowName?: string;
   output?: unknown;
   seq?: number;
   source?: string;
@@ -883,6 +894,7 @@ export type RuntypeDispatchSSEEvent = {
   id?: string;
   index?: number;
   name?: string;
+  outputVariable?: string;
   seq?: number;
   startedAt: string;
   stepId?: string;

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -1595,6 +1595,74 @@ export class AgentWidgetSession {
     }
   }
 
+  private resolveWebMcpToolStartedAt(
+    toolMessage: AgentWidgetMessage,
+  ): number {
+    const stored = this.messages.find((m) => m.id === toolMessage.id);
+    const candidates = [
+      stored?.toolCall?.startedAt,
+      toolMessage.toolCall?.startedAt,
+    ];
+    for (const candidate of candidates) {
+      if (typeof candidate === "number" && Number.isFinite(candidate)) {
+        return candidate;
+      }
+    }
+    return Date.now();
+  }
+
+  private markWebMcpToolRunning(
+    toolMessage: AgentWidgetMessage,
+  ): number {
+    const startedAt = this.resolveWebMcpToolStartedAt(toolMessage);
+    this.upsertMessage({
+      ...toolMessage,
+      streaming: true,
+      agentMetadata: {
+        ...toolMessage.agentMetadata,
+        awaitingLocalTool: false,
+      },
+      toolCall: toolMessage.toolCall
+        ? {
+            ...toolMessage.toolCall,
+            status: "running",
+            startedAt,
+            completedAt: undefined,
+            duration: undefined,
+            durationMs: undefined,
+          }
+        : toolMessage.toolCall,
+    });
+    return startedAt;
+  }
+
+  private markWebMcpToolComplete(
+    toolMessage: AgentWidgetMessage,
+    result: unknown,
+    startedAt: number,
+  ): void {
+    const completedAt = Date.now();
+    this.upsertMessage({
+      ...toolMessage,
+      streaming: false,
+      agentMetadata: {
+        ...toolMessage.agentMetadata,
+        awaitingLocalTool: false,
+      },
+      toolCall: toolMessage.toolCall
+        ? {
+            ...toolMessage.toolCall,
+            status: "complete",
+            result,
+            startedAt,
+            completedAt,
+            duration: undefined,
+            durationMs: Math.max(0, completedAt - startedAt),
+          }
+        : toolMessage.toolCall,
+    });
+  }
+
   /**
    * Resolve TWO OR MORE parallel local-tool awaits sharing one paused
    * executionId with a SINGLE `/resume` (core#3878). Each call is executed
@@ -1640,14 +1708,10 @@ export class AgentWidgetSession {
         this.webMcpInflightKeys.add(dedupeKey);
         claimedKeys.push(dedupeKey);
 
-        // Clear the awaiting flag so the local-tool UI doesn't linger.
-        this.upsertMessage({
-          ...toolMessage,
-          agentMetadata: {
-            ...toolMessage.agentMetadata,
-            awaitingLocalTool: false,
-          },
-        });
+        // Clear the awaiting flag and keep the tool bubble running while the
+        // browser-side WebMCP promise is in flight. The initial `step_await`
+        // only means the server paused for a local tool; it is not completion.
+        const startedAt = this.markWebMcpToolRunning(toolMessage);
 
         const controller = new AbortController();
         this.webMcpResolveControllers.add(controller);
@@ -1695,6 +1759,7 @@ export class AgentWidgetSession {
           this.webMcpInflightKeys.delete(dedupeKey);
           return null;
         }
+        this.markWebMcpToolComplete(toolMessage, output, startedAt);
         return { dedupeKey, resumeKey, output };
       }),
     );
@@ -1842,14 +1907,10 @@ export class AgentWidgetSession {
 
     // Mark resolved on the message so the UI's local-tool sheet (if any
     // generic one ever lands) does not show — this is a fully-automatic
-    // tool from the user's perspective, modulo the confirm bubble.
-    this.upsertMessage({
-      ...toolMessage,
-      agentMetadata: {
-        ...toolMessage.agentMetadata,
-        awaitingLocalTool: false,
-      },
-    });
+    // tool from the user's perspective, modulo the confirm bubble. Keep the
+    // tool bubble running until the browser-side promise resolves; the
+    // initial step_await was only the server pause, not tool completion.
+    const startedAt = this.markWebMcpToolRunning(toolMessage);
 
     // Per-resolve AbortController, NOT the shared `this.abortController`.
     // A single turn can produce multiple `webmcp:*` step_await messages —
@@ -1900,6 +1961,7 @@ export class AgentWidgetSession {
       if (signal.aborted) {
         return;
       }
+      this.markWebMcpToolComplete(toolMessage, resumeOutput, startedAt);
       // Mark resolved as soon as the HTTP /resume returns OK — not after the
       // SSE stream finishes. `connectStream` swallows downstream SSE errors
       // (they surface via onError, not by rethrowing), so awaiting it doesn't

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -2673,6 +2673,17 @@ export class AgentWidgetSession {
             ...(merged.agentMetadata ?? {}),
             awaitingLocalTool: false,
           };
+          // If the tool already completed, a stale duplicate step_await should
+          // not overwrite the measured result/duration and flip the bubble back
+          // to "running". Keep the completed state while still preserving the
+          // metadata correction above.
+          if (
+            this.webMcpResolvedKeys.has(reKey) &&
+            existing.toolCall?.status === "complete"
+          ) {
+            merged.toolCall = existing.toolCall;
+            merged.streaming = false;
+          }
         }
       }
       return merged;

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -76,6 +76,20 @@ function buildDispatchErrorContent(
   return err.message ? `${base}\n\n_Details: ${err.message}_` : base;
 }
 
+const buildWebMcpErrorResult = (message: string) => ({
+  isError: true,
+  content: [{ type: "text" as const, text: message }],
+});
+
+const getWebMcpErrorMessage = (
+  error: unknown,
+  fallback = "WebMCP tool execution failed.",
+): string => {
+  if (error instanceof Error && error.message) return error.message;
+  if (typeof error === "string" && error) return error;
+  return fallback;
+};
+
 export class AgentWidgetSession {
   private client: AgentWidgetClient;
   private messages: AgentWidgetMessage[];
@@ -1640,8 +1654,12 @@ export class AgentWidgetSession {
     toolMessage: AgentWidgetMessage,
     result: unknown,
     startedAt: number,
+    completedAt = Date.now(),
   ): void {
-    const completedAt = Date.now();
+    // A teardown such as clearMessages()/hydrateMessages()/new send can remove
+    // the bubble while an aborted WebMCP promise is settling. Never resurrect a
+    // cleared message just to mark the old resolve complete.
+    if (!this.messages.some((message) => message.id === toolMessage.id)) return;
     this.upsertMessage({
       ...toolMessage,
       streaming: false,
@@ -1681,6 +1699,14 @@ export class AgentWidgetSession {
     executionId: string,
     snapshots: AgentWidgetMessage[],
   ): Promise<void> {
+    type ExecutedWebMcpTool = {
+      dedupeKey: string;
+      resumeKey: string;
+      output: unknown;
+      toolMessage: AgentWidgetMessage;
+      startedAt: number;
+      completedAt: number;
+    };
     const claimedKeys: string[] = [];
     const controllers: AbortController[] = [];
     // Dedicated controller for the shared resume fetch so cancel() can abort it
@@ -1750,25 +1776,43 @@ export class AgentWidgetSession {
                 error instanceof Error ? error : new Error(String(error)),
               );
             }
+            this.markWebMcpToolComplete(
+              toolMessage,
+              buildWebMcpErrorResult(
+                isAbortError
+                  ? "Aborted by cancel()"
+                  : getWebMcpErrorMessage(error),
+              ),
+              startedAt,
+            );
             // Release the dedupe claim so a re-emit can retry this call.
             this.webMcpInflightKeys.delete(dedupeKey);
             return null;
           }
         }
         if (controller.signal.aborted) {
+          this.markWebMcpToolComplete(
+            toolMessage,
+            buildWebMcpErrorResult("Aborted by cancel()"),
+            startedAt,
+          );
           this.webMcpInflightKeys.delete(dedupeKey);
           return null;
         }
-        this.markWebMcpToolComplete(toolMessage, output, startedAt);
-        return { dedupeKey, resumeKey, output };
+        return {
+          dedupeKey,
+          resumeKey,
+          output,
+          toolMessage,
+          startedAt,
+          completedAt: Date.now(),
+        };
       }),
     );
 
+    let ready: ExecutedWebMcpTool[] = [];
     try {
-      const ready = executed.filter(
-        (r): r is { dedupeKey: string; resumeKey: string; output: unknown } =>
-          r !== null,
-      );
+      ready = executed.filter((r): r is ExecutedWebMcpTool => r !== null);
       // Everything deduped/aborted/failed — nothing to post.
       if (ready.length === 0) return;
 
@@ -1788,9 +1832,17 @@ export class AgentWidgetSession {
         throw new Error(errorData?.error ?? `Resume failed: ${response.status}`);
       }
       // Server accepted the batch — mark every included call resolved so stale
-      // re-emits don't re-execute the page tool.
+      // re-emits don't re-execute the page tool, then complete each bubble.
+      // Do this only after /resume HTTP success; if /resume fails, the server
+      // may still be paused and the retry path must not show a final result.
       for (const r of ready) {
         this.webMcpResolvedKeys.add(r.dedupeKey);
+        this.markWebMcpToolComplete(
+          r.toolMessage,
+          r.output,
+          r.startedAt,
+          r.completedAt,
+        );
       }
       if (response.body) {
         await this.connectStream(response.body, { allowReentry: true });
@@ -1805,6 +1857,14 @@ export class AgentWidgetSession {
         this.callbacks.onError?.(
           error instanceof Error ? error : new Error(String(error)),
         );
+      } else {
+        for (const r of ready) {
+          this.markWebMcpToolComplete(
+            r.toolMessage,
+            buildWebMcpErrorResult("Aborted by cancel()"),
+            r.startedAt,
+          );
+        }
       }
     } finally {
       for (const key of claimedKeys) {
@@ -1938,6 +1998,8 @@ export class AgentWidgetSession {
       signal,
     );
 
+    let phase: "execute" | "resume" = "execute";
+    let completedAt = startedAt;
     try {
       let resumeOutput: unknown;
       if (!execPromise) {
@@ -1952,6 +2014,7 @@ export class AgentWidgetSession {
       } else {
         resumeOutput = await execPromise;
       }
+      completedAt = Date.now();
       // If cancel() fired during execute, the bridge returned an aborted
       // result — don't post it. The server's SSE has been torn down; a
       // /resume now would just produce an orphan dispatch on the server.
@@ -1959,9 +2022,13 @@ export class AgentWidgetSession {
       // the resolve set) so we don't clobber a sibling resolve or a live
       // dispatch's controller here.
       if (signal.aborted) {
+        this.markWebMcpToolComplete(
+          toolMessage,
+          buildWebMcpErrorResult("Aborted by cancel()"),
+          startedAt,
+        );
         return;
       }
-      this.markWebMcpToolComplete(toolMessage, resumeOutput, startedAt);
       // Mark resolved as soon as the HTTP /resume returns OK — not after the
       // SSE stream finishes. `connectStream` swallows downstream SSE errors
       // (they surface via onError, not by rethrowing), so awaiting it doesn't
@@ -1975,9 +2042,16 @@ export class AgentWidgetSession {
       // call (only same-tool PARALLEL calls could collide on the name).
       const resumeKey =
         toolMessage.agentMetadata?.webMcpToolCallId ?? wireToolName;
+      phase = "resume";
       await this.resumeWithToolOutput(executionId, resumeKey, resumeOutput, {
         onHttpOk: () => {
           this.webMcpResolvedKeys.add(dedupeKey);
+          this.markWebMcpToolComplete(
+            toolMessage,
+            resumeOutput,
+            startedAt,
+            completedAt,
+          );
         },
         signal,
       });
@@ -1990,6 +2064,17 @@ export class AgentWidgetSession {
       // Streaming/teardown handled by the shared `finally` (gated on the
       // resolve set) — do NOT null the shared `this.abortController` here; it
       // may belong to a live dispatch or sibling resolve, not to us.
+      if (phase === "execute" || isAbortError || signal.aborted) {
+        this.markWebMcpToolComplete(
+          toolMessage,
+          buildWebMcpErrorResult(
+            isAbortError || signal.aborted
+              ? "Aborted by cancel()"
+              : getWebMcpErrorMessage(error),
+          ),
+          startedAt,
+        );
+      }
       if (!isAbortError) {
         // The bridge normalizes tool errors into result objects, so reaching
         // here means a network failure during `/resume` itself, OR a stream

--- a/packages/widget/src/session.webmcp.test.ts
+++ b/packages/widget/src/session.webmcp.test.ts
@@ -351,11 +351,12 @@ describe("AgentWidgetSession — WebMCP resolve", () => {
     expect(executeSpy).not.toHaveBeenCalled();
   });
 
-  it("a stale step_await re-emit does not resurrect awaitingLocalTool once resolved", () => {
+  it("a stale step_await re-emit does not resurrect awaitingLocalTool or reset completed tool state once resolved", () => {
     // BugBot: a duplicate step_await (awaitingLocalTool:true) for an
     // already-resolved webmcp tool must not flip the message back to awaiting
-    // and show a stuck local-tool wait. upsertMessage clears it when the
-    // tool's `${executionId}:${toolCallId}` key is inflight/resolved.
+    // or running and show a stuck local-tool wait / lose the measured duration.
+    // upsertMessage clears it when the tool's `${executionId}:${toolCallId}`
+    // key is inflight/resolved.
     const session = makeSession().session;
     const s = session as unknown as {
       webMcpResolvedKeys: Set<string>;
@@ -367,11 +368,41 @@ describe("AgentWidgetSession — WebMCP resolve", () => {
     s.upsertMessage({
       ...awaitingMessage("tool-1", "webmcp:search"),
       agentMetadata: { executionId: "exec-1", awaitingLocalTool: false },
+      streaming: false,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "complete",
+        args: { q: "shoes" },
+        result: { content: [{ type: "text", text: "ok" }] },
+        startedAt: 1_000,
+        completedAt: 2_200,
+        durationMs: 1_200,
+      },
     });
-    // Stale re-emit flips awaiting back to true on the wire.
-    s.upsertMessage(awaitingMessage("tool-1", "webmcp:search"));
+    // Stale re-emit flips awaiting back to true and carries the running state
+    // emitted by client.ts for WebMCP step_await events.
+    s.upsertMessage({
+      ...awaitingMessage("tool-1", "webmcp:search"),
+      streaming: false,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "running",
+        args: { q: "shoes" },
+        startedAt: 3_000,
+      },
+    });
     const stored = s.messages.find((m) => m.toolCall?.id === "tool-1");
     expect(stored?.agentMetadata?.awaitingLocalTool).toBe(false);
+    expect(stored?.streaming).toBe(false);
+    expect(stored?.toolCall?.status).toBe("complete");
+    expect(stored?.toolCall?.result).toEqual({
+      content: [{ type: "text", text: "ok" }],
+    });
+    expect(stored?.toolCall?.startedAt).toBe(1_000);
+    expect(stored?.toolCall?.completedAt).toBe(2_200);
+    expect(stored?.toolCall?.durationMs).toBe(1_200);
   });
 
   it("an error event does not clear streaming while a webmcp resolve is in flight", () => {

--- a/packages/widget/src/session.webmcp.test.ts
+++ b/packages/widget/src/session.webmcp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 import { AgentWidgetSession } from "./session";
 import type {
@@ -80,6 +80,10 @@ describe("AgentWidgetSession — WebMCP resolve", () => {
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("posts result to /resume on the happy path", async () => {
     const { session, executeSpy, resumeSpy } = makeSession({
       executeReturn: {
@@ -95,6 +99,33 @@ describe("AgentWidgetSession — WebMCP resolve", () => {
       { "webmcp:search": { content: [{ type: "text", text: "hi" }] } },
       expect.objectContaining({ signal: expect.any(AbortSignal) }),
     );
+  });
+
+  it("records the elapsed time of the resolved browser WebMCP promise", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+    const { session } = makeSession({
+      executeImpl: async () => {
+        vi.advanceTimersByTime(1_250);
+        return { content: [{ type: "text", text: "loaded jade" }] };
+      },
+    });
+
+    await session.resolveWebMcpToolCall(
+      awaitingMessage("tool-1", "webmcp:get_product_by_url"),
+    );
+
+    const stored = (
+      session as unknown as { messages: AgentWidgetMessage[] }
+    ).messages.find((m) => m.toolCall?.id === "tool-1");
+    expect(stored?.agentMetadata?.awaitingLocalTool).toBe(false);
+    expect(stored?.toolCall?.status).toBe("complete");
+    expect(stored?.toolCall?.startedAt).toBe(1_000);
+    expect(stored?.toolCall?.completedAt).toBe(2_250);
+    expect(stored?.toolCall?.durationMs).toBe(1_250);
+    expect(stored?.toolCall?.result).toEqual({
+      content: [{ type: "text", text: "loaded jade" }],
+    });
   });
 
   it("still resumes (with isError) when the bridge is not operational", async () => {
@@ -576,6 +607,10 @@ describe("AgentWidgetSession — WebMCP parallel batched resume (core#3878)", ()
     vi.clearAllMocks();
   });
 
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   // A `step_await(local_tool_required)` message as client.ts emits it for a
   // PARALLEL local-tool call: the per-call `toolCallId` is both the toolCall.id
   // AND `agentMetadata.webMcpToolCallId`. Two of these for one executionId share
@@ -703,6 +738,52 @@ describe("AgentWidgetSession — WebMCP parallel batched resume (core#3878)", ()
       unknown
     >;
     expect(Object.keys(toolOutputs).sort()).toEqual(["toolu_A", "toolu_B"]);
+  });
+
+  it("records elapsed time for each resolved tool in a batched WebMCP resume", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    let releaseA: (r: WebMcpToolResult) => void = () => undefined;
+    let releaseB: (r: WebMcpToolResult) => void = () => undefined;
+    const pA = new Promise<WebMcpToolResult>((r) => (releaseA = r));
+    const pB = new Promise<WebMcpToolResult>((r) => (releaseB = r));
+    const { session, resumeSpy } = makeSession();
+    const client = (session as unknown as { client: Record<string, unknown> })
+      .client;
+    (client.executeWebMcpToolCall as ReturnType<typeof vi.fn>).mockImplementation(
+      (_name: string, args: { sku: string }) =>
+        args.sku === "SHOE-001" ? pA : pB,
+    );
+
+    feed(session, parallelAwait("toolu_A", "SHOE-001"));
+    feed(session, parallelAwait("toolu_B", "SHOE-007"));
+    endStream(session);
+    await flushMicrotasks();
+
+    vi.setSystemTime(1_800);
+    releaseA({ content: [{ type: "text", text: "a" }] });
+    await flushMicrotasks();
+
+    let messages = (session as unknown as { messages: AgentWidgetMessage[] })
+      .messages;
+    const toolA = messages.find((m) => m.toolCall?.id === "toolu_A");
+    const toolBWhileRunning = messages.find((m) => m.toolCall?.id === "toolu_B");
+    expect(toolA?.toolCall?.status).toBe("complete");
+    expect(toolA?.toolCall?.durationMs).toBe(800);
+    expect(toolBWhileRunning?.toolCall?.status).toBe("running");
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    vi.setSystemTime(2_600);
+    releaseB({ content: [{ type: "text", text: "b" }] });
+    await flushMicrotasks();
+
+    messages = (session as unknown as { messages: AgentWidgetMessage[] })
+      .messages;
+    const toolB = messages.find((m) => m.toolCall?.id === "toolu_B");
+    expect(toolB?.toolCall?.status).toBe("complete");
+    expect(toolB?.toolCall?.durationMs).toBe(1_600);
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
   });
 
   it("dedupes a duplicate parallel await within the same batch", async () => {

--- a/packages/widget/src/session.webmcp.test.ts
+++ b/packages/widget/src/session.webmcp.test.ts
@@ -183,11 +183,41 @@ describe("AgentWidgetSession — WebMCP resolve", () => {
 
     const msg = awaitingMessage("tool-1", "webmcp:search");
     await session.resolveWebMcpToolCall(msg);
+    const afterFailedResume = (
+      session as unknown as { messages: AgentWidgetMessage[] }
+    ).messages.find((m) => m.toolCall?.id === "tool-1");
+    expect(afterFailedResume?.toolCall?.status).toBe("running");
+    expect(afterFailedResume?.toolCall?.result).toBeUndefined();
+    expect(afterFailedResume?.toolCall?.durationMs).toBeUndefined();
+
     await session.resolveWebMcpToolCall(msg); // retry — must be allowed
     await session.resolveWebMcpToolCall(msg); // post-success — must be blocked
 
     expect(executeSpy).toHaveBeenCalledTimes(2);
     expect(resumeSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("marks the bubble complete with an error when browser execution throws before /resume", async () => {
+    const { session, resumeSpy } = makeSession({
+      executeImpl: async () => {
+        throw new Error("page tool exploded");
+      },
+    });
+
+    await session.resolveWebMcpToolCall(
+      awaitingMessage("tool-1", "webmcp:search"),
+    );
+
+    const stored = (
+      session as unknown as { messages: AgentWidgetMessage[] }
+    ).messages.find((m) => m.toolCall?.id === "tool-1");
+    expect(resumeSpy).not.toHaveBeenCalled();
+    expect(stored?.toolCall?.status).toBe("complete");
+    expect(stored?.toolCall?.durationMs).toBeGreaterThanOrEqual(0);
+    expect(stored?.toolCall?.result).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: "page tool exploded" }],
+    });
   });
 
   it("threads an AbortSignal into resumeFlow", async () => {
@@ -220,6 +250,14 @@ describe("AgentWidgetSession — WebMCP resolve", () => {
     release();
     await inflight;
     expect(resumeSpy).not.toHaveBeenCalled();
+    const stored = (
+      session as unknown as { messages: AgentWidgetMessage[] }
+    ).messages.find((m) => m.toolCall?.id === "tool-1");
+    expect(stored?.toolCall?.status).toBe("complete");
+    expect(stored?.toolCall?.result).toMatchObject({
+      isError: true,
+      content: [{ type: "text", text: "Aborted by cancel()" }],
+    });
   });
 
   it("does NOT abort the shared session abortController", async () => {
@@ -769,8 +807,8 @@ describe("AgentWidgetSession — WebMCP parallel batched resume (core#3878)", ()
       .messages;
     const toolA = messages.find((m) => m.toolCall?.id === "toolu_A");
     const toolBWhileRunning = messages.find((m) => m.toolCall?.id === "toolu_B");
-    expect(toolA?.toolCall?.status).toBe("complete");
-    expect(toolA?.toolCall?.durationMs).toBe(800);
+    expect(toolA?.toolCall?.status).toBe("running");
+    expect(toolA?.toolCall?.durationMs).toBeUndefined();
     expect(toolBWhileRunning?.toolCall?.status).toBe("running");
     expect(resumeSpy).not.toHaveBeenCalled();
 
@@ -780,10 +818,39 @@ describe("AgentWidgetSession — WebMCP parallel batched resume (core#3878)", ()
 
     messages = (session as unknown as { messages: AgentWidgetMessage[] })
       .messages;
+    const completedToolA = messages.find((m) => m.toolCall?.id === "toolu_A");
     const toolB = messages.find((m) => m.toolCall?.id === "toolu_B");
+    expect(completedToolA?.toolCall?.status).toBe("complete");
+    expect(completedToolA?.toolCall?.durationMs).toBe(800);
     expect(toolB?.toolCall?.status).toBe("complete");
     expect(toolB?.toolCall?.durationMs).toBe(1_600);
     expect(resumeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark batched WebMCP bubbles complete when the shared /resume fails", async () => {
+    const { session, client, resumeSpy } = makeSession();
+    (client.resumeFlow as ReturnType<typeof vi.fn>).mockImplementationOnce(
+      async () => {
+        throw new Error("resume failed");
+      },
+    );
+
+    feed(session, parallelAwait("toolu_A", "SHOE-001"));
+    feed(session, parallelAwait("toolu_B", "SHOE-007"));
+    endStream(session);
+    await flushMicrotasks();
+
+    const messages = (session as unknown as { messages: AgentWidgetMessage[] })
+      .messages;
+    const toolA = messages.find((m) => m.toolCall?.id === "toolu_A");
+    const toolB = messages.find((m) => m.toolCall?.id === "toolu_B");
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    expect(toolA?.toolCall?.status).toBe("running");
+    expect(toolA?.toolCall?.result).toBeUndefined();
+    expect(toolA?.toolCall?.durationMs).toBeUndefined();
+    expect(toolB?.toolCall?.status).toBe("running");
+    expect(toolB?.toolCall?.result).toBeUndefined();
+    expect(toolB?.toolCall?.durationMs).toBeUndefined();
   });
 
   it("dedupes a duplicate parallel await within the same batch", async () => {


### PR DESCRIPTION
## Summary
- keep WebMCP local-tool bubbles running after `step_await` until the browser-side page tool promise resolves
- record actual `completedAt`/`durationMs` for single and batched WebMCP resolves
- add regression coverage plus a patch changeset
- refresh generated Runtype OpenAPI contract for current optional SSE fields

## Root Cause
`step_await(local_tool_required)` was treated as tool completion for every local tool. For `webmcp:*` calls, that event only means Core paused for a browser-side local tool, so Persona was setting `completedAt` equal to `startedAt` before the async WebMCP promise ran.

## Validation
- `pnpm --filter @runtypelabs/persona typecheck`
- `pnpm --filter @runtypelabs/persona lint`
- `pnpm --filter @runtypelabs/persona test:run -- client.test.ts session.webmcp.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches widget streaming/session state for WebMCP and batched /resume timing; behavior is heavily tested but wrong completion timing could still affect dispatch retry UX.
> 
> **Overview**
> Fixes **WebMCP tool bubbles** being marked complete (with zero duration) as soon as `step_await(local_tool_required)` arrives, when that event only means the server paused for a browser page tool—not that execution finished.
> 
> In **`client.ts`**, `webmcp:*` local-tool awaits now emit **`running`** tool messages and omit `completedAt`/`durationMs`; other local tools (e.g. `ask_user_question`) still show **complete** at the pause.
> 
> In **`session.ts`**, resolve paths use **`markWebMcpToolRunning`** / **`markWebMcpToolComplete`** to measure elapsed time from browser `executeWebMcpToolCall` through successful **`/resume`** (single and batched). Bubbles stay running on **`/resume` failure** so retries stay valid; exec/abort/cancel paths complete with structured errors. Stale duplicate `step_await` events no longer reset completed duration/result.
> 
> Adds **regression tests** in `client.test.ts` and `session.webmcp.test.ts`, a **patch changeset** for `@runtypelabs/persona`, **async simulated latency** in the embedded WebMCP demo wire log, and refreshes **generated OpenAPI SSE contract** optional fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82da27318a999969cef22033d8e18b1ea1bd958d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->