### PR TITLE
feat(embedded-app): card-stack hero home page + UX polish

### DIFF
--- a/.changeset/webmcp-docked-flow.md
+++ b/.changeset/webmcp-docked-flow.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": minor
+---
+
+Add `WEBMCP_DOCKED_FLOW`, a tool-less dashboard-copilot flow for the docked panel demo. Like the other WebMCP flows, the page registers its workspace tools on `document.modelContext` and the proxy forwards them as `clientTools[]`.

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -38,13 +38,25 @@
             <a class="hero-cta-primary" href="#quick-start">Get started <span aria-hidden="true">→</span></a>
             <a class="hero-cta-secondary" href="#try-it">Try it live</a>
           </div>
+          <button
+            type="button"
+            class="install-command hero-install"
+            data-copy-text="npx @runtypelabs/cli@latest persona init"
+            data-copy-default="Copy"
+            data-copy-success="Copied!"
+            aria-label="Copy Persona init command"
+          >
+            <span class="install-prefix">$</span>
+            <span>npx @runtypelabs/cli@latest persona init</span>
+            <span class="install-copy" data-copy-label>Copy</span>
+          </button>
           <div class="hero-features">
-            <span class="hero-feature-pill">Style Isolation</span>
-            <span class="hero-feature-pill">SSE Streaming</span>
-            <span class="hero-feature-pill">Agent Loops</span>
-            <span class="hero-feature-pill">Theming</span>
-            <span class="hero-feature-pill">Voice Input</span>
-            <span class="hero-feature-pill">Vanilla JS</span>
+            <span class="hero-feature-pill">Won't break your styles</span>
+            <span class="hero-feature-pill">Works with any backend</span>
+            <span class="hero-feature-pill">Agents that operate your page</span>
+            <span class="hero-feature-pill">Themeable to your brand</span>
+            <span class="hero-feature-pill">Voice built in</span>
+            <span class="hero-feature-pill">No framework required</span>
           </div>
           <div class="hero-badges">
             <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=5B2EFF&label=npm" alt="npm"></a>
@@ -352,6 +364,46 @@
       </section>
 
       <!-- Theme Editor -->
+      <!-- WebMCP -->
+      <section class="card cardFull webmcp-section reveal-el" id="webmcp">
+        <span class="label">Agentic</span>
+        <h2 class="card-title kern-tight" style="font-size: 24px;">Persona doesn't just chat — it operates your page</h2>
+        <p>Expose your page's actions as <a href="https://github.com/webmachinelearning/webmcp" target="_blank" rel="noopener">WebMCP</a> tools — search, carts, bookings, forms — and the agent drives them directly, with user approval built in. No backend integration required: the tools live in your page.</p>
+        <div class="webmcp-grid">
+          <a class="webmcp-demo-card" href="/webmcp-demo.html">
+            <span class="webmcp-demo-tag">Commerce</span>
+            <strong class="webmcp-demo-title">WebMCP Storefront</strong>
+            <p>The agent searches a live catalog, builds the cart, and walks checkout — every tool call visible in a wire log.</p>
+            <span class="webmcp-demo-cta">Open demo <span aria-hidden="true">→</span></span>
+          </a>
+          <a class="webmcp-demo-card" href="/webmcp-calendar.html">
+            <span class="webmcp-demo-tag">Scheduling</span>
+            <strong class="webmcp-demo-title">WebMCP Calendar</strong>
+            <p>A team calendar copilot — the agent reads availability, finds conflicts, and books events through page tools.</p>
+            <span class="webmcp-demo-cta">Open demo <span aria-hidden="true">→</span></span>
+          </a>
+          <div class="webmcp-code">
+            <div class="code-showcase">
+              <pre><code>// Your page registers a tool…
+document.modelContext.registerTool({
+  name: "search_products",
+  description: "Search the catalog by free-text query.",
+  inputSchema: {
+    type: "object",
+    properties: { query: { type: "string" } },
+    required: ["query"],
+  },
+  async execute({ query }) {
+    return searchCatalog(query);
+  },
+});
+
+// …and the Persona agent can call it. That's the whole integration.</code></pre>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section class="card cardFull theme-editor-section reveal-el">
         <span class="label">Customization</span>
         <h2 class="card-title kern-tight">Theme Editor</h2>
@@ -373,18 +425,42 @@
       <section class="card cardFull reveal-el" id="demos">
         <span class="label">Demos</span>
         <h2 class="card-title kern-tight">See what Persona can do</h2>
-        <p>Explore different use cases across full-page layouts, embedded contexts, and business scenarios.</p>
-        <div id="demo-carousel-mount"></div>
-      </section>
-
-      <!-- Advanced -->
-      <section class="card cardFull advanced-cta-section reveal-el">
-        <span class="label">More</span>
-        <h2 class="card-title kern-tight">Advanced examples</h2>
-        <p>Configuration patterns, plugin hooks, and integration recipes — agent loops, tool approval, dynamic forms, voice, artifacts, and more.</p>
+        <p>A few favorites across agentic, layout, and business scenarios — or browse the full gallery.</p>
+        <div class="featured-grid">
+          <a class="example-item" href="/webmcp-demo.html">
+            <span class="example-item-tag">Agentic</span>
+            WebMCP Storefront
+            <span class="example-item-desc">The agent drives a live catalog, cart, and checkout</span>
+          </a>
+          <a class="example-item" href="/webmcp-calendar.html">
+            <span class="example-item-tag">Agentic</span>
+            WebMCP Calendar
+            <span class="example-item-desc">Reads availability and books events through page tools</span>
+          </a>
+          <a class="example-item" href="/bakery.html">
+            <span class="example-item-tag">Business</span>
+            Bakery Assistant
+            <span class="example-item-desc">Full business site with context-aware chat and checkout</span>
+          </a>
+          <a class="example-item" href="/fullscreen-assistant-demo.html">
+            <span class="example-item-tag">Layout</span>
+            Fullscreen Assistant
+            <span class="example-item-desc">Full-viewport dark split layout with artifacts</span>
+          </a>
+          <a class="example-item" href="/approval-demo.html">
+            <span class="example-item-tag">Agentic</span>
+            Tool Approval
+            <span class="example-item-desc">User confirmation before the agent executes a tool</span>
+          </a>
+          <a class="example-item" href="/voice-integration-demo.html">
+            <span class="example-item-tag">Voice</span>
+            Voice Integration
+            <span class="example-item-desc">Voice input powered by ElevenLabs</span>
+          </a>
+        </div>
         <div class="advanced-cta-actions">
           <a class="advanced-cta-link" href="/advanced.html">
-            Browse advanced examples
+            Browse all examples
             <span aria-hidden="true">→</span>
           </a>
           <a class="advanced-cta-link advanced-cta-link--secondary" href="/standalone/sample.html">

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -59,9 +59,25 @@
         <div class="carousel-3d" id="hero-carousel" role="region" aria-roledescription="carousel" aria-label="Live demo gallery">
           <div class="carousel-3d-scene">
             <div class="carousel-3d-card">
+              <a href="/webmcp-demo.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe src="/webmcp-demo.html" tabindex="-1" title="WebMCP Storefront"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">WebMCP Storefront</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
+              <a href="/webmcp-calendar.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe data-src="/webmcp-calendar.html" tabindex="-1" title="WebMCP Calendar"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">WebMCP Calendar</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
               <a href="/bakery.html" class="carousel-3d-card-link">
                 <div class="carousel-3d-iframe-wrap">
-                  <iframe src="/bakery.html" tabindex="-1" title="Bakery Assistant"></iframe>
+                  <iframe data-src="/bakery.html" tabindex="-1" title="Bakery Assistant"></iframe>
                 </div>
                 <span class="carousel-3d-card-title">Bakery Assistant</span>
               </a>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -7,16 +7,37 @@
   <link rel="stylesheet" href="/src/App.css">
   <link rel="icon" href="/favicon.ico" />
   <title>Persona — AI Chat Widget by Runtype</title>
+  <meta name="description" content="Persona is an open-source, themeable AI chat widget you can add to any website in minutes. SSE streaming, agent loops, tool use, and style isolation — zero framework dependencies.">
+  <meta property="og:title" content="Persona — Open Source AI Chat Widget">
+  <meta property="og:description" content="Add a streaming AI chat to any website, in minutes. Themeable, pluggable, zero framework dependencies.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://persona-chat.dev/">
 </head>
 <body>
   <div class="page">
+    <!-- Top nav -->
+    <header class="site-nav">
+      <a class="site-nav-brand" href="/">Persona</a>
+      <nav class="site-nav-links" aria-label="Page sections">
+        <a href="#try-it">Live demo</a>
+        <a href="#quick-start">Quick start</a>
+        <a href="#demos">Demos</a>
+        <a href="/theme.html">Theme editor</a>
+        <a class="site-nav-github" href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener">GitHub</a>
+      </nav>
+    </header>
+
     <!-- Hero — 3D Carousel Showcase -->
     <section class="hero-split">
       <div class="hero-split-inner">
         <div class="hero-panel">
           <span class="label">Open Source AI Chat Widget</span>
-          <h1 class="kern-tight">Add a streaming AI chat<br>to any website, in minutes.</h1>
+          <h1 class="kern-tight">Add a streaming AI chat to any website, in minutes.</h1>
           <p>Themeable, pluggable, zero framework dependencies. Style isolation, SSE streaming, agent loops, and tool use — all in one drop-in widget.</p>
+          <div class="hero-cta">
+            <a class="hero-cta-primary" href="#quick-start">Get started <span aria-hidden="true">→</span></a>
+            <a class="hero-cta-secondary" href="#try-it">Try it live</a>
+          </div>
           <div class="hero-features">
             <span class="hero-feature-pill">Style Isolation</span>
             <span class="hero-feature-pill">SSE Streaming</span>
@@ -35,7 +56,7 @@
             <a href="https://runtype.com" target="_blank" rel="noopener"><img src="/runtype-logo.svg" alt="Runtype" class="runtype-logo"></a>
           </div>
         </div>
-        <div class="carousel-3d" id="hero-carousel">
+        <div class="carousel-3d" id="hero-carousel" role="region" aria-roledescription="carousel" aria-label="Live demo gallery">
           <div class="carousel-3d-scene">
             <div class="carousel-3d-card">
               <a href="/bakery.html" class="carousel-3d-card-link">
@@ -48,7 +69,7 @@
             <div class="carousel-3d-card">
               <a href="/fullscreen-assistant-demo.html" class="carousel-3d-card-link">
                 <div class="carousel-3d-iframe-wrap">
-                  <iframe src="/fullscreen-assistant-demo.html" loading="lazy" tabindex="-1" title="Fullscreen Layout"></iframe>
+                  <iframe data-src="/fullscreen-assistant-demo.html" tabindex="-1" title="Fullscreen Layout"></iframe>
                 </div>
                 <span class="carousel-3d-card-title">Fullscreen Layout</span>
               </a>
