### PR TITLE
feat(widget): user-friendly tool approval bubbles

### DIFF
--- a/.changeset/approval-bubble-friendly-description.md
+++ b/.changeset/approval-bubble-friendly-description.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Make tool approval bubbles user-friendly by default. The agent-facing tool description and raw parameters JSON are now collapsed behind a "Show details" toggle, and the bubble leads with a humanized summary line ("The assistant wants to use “Add to cart”."). New `approval` config options: `detailsDisplay` (`"collapsed"` | `"expanded"` | `"hidden"`), `formatDescription` for custom summary copy, and `showDetailsLabel`/`hideDetailsLabel`.

--- a/.changeset/approval-bubble-friendly-description.md
+++ b/.changeset/approval-bubble-friendly-description.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona": minor
 ---
 
-Make tool approval bubbles user-friendly by default. The agent-facing tool description and raw parameters JSON are now collapsed behind a "Show details" toggle, and the bubble leads with a humanized summary line ("The assistant wants to use “Add to cart”."). New `approval` config options: `detailsDisplay` (`"collapsed"` | `"expanded"` | `"hidden"`), `formatDescription` for custom summary copy, and `showDetailsLabel`/`hideDetailsLabel`.
+Make tool approval bubbles user-friendly by default. The agent-facing tool description and raw parameters JSON are now collapsed behind a "Show details" toggle, and the bubble leads with a humanized summary line ("The assistant wants to use “Add to cart”."). WebMCP tools that declare a display name via the spec's `ToolDescriptor.title` get that label instead, and custom `webmcp.onConfirm` handlers receive it as `info.title`. New `approval` config options: `detailsDisplay` (`"collapsed"` | `"expanded"` | `"hidden"`), `formatDescription` for custom summary copy (receives `displayTitle`), and `showDetailsLabel`/`hideDetailsLabel`.

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ examples/standalone-widget/
 .npmrc
 # Local generated API contract cache
 packages/widget/openapi/runtype-public-openapi.local.json
+.claude/

