### PR TITLE
Fix stale WebMCP tool state re-emits

### DIFF
--- a/.changeset/stale-webmcp-tool-state.md
+++ b/.changeset/stale-webmcp-tool-state.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Preserve in-flight and locally-completed WebMCP tool state when stale await events are re-emitted.

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -2651,9 +2651,11 @@ export class AgentWidgetSession {
       // WebMCP equivalent: once a `webmcp:*` tool has started resolving
       // (inflight) or resolved, a duplicate `step_await` re-emit must not
       // flip `awaitingLocalTool` back to true and resurrect the "waiting on
-      // local tool" UI. resolveWebMcpToolCall's dedupe path returns without
-      // re-touching the message, so correct the merge here (also avoids a
-      // one-frame flash before that microtask runs).
+      // local tool" UI. It also must not overwrite an existing running or
+      // completed toolCall with the fresh running skeleton emitted by client.ts
+      // for every step_await. resolveWebMcpToolCall's dedupe path returns
+      // without re-touching the message, so correct the merge here (also avoids
+      // a one-frame flash before that microtask runs).
       const reTcName = withSequence.toolCall?.name;
       const reExecId = withSequence.agentMetadata?.executionId;
       const reTcId = withSequence.toolCall?.id;
@@ -2665,25 +2667,26 @@ export class AgentWidgetSession {
         withSequence.agentMetadata?.awaitingLocalTool === true
       ) {
         const reKey = `${reExecId}:${reTcId}`;
-        if (
-          this.webMcpInflightKeys.has(reKey) ||
-          this.webMcpResolvedKeys.has(reKey)
-        ) {
+        const isInflight = this.webMcpInflightKeys.has(reKey);
+        const isResolved = this.webMcpResolvedKeys.has(reKey);
+        const existingToolName = existing.toolCall?.name;
+        const hasCompletedTool =
+          existing.agentMetadata?.executionId === reExecId &&
+          existing.toolCall?.id === reTcId &&
+          existingToolName !== undefined &&
+          isWebMcpToolName(existingToolName) &&
+          existing.toolCall?.status === "complete";
+        if (isInflight || isResolved || hasCompletedTool) {
           merged.agentMetadata = {
             ...(merged.agentMetadata ?? {}),
             awaitingLocalTool: false,
           };
-          // If the tool already completed, a stale duplicate step_await should
-          // not overwrite the measured result/duration and flip the bubble back
-          // to "running". Keep the completed state while still preserving the
-          // metadata correction above.
-          if (
-            this.webMcpResolvedKeys.has(reKey) &&
-            existing.toolCall?.status === "complete"
-          ) {
-            merged.toolCall = existing.toolCall;
-            merged.streaming = false;
-          }
+          // Preserve the in-flight/completed tool state. For in-flight calls,
+          // this keeps the original `startedAt`; for completed calls, it keeps
+          // the measured duration/result even when the call completed with a
+          // local/browser error and therefore was not promoted to resolved.
+          merged.toolCall = existing.toolCall;
+          merged.streaming = existing.streaming;
         }
       }
       return merged;

--- a/packages/widget/src/session.webmcp.test.ts
+++ b/packages/widget/src/session.webmcp.test.ts
@@ -405,6 +405,147 @@ describe("AgentWidgetSession — WebMCP resolve", () => {
     expect(stored?.toolCall?.durationMs).toBe(1_200);
   });
 
+  it("a stale step_await re-emit does not reset in-flight WebMCP tool timing", () => {
+    const session = makeSession().session;
+    const s = session as unknown as {
+      webMcpInflightKeys: Set<string>;
+      upsertMessage: (m: AgentWidgetMessage) => void;
+      messages: AgentWidgetMessage[];
+    };
+    s.webMcpInflightKeys.add("exec-1:tool-1");
+    s.upsertMessage({
+      ...awaitingMessage("tool-1", "webmcp:search"),
+      agentMetadata: { executionId: "exec-1", awaitingLocalTool: false },
+      streaming: true,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "running",
+        args: { q: "shoes" },
+        startedAt: 1_000,
+      },
+    });
+
+    s.upsertMessage({
+      ...awaitingMessage("tool-1", "webmcp:search"),
+      streaming: false,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "running",
+        args: { q: "shoes" },
+        startedAt: 3_000,
+      },
+    });
+
+    const stored = s.messages.find((m) => m.toolCall?.id === "tool-1");
+    expect(stored?.agentMetadata?.awaitingLocalTool).toBe(false);
+    expect(stored?.streaming).toBe(true);
+    expect(stored?.toolCall?.status).toBe("running");
+    expect(stored?.toolCall?.startedAt).toBe(1_000);
+    expect(stored?.toolCall?.durationMs).toBeUndefined();
+  });
+
+  it("a stale step_await re-emit does not reset completed WebMCP local-error state", () => {
+    const session = makeSession().session;
+    const s = session as unknown as {
+      upsertMessage: (m: AgentWidgetMessage) => void;
+      messages: AgentWidgetMessage[];
+    };
+    s.upsertMessage({
+      ...awaitingMessage("tool-1", "webmcp:search"),
+      agentMetadata: { executionId: "exec-1", awaitingLocalTool: false },
+      streaming: false,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "complete",
+        args: { q: "shoes" },
+        result: {
+          isError: true,
+          content: [{ type: "text", text: "page tool exploded" }],
+        },
+        startedAt: 1_000,
+        completedAt: 1_500,
+        durationMs: 500,
+      },
+    });
+
+    s.upsertMessage({
+      ...awaitingMessage("tool-1", "webmcp:search"),
+      streaming: false,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "running",
+        args: { q: "shoes" },
+        startedAt: 3_000,
+      },
+    });
+
+    const stored = s.messages.find((m) => m.toolCall?.id === "tool-1");
+    expect(stored?.agentMetadata?.awaitingLocalTool).toBe(false);
+    expect(stored?.streaming).toBe(false);
+    expect(stored?.toolCall?.status).toBe("complete");
+    expect(stored?.toolCall?.result).toEqual({
+      isError: true,
+      content: [{ type: "text", text: "page tool exploded" }],
+    });
+    expect(stored?.toolCall?.startedAt).toBe(1_000);
+    expect(stored?.toolCall?.completedAt).toBe(1_500);
+    expect(stored?.toolCall?.durationMs).toBe(500);
+  });
+
+  it("a new execution reusing a completed tool id is not treated as stale", () => {
+    const session = makeSession().session;
+    const s = session as unknown as {
+      upsertMessage: (m: AgentWidgetMessage) => void;
+      messages: AgentWidgetMessage[];
+    };
+    s.upsertMessage({
+      ...awaitingMessage("tool-1", "webmcp:search"),
+      id: "tool-tool-1",
+      agentMetadata: { executionId: "exec-1", awaitingLocalTool: false },
+      streaming: false,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "complete",
+        args: { q: "shoes" },
+        result: {
+          isError: true,
+          content: [{ type: "text", text: "page tool exploded" }],
+        },
+        startedAt: 1_000,
+        completedAt: 1_500,
+        durationMs: 500,
+      },
+    });
+
+    s.upsertMessage({
+      ...awaitingMessage("tool-1", "webmcp:search", "exec-2"),
+      id: "tool-tool-1",
+      streaming: false,
+      toolCall: {
+        id: "tool-1",
+        name: "webmcp:search",
+        status: "running",
+        args: { q: "boots" },
+        startedAt: 3_000,
+      },
+    });
+
+    const stored = s.messages.find((m) => m.id === "tool-tool-1");
+    expect(stored?.agentMetadata?.executionId).toBe("exec-2");
+    expect(stored?.agentMetadata?.awaitingLocalTool).toBe(true);
+    expect(stored?.toolCall?.status).toBe("running");
+    expect(stored?.toolCall?.args).toEqual({ q: "boots" });
+    expect(stored?.toolCall?.startedAt).toBe(3_000);
+    expect(stored?.toolCall?.result).toBeUndefined();
+    expect(stored?.toolCall?.completedAt).toBeUndefined();
+    expect(stored?.toolCall?.durationMs).toBeUndefined();
+  });
+
   it("an error event does not clear streaming while a webmcp resolve is in flight", () => {
     // BugBot: the error handler mirrors the idle handler — it must not tear
     // down streaming while a sibling/successor resolve is still executing.


### PR DESCRIPTION
## Summary
- Preserve existing in-flight WebMCP tool state when stale `step_await` events are re-emitted
- Preserve locally completed WebMCP error results/durations even when the call never reaches the resolved-key set
- Add regression coverage and a patch changeset

## Testing
- `pnpm --filter @runtypelabs/persona test:run -- client.test.ts session.webmcp.test.ts`
- `pnpm --filter @runtypelabs/persona typecheck`
- `pnpm --filter @runtypelabs/persona lint`
- `git diff --check`

Follow-up to merged PR #242 / Cursor BugBot feedback.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted upsert merge logic for WebMCP duplicates with regression tests; no auth, API, or broad behavioral refactors.
> 
> **Overview**
> Fixes **WebMCP message merge** in `upsertMessage` when duplicate `step_await` events arrive with `awaitingLocalTool: true` and a fresh “running” tool skeleton from the client.
> 
> Stale re-emits no longer flip **`awaitingLocalTool`** back on or replace an existing bubble when the call is **in-flight** (`webMcpInflightKeys`), **server-resolved** (`webMcpResolvedKeys`), or **already complete** in the stored message (including **local/browser errors** that never enter the resolved set). The merge keeps the prior **`toolCall`** (timing, result, duration) and **`streaming`** flag instead of only doing that for resolved success paths.
> 
> Adds **regression tests** for in-flight timing, completed error state, and a **new `executionId`** reusing the same tool id (must not be treated as stale). Includes a **patch changeset** for `@runtypelabs/persona`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2fcea4d9f9ec2efcb56b714560dd31d15531764. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->