@@ -56,7 +77,7 @@
             <div class="carousel-3d-card">
               <a href="/docked-panel-demo.html" class="carousel-3d-card-link">
                 <div class="carousel-3d-iframe-wrap">
-                  <iframe src="/docked-panel-demo.html" loading="lazy" tabindex="-1" title="Docked Panel"></iframe>
+                  <iframe data-src="/docked-panel-demo.html" tabindex="-1" title="Docked Panel"></iframe>
                 </div>
                 <span class="carousel-3d-card-title">Docked Panel</span>
               </a>
@@ -64,7 +85,7 @@
             <div class="carousel-3d-card">
               <a href="/action-middleware.html" class="carousel-3d-card-link">
                 <div class="carousel-3d-iframe-wrap">
-                  <iframe src="/action-middleware.html" loading="lazy" tabindex="-1" title="Action Middleware"></iframe>
+                  <iframe data-src="/action-middleware.html" tabindex="-1" title="Action Middleware"></iframe>
                 </div>
                 <span class="carousel-3d-card-title">Action Middleware</span>
               </a>
@@ -72,7 +93,7 @@
             <div class="carousel-3d-card">
               <a href="/theme.html" class="carousel-3d-card-link">
                 <div class="carousel-3d-iframe-wrap">
-                  <iframe src="/theme.html" loading="lazy" tabindex="-1" title="Theme Editor"></iframe>
+                  <iframe data-src="/theme.html" tabindex="-1" title="Theme Editor"></iframe>
                 </div>
                 <span class="carousel-3d-card-title">Theme Editor</span>
               </a>
@@ -80,12 +101,19 @@
             <div class="carousel-3d-card">
               <a href="/launcher-demo.html" class="carousel-3d-card-link">
                 <div class="carousel-3d-iframe-wrap">
-                  <iframe src="/launcher-demo.html" loading="lazy" tabindex="-1" title="Default Launcher"></iframe>
+                  <iframe data-src="/launcher-demo.html" tabindex="-1" title="Default Launcher"></iframe>
                 </div>
                 <span class="carousel-3d-card-title">Default Launcher</span>
               </a>
             </div>
           </div>
+          <div class="carousel-3d-controls">
+            <button type="button" class="carousel-3d-nav" data-carousel-prev aria-label="Previous demo">&larr;</button>
+            <div class="carousel-3d-dots" data-carousel-dots></div>
+            <button type="button" class="carousel-3d-nav" data-carousel-next aria-label="Next demo">&rarr;</button>
+          </div>
+          <p class="carousel-3d-hint" aria-hidden="true">Click a card to open it full size</p>
+          <span class="visually-hidden" aria-live="polite" data-carousel-status></span>
         </div>
       </div>
     </section>
@@ -93,7 +121,7 @@
     <main class="shell">
 
       <!-- Live Demo -->
-      <section class="card cardFull tryit-section reveal-el">
+      <section class="card cardFull tryit-section reveal-el" id="try-it">
         <span class="label">Live Demo</span>
         <h2 class="card-title kern-tight" style="font-size: 24px;">Try it live</h2>
         <p>Ask Persona anything — or pick a suggestion below to explore.</p>
@@ -109,7 +137,7 @@
 
 
       <!-- Quick Start -->
-      <section class="card cardFull quick-start-section reveal-el">
+      <section class="card cardFull quick-start-section reveal-el" id="quick-start">
         <span class="label">Quick Start</span>
         <h2 class="card-title kern-tight" style="font-size: 24px;">Choose your integration path</h2>
         <p>Ship to prod with Runtype in minutes, or wire Persona into your own SSE backend.</p>
@@ -326,7 +354,7 @@
       </section>
 
       <!-- Demos -->
-      <section class="card cardFull reveal-el">
+      <section class="card cardFull reveal-el" id="demos">
         <span class="label">Demos</span>
         <h2 class="card-title kern-tight">See what Persona can do</h2>
         <p>Explore different use cases across full-page layouts, embedded contexts, and business scenarios.</p>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -50,17 +50,17 @@
             <span>npx @runtypelabs/cli@latest persona init</span>
             <span class="install-copy" data-copy-label>Copy</span>
           </button>
-          <div class="hero-features">
-            <span class="hero-feature-pill">Won't break your styles</span>
-            <span class="hero-feature-pill">Works with any backend</span>
-            <span class="hero-feature-pill">Agents that operate your page</span>
-            <span class="hero-feature-pill">Themeable to your brand</span>
-            <span class="hero-feature-pill">Voice built in</span>
-            <span class="hero-feature-pill">No framework required</span>
-          </div>
+          <ul class="hero-features" aria-label="Why Persona">
+            <li>Agents that operate your page</li>
+            <li>Voice built in</li>
+            <li>Won't break your styles</li>
+            <li>Works with any backend</li>
+            <li>Themeable to your brand</li>
+            <li>No framework required</li>
+          </ul>
           <div class="hero-badges">
             <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=5B2EFF&label=npm" alt="npm"></a>
-            <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/runtypelabs/persona?style=flat&color=5B2EFF&label=GitHub" alt="GitHub"></a>
+            <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/badge/GitHub-runtypelabs%2Fpersona-5B2EFF?style=flat&logo=github&logoColor=white" alt="GitHub"></a>
             <a href="https://deepwiki.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
           </div>
           <div class="hero-byline">

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -87,6 +87,14 @@
               </a>
             </div>
             <div class="carousel-3d-card">
+              <a href="/webmcp-slides.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe data-src="/webmcp-slides.html" tabindex="-1" title="WebMCP Slides"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">WebMCP Slides</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
               <a href="/bakery.html" class="carousel-3d-card-link">
                 <div class="carousel-3d-iframe-wrap">
                   <iframe data-src="/bakery.html" tabindex="-1" title="Bakery Assistant"></iframe>

--- a/examples/embedded-app/index.html
+++ b/examples/embedded-app/index.html
@@ -10,36 +10,87 @@
 </head>
 <body>
   <div class="page">
+    <!-- Hero — 3D Carousel Showcase -->
+    <section class="hero-split">
+      <div class="hero-split-inner">
+        <div class="hero-panel">
+          <span class="label">Open Source AI Chat Widget</span>
+          <h1 class="kern-tight">Add a streaming AI chat<br>to any website, in minutes.</h1>
+          <p>Themeable, pluggable, zero framework dependencies. Style isolation, SSE streaming, agent loops, and tool use — all in one drop-in widget.</p>
+          <div class="hero-features">
+            <span class="hero-feature-pill">Style Isolation</span>
+            <span class="hero-feature-pill">SSE Streaming</span>
+            <span class="hero-feature-pill">Agent Loops</span>
+            <span class="hero-feature-pill">Theming</span>
+            <span class="hero-feature-pill">Voice Input</span>
+            <span class="hero-feature-pill">Vanilla JS</span>
+          </div>
+          <div class="hero-badges">
+            <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=5B2EFF&label=npm" alt="npm"></a>
+            <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/runtypelabs/persona?style=flat&color=5B2EFF&label=GitHub" alt="GitHub"></a>
+            <a href="https://deepwiki.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
+          </div>
+          <div class="hero-byline">
+            <span>Built by</span>
+            <a href="https://runtype.com" target="_blank" rel="noopener"><img src="/runtype-logo.svg" alt="Runtype" class="runtype-logo"></a>
+          </div>
+        </div>
+        <div class="carousel-3d" id="hero-carousel">
+          <div class="carousel-3d-scene">
+            <div class="carousel-3d-card">
+              <a href="/bakery.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe src="/bakery.html" tabindex="-1" title="Bakery Assistant"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">Bakery Assistant</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
+              <a href="/fullscreen-assistant-demo.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe src="/fullscreen-assistant-demo.html" loading="lazy" tabindex="-1" title="Fullscreen Layout"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">Fullscreen Layout</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
+              <a href="/docked-panel-demo.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe src="/docked-panel-demo.html" loading="lazy" tabindex="-1" title="Docked Panel"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">Docked Panel</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
+              <a href="/action-middleware.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe src="/action-middleware.html" loading="lazy" tabindex="-1" title="Action Middleware"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">Action Middleware</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
+              <a href="/theme.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe src="/theme.html" loading="lazy" tabindex="-1" title="Theme Editor"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">Theme Editor</span>
+              </a>
+            </div>
+            <div class="carousel-3d-card">
+              <a href="/launcher-demo.html" class="carousel-3d-card-link">
+                <div class="carousel-3d-iframe-wrap">
+                  <iframe src="/launcher-demo.html" loading="lazy" tabindex="-1" title="Default Launcher"></iframe>
+                </div>
+                <span class="carousel-3d-card-title">Default Launcher</span>
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <main class="shell">
-
-      <!-- Hero -->
-      <section class="hero cardFull reveal-el">
-        <span class="label">Open Source AI Chat Widget</span>
-        <h1 class="kern-tight" style="font-size: 40px; line-height: 1.05;">
-          Add a streaming AI chat<br>to any website, in minutes.
-        </h1>
-        <p>Themeable, pluggable, zero framework dependencies. Style isolation, SSE streaming, agent loops, and tool use — all in one drop-in widget.</p>
-
-        <div class="hero-features">
-          <span class="hero-feature-pill">Style Isolation</span>
-          <span class="hero-feature-pill">SSE Streaming</span>
-          <span class="hero-feature-pill">Agent Loops</span>
-          <span class="hero-feature-pill">Theming</span>
-          <span class="hero-feature-pill">Voice Input</span>
-          <span class="hero-feature-pill">Vanilla JS</span>
-        </div>
-
-        <div class="hero-badges">
-          <a href="https://www.npmjs.com/package/@runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/npm/v/@runtypelabs/persona?style=flat&color=5B2EFF&label=npm" alt="npm"></a>
-          <a href="https://github.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://img.shields.io/github/stars/runtypelabs/persona?style=flat&color=5B2EFF&label=GitHub" alt="GitHub"></a>
-          <a href="https://deepwiki.com/runtypelabs/persona" target="_blank" rel="noopener"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"></a>
-        </div>
-
-        <div class="hero-byline">
-          <span>Built by</span>
-          <a href="https://runtype.com" target="_blank" rel="noopener"><img src="/runtype-logo.svg" alt="Runtype" class="runtype-logo"></a>
-        </div>
-      </section>
 
       <!-- Live Demo -->
       <section class="card cardFull tryit-section reveal-el">
@@ -316,6 +367,17 @@
       </footer>
 
     </main>
+
+    <!-- Demo Lightbox -->
+    <dialog class="demo-lightbox" id="demo-lightbox">
+      <div class="demo-lightbox-chrome">
+        <button type="button" class="demo-lightbox-close" aria-label="Close demo preview">
+          <span aria-hidden="true">&times;</span>
+          <span class="demo-lightbox-hint">esc</span>
+        </button>
+      </div>
+      <iframe class="demo-lightbox-iframe" src="" title="Demo preview"></iframe>
+    </dialog>
   </div>
 
   <!-- Scroll reveal & copy buttons -->