--- a/examples/embedded-app/src/webmcp-demo.ts
+++ b/examples/embedded-app/src/webmcp-demo.ts
@@ -37,6 +37,8 @@ interface RegisterableModelContext {
   registerTool(
     tool: {
       name: string;
+      /** User-facing label (WebMCP `ToolDescriptor.title`) — shown in Persona's approval bubble. */
+      title?: string;
       description: string;
       inputSchema?: object;
       annotations?: Record<string, unknown>;
@@ -391,6 +393,7 @@ if (!modelContext) {
   modelContext.registerTool(
     {
       name: "search_products",
+      title: "Search the catalog",
       description:
         "Search the product catalog by free-text query (e.g. 'waterproof trail shoe', 'blue running', 'jacket'). Returns matching products with SKU, title, brand, color, and price.",
       inputSchema: {
@@ -431,6 +434,7 @@ if (!modelContext) {
   modelContext.registerTool(
     {
       name: "view_product",
+      title: "View product details",
       description:
         "Look at one product in detail by SKU (from search_products results). Highlights it on the page and returns its full description. Read-only.",
       inputSchema: {
@@ -477,6 +481,7 @@ if (!modelContext) {
   modelContext.registerTool(
     {
       name: "add_to_cart",
+      title: "Add to your cart",
       description:
         "Add a product to the shopper's cart by SKU (from search_products results). Returns the updated cart so you can confirm the running total.",
       inputSchema: {
@@ -523,6 +528,7 @@ if (!modelContext) {
   modelContext.registerTool(
     {
       name: "remove_from_cart",
+      title: "Remove from your cart",
       description:
         "Remove a product from the cart by SKU, or reduce its quantity. Omit quantity to remove the line entirely. Returns the updated cart.",
       inputSchema: {
@@ -590,6 +596,7 @@ if (!modelContext) {
   modelContext.registerTool(
     {
       name: "apply_promo",
+      title: "Apply a promo code",
       description:
         "Apply a promo code to the cart (e.g. TRAIL10, TRAILVIP, SUMMIT20). Returns whether it was accepted and the updated cart with the discount applied.",
       inputSchema: {

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -20,13 +20,13 @@
   {
     "name": "⛔ CRITICAL · ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "138 kB",
+    "limit": "139 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "139 kB",
+    "limit": "140 kB",
     "gzip": true
   },
   {

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -544,6 +544,29 @@ initAgentWidget({
 });
 ```
 
+**Give your tools user-facing names.** The approval bubble (and any custom
+`onConfirm` handler, via `info.title`) shows a human-readable label for the
+tool being called. Declare it once at registration with the WebMCP spec's
+top-level `title` field:
+
+```ts
+document.modelContext.registerTool({
+  name: "add_to_cart",
+  title: "Add to Cart", // shown to users in the approval bubble
+  description: "Add products to the shopping cart. IMPORTANT: …", // agent-facing
+  inputSchema: { /* … */ },
+  execute: async (args) => { /* … */ },
+});
+```
+
+Tools without a `title` get a label derived from their name
+(`add_to_cart` → "Add to cart"). The agent-facing `description` is never shown
+as the headline — it sits behind the approval bubble's "Show details" toggle.
+See [Tool Calls & Approvals](#tool-calls--approvals) for the full summary-line
+resolution order and `approval.formatDescription` for parameter-aware copy.
+(The legacy `annotations.title` is *not* read — the polyfill's consumer surface
+doesn't expose annotations; use top-level `title`.)
+
 **Using WebMCP against a non-Runtype backend (e.g. the Vercel AI SDK)?** The
 widget's WebMCP loop expects Runtype's proxy wire protocol (a `step_await` pause
 → `/resume` round-trip). See
@@ -2333,11 +2356,43 @@ config: {
 | `title` | `string?` | Title text above the description. |
 | `approveLabel` | `string?` | Label for the approve button. |
 | `denyLabel` | `string?` | Label for the deny button. |
+| `detailsDisplay` | `'collapsed' \| 'expanded' \| 'hidden'?` | How the technical details (agent-facing tool description + raw parameters JSON) are presented. Default: `'collapsed'` (behind a "Show details" toggle). `'expanded'` shows them open; `'hidden'` never renders them. |
+| `showDetailsLabel`, `hideDetailsLabel` | `string?` | Labels for the details toggle. Defaults: `"Show details"` / `"Hide details"`. |
+| `formatDescription` | `(approval) => string \| undefined` | Build the user-facing summary line. Receives `{ toolName, toolType, description, parameters, displayTitle }`. Return a falsy value to fall back to the default copy for that approval. |
 | `backgroundColor`, `borderColor`, `titleColor`, `descriptionColor` | `string?` | Bubble styling. |
 | `approveButtonColor`, `approveButtonTextColor` | `string?` | Approve button styling. |
 | `denyButtonColor`, `denyButtonTextColor` | `string?` | Deny button styling. |
 | `parameterBackgroundColor`, `parameterTextColor` | `string?` | Parameters block styling. |
 | `onDecision` | `(data, decision) => Promise<Response \| ReadableStream \| void>?` | Custom approval handler. Return `void` for SDK auto-resolve. |
+
+**How the summary line is chosen.** A tool's wire `description` is written for the
+agent (usage rules, prompt prose), not for end users, so the bubble doesn't lead
+with it. The user-facing summary resolves in priority order:
+
+1. `formatDescription(...)` from your config, when it returns a non-empty string
+2. The display title the tool declared via the WebMCP spec's `ToolDescriptor.title`
+   (e.g. `"Add to Cart"`) — WebMCP tools only
+3. The humanized tool name — `add_to_cart` / `webmcp:add_to_cart` →
+   "Add to cart", `getProductDetails` → "Get product details"
+4. The raw `description` (only when the approval carries no tool name at all)
+
+The agent-facing description and the raw parameters JSON stay available behind
+the "Show details" toggle (see `detailsDisplay`).
+
+```ts
+initAgentWidget({
+  // ...config
+  approval: {
+    // Optional: fully custom, parameter-aware copy per tool. Falsy returns
+    // fall back to the default summary, so a sparse map is fine.
+    formatDescription: ({ toolName, parameters }) =>
+      ({
+        add_to_cart: "Add these items to your shopping cart",
+        apply_promo_code: `Apply promo code “${(parameters as { code?: string })?.code}”`,
+      })[toolName.replace(/^webmcp:/, "")],
+  },
+});
+```
 
 #### Suggestion Chips
 

--- a/packages/widget/src/components/approval-bubble.test.ts
+++ b/packages/widget/src/components/approval-bubble.test.ts
@@ -1,7 +1,12 @@
 // @vitest-environment jsdom
 
-import { describe, expect, it } from "vitest";
-import { createApprovalBubble } from "./approval-bubble";
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  approvalDetailsExpansionState,
+  createApprovalBubble,
+  humanizeToolName,
+  updateApprovalDetailsUI,
+} from "./approval-bubble";
 import type {
   AgentWidgetApproval,
   AgentWidgetConfig,
@@ -54,5 +59,155 @@ describe("createApprovalBubble shadow", () => {
     const config: AgentWidgetConfig = { approval: false } as AgentWidgetConfig;
     const bubble = createApprovalBubble(makeMessage(), config);
     expect(bubble.style.boxShadow).toContain("--persona-approval-shadow");
+  });
+});
+
+const TOOL_DESCRIPTION =
+  "Add products to the shopping cart. IMPORTANT: If a product has required options you MUST include the variantId.";
+
+const makeDetailedMessage = (
+  approval: Partial<AgentWidgetApproval> = {}
+): AgentWidgetMessage =>
+  makeMessage({
+    toolType: "webmcp",
+    description: TOOL_DESCRIPTION,
+    parameters: { items: [{ productEntityId: 129, quantity: 1 }] },
+    ...approval,
+  });
+
+const getSummary = (bubble: HTMLElement) =>
+  bubble.querySelector("[data-approval-summary]") as HTMLElement | null;
+const getToggle = (bubble: HTMLElement) =>
+  bubble.querySelector('button[data-bubble-type="approval"]') as HTMLElement | null;
+const getDetails = (bubble: HTMLElement) =>
+  bubble.querySelector("[data-approval-details]") as HTMLElement | null;
+
+beforeEach(() => {
+  approvalDetailsExpansionState.clear();
+});
+
+describe("humanizeToolName", () => {
+  it("converts snake_case to a sentence", () => {
+    expect(humanizeToolName("add_to_cart")).toBe("Add to cart");
+  });
+
+  it("strips the webmcp: prefix", () => {
+    expect(humanizeToolName("webmcp:add_to_cart")).toBe("Add to cart");
+  });
+
+  it("splits camelCase and kebab-case", () => {
+    expect(humanizeToolName("getProductDetails")).toBe("Get product details");
+    expect(humanizeToolName("apply-promo-code")).toBe("Apply promo code");
+  });
+
+  it("returns the input when nothing word-like remains", () => {
+    expect(humanizeToolName("")).toBe("");
+  });
+});
+
+describe("createApprovalBubble summary and details", () => {
+  it("shows a friendly summary instead of the agent-facing description", () => {
+    const bubble = createApprovalBubble(makeDetailedMessage());
+    expect(getSummary(bubble)?.textContent).toBe(
+      "The assistant wants to use “Add to cart”."
+    );
+    expect(getSummary(bubble)?.textContent).not.toContain("IMPORTANT");
+  });
+
+  it("collapses the description and parameters behind a toggle by default", () => {
+    const bubble = createApprovalBubble(makeDetailedMessage());
+    const toggle = getToggle(bubble);
+    const details = getDetails(bubble);
+    expect(toggle?.getAttribute("aria-expanded")).toBe("false");
+    expect(toggle?.textContent).toContain("Show details");
+    expect(details?.style.display).toBe("none");
+    expect(details?.textContent).toContain("IMPORTANT");
+    expect(details?.querySelector("pre")?.textContent).toContain("productEntityId");
+  });
+
+  it("renders details expanded when detailsDisplay is 'expanded'", () => {
+    const config = { approval: { detailsDisplay: "expanded" } } as AgentWidgetConfig;
+    const bubble = createApprovalBubble(makeDetailedMessage(), config);
+    expect(getToggle(bubble)?.getAttribute("aria-expanded")).toBe("true");
+    expect(getToggle(bubble)?.textContent).toContain("Hide details");
+    expect(getDetails(bubble)?.style.display).toBe("");
+  });
+
+  it("omits the details section entirely when detailsDisplay is 'hidden'", () => {
+    const config = { approval: { detailsDisplay: "hidden" } } as AgentWidgetConfig;
+    const bubble = createApprovalBubble(makeDetailedMessage(), config);
+    expect(getToggle(bubble)).toBeNull();
+    expect(getDetails(bubble)).toBeNull();
+    expect(bubble.textContent).not.toContain("IMPORTANT");
+  });
+
+  it("respects a per-message expansion override from prior toggling", () => {
+    approvalDetailsExpansionState.set("msg-1", true);
+    const bubble = createApprovalBubble(makeDetailedMessage());
+    expect(getToggle(bubble)?.getAttribute("aria-expanded")).toBe("true");
+    expect(getDetails(bubble)?.style.display).toBe("");
+  });
+
+  it("uses formatDescription for the summary when provided", () => {
+    const config = {
+      approval: {
+        formatDescription: ({ toolName }: { toolName: string }) =>
+          `Allow the page to run ${toolName}?`,
+      },
+    } as AgentWidgetConfig;
+    const bubble = createApprovalBubble(makeDetailedMessage(), config);
+    expect(getSummary(bubble)?.textContent).toBe("Allow the page to run add_to_cart?");
+  });
+
+  it("falls back to the default summary when formatDescription returns a falsy value", () => {
+    const config = {
+      approval: { formatDescription: () => undefined },
+    } as AgentWidgetConfig;
+    const bubble = createApprovalBubble(makeDetailedMessage(), config);
+    expect(getSummary(bubble)?.textContent).toBe(
+      "The assistant wants to use “Add to cart”."
+    );
+  });
+
+  it("falls back to the raw description when there is no tool name, without duplicating it in details", () => {
+    const bubble = createApprovalBubble(makeDetailedMessage({ toolName: "" }));
+    expect(getSummary(bubble)?.textContent).toBe(TOOL_DESCRIPTION);
+    const details = getDetails(bubble);
+    expect(details?.textContent).not.toContain("IMPORTANT");
+    expect(details?.querySelector("pre")?.textContent).toContain("productEntityId");
+  });
+
+  it("renders no toggle when there is nothing to show in details", () => {
+    const bubble = createApprovalBubble(
+      makeDetailedMessage({ toolName: "", description: "", parameters: undefined })
+    );
+    expect(getToggle(bubble)).toBeNull();
+    expect(getDetails(bubble)).toBeNull();
+  });
+
+  it("honors custom toggle labels", () => {
+    const config = {
+      approval: { showDetailsLabel: "Mehr anzeigen", hideDetailsLabel: "Weniger anzeigen" },
+    } as AgentWidgetConfig;
+    const bubble = createApprovalBubble(makeDetailedMessage(), config);
+    expect(getToggle(bubble)?.textContent).toContain("Mehr anzeigen");
+  });
+});
+
+describe("updateApprovalDetailsUI", () => {
+  it("syncs visibility and toggle state after the expansion state changes", () => {
+    const bubble = createApprovalBubble(makeDetailedMessage());
+    expect(getDetails(bubble)?.style.display).toBe("none");
+
+    approvalDetailsExpansionState.set("msg-1", true);
+    updateApprovalDetailsUI("msg-1", bubble);
+    expect(getDetails(bubble)?.style.display).toBe("");
+    expect(getToggle(bubble)?.getAttribute("aria-expanded")).toBe("true");
+    expect(getToggle(bubble)?.textContent).toContain("Hide details");
+
+    approvalDetailsExpansionState.set("msg-1", false);
+    updateApprovalDetailsUI("msg-1", bubble);
+    expect(getDetails(bubble)?.style.display).toBe("none");
+    expect(getToggle(bubble)?.textContent).toContain("Show details");
   });
 });

--- a/packages/widget/src/components/approval-bubble.test.ts
+++ b/packages/widget/src/components/approval-bubble.test.ts
@@ -85,10 +85,9 @@ const getDetails = (bubble: HTMLElement) =>
 
 beforeEach(() => {
   approvalDetailsExpansionState.clear();
-  // Evict any display title recorded by a prior test (empty title = evict).
-  recordWebMcpToolDisplayTitles([
-    { name: "add_to_cart", description: "", title: "" },
-  ]);
+  // Reset display titles recorded by a prior test (the map is rebuilt from
+  // each full snapshot, so recording an empty snapshot clears it).
+  recordWebMcpToolDisplayTitles([]);
 });
 
 describe("humanizeToolName", () => {

--- a/packages/widget/src/components/approval-bubble.test.ts
+++ b/packages/widget/src/components/approval-bubble.test.ts
@@ -7,6 +7,7 @@ import {
   humanizeToolName,
   updateApprovalDetailsUI,
 } from "./approval-bubble";
+import { recordWebMcpToolDisplayTitles } from "../webmcp-bridge";
 import type {
   AgentWidgetApproval,
   AgentWidgetConfig,
@@ -84,6 +85,10 @@ const getDetails = (bubble: HTMLElement) =>
 
 beforeEach(() => {
   approvalDetailsExpansionState.clear();
+  // Evict any display title recorded by a prior test (empty title = evict).
+  recordWebMcpToolDisplayTitles([
+    { name: "add_to_cart", description: "", title: "" },
+  ]);
 });
 
 describe("humanizeToolName", () => {
@@ -183,6 +188,57 @@ describe("createApprovalBubble summary and details", () => {
     );
     expect(getToggle(bubble)).toBeNull();
     expect(getDetails(bubble)).toBeNull();
+  });
+
+  it("prefers a declared WebMCP display title over the humanized tool name", () => {
+    recordWebMcpToolDisplayTitles([
+      { name: "add_to_cart", description: "", title: "Add to Cart" },
+    ]);
+    const bubble = createApprovalBubble(makeDetailedMessage());
+    expect(getSummary(bubble)?.textContent).toBe(
+      "The assistant wants to use “Add to Cart”."
+    );
+  });
+
+  it("resolves the declared title for wire-prefixed tool names", () => {
+    recordWebMcpToolDisplayTitles([
+      { name: "add_to_cart", description: "", title: "Add to Cart" },
+    ]);
+    const bubble = createApprovalBubble(
+      makeDetailedMessage({ toolName: "webmcp:add_to_cart", toolType: undefined })
+    );
+    expect(getSummary(bubble)?.textContent).toBe(
+      "The assistant wants to use “Add to Cart”."
+    );
+  });
+
+  it("ignores recorded titles for non-WebMCP approvals", () => {
+    recordWebMcpToolDisplayTitles([
+      { name: "add_to_cart", description: "", title: "Add to Cart" },
+    ]);
+    const bubble = createApprovalBubble(
+      makeDetailedMessage({ toolType: undefined })
+    );
+    expect(getSummary(bubble)?.textContent).toBe(
+      "The assistant wants to use “Add to cart”."
+    );
+  });
+
+  it("passes the declared title to formatDescription as displayTitle", () => {
+    recordWebMcpToolDisplayTitles([
+      { name: "add_to_cart", description: "", title: "Add to Cart" },
+    ]);
+    const seen: unknown[] = [];
+    const config = {
+      approval: {
+        formatDescription: (ctx: { displayTitle?: string }) => {
+          seen.push(ctx.displayTitle);
+          return undefined;
+        },
+      },
+    } as AgentWidgetConfig;
+    createApprovalBubble(makeDetailedMessage(), config);
+    expect(seen).toEqual(["Add to Cart"]);
   });
 
   it("honors custom toggle labels", () => {

--- a/packages/widget/src/components/approval-bubble.ts
+++ b/packages/widget/src/components/approval-bubble.ts
@@ -2,6 +2,86 @@ import { createElement } from "../utils/dom";
 import { AgentWidgetMessage, AgentWidgetConfig } from "../types";
 import { formatUnknownValue } from "../utils/formatting";
 import { renderLucideIcon } from "../utils/icons";
+import { WEBMCP_TOOL_PREFIX } from "../webmcp-bridge";
+
+/**
+ * Per-message expanded/collapsed state for the technical-details section.
+ * Absent means "use the config default" (`approval.detailsDisplay`). Lives at
+ * module scope so the choice survives idiomorph re-renders, mirroring
+ * `toolExpansionState` in tool-bubble.ts.
+ */
+export const approvalDetailsExpansionState = new Map<string, boolean>();
+
+/**
+ * Turn a wire tool name into a user-facing label: strips the `webmcp:`
+ * prefix and splits snake_case / kebab-case / camelCase into a sentence
+ * (`add_to_cart` → "Add to cart"). Falls back to the input when nothing
+ * word-like remains.
+ */
+export const humanizeToolName = (toolName: string): string => {
+  const bare = toolName.startsWith(WEBMCP_TOOL_PREFIX)
+    ? toolName.slice(WEBMCP_TOOL_PREFIX.length)
+    : toolName;
+  const words = bare
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[_\-\s.]+/)
+    .filter(Boolean);
+  if (words.length === 0) return toolName;
+  const sentence = words.join(" ").toLowerCase();
+  return sentence.charAt(0).toUpperCase() + sentence.slice(1);
+};
+
+const resolveApprovalConfig = (config?: AgentWidgetConfig) =>
+  config?.approval !== false ? config?.approval : undefined;
+
+const isDetailsExpanded = (
+  messageId: string,
+  config?: AgentWidgetConfig
+): boolean => {
+  const detailsMode = resolveApprovalConfig(config)?.detailsDisplay ?? "collapsed";
+  return approvalDetailsExpansionState.get(messageId) ?? detailsMode === "expanded";
+};
+
+const applyDetailsToggleState = (
+  toggle: HTMLElement,
+  expanded: boolean,
+  config?: AgentWidgetConfig
+): void => {
+  const approvalConfig = resolveApprovalConfig(config);
+  toggle.setAttribute("aria-expanded", expanded ? "true" : "false");
+  const label = toggle.querySelector("[data-approval-details-label]") as HTMLElement | null;
+  if (label) {
+    label.textContent = expanded
+      ? (approvalConfig?.hideDetailsLabel ?? "Hide details")
+      : (approvalConfig?.showDetailsLabel ?? "Show details");
+  }
+  const chevronHolder = toggle.querySelector("[data-approval-details-chevron]") as HTMLElement | null;
+  if (chevronHolder) {
+    chevronHolder.innerHTML = "";
+    const chevron = renderLucideIcon(expanded ? "chevron-up" : "chevron-down", 14, "currentColor", 2);
+    if (chevron) {
+      chevronHolder.appendChild(chevron);
+    }
+  }
+};
+
+/**
+ * Sync the technical-details section (toggle label/chevron + visibility) with
+ * `approvalDetailsExpansionState`. Called from the ui.ts expansion event
+ * delegation after a toggle click.
+ */
+export const updateApprovalDetailsUI = (
+  messageId: string,
+  bubble: HTMLElement,
+  config?: AgentWidgetConfig
+): void => {
+  const toggle = bubble.querySelector('button[data-bubble-type="approval"]') as HTMLElement | null;
+  const details = bubble.querySelector("[data-approval-details]") as HTMLElement | null;
+  if (!toggle || !details) return;
+  const expanded = isDetailsExpanded(messageId, config);
+  applyDetailsToggleState(toggle, expanded, config);
+  details.style.display = expanded ? "" : "none";
+};
 
 /**
  * Update an existing approval bubble's UI after status changes.
@@ -160,30 +240,87 @@ export const createApprovalBubble = (
 
   content.appendChild(titleRow);
 
-  // Description
-  const description = createElement("p", "persona-text-sm persona-mt-0.5 persona-text-persona-muted");
-  if (approvalConfig?.descriptionColor) {
-    description.style.color = approvalConfig.descriptionColor;
-  }
-  description.textContent = approval.description;
-  content.appendChild(description);
+  // User-facing summary line. The wire `description` is the tool's
+  // agent-facing description (prompt prose, usage rules), so it is not shown
+  // here — it lives in the collapsible details section below.
+  const summaryFromConfig = approvalConfig?.formatDescription?.({
+    toolName: approval.toolName,
+    toolType: approval.toolType,
+    description: approval.description,
+    parameters: approval.parameters,
+  });
+  const summaryFallsBackToDescription = !approval.toolName;
+  const summaryText =
+    summaryFromConfig ||
+    (summaryFallsBackToDescription
+      ? approval.description
+      : `The assistant wants to use “${humanizeToolName(approval.toolName)}”.`);
 
-  // Parameters block
-  if (approval.parameters) {
-    const paramsPre = createElement(
-      "pre",
-      "persona-mt-2 persona-text-xs persona-p-2 persona-rounded persona-overflow-x-auto persona-max-h-32 persona-bg-persona-container persona-text-persona-primary"
-    );
-    if (approvalConfig?.parameterBackgroundColor) {
-      paramsPre.style.backgroundColor = approvalConfig.parameterBackgroundColor;
+  const summary = createElement("p", "persona-text-sm persona-mt-0.5 persona-text-persona-muted");
+  summary.setAttribute("data-approval-summary", "true");
+  if (approvalConfig?.descriptionColor) {
+    summary.style.color = approvalConfig.descriptionColor;
+  }
+  summary.textContent = summaryText;
+  content.appendChild(summary);
+
+  // Technical details: agent-facing description + raw parameters JSON,
+  // collapsed behind a toggle by default (`approval.detailsDisplay`).
+  const detailsMode = approvalConfig?.detailsDisplay ?? "collapsed";
+  const showDescriptionInDetails = Boolean(approval.description) && !summaryFallsBackToDescription;
+  const hasDetails = showDescriptionInDetails || Boolean(approval.parameters);
+  if (detailsMode !== "hidden" && hasDetails) {
+    const expanded = isDetailsExpanded(message.id, config);
+
+    const toggle = createElement(
+      "button",
+      "persona-inline-flex persona-items-center persona-gap-1 persona-mt-1 persona-p-0 persona-border-none persona-bg-transparent persona-text-xs persona-font-medium persona-cursor-pointer persona-text-persona-muted"
+    ) as HTMLButtonElement;
+    toggle.type = "button";
+    toggle.setAttribute("data-expand-header", "true");
+    toggle.setAttribute("data-bubble-type", "approval");
+    if (approvalConfig?.descriptionColor) {
+      toggle.style.color = approvalConfig.descriptionColor;
     }
-    if (approvalConfig?.parameterTextColor) {
-      paramsPre.style.color = approvalConfig.parameterTextColor;
+    const toggleLabel = createElement("span");
+    toggleLabel.setAttribute("data-approval-details-label", "true");
+    const chevronHolder = createElement("span", "persona-inline-flex persona-items-center");
+    chevronHolder.setAttribute("data-approval-details-chevron", "true");
+    toggle.append(toggleLabel, chevronHolder);
+    applyDetailsToggleState(toggle, expanded, config);
+    content.appendChild(toggle);
+
+    const details = createElement("div");
+    details.setAttribute("data-approval-details", "true");
+    details.style.display = expanded ? "" : "none";
+
+    if (showDescriptionInDetails) {
+      const description = createElement("p", "persona-text-sm persona-mt-1 persona-text-persona-muted");
+      if (approvalConfig?.descriptionColor) {
+        description.style.color = approvalConfig.descriptionColor;
+      }
+      description.textContent = approval.description;
+      details.appendChild(description);
     }
-    paramsPre.style.fontSize = "0.75rem";
-    paramsPre.style.lineHeight = "1rem";
-    paramsPre.textContent = formatUnknownValue(approval.parameters);
-    content.appendChild(paramsPre);
+
+    if (approval.parameters) {
+      const paramsPre = createElement(
+        "pre",
+        "persona-mt-2 persona-text-xs persona-p-2 persona-rounded persona-overflow-x-auto persona-max-h-32 persona-bg-persona-container persona-text-persona-primary"
+      );
+      if (approvalConfig?.parameterBackgroundColor) {
+        paramsPre.style.backgroundColor = approvalConfig.parameterBackgroundColor;
+      }
+      if (approvalConfig?.parameterTextColor) {
+        paramsPre.style.color = approvalConfig.parameterTextColor;
+      }
+      paramsPre.style.fontSize = "0.75rem";
+      paramsPre.style.lineHeight = "1rem";
+      paramsPre.textContent = formatUnknownValue(approval.parameters);
+      details.appendChild(paramsPre);
+    }
+
+    content.appendChild(details);
   }
 
   // Action buttons (only shown when pending)

--- a/packages/widget/src/components/approval-bubble.ts
+++ b/packages/widget/src/components/approval-bubble.ts
@@ -2,7 +2,7 @@ import { createElement } from "../utils/dom";
 import { AgentWidgetMessage, AgentWidgetConfig } from "../types";
 import { formatUnknownValue } from "../utils/formatting";
 import { renderLucideIcon } from "../utils/icons";
-import { WEBMCP_TOOL_PREFIX } from "../webmcp-bridge";
+import { WEBMCP_TOOL_PREFIX, getWebMcpToolDisplayTitle } from "../webmcp-bridge";
 
 /**
  * Per-message expanded/collapsed state for the technical-details section.
@@ -242,19 +242,28 @@ export const createApprovalBubble = (
 
   // User-facing summary line. The wire `description` is the tool's
   // agent-facing description (prompt prose, usage rules), so it is not shown
-  // here — it lives in the collapsible details section below.
+  // here — it lives in the collapsible details section below. Label priority:
+  // formatDescription → declared WebMCP `title` → humanized tool name →
+  // raw description (no tool name at all).
+  const isWebMcpTool =
+    approval.toolType === "webmcp" ||
+    approval.toolName.startsWith(WEBMCP_TOOL_PREFIX);
+  const declaredTitle = isWebMcpTool
+    ? getWebMcpToolDisplayTitle(approval.toolName)
+    : undefined;
   const summaryFromConfig = approvalConfig?.formatDescription?.({
     toolName: approval.toolName,
     toolType: approval.toolType,
     description: approval.description,
     parameters: approval.parameters,
+    ...(declaredTitle ? { displayTitle: declaredTitle } : {}),
   });
   const summaryFallsBackToDescription = !approval.toolName;
   const summaryText =
     summaryFromConfig ||
     (summaryFallsBackToDescription
       ? approval.description
-      : `The assistant wants to use “${humanizeToolName(approval.toolName)}”.`);
+      : `The assistant wants to use “${declaredTitle ?? humanizeToolName(approval.toolName)}”.`);
 
   const summary = createElement("p", "persona-text-sm persona-mt-0.5 persona-text-persona-muted");
   summary.setAttribute("data-approval-summary", "true");

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1867,6 +1867,29 @@ export type AgentWidgetApprovalConfig = {
   /** Label for the deny button */
   denyLabel?: string;
   /**
+   * How the technical details (the tool's agent-facing description and the
+   * raw parameters JSON) are presented:
+   * - `"collapsed"` (default) — hidden behind a "Show details" toggle
+   * - `"expanded"` — visible, with the toggle available to hide them
+   * - `"hidden"` — never rendered
+   */
+  detailsDisplay?: "collapsed" | "expanded" | "hidden";
+  /** Label for the toggle that reveals the technical details */
+  showDetailsLabel?: string;
+  /** Label for the toggle that hides the technical details */
+  hideDetailsLabel?: string;
+  /**
+   * Build the user-facing summary line for an approval request. Overrides the
+   * default "The assistant wants to use “Tool name”." copy. Return a falsy
+   * value to fall back to the default for that approval.
+   */
+  formatDescription?: (approval: {
+    toolName: string;
+    toolType?: string;
+    description: string;
+    parameters?: unknown;
+  }) => string | undefined;
+  /**
    * Custom handler for approval decisions.
    * Return void to let the SDK auto-resolve via the API,
    * or return a Response/ReadableStream for custom handling.

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -255,6 +255,12 @@ export type WebMcpConfirmInfo = {
   toolName: string;
   args: unknown;
   description?: string;
+  /**
+   * Display title the tool declared via the WebMCP spec's
+   * `ToolDescriptor.title` (e.g. `"Add to Cart"`). Absent when the tool
+   * didn't declare one.
+   */
+  title?: string;
   annotations?: {
     readOnlyHint?: boolean;
     untrustedContentHint?: boolean;
@@ -1881,13 +1887,16 @@ export type AgentWidgetApprovalConfig = {
   /**
    * Build the user-facing summary line for an approval request. Overrides the
    * default "The assistant wants to use “Tool name”." copy. Return a falsy
-   * value to fall back to the default for that approval.
+   * value to fall back to the default for that approval. `displayTitle` is
+   * the display name the tool declared via the WebMCP spec's
+   * `ToolDescriptor.title`, when one exists.
    */
   formatDescription?: (approval: {
     toolName: string;
     toolType?: string;
     description: string;
     parameters?: unknown;
+    displayTitle?: string;
   }) => string | undefined;
   /**
    * Custom handler for approval decisions.

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -86,7 +86,7 @@ import {
   setCurrentAnswer,
 } from "./components/ask-user-question-bubble";
 import { formatElapsedMs } from "./utils/formatting";
-import { createApprovalBubble } from "./components/approval-bubble";
+import { approvalDetailsExpansionState, createApprovalBubble, updateApprovalDetailsUI } from "./components/approval-bubble";
 import { createSuggestions } from "./components/suggestions";
 import { EventStreamBuffer } from "./utils/event-stream-buffer";
 import { EventStreamStore } from "./utils/event-stream-store";
@@ -1225,7 +1225,7 @@ export const createAgentExperience = (
     if (!headerButton) return;
     
     // Find the parent bubble element
-    const bubble = headerButton.closest('.persona-reasoning-bubble, .persona-tool-bubble') as HTMLElement;
+    const bubble = headerButton.closest('.persona-reasoning-bubble, .persona-tool-bubble, .persona-approval-bubble') as HTMLElement;
     if (!bubble) return;
     
     // Get message ID from bubble
@@ -1249,6 +1249,12 @@ export const createAgentExperience = (
         toolExpansionState.add(messageId);
       }
       updateToolBubbleUI(messageId, bubble, config);
+    } else if (bubbleType === 'approval') {
+      const approvalConfig = config.approval !== false ? config.approval : undefined;
+      const defaultExpanded = (approvalConfig?.detailsDisplay ?? 'collapsed') === 'expanded';
+      const expanded = approvalDetailsExpansionState.get(messageId) ?? defaultExpanded;
+      approvalDetailsExpansionState.set(messageId, !expanded);
+      updateApprovalDetailsUI(messageId, bubble, config);
     }
     // Invalidate cached wrapper so next render rebuilds with current expansion state
     messageCache.delete(messageId);

--- a/packages/widget/src/webmcp-bridge.test.ts
+++ b/packages/widget/src/webmcp-bridge.test.ts
@@ -228,6 +228,21 @@ describe("WebMCP display titles", () => {
     expect(getWebMcpToolDisplayTitle("add_to_cart")).toBeUndefined();
   });
 
+  it("evicts the title when the tool is removed from the registry entirely", async () => {
+    registry.tools = [
+      fakeTool({ name: "add_to_cart", title: "Add to Cart" }),
+      fakeTool({ name: "search_products", title: "Search the catalog" }),
+    ];
+    const bridge = new WebMcpBridge({ enabled: true });
+    await bridge.snapshotForDispatch();
+    expect(getWebMcpToolDisplayTitle("add_to_cart")).toBe("Add to Cart");
+
+    registry.tools = [fakeTool({ name: "search_products", title: "Search the catalog" })];
+    await bridge.snapshotForDispatch();
+    expect(getWebMcpToolDisplayTitle("add_to_cart")).toBeUndefined();
+    expect(getWebMcpToolDisplayTitle("search_products")).toBe("Search the catalog");
+  });
+
   it("passes the declared title to the confirm gate", async () => {
     registry.tools = [fakeTool({ name: "add_to_cart", title: "Add to Cart" })];
     const onConfirm = vi.fn(async () => true);

--- a/packages/widget/src/webmcp-bridge.test.ts
+++ b/packages/widget/src/webmcp-bridge.test.ts
@@ -27,6 +27,7 @@ vi.mock("@mcp-b/webmcp-polyfill", () => ({
 // Import AFTER vi.mock so the bridge's dynamic import resolves to the mock.
 import {
   WebMcpBridge,
+  getWebMcpToolDisplayTitle,
   isWebMcpToolName,
   stripWebMcpPrefix,
   computeClientToolsFingerprint,
@@ -39,6 +40,7 @@ type MockTool = {
   name: string;
   description?: string;
   inputSchema?: object;
+  title?: string;
   execute: (args: Record<string, unknown>, client: MockClient) => unknown;
 };
 
@@ -47,10 +49,13 @@ const registry: { tools: MockTool[] } = { tools: [] };
 /** A fake `document.modelContext` exposing the strict consumer surface. */
 const makeModelContext = () => ({
   async getTools() {
+    // Mirrors the real polyfill's getRegisteredToolInfos(): `title` is always
+    // present, "" when the tool didn't declare one; annotations are absent.
     return registry.tools.map((t) => ({
       name: t.name,
       description: t.description ?? `mock ${t.name}`,
       inputSchema: JSON.stringify(t.inputSchema ?? { type: "object" }),
+      title: t.title ?? "",
     }));
   },
   async executeTool(
@@ -196,6 +201,52 @@ describe("WebMcpBridge.snapshotForDispatch", () => {
       "foo",
       "bar",
     ]);
+  });
+});
+
+describe("WebMCP display titles", () => {
+  it("records declared titles on snapshot and exposes them via getWebMcpToolDisplayTitle", async () => {
+    registry.tools = [
+      fakeTool({ name: "add_to_cart", title: "Add to Cart" }),
+      fakeTool({ name: "search_products" }),
+    ];
+    const bridge = new WebMcpBridge({ enabled: true });
+    await bridge.snapshotForDispatch();
+    expect(getWebMcpToolDisplayTitle("add_to_cart")).toBe("Add to Cart");
+    expect(getWebMcpToolDisplayTitle("webmcp:add_to_cart")).toBe("Add to Cart");
+    expect(getWebMcpToolDisplayTitle("search_products")).toBeUndefined();
+  });
+
+  it("evicts a stale title when the tool re-registers without one", async () => {
+    registry.tools = [fakeTool({ name: "add_to_cart", title: "Add to Cart" })];
+    const bridge = new WebMcpBridge({ enabled: true });
+    await bridge.snapshotForDispatch();
+    expect(getWebMcpToolDisplayTitle("add_to_cart")).toBe("Add to Cart");
+
+    registry.tools = [fakeTool({ name: "add_to_cart" })];
+    await bridge.snapshotForDispatch();
+    expect(getWebMcpToolDisplayTitle("add_to_cart")).toBeUndefined();
+  });
+
+  it("passes the declared title to the confirm gate", async () => {
+    registry.tools = [fakeTool({ name: "add_to_cart", title: "Add to Cart" })];
+    const onConfirm = vi.fn(async () => true);
+    const bridge = new WebMcpBridge({ enabled: true, onConfirm });
+    const r = await bridge.executeToolCall("webmcp:add_to_cart", {});
+    expect(r.isError).toBeFalsy();
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ toolName: "add_to_cart", title: "Add to Cart" })
+    );
+  });
+
+  it("omits title from the confirm gate when the tool didn't declare one", async () => {
+    registry.tools = [fakeTool({ name: "add_to_cart" })];
+    const onConfirm = vi.fn(async () => true);
+    const bridge = new WebMcpBridge({ enabled: true, onConfirm });
+    await bridge.executeToolCall("webmcp:add_to_cart", {});
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.not.objectContaining({ title: expect.anything() })
+    );
   });
 });
 

--- a/packages/widget/src/webmcp-bridge.ts
+++ b/packages/widget/src/webmcp-bridge.ts
@@ -66,6 +66,14 @@ interface ModelContextToolInfo {
   description: string;
   /** JSON-encoded JSON Schema for the tool's input. */
   inputSchema?: string;
+  /**
+   * Display title declared on the tool (`ToolDescriptor.title` in the WebMCP
+   * spec). The polyfill returns `""` when the tool didn't declare one. Note:
+   * `annotations` (incl. the legacy `annotations.title`) are NOT exposed on
+   * this strict consumer surface — top-level `title` is the only display-name
+   * channel available to us.
+   */
+  title?: string;
 }
 
 interface ModelContextCoreLike {
@@ -76,6 +84,42 @@ interface ModelContextCoreLike {
     options?: { signal?: AbortSignal },
   ): Promise<string | null>;
 }
+
+/**
+ * Page-global map of bare tool name → declared display title
+ * (`ToolDescriptor.title`). `document.modelContext` is page-global, so a
+ * single map shared across widget/bridge instances is semantically correct.
+ * Refreshed on every registry read (`snapshotForDispatch` / `executeToolCall`)
+ * and consumed by the approval bubble's summary line via
+ * `getWebMcpToolDisplayTitle`.
+ */
+const webMcpToolDisplayTitles = new Map<string, string>();
+
+/**
+ * Record declared display titles from a fresh `getTools()` read. A tool that
+ * no longer declares a title is evicted so a stale label can't outlive a
+ * re-registration. Exported for tests; production callers are the bridge's
+ * registry reads.
+ */
+export const recordWebMcpToolDisplayTitles = (
+  infos: ModelContextToolInfo[],
+): void => {
+  for (const info of infos) {
+    const title = info.title?.trim();
+    if (title) webMcpToolDisplayTitles.set(info.name, title);
+    else webMcpToolDisplayTitles.delete(info.name);
+  }
+};
+
+/**
+ * Look up the display title a page tool declared via the WebMCP spec's
+ * `ToolDescriptor.title`. Accepts wire (`webmcp:add_to_cart`) or bare
+ * (`add_to_cart`) names. Returns `undefined` when the tool didn't declare
+ * one (callers fall back to humanizing the tool name).
+ */
+export const getWebMcpToolDisplayTitle = (
+  toolName: string,
+): string | undefined => webMcpToolDisplayTitles.get(stripWebMcpPrefix(toolName));
 
 const log = {
   warn(message: string, ...rest: unknown[]): void {
@@ -220,6 +264,7 @@ export class WebMcpBridge {
       log.warn("getTools() threw — shipping an empty WebMCP snapshot.", err);
       return [];
     }
+    recordWebMcpToolDisplayTitles(infos);
 
     const pageOrigin = typeof location !== "undefined" ? location.origin : "";
 
@@ -295,6 +340,7 @@ export class WebMcpBridge {
       const message = err instanceof Error ? err.message : String(err);
       return errorResult(`Failed to read WebMCP registry: ${message}`);
     }
+    recordWebMcpToolDisplayTitles(infos);
     const info = infos.find((candidate) => candidate.name === bareName);
 
     if (!info) {
@@ -323,10 +369,12 @@ export class WebMcpBridge {
 
     // Confirm-by-default gate. Every `webmcp:*` call routes through here,
     // regardless of `annotations.readOnlyHint`.
+    const displayTitle = getWebMcpToolDisplayTitle(bareName);
     const gateInfo: WebMcpConfirmInfo = {
       toolName: bareName,
       args,
       description: info.description,
+      ...(displayTitle ? { title: displayTitle } : {}),
       reason: "gate",
     };
     if (!(await this.requestConfirm(gateInfo))) {

--- a/packages/widget/src/webmcp-bridge.ts
+++ b/packages/widget/src/webmcp-bridge.ts
@@ -96,18 +96,19 @@ interface ModelContextCoreLike {
 const webMcpToolDisplayTitles = new Map<string, string>();
 
 /**
- * Record declared display titles from a fresh `getTools()` read. A tool that
- * no longer declares a title is evicted so a stale label can't outlive a
- * re-registration. Exported for tests; production callers are the bridge's
- * registry reads.
+ * Record declared display titles from a fresh `getTools()` read. The map is
+ * rebuilt from scratch — callers always pass the FULL registry snapshot — so
+ * a tool that unregistered or dropped its title can't leave a stale label
+ * behind. Exported for tests; production callers are the bridge's registry
+ * reads.
  */
 export const recordWebMcpToolDisplayTitles = (
   infos: ModelContextToolInfo[],
 ): void => {
+  webMcpToolDisplayTitles.clear();
   for (const info of infos) {
     const title = info.title?.trim();
     if (title) webMcpToolDisplayTitles.set(info.name, title);
-    else webMcpToolDisplayTitles.delete(info.name);
   }
 };
 


### PR DESCRIPTION
## Summary

The tool approval bubble previously rendered the tool's full agent-facing description verbatim — for WebMCP tools this is prompt prose ("IMPORTANT: If a product has required options you MUST…") that was never meant for end users.

- **Friendly headline by default** — the summary line is now built from a humanized tool name (`add_to_cart` / `webmcp:add_to_cart` → "Add to cart", `getProductDetails` → "Get product details"): *The assistant wants to use "Add to cart".*
- **Technical details collapsed by default** — the agent-facing description and raw parameters JSON move behind a "Show details" toggle. Toggle state survives idiomorph re-renders via the same module-scope-state + event-delegation pattern as tool bubbles.
- **New `approval` config options:**
  - `detailsDisplay: 'collapsed' | 'expanded' | 'hidden'` (default `'collapsed'`; `'expanded'` restores always-visible details, `'hidden'` removes them entirely)
  - `formatDescription(approval)` — integrator-supplied user-facing summary copy per tool
  - `showDetailsLabel` / `hideDetailsLabel` for i18n

Edge case: approvals with no tool name still use the description as the summary line (and don't duplicate it inside details).

## Before / After

| Before | After |
| --- | --- |
| Full agent-facing description + raw parameters JSON always visible | "The assistant wants to use "Add to cart"." with a *Show details ▾* toggle |

## Testing

- 15 new tests in `approval-bubble.test.ts` (humanization, default collapse, expanded/hidden modes, formatDescription override + fallback, no-tool-name fallback, custom labels, expansion-state sync)
- All 1104 widget tests, lint, typecheck, and build pass
- Changeset included (minor)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and configuration changes to approval presentation; approve/deny behavior is unchanged aside from richer WebMCP confirm metadata.
> 
> **Overview**
> Tool approval bubbles now lead with a **user-facing summary** instead of the agent-facing tool description. By default users see copy like *The assistant wants to use “Add to cart”.* while the wire description and raw parameters JSON sit behind a **“Show details”** toggle (`approval.detailsDisplay`: `collapsed` | `expanded` | `hidden`, plus customizable toggle labels).
> 
> **Summary line resolution** is `formatDescription` → WebMCP `ToolDescriptor.title` (via a registry refreshed on each `getTools()` snapshot) → humanized tool name → raw description only when there is no tool name. The WebMCP bridge records display titles and passes **`info.title`** into custom `onConfirm` handlers; the embedded demo registers `title` on each tool.
> 
> New **`approval`** options: `formatDescription` (receives `displayTitle`), `detailsDisplay`, `showDetailsLabel` / `hideDetailsLabel`. Toggle state is wired through `ui.ts` event delegation like tool bubbles. Docs, changeset (minor), bundle size limits bumped slightly, and broad test coverage in `approval-bubble.test.ts` / `webmcp-bridge.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31786775e45029581ce24f10d74b937aa9f73960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->