--- a/examples/embedded-app/src/docked-panel-demo.ts
+++ b/examples/embedded-app/src/docked-panel-demo.ts
@@ -6,13 +6,37 @@ import {
   initAgentWidget,
   markdownPostprocessor,
   type AgentWidgetInitHandle,
+  type WebMcpConfirmInfo,
 } from "@runtypelabs/persona";
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
 
+// The docked Copilot is WebMCP-powered: this page registers four workspace
+// tools on document.modelContext (see "WebMCP page tools" at the bottom) and
+// the dispatch-docked flow drives them — read the dashboard, switch sections,
+// log activity, and even move the assistant's own dock.
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
 const apiUrl =
   import.meta.env.VITE_PROXY_URL
-    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch`
-    : `http://localhost:${proxyPort}/api/chat/dispatch`;
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-docked`
+    : `http://localhost:${proxyPort}/api/chat/dispatch-docked`;
+
+/** Minimal structural view of the WebMCP producer surface (see webmcp-demo.ts). */
+interface RegisterableModelContext {
+  registerTool(
+    tool: {
+      name: string;
+      title?: string;
+      description: string;
+      inputSchema?: object;
+      annotations?: Record<string, unknown>;
+      execute: (args: Record<string, unknown>) => unknown;
+    },
+    options?: { signal?: AbortSignal },
+  ): void;
+}
+
+/** Read-only tools run without confirmation; mutations get Persona's approval bubble. */
+const READ_ONLY_TOOLS = new Set(["get_workspace_overview", "switch_section"]);
 
 const dockSideSelect = document.getElementById("dock-side") as HTMLSelectElement | null;
 const dockWidthInput = document.getElementById("dock-width") as HTMLInputElement | null;
@@ -163,14 +187,23 @@ function createController(): AgentWidgetInitHandle {
       copy: {
         ...DEFAULT_WIDGET_CONFIG.copy,
         welcomeTitle: "Ask Copilot",
-        welcomeSubtitle: "Search docs, get answers, or draft content next to your work.",
+        welcomeSubtitle:
+          "I can read this dashboard, switch sections, log activity, and even move my own panel — using the page's own tools.",
         inputPlaceholder: "Ask a question or describe what you need…",
       },
+      // Ordered to walk the tool surface: read-only overview (auto-approved),
+      // read-only-ish navigation, then two mutations that raise approval bubbles
+      // (one of which moves the assistant's own dock).
       suggestionChips: [
-        "What should I review before publishing today?",
-        "Draft a short update for stakeholders on this week’s changes.",
-        "Summarize performance and catalog updates from the last 7 days.",
+        "What needs my attention on this dashboard?",
+        "Switch to the Catalog section",
+        "Log a note that the launch checklist is done",
+        "Move your panel to the left side, 360px wide",
       ],
+      webmcp: {
+        enabled: true,
+        autoApprove: (info: WebMcpConfirmInfo): boolean => READ_ONLY_TOOLS.has(info.toolName),
+      },
       postprocessMessage: ({ text }) => markdownPostprocessor(text),
     },
   });
@@ -256,3 +289,181 @@ assistantToggle.addEventListener("click", () => {
   document.getElementById("assistant-coachmark")?.remove();
   controller.toggle();
 });
+
+// ---------------------------------------------------------------------------
+// WebMCP page tools
+//
+// Mocked workspace actions in the same spirit as webmcp-demo.ts: the page
+// owns the tools, Persona drives them, and every result is visible on the
+// dashboard. Read-only tools auto-approve (see READ_ONLY_TOOLS); mutations
+// raise Persona's in-panel approval bubble.
+// ---------------------------------------------------------------------------
+
+initializeWebMCPPolyfill();
+
+const modelContext = (
+  document as Document & { modelContext?: RegisterableModelContext }
+).modelContext;
+
+if (modelContext) {
+  const navItems = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll<HTMLElement>(".workspace-nav .nav-item"));
+  const sectionName = (el: HTMLElement): string => el.textContent?.trim() ?? "";
+
+  // -- get_workspace_overview (read-only) --
+  modelContext.registerTool({
+    name: "get_workspace_overview",
+    title: "Read the dashboard",
+    description:
+      "Read the current workspace: available sections and which is active, the overview banner, the highlight cards, the recent-activity feed, and the assistant's current dock layout.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute() {
+      const banner = document.querySelector(".workspace-banner");
+      const cards = Array.from(document.querySelectorAll(".workspace-card")).map((card) => ({
+        title: card.querySelector("h4")?.textContent?.trim() ?? "",
+        summary: card.querySelector("p")?.textContent?.trim() ?? "",
+      }));
+      const activity = Array.from(document.querySelectorAll(".workspace-feed .feed-item")).map(
+        (item) => {
+          const spans = item.querySelectorAll("span");
+          return {
+            when: spans[0]?.textContent?.trim() ?? "",
+            title: spans[1]?.textContent?.trim() ?? "",
+            detail: spans[2]?.textContent?.trim() ?? "",
+          };
+        },
+      );
+      return {
+        sections: navItems().map((el) => ({
+          name: sectionName(el),
+          active: el.classList.contains("is-active"),
+        })),
+        banner: {
+          title: banner?.querySelector("h3")?.textContent?.trim() ?? "",
+          text: banner?.querySelector("p")?.textContent?.trim() ?? "",
+        },
+        cards,
+        activity,
+        dock: getDockConfig(),
+      };
+    },
+  });
+
+  // -- switch_section (read-only-ish navigation) --
+  modelContext.registerTool({
+    name: "switch_section",
+    title: "Switch workspace section",
+    description:
+      "Highlight a section in the workspace navigation. Valid section names come from get_workspace_overview (e.g. Overview, Automation, Audience, Catalog, Publishing).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        section: { type: "string", description: "Exact name of the section to activate." },
+      },
+      required: ["section"],
+    },
+    annotations: { readOnlyHint: true },
+    execute(args) {
+      const requested = String(args.section ?? "").trim().toLowerCase();
+      const items = navItems();
+      const target = items.find((el) => sectionName(el).toLowerCase() === requested);
+      if (!target) {
+        return {
+          error: `Unknown section "${args.section}". Available: ${items.map(sectionName).join(", ")}.`,
+        };
+      }
+      items.forEach((el) => {
+        el.classList.toggle("is-active", el === target);
+        if (el === target) el.setAttribute("aria-current", "page");
+        else el.removeAttribute("aria-current");
+      });
+      updateStatus(`Switched to ${sectionName(target)}.`);
+      return { ok: true, active: sectionName(target) };
+    },
+  });
+
+  // -- set_dock_layout (mutating — the assistant repositions itself) --
+  modelContext.registerTool({
+    name: "set_dock_layout",
+    title: "Move the assistant dock",
+    description:
+      "Reposition or resize the assistant's own docked panel. All fields optional; omitted ones keep their current value. side: 'left' | 'right'. width: CSS width like '360px'. reveal: 'resize' | 'emerge' | 'overlay' | 'push'. animate: boolean.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        side: { type: "string", enum: ["left", "right"] },
+        width: { type: "string", description: "CSS width for the open dock, e.g. '360px'." },
+        reveal: { type: "string", enum: ["resize", "emerge", "overlay", "push"] },
+        animate: { type: "boolean" },
+      },
+    },
+    execute(args) {
+      if (args.side !== undefined) {
+        if (args.side !== "left" && args.side !== "right") {
+          return { error: `Invalid side "${args.side}" — use "left" or "right".` };
+        }
+        sideSelect.value = args.side;
+      }
+      if (args.width !== undefined) {
+        const raw = String(args.width).trim();
+        const width = /^\d+(\.\d+)?$/.test(raw) ? `${raw}px` : raw;
+        if (!/^\d+(\.\d+)?(px|rem|em|vw|%)$/.test(width)) {
+          return { error: `Invalid width "${args.width}" — use a CSS length like "360px".` };
+        }
+        widthInput.value = width;
+      }
+      if (args.reveal !== undefined) {
+        const reveal = String(args.reveal);
+        if (!["resize", "emerge", "overlay", "push"].includes(reveal)) {
+          return { error: `Invalid reveal "${args.reveal}" — use resize, emerge, overlay, or push.` };
+        }
+        revealSelect.value = reveal;
+      }
+      if (args.animate !== undefined) {
+        animateCheck.checked = Boolean(args.animate);
+      }
+      applyDockSettings();
+      return { ok: true, dock: getDockConfig() };
+    },
+  });
+
+  // -- log_activity (mutating — visible feed update) --
+  modelContext.registerTool({
+    name: "log_activity",
+    title: "Log activity",
+    description:
+      "Add an entry to the dashboard's Recent activity feed. Use a short title and put any detail in the body.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        title: { type: "string", description: "Short headline for the entry." },
+        detail: { type: "string", description: "One-sentence detail shown under the title." },
+      },
+      required: ["title"],
+    },
+    execute(args) {
+      const feed = document.querySelector(".workspace-feed");
+      if (!feed) return { error: "Activity feed not found on the page." };
+
+      // Built with textContent — agent-supplied strings never touch innerHTML.
+      const item = document.createElement("div");
+      item.className = "feed-item";
+      const meta = document.createElement("span");
+      meta.className = "feed-meta";
+      meta.textContent = "Just now";
+      const title = document.createElement("span");
+      title.className = "feed-title";
+      title.textContent = String(args.title ?? "").trim() || "Untitled note";
+      item.append(meta, title);
+      if (args.detail !== undefined && String(args.detail).trim()) {
+        const detail = document.createElement("span");
+        detail.textContent = String(args.detail).trim();
+        item.append(detail);
+      }
+      feed.querySelector(".workspace-feed__heading")?.after(item);
+      updateStatus("Activity logged.");
+      return { ok: true, logged: title.textContent };
+    },
+  });
+}

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -200,6 +200,90 @@ code {
 }
 
 /* ======================================================================
+   Top Nav
+   ====================================================================== */
+
+html {
+  scroll-behavior: smooth;
+}
+
+section[id] {
+  scroll-margin-top: 24px;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.site-nav {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 20;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 18px 3vw;
+}
+
+.site-nav-brand {
+  font-family: var(--font-serif);
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--foreground);
+  text-decoration: none;
+}
+
+.site-nav-links {
+  display: flex;
+  align-items: center;
+  gap: 22px;
+}
+
+.site-nav-links a {
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--muted);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.site-nav-links a:hover {
+  color: var(--foreground);
+}
+
+.site-nav-github {
+  padding: 7px 14px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: var(--foreground) !important;
+}
+
+.site-nav-github:hover {
+  border-color: var(--foreground);
+}
+
+@media (max-width: 960px) {
+  .site-nav-links a:not(.site-nav-github) {
+    display: none;
+  }
+}
+
+/* ======================================================================
    Hero Split — 3D Carousel Layout
    ====================================================================== */
 
@@ -207,13 +291,13 @@ code {
   position: relative;
   z-index: 1;
   width: 100%;
-  padding: 3vw 3vw 0;
+  padding: 72px 3vw 0;
 }
 
 .hero-split-inner {
   display: flex;
   align-items: center;
-  min-height: calc(100vh - 6vw);
+  min-height: calc(100vh - 72px - 3vw);
   gap: 3vw;
 }
 
@@ -259,13 +343,61 @@ code {
   justify-content: flex-start;
 }
 
+/* Hero CTAs */
+.hero-cta {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-top: 4px;
+}
+
+.hero-cta-primary,
+.hero-cta-secondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 10px 18px;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 600;
+  border-radius: var(--radius);
+  text-decoration: none;
+  transition: transform 0.15s ease, background 0.15s ease, border-color 0.15s ease;
+}
+
+.hero-cta-primary {
+  color: var(--primary-foreground);
+  background: var(--primary);
+  border: 1px solid var(--primary);
+  box-shadow: 0 4px 14px -4px rgba(91, 46, 255, 0.45);
+}
+
+.hero-cta-primary:hover {
+  background: var(--primary-hover);
+  border-color: var(--primary-hover);
+  transform: translateY(-1px);
+}
+
+.hero-cta-secondary {
+  color: var(--foreground);
+  background: transparent;
+  border: 1px solid var(--border);
+}
+
+.hero-cta-secondary:hover {
+  border-color: var(--foreground);
+  transform: translateY(-1px);
+}
+
 /* Card Stack — right side */
 .carousel-3d {
   flex: 1;
   perspective: 1200px;
   display: flex;
+  flex-direction: column;
   align-items: center;
   justify-content: center;
+  gap: 18px;
   min-height: 420px;
   position: relative;
   animation: hero-fade-in 0.8s var(--ease-smooth) 0.3s both;
@@ -353,6 +485,110 @@ code {
   letter-spacing: 0.01em;
 }
 
+/* Carousel controls — arrows + dots */
+.carousel-3d-controls {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  position: relative;
+  z-index: 1;
+}
+
+.carousel-3d-nav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  color: var(--muted);
+  font-size: 15px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+}
+
+.carousel-3d-nav:hover {
+  color: var(--primary);
+  border-color: var(--primary);
+  transform: translateY(-1px);
+}
+
+.carousel-3d-dots {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.carousel-3d-dot {
+  width: 8px;
+  height: 8px;
+  padding: 0;
+  border: none;
+  border-radius: 999px;
+  background: var(--border);
+  cursor: pointer;
+  transition: background 0.25s ease, width 0.25s var(--ease-smooth);
+}
+
+.carousel-3d-dot:hover {
+  background: var(--muted-light);
+}
+
+.carousel-3d-dot.is-active {
+  width: 22px;
+  background: var(--primary);
+}
+
+.carousel-3d-hint {
+  margin: -6px 0 0;
+  font-family: var(--font-label);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted-light);
+  position: relative;
+  z-index: 1;
+}
+
+/* "Open demo" affordance on the front card */
+.carousel-3d-card-link {
+  position: relative;
+}
+
+.carousel-3d-card.is-front .carousel-3d-card-link::after {
+  content: 'Open demo ↗';
+  position: absolute;
+  top: 42%;
+  left: 50%;
+  transform: translate(-50%, -50%) scale(0.96);
+  padding: 9px 16px;
+  border-radius: 999px;
+  background: rgba(20, 20, 28, 0.82);
+  color: #fff;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  backdrop-filter: blur(6px);
+  -webkit-backdrop-filter: blur(6px);
+  transition: opacity 0.2s ease, transform 0.2s var(--ease-smooth);
+}
+
+.carousel-3d-card.is-front .carousel-3d-card-link:hover::after,
+.carousel-3d-card.is-front .carousel-3d-card-link:focus-visible::after {
+  opacity: 1;
+  transform: translate(-50%, -50%) scale(1);
+}
+
 @keyframes card-approach {
   from { transform: scale(1) translateY(0); }
   to { transform: scale(1.04) translateY(-8px); }
@@ -389,7 +625,7 @@ code {
 /* Hero responsive — small tablet / large phone */
 @media (max-width: 960px) {
   .hero-split {
-    padding: 24px 16px 0;
+    padding: 76px 16px 0;
   }
 
   .hero-split-inner {
@@ -428,7 +664,7 @@ code {
 /* Hero responsive — phone */
 @media (max-width: 640px) {
   .hero-split {
-    padding: 12px 10px 0;
+    padding: 64px 10px 0;
   }
 
   .hero-split-inner {
@@ -503,6 +739,29 @@ code {
     font-size: 11px;
     padding: 8px 10px;
   }
+
+  .site-nav {
+    padding: 14px 16px;
+  }
+
+  .site-nav-brand {
+    font-size: 19px;
+  }
+
+  .hero-cta {
+    justify-content: center;
+    flex-wrap: wrap;
+  }
+
+  .hero-cta-primary,
+  .hero-cta-secondary {
+    padding: 9px 15px;
+    font-size: 13px;
+  }
+
+  .carousel-3d-hint {
+    display: none;
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -510,6 +769,10 @@ code {
   .carousel-3d {
     animation: none;
     opacity: 1;
+  }
+
+  .carousel-3d-card {
+    transition: none;
   }
 }
 
@@ -619,7 +882,7 @@ code {
  * the header close control. With `width`/`height` 32px and `box-sizing: border-box`,
  * horizontal padding 18+18px leaves no room for the SVG.
  */
-.page button:not([data-persona-root] *):not(.quick-start-tab),
+.page button:not([data-persona-root] *):not(.quick-start-tab):not(.carousel-3d-dot):not(.carousel-3d-nav),
 .page select:not([data-persona-root] *),
 .page .btn:not([data-persona-root] *) {
   font-family: var(--font-sans);

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -466,9 +466,11 @@ section[id] {
   position: absolute;
   top: 0;
   left: 0;
-  width: calc(50vw * 3);
-  height: calc(50vw * 1.6875);
-  transform: scale(0.3333);
+  /* Simulate a ~laptop-sized viewport (2x the card), not a 4K monitor, so
+     demo pages render at a readable size. Height = 2x the wrap's 16:9. */
+  width: calc(50vw * 2);
+  height: calc(50vw * 1.125);
+  transform: scale(0.5);
   transform-origin: top left;
   border: none;
   pointer-events: none;

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -199,6 +199,322 @@ code {
   opacity: 1;
 }
 
+/* ======================================================================
+   Hero Split — 3D Carousel Layout
+   ====================================================================== */
+
+.hero-split {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  padding: 3vw 3vw 0;
+}
+
+.hero-split-inner {
+  display: flex;
+  align-items: center;
+  min-height: calc(100vh - 6vw);
+  gap: 3vw;
+}
+
+/* Floating glass panel — left side */
+.hero-panel {
+  flex: 0 0 clamp(280px, 24vw, 420px);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 32px 28px 28px;
+  background: rgba(255, 255, 255, 0.88);
+  backdrop-filter: blur(24px);
+  -webkit-backdrop-filter: blur(24px);
+  border: 1px solid rgba(255, 255, 255, 0.7);
+  border-radius: 16px;
+  box-shadow:
+    0 8px 32px rgba(0, 0, 0, 0.06),
+    0 0 0 1px rgba(0, 0, 0, 0.03);
+  z-index: 2;
+  position: relative;
+  animation: hero-fade-in 0.8s var(--ease-smooth) 0.1s both;
+}
+
+.hero-panel h1 {
+  font-size: clamp(26px, 2.2vw, 38px);
+  line-height: 1.08;
+  margin: 4px 0 0;
+}
+
+.hero-panel p {
+  max-width: 340px;
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--muted);
+  margin-bottom: 0;
+}
+
+.hero-panel .hero-features {
+  justify-content: flex-start;
+}
+
+.hero-panel .hero-badges {
+  justify-content: flex-start;
+}
+
+/* Card Stack — right side */
+.carousel-3d {
+  flex: 1;
+  perspective: 1200px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 420px;
+  position: relative;
+  animation: hero-fade-in 0.8s var(--ease-smooth) 0.3s both;
+}
+
+.carousel-3d::before {
+  content: '';
+  position: absolute;
+  width: 500px;
+  height: 400px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: radial-gradient(ellipse, rgba(91, 46, 255, 0.06) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: -1;
+}
+
+.carousel-3d-scene {
+  width: 50vw;
+  height: calc(50vw * 0.62);
+  position: relative;
+  transform: rotateY(-4deg) rotateX(2deg);
+  transform-style: flat;
+}
+
+.carousel-3d-card {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  transition:
+    transform 0.7s var(--ease-smooth),
+    opacity 0.7s var(--ease-smooth);
+  will-change: transform, opacity;
+}
+
+.carousel-3d-card-link {
+  display: block;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow:
+    0 12px 40px -8px rgba(0, 0, 0, 0.18),
+    0 0 0 1px rgba(0, 0, 0, 0.06);
+  transition: box-shadow 0.3s ease;
+  background: #fff;
+}
+
+.carousel-3d-card-link:hover {
+  box-shadow:
+    0 16px 48px -8px rgba(91, 46, 255, 0.25),
+    0 0 0 1px rgba(91, 46, 255, 0.15);
+}
+
+.carousel-3d-iframe-wrap {
+  width: 50vw;
+  height: calc(50vw * 0.5625);
+  overflow: hidden;
+  position: relative;
+  background: linear-gradient(135deg, var(--background) 0%, var(--accent) 100%);
+}
+
+.carousel-3d-iframe-wrap iframe {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: calc(50vw * 3);
+  height: calc(50vw * 1.6875);
+  transform: scale(0.3333);
+  transform-origin: top left;
+  border: none;
+  pointer-events: none;
+}
+
+.carousel-3d-card-title {
+  display: block;
+  padding: 10px 14px;
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--muted);
+  text-align: center;
+  letter-spacing: 0.01em;
+}
+
+@keyframes card-approach {
+  from { transform: scale(1) translateY(0); }
+  to { transform: scale(1.04) translateY(-8px); }
+}
+
+.carousel-3d-card.is-approaching {
+  animation: card-approach 4s ease-in forwards;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .carousel-3d-card.is-approaching {
+    animation: none;
+  }
+}
+
+@keyframes hero-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(16px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Hero responsive — tablet (vw handles card scaling, just tweak panel) */
+@media (max-width: 1080px) {
+  .hero-panel h1 {
+    font-size: clamp(24px, 2.5vw, 32px);
+  }
+}
+
+/* Hero responsive — small tablet / large phone */
+@media (max-width: 960px) {
+  .hero-split {
+    padding: 24px 16px 0;
+  }
+
+  .hero-split-inner {
+    flex-direction: column;
+    min-height: auto;
+    gap: 20px;
+  }
+
+  .hero-panel {
+    flex: none;
+    width: 100%;
+    max-width: 540px;
+    text-align: center;
+    align-items: center;
+    padding: 24px 24px 20px;
+    gap: 10px;
+  }
+
+  .hero-panel p {
+    max-width: 460px;
+  }
+
+  .hero-panel .hero-features {
+    justify-content: center;
+  }
+
+  .hero-panel .hero-badges {
+    justify-content: center;
+  }
+
+  .carousel-3d {
+    min-height: 320px;
+  }
+}
+
+/* Hero responsive — phone */
+@media (max-width: 640px) {
+  .hero-split {
+    padding: 12px 10px 0;
+  }
+
+  .hero-split-inner {
+    gap: 14px;
+  }
+
+  .hero-panel {
+    padding: 20px 16px 16px;
+    gap: 8px;
+    border-radius: 12px;
+  }
+
+  .hero-panel .label {
+    font-size: 10px;
+  }
+
+  .hero-panel h1 {
+    font-size: 24px;
+  }
+
+  .hero-panel p {
+    font-size: 13px;
+    line-height: 1.5;
+    margin-bottom: 0;
+  }
+
+  .hero-panel .hero-features {
+    gap: 4px;
+    margin-top: 0;
+  }
+
+  .hero-panel .hero-feature-pill {
+    font-size: 11px;
+    padding: 3px 8px;
+  }
+
+  .hero-panel .hero-badges {
+    gap: 6px;
+  }
+
+  .hero-panel .hero-badges img {
+    height: 18px;
+  }
+
+  .hero-panel .hero-byline {
+    font-size: 12px;
+  }
+
+  .carousel-3d {
+    min-height: auto;
+    width: calc(100% + 20px);
+    margin-left: -10px;
+  }
+
+  .carousel-3d-scene {
+    width: 88vw;
+    height: calc(88vw * 0.62);
+  }
+
+  .carousel-3d-iframe-wrap {
+    width: 88vw;
+    height: calc(88vw * 0.5625);
+  }
+
+  .carousel-3d-iframe-wrap iframe {
+    width: calc(88vw * 3);
+    height: calc(88vw * 1.6875);
+    transform: scale(0.3333);
+  }
+
+  .carousel-3d-card-title {
+    font-size: 11px;
+    padding: 8px 10px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-panel,
+  .carousel-3d {
+    animation: none;
+    opacity: 1;
+  }
+}
+
+/* ====================================================================== */
+
 .hero h1 {
   margin: 4px 0 0;
   font-size: 36px;
@@ -1066,6 +1382,84 @@ code {
 
 .theme-editor-link:hover .theme-cta-arrow {
   transform: translateX(4px);
+}
+
+/* Demo Lightbox */
+.demo-lightbox {
+  width: 90vw;
+  max-width: 1600px;
+  height: 85vh;
+  padding: 0;
+  border: none;
+  border-radius: 14px;
+  overflow: hidden;
+  background: #fff;
+  box-shadow: 0 24px 80px -12px rgba(0, 0, 0, 0.35);
+}
+
+.demo-lightbox::backdrop {
+  background: rgba(6, 8, 14, 0.55);
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}
+
+.demo-lightbox-chrome {
+  position: absolute;
+  top: 0;
+  right: 0;
+  z-index: 2;
+  padding: 12px;
+}
+
+.demo-lightbox-close {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px !important;
+  border: none !important;
+  border-radius: 8px !important;
+  background: rgba(0, 0, 0, 0.55) !important;
+  color: #fff !important;
+  font-size: 16px !important;
+  font-weight: 400 !important;
+  cursor: pointer;
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  transition: background 0.2s ease !important;
+  box-shadow: none !important;
+}
+
+.demo-lightbox-close:hover {
+  background: rgba(0, 0, 0, 0.75) !important;
+  transform: none !important;
+}
+
+.demo-lightbox-hint {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  opacity: 0.6;
+  letter-spacing: 0.02em;
+}
+
+.demo-lightbox-iframe {
+  width: 100%;
+  height: 100%;
+  border: none;
+}
+
+@media (max-width: 640px) {
+  .demo-lightbox {
+    width: 100vw;
+    height: 100dvh;
+    max-width: none;
+    max-height: none;
+    border-radius: 0;
+    margin: 0;
+  }
+
+  .demo-lightbox-hint {
+    display: none;
+  }
 }
 
 /* Footer */

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -694,13 +694,13 @@ section[id] {
   }
 
   .hero-panel .hero-features {
-    gap: 4px;
-    margin-top: 0;
+    column-gap: 20px;
+    row-gap: 5px;
+    margin-top: 4px;
   }
 
-  .hero-panel .hero-feature-pill {
-    font-size: 11px;
-    padding: 3px 8px;
+  .hero-panel .hero-features li {
+    font-size: 12px;
   }
 
   .hero-panel .hero-badges {
@@ -795,22 +795,45 @@ section[id] {
 }
 
 .hero-features {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
+  list-style: none;
+  margin: 8px 0 0;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(2, max-content);
+  column-gap: 24px;
+  row-gap: 7px;
   justify-content: center;
-  margin-top: 4px;
 }
 
-.hero-feature-pill {
-  font-size: 12px;
+/* If the panel is too narrow for two columns, fall back to one clean column
+   instead of letting labels collide. */
+@media (max-width: 1180px) and (min-width: 901px), (max-width: 420px) {
+  .hero-features {
+    grid-template-columns: max-content;
+  }
+}
+
+.hero-features li {
+  position: relative;
+  padding-left: 20px;
+  font-size: 13px;
   font-weight: 500;
-  color: var(--muted);
-  padding: 4px 10px;
-  border-radius: 100px;
-  border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.6);
+  color: var(--secondary-text);
+  letter-spacing: 0.01em;
   white-space: nowrap;
+}
+
+.hero-features li::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  width: 12px;
+  height: 12px;
+  background-color: var(--primary);
+  /* Inline check glyph, masked so it inherits --primary */
+  -webkit-mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.2 3.2L13 5" stroke="black" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>') center / contain no-repeat;
+  mask: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="none"><path d="M3 8.5l3.2 3.2L13 5" stroke="black" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"/></svg>') center / contain no-repeat;
 }
 
 .hero-badges {

--- a/examples/embedded-app/src/index.css
+++ b/examples/embedded-app/src/index.css
@@ -1943,3 +1943,111 @@ section[id] {
     padding: 24px 16px;
   }
 }
+
+/* ---------------------------------------------------------------------------
+   Hero install one-liner
+   --------------------------------------------------------------------------- */
+.hero-install {
+  margin-top: 10px;
+  text-align: left;
+}
+
+@media (max-width: 640px) {
+  .hero-install {
+    font-size: 12px;
+    padding: 10px 12px;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   WebMCP section
+   --------------------------------------------------------------------------- */
+.webmcp-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 20px;
+}
+
+.webmcp-demo-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 20px;
+  border-radius: var(--radius);
+  background: var(--accent);
+  border: 1px solid var(--border);
+  text-decoration: none;
+  color: var(--foreground);
+  transition: all 0.2s ease;
+}
+
+.webmcp-demo-card:hover {
+  border-color: var(--primary);
+  transform: translateY(-2px);
+}
+
+.webmcp-demo-card p {
+  margin: 0;
+  font-size: 14px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.webmcp-demo-tag {
+  align-self: flex-start;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary);
+}
+
+.webmcp-demo-title {
+  font-size: 17px;
+  font-weight: 700;
+}
+
+.webmcp-demo-cta {
+  margin-top: auto;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--primary);
+}
+
+.webmcp-code {
+  grid-column: 1 / -1;
+}
+
+@media (max-width: 720px) {
+  .webmcp-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------------------------------------------------------------------------
+   Featured demo grid (home "Demos" section)
+   --------------------------------------------------------------------------- */
+#demos .featured-grid {
+  margin-top: 20px;
+}
+
+.example-item-tag {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--primary);
+  margin-bottom: 2px;
+}
+
+.example-item-desc {
+  font-size: 12.5px;
+  font-weight: 400;
+  color: var(--muted);
+  margin-top: 2px;
+}
+
+#demos .advanced-cta-actions {
+  margin-top: 20px;
+}

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -345,26 +345,81 @@ function initHeroCarousel() {
   const VISIBLE = 5;
   const CYCLE_MS = 4000;
   const stack = [...cards];
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   let paused = false;
   let cycling = false;
+  let inView = true;
+
+  const container = scene.closest('.carousel-3d') as HTMLElement | null;
+  const dotsMount = container?.querySelector('[data-carousel-dots]') as HTMLElement | null;
+  const status = container?.querySelector('[data-carousel-status]') as HTMLElement | null;
+  const cardTitle = (card: HTMLElement) =>
+    card.querySelector('.carousel-3d-card-title')?.textContent?.trim() || 'Demo';
+
+  // Defer offscreen card iframes until the page has finished loading so the
+  // front card (and the rest of the page) wins the bandwidth race.
+  function hydrateDeferredIframes() {
+    scene!.querySelectorAll('iframe[data-src]').forEach((el) => {
+      const frame = el as HTMLIFrameElement;
+      frame.src = frame.dataset.src!;
+      frame.removeAttribute('data-src');
+    });
+  }
+  if (document.readyState === 'complete') {
+    hydrateDeferredIframes();
+  } else {
+    window.addEventListener('load', () => setTimeout(hydrateDeferredIframes, 250), { once: true });
+  }
 
   function applyStyle(card: HTMLElement, i: number) {
     const p = Math.min(i, VISIBLE);
     card.style.transform = `translateX(${p * 16}px) translateY(${p * 4}px) rotate(${p * 0.8}deg)`;
     card.style.opacity = i >= VISIBLE ? '0' : i >= 4 ? '0.5' : i >= 3 ? '0.7' : '1';
     card.style.zIndex = i >= VISIBLE ? '0' : String(cards.length - i);
+    // Only the front card participates in the tab order; back cards act as
+    // bring-to-front controls for pointer users.
+    const link = card.querySelector('.carousel-3d-card-link') as HTMLAnchorElement | null;
+    if (link) link.tabIndex = i === 0 ? 0 : -1;
+    card.classList.toggle('is-front', i === 0);
   }
 
-  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+  // Dots — one per card, in original DOM order; clicking brings that card forward.
+  const dots: HTMLButtonElement[] = [];
+  if (dotsMount) {
+    cards.forEach((card) => {
+      const dot = document.createElement('button');
+      dot.type = 'button';
+      dot.className = 'carousel-3d-dot';
+      dot.setAttribute('aria-label', `Show ${cardTitle(card)} demo`);
+      dot.addEventListener('click', () => {
+        goToCard(stack.indexOf(card));
+        resetAutoAdvance();
+      });
+      dotsMount.appendChild(dot);
+      dots.push(dot);
+    });
+  }
+
+  function syncUi() {
+    const front = stack[0];
+    const frontIdx = cards.indexOf(front);
+    dots.forEach((dot, i) => {
+      dot.classList.toggle('is-active', i === frontIdx);
+      if (i === frontIdx) dot.setAttribute('aria-current', 'true');
+      else dot.removeAttribute('aria-current');
+    });
+    if (status) status.textContent = `${cardTitle(front)} demo, ${frontIdx + 1} of ${cards.length}`;
+  }
+
+  function applyAll() {
     stack.forEach((card, i) => applyStyle(card, i));
-    return;
+    syncUi();
   }
 
-  stack.forEach((card, i) => applyStyle(card, i));
-  stack[0].classList.add('is-approaching');
+  applyAll();
+  if (!reducedMotion) stack[0].classList.add('is-approaching');
 
-  const container = scene.closest('.carousel-3d') as HTMLElement;
-  if (container) {
+  if (container && !reducedMotion) {
     container.addEventListener('mouseenter', () => {
       paused = true;
       stack[0].style.animationPlayState = 'paused';
@@ -373,50 +428,86 @@ function initHeroCarousel() {
       paused = false;
       stack[0].style.animationPlayState = 'running';
     });
+    // Don't burn cycles animating a carousel the visitor has scrolled past.
+    const visibility = new IntersectionObserver((entries) => {
+      inView = entries[0]?.isIntersecting ?? true;
+    });
+    visibility.observe(container);
   }
 
-  function cycleForward() {
-    if (cycling) return;
-    cycling = true;
+  function settleAfter(ms: number, fn: () => void) {
+    setTimeout(() => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(fn);
+      });
+    }, ms);
+  }
 
-    const front = stack[0];
-    const computed = getComputedStyle(front).transform;
-    front.style.transform = computed;
-    front.classList.remove('is-approaching');
-    void front.offsetWidth;
+  // Bring the card currently at stack position `targetPos` to the front. The
+  // cards in front of it peel away together; the rest slide up the stack.
+  function goToCard(targetPos: number) {
+    if (cycling || targetPos <= 0 || targetPos >= stack.length) return;
 
-    front.style.transition = `transform 0.6s var(--ease-smooth), opacity 0.6s var(--ease-smooth)`;
-    front.style.transform = 'translateX(-60px) translateY(-30px) rotate(-2deg) scale(0.96)';
-    front.style.opacity = '0';
-    front.style.zIndex = String(cards.length + 1);
-
-    for (let i = 1; i < stack.length; i++) {
-      stack[i].style.transition = '';
-      applyStyle(stack[i], i - 1);
+    if (reducedMotion) {
+      stack.push(...stack.splice(0, targetPos));
+      applyAll();
+      return;
     }
 
-    setTimeout(() => {
-      const old = stack.shift()!;
-      stack.push(old);
+    cycling = true;
+    const peeled = stack.slice(0, targetPos);
 
-      old.style.transition = 'none';
-      old.style.animationPlayState = '';
-      applyStyle(old, stack.indexOf(old));
+    peeled.forEach((card, i) => {
+      card.classList.remove('is-approaching');
+      const computed = getComputedStyle(card).transform;
+      card.style.transform = computed;
+      void card.offsetWidth;
+      card.style.transition = `transform 0.6s var(--ease-smooth), opacity 0.6s var(--ease-smooth)`;
+      card.style.transform = 'translateX(-60px) translateY(-30px) rotate(-2deg) scale(0.96)';
+      card.style.opacity = '0';
+      card.style.zIndex = String(cards.length + peeled.length - i);
+    });
 
+    stack.push(...stack.splice(0, targetPos));
+    for (let i = 0; i < stack.length; i++) {
+      if (peeled.includes(stack[i])) continue;
+      stack[i].style.transition = '';
+      applyStyle(stack[i], i);
+    }
+
+    settleAfter(700, () => {
+      peeled.forEach((card) => {
+        card.style.transition = 'none';
+        card.style.animationPlayState = '';
+        applyStyle(card, stack.indexOf(card));
+      });
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
-          old.style.transition = '';
+          peeled.forEach((card) => {
+            card.style.transition = '';
+          });
           stack[0].classList.add('is-approaching');
           cycling = false;
         });
       });
-    }, 700);
+    });
+    syncUi();
+  }
+
+  function cycleForward() {
+    goToCard(1);
   }
 
   function cycleBackward() {
     if (cycling) return;
-    cycling = true;
 
+    if (reducedMotion) {
+      stack.unshift(stack.pop()!);
+      applyAll();
+      return;
+    }
+
+    cycling = true;
     stack[0].classList.remove('is-approaching');
 
     const incoming = stack.pop()!;
@@ -436,29 +527,37 @@ function initHeroCarousel() {
       applyStyle(stack[i], i);
     }
 
-    setTimeout(() => {
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => {
-          stack[0].classList.add('is-approaching');
-          cycling = false;
-        });
-      });
-    }, 700);
+    settleAfter(700, () => {
+      stack[0].classList.add('is-approaching');
+      cycling = false;
+    });
+    syncUi();
   }
 
-  let autoId = setInterval(() => {
-    if (!paused && !cycling) cycleForward();
-  }, CYCLE_MS);
-
+  let autoId: ReturnType<typeof setInterval> | undefined;
   function resetAutoAdvance() {
+    if (reducedMotion) return;
     clearInterval(autoId);
     autoId = setInterval(() => {
-      if (!paused && !cycling) cycleForward();
+      if (!paused && !cycling && inView && !document.hidden) cycleForward();
     }, CYCLE_MS);
   }
+  resetAutoAdvance();
+
+  container?.querySelector('[data-carousel-prev]')?.addEventListener('click', () => {
+    cycleBackward();
+    resetAutoAdvance();
+  });
+  container?.querySelector('[data-carousel-next]')?.addEventListener('click', () => {
+    cycleForward();
+    resetAutoAdvance();
+  });
 
   document.addEventListener('keydown', (e) => {
     if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+
+    const target = e.target as HTMLElement | null;
+    if (target && (target.isContentEditable || /^(input|textarea|select)$/i.test(target.tagName))) return;
 
     const lightbox = document.getElementById('demo-lightbox') as HTMLDialogElement;
     if (lightbox?.open) return;
@@ -474,6 +573,13 @@ function initHeroCarousel() {
     }
     resetAutoAdvance();
   });
+
+  // Expose stack order so the lightbox can tell front cards from back cards.
+  (window as Window & { __heroCarouselStack?: HTMLElement[] }).__heroCarouselStack = stack;
+  (window as Window & { __heroCarouselGoTo?: (pos: number) => void }).__heroCarouselGoTo = (pos) => {
+    goToCard(pos);
+    resetAutoAdvance();
+  };
 }
 
 initHeroCarousel();
@@ -492,6 +598,22 @@ function initDemoLightbox() {
   document.querySelectorAll('.carousel-3d-card-link').forEach(link => {
     link.addEventListener('click', (e) => {
       e.preventDefault();
+
+      // Clicking a back card brings it to the front instead of opening it —
+      // its visible edge reads as a "next card" affordance, not a link.
+      const card = link.closest('.carousel-3d-card') as HTMLElement | null;
+      const win = window as Window & {
+        __heroCarouselStack?: HTMLElement[];
+        __heroCarouselGoTo?: (pos: number) => void;
+      };
+      if (card && win.__heroCarouselStack && win.__heroCarouselGoTo) {
+        const pos = win.__heroCarouselStack.indexOf(card);
+        if (pos > 0) {
+          win.__heroCarouselGoTo(pos);
+          return;
+        }
+      }
+
       const anchor = link as HTMLAnchorElement;
       iframe.src = anchor.href;
       iframe.title = link.querySelector('.carousel-3d-card-title')?.textContent || 'Demo preview';

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -416,8 +416,16 @@ function initHeroCarousel() {
     syncUi();
   }
 
+  // Start (or restart) the front card's approach animation, honoring an
+  // in-progress hover pause — the stack can rotate while the pointer stays
+  // over the carousel, and the new front card must come up already paused.
+  function startApproach() {
+    stack[0].classList.add('is-approaching');
+    stack[0].style.animationPlayState = paused ? 'paused' : 'running';
+  }
+
   applyAll();
-  if (!reducedMotion) stack[0].classList.add('is-approaching');
+  if (!reducedMotion) startApproach();
 
   if (container && !reducedMotion) {
     container.addEventListener('mouseenter', () => {
@@ -435,6 +443,15 @@ function initHeroCarousel() {
     visibility.observe(container);
   }
 
+  function finishCycle() {
+    cycling = false;
+    if (!pendingTarget) return;
+    const queued = pendingTarget;
+    pendingTarget = null;
+    const pos = stack.indexOf(queued);
+    if (pos > 0) goToCard(pos);
+  }
+
   function settleAfter(ms: number, fn: () => void) {
     setTimeout(() => {
       requestAnimationFrame(() => {
@@ -445,8 +462,15 @@ function initHeroCarousel() {
 
   // Bring the card currently at stack position `targetPos` to the front. The
   // cards in front of it peel away together; the rest slide up the stack.
+  // Requests that land mid-transition are queued (the click's default was
+  // already prevented, so dropping them would swallow the click entirely).
+  let pendingTarget: HTMLElement | null = null;
   function goToCard(targetPos: number) {
-    if (cycling || targetPos <= 0 || targetPos >= stack.length) return;
+    if (targetPos <= 0 || targetPos >= stack.length) return;
+    if (cycling) {
+      pendingTarget = stack[targetPos];
+      return;
+    }
 
     if (reducedMotion) {
       stack.push(...stack.splice(0, targetPos));
@@ -486,8 +510,8 @@ function initHeroCarousel() {
           peeled.forEach((card) => {
             card.style.transition = '';
           });
-          stack[0].classList.add('is-approaching');
-          cycling = false;
+          startApproach();
+          finishCycle();
         });
       });
     });
@@ -528,8 +552,8 @@ function initHeroCarousel() {
     }
 
     settleAfter(700, () => {
-      stack[0].classList.add('is-approaching');
-      cycling = false;
+      startApproach();
+      finishCycle();
     });
     syncUi();
   }
@@ -558,6 +582,9 @@ function initHeroCarousel() {
 
     const target = e.target as HTMLElement | null;
     if (target && (target.isContentEditable || /^(input|textarea|select)$/i.test(target.tagName))) return;
+    // Roving-tabindex widgets (e.g. the Quick Start tabs) own the arrow keys
+    // while focused — don't page the carousel on the same keypress.
+    if (target?.closest('[role="tablist"], [role="tab"]')) return;
 
     const lightbox = document.getElementById('demo-lightbox') as HTMLDialogElement;
     if (lightbox?.open) return;
@@ -637,7 +664,11 @@ function initDemoLightbox() {
 
   lightbox.addEventListener('close', () => {
     iframe.src = '';
-    if (!closedByPopstate) history.back();
+    // Only rewind if the lightbox entry is still the active one — the visitor
+    // may have navigated (e.g. a hash link) while the modal was open, and
+    // history.back() would undo that navigation instead.
+    const state = history.state as { demoLightbox?: boolean } | null;
+    if (!closedByPopstate && state?.demoLightbox) history.back();
     closedByPopstate = false;
   });
 }

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -151,7 +151,7 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Theme Editor](/theme.html) — visually customize the widget theme and styling in real time
 - [Action Middleware](/action-middleware.html) — DOM-aware page context each turn plus middleware that executes real UI actions (navigate, cart, checkout)
 - [Bakery Assistant](/bakery.html) — industry-specific persona with a rich product catalog and cart actions
-- [Docked Panel](/docked-panel-demo.html) — alternative layout with the widget docked to the side of the page
+- [Docked Panel](/docked-panel-demo.html) — WebMCP-powered dashboard copilot docked to the side of the page; it reads the workspace, switches sections, logs activity, and can move its own dock via page tools
 - [Feedback Integration](/feedback-integration-demo.html) — wiring feedback events to an external API
 - [Custom Loading Indicator](/custom-loading-indicator.html) — replace the default loading UX with your own
 - [Agent Loop Execution](/agent-demo.html) — multi-turn reasoning with internal thought processes and tool use

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -504,6 +504,7 @@ function initHeroCarousel() {
   }
 
   function cycleForward() {
+    if (cycling && pendingTarget) return;
     goToCard(1);
   }
 

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -6,7 +6,6 @@ import {
   createAgentExperience,
   createLocalStorageAdapter,
   markdownPostprocessor,
-  createDemoCarousel,
   DEFAULT_WIDGET_CONFIG
 } from "@runtypelabs/persona";
 
@@ -166,6 +165,7 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Stream Animations](/stream-animations-demo.html) — customize how streamed text animates in
 - [Persistent Composer](/persistent-composer.html) — always-visible composer bar layout
 - [WebMCP Storefront](/webmcp-demo.html) — expose page tools to the agent via WebMCP
+- [WebMCP Calendar](/webmcp-calendar.html) — a team calendar copilot that reads availability and books events through WebMCP page tools
 
 ## Customization
 
@@ -314,22 +314,6 @@ const inlineController = createAgentExperience(inlineMount, {
   postprocessMessage: ({ text, streaming }) => codeBlockCopyPostprocessor(text, streaming)
 });
 setupCodeCopyHandler(inlineMount);
-
-// ---------------------------------------------------------------------------
-// Demo Carousel
-// ---------------------------------------------------------------------------
-
-const carouselMount = document.getElementById("demo-carousel-mount");
-if (carouselMount) {
-  createDemoCarousel(carouselMount, {
-    items: [
-      { url: "/launcher-demo.html", title: "Default Launcher", description: "Out-of-the-box chat widget experience" },
-      { url: "/bakery.html", title: "Site Nav, Checkout", description: "Full business site with context-aware chat" },
-      { url: "/fullscreen-assistant-demo.html", title: "Fullscreen", description: "Full-viewport dark layout with artifacts" },
-      { url: "/docked-panel-demo.html", title: "Docked Assistant", description: "Side-docked assistant layout" },
-    ],
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Hero 3D Carousel

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -166,6 +166,7 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Persistent Composer](/persistent-composer.html) — always-visible composer bar layout
 - [WebMCP Storefront](/webmcp-demo.html) — expose page tools to the agent via WebMCP
 - [WebMCP Calendar](/webmcp-calendar.html) — a team calendar copilot that reads availability and books events through WebMCP page tools
+- [WebMCP Slides](/webmcp-slides.html) — a Deck Copilot that edits a slide deck through WebMCP page tools, with selection-scoped tools and presenter-mode controls
 
 ## Customization
 

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -468,6 +468,11 @@ function initHeroCarousel() {
 
     peeled.forEach((card, i) => {
       card.classList.remove('is-approaching');
+      // Hand off front-card status immediately — a peeling card must not keep
+      // the is-front affordance or sit in the tab order for the 700ms flight.
+      card.classList.remove('is-front');
+      const link = card.querySelector('.carousel-3d-card-link') as HTMLAnchorElement | null;
+      if (link) link.tabIndex = -1;
       const computed = getComputedStyle(card).transform;
       card.style.transform = computed;
       void card.offsetWidth;

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -330,3 +330,194 @@ if (carouselMount) {
     ],
   });
 }
+
+// ---------------------------------------------------------------------------
+// Hero 3D Carousel
+// ---------------------------------------------------------------------------
+
+function initHeroCarousel() {
+  const scene = document.querySelector('.carousel-3d-scene') as HTMLElement | null;
+  if (!scene) return;
+
+  const cards = Array.from(scene.querySelectorAll('.carousel-3d-card')) as HTMLElement[];
+  if (!cards.length) return;
+
+  const VISIBLE = 5;
+  const CYCLE_MS = 4000;
+  const stack = [...cards];
+  let paused = false;
+  let cycling = false;
+
+  function applyStyle(card: HTMLElement, i: number) {
+    const p = Math.min(i, VISIBLE);
+    card.style.transform = `translateX(${p * 16}px) translateY(${p * 4}px) rotate(${p * 0.8}deg)`;
+    card.style.opacity = i >= VISIBLE ? '0' : i >= 4 ? '0.5' : i >= 3 ? '0.7' : '1';
+    card.style.zIndex = i >= VISIBLE ? '0' : String(cards.length - i);
+  }
+
+  if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+    stack.forEach((card, i) => applyStyle(card, i));
+    return;
+  }
+
+  stack.forEach((card, i) => applyStyle(card, i));
+  stack[0].classList.add('is-approaching');
+
+  const container = scene.closest('.carousel-3d') as HTMLElement;
+  if (container) {
+    container.addEventListener('mouseenter', () => {
+      paused = true;
+      stack[0].style.animationPlayState = 'paused';
+    });
+    container.addEventListener('mouseleave', () => {
+      paused = false;
+      stack[0].style.animationPlayState = 'running';
+    });
+  }
+
+  function cycleForward() {
+    if (cycling) return;
+    cycling = true;
+
+    const front = stack[0];
+    const computed = getComputedStyle(front).transform;
+    front.style.transform = computed;
+    front.classList.remove('is-approaching');
+    void front.offsetWidth;
+
+    front.style.transition = `transform 0.6s var(--ease-smooth), opacity 0.6s var(--ease-smooth)`;
+    front.style.transform = 'translateX(-60px) translateY(-30px) rotate(-2deg) scale(0.96)';
+    front.style.opacity = '0';
+    front.style.zIndex = String(cards.length + 1);
+
+    for (let i = 1; i < stack.length; i++) {
+      stack[i].style.transition = '';
+      applyStyle(stack[i], i - 1);
+    }
+
+    setTimeout(() => {
+      const old = stack.shift()!;
+      stack.push(old);
+
+      old.style.transition = 'none';
+      old.style.animationPlayState = '';
+      applyStyle(old, stack.indexOf(old));
+
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          old.style.transition = '';
+          stack[0].classList.add('is-approaching');
+          cycling = false;
+        });
+      });
+    }, 700);
+  }
+
+  function cycleBackward() {
+    if (cycling) return;
+    cycling = true;
+
+    stack[0].classList.remove('is-approaching');
+
+    const incoming = stack.pop()!;
+    stack.unshift(incoming);
+
+    incoming.style.transition = 'none';
+    incoming.style.transform = 'translateX(80px) translateY(20px) rotate(3deg)';
+    incoming.style.opacity = '0';
+    incoming.style.zIndex = String(cards.length + 1);
+    void incoming.offsetWidth;
+
+    incoming.style.transition = `transform 0.6s var(--ease-smooth), opacity 0.6s var(--ease-smooth)`;
+    applyStyle(incoming, 0);
+
+    for (let i = 1; i < stack.length; i++) {
+      stack[i].style.transition = '';
+      applyStyle(stack[i], i);
+    }
+
+    setTimeout(() => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          stack[0].classList.add('is-approaching');
+          cycling = false;
+        });
+      });
+    }, 700);
+  }
+
+  let autoId = setInterval(() => {
+    if (!paused && !cycling) cycleForward();
+  }, CYCLE_MS);
+
+  function resetAutoAdvance() {
+    clearInterval(autoId);
+    autoId = setInterval(() => {
+      if (!paused && !cycling) cycleForward();
+    }, CYCLE_MS);
+  }
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'ArrowRight' && e.key !== 'ArrowLeft') return;
+
+    const lightbox = document.getElementById('demo-lightbox') as HTMLDialogElement;
+    if (lightbox?.open) return;
+
+    if (!container) return;
+    const rect = container.getBoundingClientRect();
+    if (rect.bottom < 0 || rect.top > window.innerHeight) return;
+
+    if (e.key === 'ArrowRight') {
+      cycleForward();
+    } else {
+      cycleBackward();
+    }
+    resetAutoAdvance();
+  });
+}
+
+initHeroCarousel();
+
+// ---------------------------------------------------------------------------
+// Demo Lightbox
+// ---------------------------------------------------------------------------
+
+function initDemoLightbox() {
+  const lightbox = document.getElementById('demo-lightbox') as HTMLDialogElement | null;
+  if (!lightbox) return;
+
+  const iframe = lightbox.querySelector('.demo-lightbox-iframe') as HTMLIFrameElement;
+  let closedByPopstate = false;
+
+  document.querySelectorAll('.carousel-3d-card-link').forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const anchor = link as HTMLAnchorElement;
+      iframe.src = anchor.href;
+      iframe.title = link.querySelector('.carousel-3d-card-title')?.textContent || 'Demo preview';
+      lightbox.showModal();
+      history.pushState({ demoLightbox: true }, '');
+    });
+  });
+
+  lightbox.addEventListener('click', (e) => {
+    if (e.target === lightbox) lightbox.close();
+  });
+
+  lightbox.querySelector('.demo-lightbox-close')?.addEventListener('click', () => lightbox.close());
+
+  window.addEventListener('popstate', () => {
+    if (lightbox.open) {
+      closedByPopstate = true;
+      lightbox.close();
+    }
+  });
+
+  lightbox.addEventListener('close', () => {
+    iframe.src = '';
+    if (!closedByPopstate) history.back();
+    closedByPopstate = false;
+  });
+}
+
+initDemoLightbox();

--- a/examples/vercel-edge/api/index.ts
+++ b/examples/vercel-edge/api/index.ts
@@ -9,6 +9,7 @@ import {
   WEBMCP_STOREFRONT_FLOW,
   WEBMCP_CALENDAR_FLOW,
   WEBMCP_SLIDES_FLOW,
+  WEBMCP_DOCKED_FLOW,
   PAGE_CONTEXT_FLOW,
   createCheckoutSession,
 } from "@runtypelabs/persona-proxy";
@@ -97,6 +98,15 @@ const webmcpSlidesApp = createChatProxyApp({
   upstreamUrl,
 });
 
+// WebMCP docked-dashboard proxy - for the docked panel demo's Copilot.
+const webmcpDockedApp = createChatProxyApp({
+  path: "/api/chat/dispatch-docked",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_DOCKED || undefined,
+  flowConfig: process.env.FLOW_ID_DOCKED ? undefined : WEBMCP_DOCKED_FLOW,
+  upstreamUrl,
+});
+
 // Page-context proxy - read-only, markdown answers about the current page.
 const pageContextApp = createChatProxyApp({
   path: "/api/chat/dispatch-page-context",
@@ -114,6 +124,7 @@ app.route("/", storefrontApp);
 app.route("/", webmcpApp);
 app.route("/", webmcpCalendarApp);
 app.route("/", webmcpSlidesApp);
+app.route("/", webmcpDockedApp);
 app.route("/", pageContextApp);
 
 app.post("/api/checkout", async (c) => {

--- a/examples/vercel-edge/src/server.ts
+++ b/examples/vercel-edge/src/server.ts
@@ -11,6 +11,7 @@ import {
   WEBMCP_STOREFRONT_FLOW,
   WEBMCP_CALENDAR_FLOW,
   WEBMCP_SLIDES_FLOW,
+  WEBMCP_DOCKED_FLOW,
   PAGE_CONTEXT_FLOW,
   createCheckoutSession
 } from "@runtypelabs/persona-proxy";
@@ -124,6 +125,18 @@ const webmcpSlidesApp = createChatProxyApp({
   upstreamUrl
 });
 
+// WebMCP docked-dashboard proxy - for the docked panel demo. Same pattern as
+// the storefront/calendar: the page registers four workspace tools on
+// document.modelContext, the widget forwards them as clientTools[], and the
+// in-code WEBMCP_DOCKED_FLOW drives them — no hosted Runtype agent / client token.
+const webmcpDockedApp = createChatProxyApp({
+  path: "/api/chat/dispatch-docked",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_DOCKED || undefined,
+  flowConfig: process.env.FLOW_ID_DOCKED ? undefined : WEBMCP_DOCKED_FLOW,
+  upstreamUrl
+});
+
 // Page-context proxy - read-only, markdown answers about the current page.
 // Used by the smart-dom-reader demo: the widget sends live page context (including
 // shadow-DOM elements) as `inputs`, and this flow injects it via {{pageContext}}.
@@ -144,6 +157,7 @@ app.route("/", storefrontApp);
 app.route("/", webmcpApp);
 app.route("/", webmcpCalendarApp);
 app.route("/", webmcpSlidesApp);
+app.route("/", webmcpDockedApp);
 app.route("/", pageContextApp);
 
 // Stripe checkout endpoint

--- a/packages/proxy/src/flows/index.ts
+++ b/packages/proxy/src/flows/index.ts
@@ -14,4 +14,5 @@ export { STOREFRONT_ASSISTANT_FLOW } from "./storefront-assistant.js";
 export { WEBMCP_STOREFRONT_FLOW } from "./webmcp-storefront.js";
 export { WEBMCP_CALENDAR_FLOW } from "./webmcp-calendar.js";
 export { WEBMCP_SLIDES_FLOW } from "./webmcp-slides.js";
+export { WEBMCP_DOCKED_FLOW } from "./webmcp-docked.js";
 export { PAGE_CONTEXT_FLOW } from "./page-context.js";

--- a/packages/proxy/src/flows/webmcp-docked.ts
+++ b/packages/proxy/src/flows/webmcp-docked.ts
@@ -1,0 +1,53 @@
+import type { RuntypeFlowConfig } from "../index.js";
+
+/**
+ * WebMCP docked-dashboard flow for the docked panel demo
+ * (`examples/embedded-app/docked-panel-demo.html`).
+ *
+ * Like the other WebMCP flows, this agent owns **no** tools of its own. The
+ * demo page registers four workspace tools on `document.modelContext` via
+ * WebMCP (`get_workspace_overview`, `switch_section`, `set_dock_layout`,
+ * `log_activity`); the widget snapshots them every turn and the proxy
+ * forwards them on the dispatch payload as `clientTools[]`. The model calls
+ * them by name and the widget executes them **on the page**, posting results
+ * back via `/resume` — so the dashboard (and even the assistant's own dock
+ * placement) updates live.
+ */
+export const WEBMCP_DOCKED_FLOW: RuntypeFlowConfig = {
+  name: "WebMCP Docked Dashboard Flow",
+  description:
+    "Dashboard copilot — drives page-provided WebMCP workspace tools (clientTools[])",
+  steps: [
+    {
+      id: "webmcp_docked_prompt",
+      name: "WebMCP Docked Prompt",
+      type: "prompt",
+      enabled: true,
+      config: {
+        model: "nemotron-3-ultra-550b-a55b",
+        reasoning: false,
+        responseFormat: "markdown",
+        outputVariable: "prompt_result",
+        userPrompt: "{{user_message}}",
+        systemPrompt: `You are Copilot, a dashboard assistant docked beside an operations workspace. You help the user read what's on the dashboard, move around it, jot activity notes, and even reposition your own panel — the page updates live as your tools run.
+
+Voice: helpful, concise, plain language. Keep replies short — a sentence or two around the actions you take.
+
+## Your tools come from the page
+
+The dashboard exposes its own tools to you. Always **use the tools** to read or change the workspace — never invent metrics, cards, sections, or activity from memory.
+
+Rules:
+- Call **get_workspace_overview** before answering questions about the dashboard — it returns the sections, the active section, the highlight cards, and the recent-activity feed.
+- **switch_section** changes which workspace section is highlighted in the side nav. Use the exact section names from the overview.
+- **set_dock_layout** moves and resizes YOUR own panel (side left/right, width, reveal style, animation). When the user says "move yourself" or "dock on the left", this is the tool. Confirm what changed afterward.
+- **log_activity** appends an entry to the Recent activity feed. Use it when the user asks you to note, record, or log something. Keep titles short; put detail in the body.
+- After a mutation, confirm briefly what changed — the page renders the result, so don't repeat the full dashboard unless asked.
+- If a tool reports an error (unknown section, invalid width), relay it plainly and suggest a fix.
+
+After your tool calls resolve, summarize the outcome in plain language. Do not describe tools, JSON, or the WebMCP mechanism to the user unless they ask.`,
+        previousMessages: "{{messages}}"
+      }
+    }
+  ]
+};


### PR DESCRIPTION
## Summary

Restores the 3D card-stack hero for persona-chat.dev (recovered from local session snapshots — the original work was never committed) and applies a UX polish pass to the home page.

### Restored (commit 1)
- Split hero: glass info panel (left) + 3D card stack of live demo iframes (right), canted, auto-rotating every 4s with an "approach the camera" animation
- Keyboard ← / → paging, pause on hover, `prefers-reduced-motion` support
- Demo lightbox: clicking a card opens the full demo in a modal with esc/backdrop/history close

### UX polish (commit 2)
- **Top nav** — slim header with anchors (Live demo / Quick start / Demos / Theme editor) and a GitHub pill; collapses to brand + GitHub on mobile
- **Hero CTAs** — primary "Get started" (→ Quick Start) and "Try it live" (→ inline widget); previously the hero had no call to action
- **Carousel controls** — visible prev/next arrows and clickable progress dots, plus an aria-live status for screen readers; back cards are removed from tab order
- **Back-card click brings it to front** instead of opening the lightbox (the fanned edge reads as a "next card" affordance, not a link)
- **"Open demo ↗" hover affordance** on the front card
- **Performance** — only the front card iframe loads eagerly; the rest hydrate after `window` load; auto-advance pauses when the tab is hidden or the carousel is scrolled offscreen
- **Fixes** — arrow keys no longer page the carousel while typing in an input (e.g. the chat composer); headline wraps naturally instead of via hard `<br>`; meta description + OG tags added
- Mobile: nav/CTA sizing, hero top padding to clear the nav

### WebMCP demos in the stack (commit 3)
- Merged latest `main` (brings in the WebMCP storefront theme from #249 and the WebMCP calendar example from #251)
- The card stack now leads with **WebMCP Storefront** (eager-loaded front card) and **WebMCP Calendar**, followed by the existing six demos — 8 cards total. The carousel is fully DOM-driven, so dots, paging, and the screen-reader status pick up the new cards automatically.

Examples-only change — no changeset needed.

## Test plan
- Verified in Chrome at desktop and 414px widths: hero, nav anchors, CTAs, arrows, dots, back-card promote, lightbox open/close (esc), deferred iframe hydration, no console errors
- `tsc` on examples shows only pre-existing errors (none in touched files)
- `vite build` of `examples/embedded-app` passes with the two new cards

### Benefit-led home page (commit 5)
- **Hero** — feature pills rewritten as benefit statements ("Won't break your styles", "Agents that operate your page", …) and a copyable `npx @runtypelabs/cli@latest persona init` one-liner placed directly under the CTAs, so the install path is zero clicks from landing
- **New "Agentic" section** after Quick Start — tells the WebMCP story instead of just showing it: storefront + calendar demo cards and a real `registerTool` excerpt demonstrating that the page-tool registration *is* the whole integration
- **Demos section** — replaced the stale 4-item lower carousel (which predated and omitted the WebMCP demos) with a categorized featured grid of six demos (Agentic / Layout / Business / Voice tags) plus "Browse all examples" links; the Advanced CTA card is folded into this section and the unused `createDemoCarousel` wiring removed
- Docs assistant prompt now lists the WebMCP Calendar demo

### WebMCP-powered docked Copilot (commit 6)
- The Docked Panel demo's Copilot now drives the dashboard through four mocked WebMCP page tools: `get_workspace_overview` and `switch_section` (read-only, auto-approved), plus `set_dock_layout` and `log_activity` (approval bubble). `set_dock_layout` lets the assistant reposition **its own dock** ("move your panel to the left, 360px wide")
- Adds the tool-less `WEBMCP_DOCKED_FLOW` to `@runtypelabs/persona-proxy` and mounts `/api/chat/dispatch-docked` in both the dev server and the Vercel production entrypoint
- ⚠️ No longer examples-only: the proxy package gains a flow export, so a changeset (`@runtypelabs/persona-proxy` minor) is included
- All four tools verified in-browser through the strict `getTools()`/`executeTool()` surface the widget bridge uses; suggestion chips and welcome copy updated to walk the tool surface

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a minor `@runtypelabs/persona-proxy` export and new chat dispatch route; dock demo tools can mutate page UI (including dock layout) but only in the example app.
> 
> **Overview**
> Rebuilds the **persona-chat.dev** landing page around a split hero (glass panel + **3D demo card stack**), a slim **top nav**, CTAs and a copyable **`persona init`** line, plus a new **Agentic / WebMCP** section and a **featured demos** grid—replacing the old in-page `createDemoCarousel` with custom carousel logic in `main.ts` (auto-advance, dots/arrows, deferred iframes, back-card promote, modal **lightbox**).
> 
> The **Docked Panel** demo becomes a **WebMCP dashboard copilot**: four `document.modelContext` tools (overview, section switch, activity log, **`set_dock_layout`** for the assistant’s own dock), widget `webmcp` + `/api/chat/dispatch-docked`, and updated chips/copy.
> 
> **`@runtypelabs/persona-proxy`** adds **`WEBMCP_DOCKED_FLOW`** (exported, changeset **minor**) and wires **`/api/chat/dispatch-docked`** on the dev server and Vercel edge handler.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb58180b1a2c408dc30e2195d43353344448d8d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->