### PR TITLE
feat(widget): render agent-supplied approval reasons

### DIFF
--- a/.changeset/approval-reason.md
+++ b/.changeset/approval-reason.md
@@ -1,0 +1,5 @@
+---
+'@runtypelabs/persona': minor
+---
+
+Render agent-supplied approval reasons. When an `agent_approval_start` or `step_await` (approval) event carries the new `reason` field, the approval bubble shows an attributed "Agent's stated reason" line between the summary and the technical details. The reason is rendered as plain text (never markdown/HTML) and is explicitly attributed to the agent, since it is the agent's own claim about its intent. New `AgentWidgetApprovalConfig` options: `reasonColor`, `reasonLabel`; `formatDescription` now also receives `reason`.

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -20,13 +20,13 @@
   {
     "name": "⛔ CRITICAL · ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "140 kB",
+    "limit": "141 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "141 kB",
+    "limit": "142 kB",
     "gzip": true
   },
   {

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -3045,6 +3045,9 @@ export class AgentWidgetClient {
               toolName: payload.toolName ?? '',
               toolType: payload.toolType,
               description: payload.description ?? `Execute ${payload.toolName ?? 'tool'}`,
+              ...(typeof payload.reason === "string" && payload.reason
+                ? { reason: payload.reason }
+                : {}),
               parameters: payload.parameters,
             },
           };
@@ -3067,6 +3070,9 @@ export class AgentWidgetClient {
               toolName: payload.toolName ?? '',
               toolType: payload.toolType,
               description: payload.description ?? `Execute ${payload.toolName ?? 'tool'}`,
+              ...(typeof payload.reason === "string" && payload.reason
+                ? { reason: payload.reason }
+                : {}),
               parameters: payload.parameters,
             },
           };

--- a/packages/widget/src/components/approval-bubble.test.ts
+++ b/packages/widget/src/components/approval-bubble.test.ts
@@ -266,3 +266,55 @@ describe("updateApprovalDetailsUI", () => {
     expect(getToggle(bubble)?.textContent).toContain("Show details");
   });
 });
+
+describe("createApprovalBubble agent reason", () => {
+  it("renders the attributed reason line as plain text when present", () => {
+    const bubble = createApprovalBubble(
+      makeDetailedMessage({
+        reason: "Adds the <b>large</b> blue tee to your cart as you asked.",
+      })
+    );
+    const reasonLine = bubble.querySelector("[data-approval-reason]") as HTMLElement;
+    expect(reasonLine).not.toBeNull();
+    expect(reasonLine.textContent).toContain("Agent's stated reason:");
+    expect(reasonLine.textContent).toContain(
+      "Adds the <b>large</b> blue tee to your cart as you asked."
+    );
+    // Plain text rendering — markup in the agent-authored string must not
+    // become elements (prompt-injection surface).
+    expect(reasonLine.querySelector("b")).toBeNull();
+  });
+
+  it("omits the reason line when no reason is provided", () => {
+    const bubble = createApprovalBubble(makeDetailedMessage());
+    expect(bubble.querySelector("[data-approval-reason]")).toBeNull();
+  });
+
+  it("applies reasonColor and a custom reasonLabel from config", () => {
+    const config: AgentWidgetConfig = {
+      approval: { reasonColor: "rgb(1, 2, 3)", reasonLabel: "Why:" },
+    } as AgentWidgetConfig;
+    const bubble = createApprovalBubble(
+      makeDetailedMessage({ reason: "Because you asked." }),
+      config
+    );
+    const reasonLine = bubble.querySelector("[data-approval-reason]") as HTMLElement;
+    expect(reasonLine.style.color).toBe("rgb(1, 2, 3)");
+    expect(reasonLine.textContent).toContain("Why:");
+    expect(reasonLine.textContent).not.toContain("Agent's stated reason:");
+  });
+
+  it("passes the reason to formatDescription", () => {
+    let seenReason: string | undefined;
+    const config: AgentWidgetConfig = {
+      approval: {
+        formatDescription: (approval: { reason?: string }) => {
+          seenReason = approval.reason;
+          return undefined;
+        },
+      },
+    } as AgentWidgetConfig;
+    createApprovalBubble(makeDetailedMessage({ reason: "Because." }), config);
+    expect(seenReason).toBe("Because.");
+  });
+});

--- a/packages/widget/src/components/approval-bubble.ts
+++ b/packages/widget/src/components/approval-bubble.ts
@@ -257,6 +257,7 @@ export const createApprovalBubble = (
     description: approval.description,
     parameters: approval.parameters,
     ...(declaredTitle ? { displayTitle: declaredTitle } : {}),
+    ...(approval.reason ? { reason: approval.reason } : {}),
   });
   const summaryFallsBackToDescription = !approval.toolName;
   const summaryText =
@@ -272,6 +273,25 @@ export const createApprovalBubble = (
   }
   summary.textContent = summaryText;
   content.appendChild(summary);
+
+  // Agent-authored justification for this specific call. It is the agent's
+  // own claim about its intent (attacker-writable under prompt injection), so
+  // it is rendered as plain text via textContent — never markdown/HTML — and
+  // explicitly attributed to the agent rather than spoken in system voice.
+  if (approval.reason) {
+    const reasonLine = createElement("p", "persona-text-sm persona-mt-1 persona-text-persona-muted");
+    reasonLine.setAttribute("data-approval-reason", "true");
+    if (approvalConfig?.reasonColor) {
+      reasonLine.style.color = approvalConfig.reasonColor;
+    } else if (approvalConfig?.descriptionColor) {
+      reasonLine.style.color = approvalConfig.descriptionColor;
+    }
+    const reasonLabel = createElement("span", "persona-font-medium");
+    reasonLabel.textContent = `${approvalConfig?.reasonLabel ?? "Agent's stated reason:"} `;
+    reasonLine.appendChild(reasonLabel);
+    reasonLine.appendChild(document.createTextNode(approval.reason));
+    content.appendChild(reasonLine);
+  }
 
   // Technical details: agent-facing description + raw parameters JSON,
   // collapsed behind a toggle by default (`approval.detailsDisplay`).

--- a/packages/widget/src/theme-reference.ts
+++ b/packages/widget/src/theme-reference.ts
@@ -229,7 +229,7 @@ export const THEME_TOKEN_DOCS = {
       description:
         'Tool approval bubble styling and behavior. Set to false to disable.',
       properties:
-        'backgroundColor, borderColor, titleColor, descriptionColor, approveButtonColor, approveButtonTextColor, denyButtonColor, denyButtonTextColor, parameterBackgroundColor, parameterTextColor, title, approveLabel, denyLabel.',
+        'backgroundColor, borderColor, titleColor, descriptionColor, reasonColor, reasonLabel, approveButtonColor, approveButtonTextColor, denyButtonColor, denyButtonTextColor, parameterBackgroundColor, parameterTextColor, title, approveLabel, denyLabel.',
     },
     copy: {
       description: 'Widget text content.',

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -1900,6 +1900,16 @@ export type AgentWidgetApprovalConfig = {
   /** Label for the deny button */
   denyLabel?: string;
   /**
+   * Color for the agent-authored reason line (the agent's per-call
+   * justification, shown attributed below the summary when present).
+   */
+  reasonColor?: string;
+  /**
+   * Label prefix for the agent-authored reason line.
+   * Defaults to "Agent's stated reason:".
+   */
+  reasonLabel?: string;
+  /**
    * How the technical details (the tool's agent-facing description and the
    * raw parameters JSON) are presented:
    * - `"collapsed"` (default) — hidden behind a "Show details" toggle
@@ -1924,6 +1934,12 @@ export type AgentWidgetApprovalConfig = {
     description: string;
     parameters?: unknown;
     displayTitle?: string;
+    /**
+     * Agent-authored justification for this specific call, when the agent
+     * provided one. It is the agent's own claim — if you fold it into the
+     * summary, keep it attributed to the agent.
+     */
+    reason?: string;
   }) => string | undefined;
   /**
    * Custom handler for approval decisions.
@@ -3883,6 +3899,13 @@ export type AgentWidgetApproval = {
   toolName: string;
   toolType?: string;
   description: string;
+  /**
+   * Agent-authored justification for this specific call (the agent's own
+   * claim about its intent, extracted server-side from the reserved
+   * `_approvalReason` parameter). Render it attributed to the agent and as
+   * plain text — it is approver context, not a system statement.
+   */
+  reason?: string;
   parameters?: unknown;
   resolvedAt?: number;
 };


### PR DESCRIPTION
## Summary

Companion to runtypelabs/core#4026 (agent-supplied approval reasons). The Runtype API now injects a reserved `_approvalReason` parameter into approval-gated tool schemas so the agent can justify each call; the value is stripped before execution and carried as `reason` on `agent_approval_start` and `step_await` (approval) SSE events.

This PR renders that reason in the approval bubble:

- `AgentWidgetApproval.reason`, populated from both approval event paths in `client.ts`.
- The bubble shows an attributed **Agent's stated reason** line between the user-facing summary and the technical-details toggle.
- **Security framing**: the reason is the agent's own claim about its intent and is attacker-writable under prompt injection, so it is rendered via `textContent` only (no markdown/HTML/links), explicitly attributed to the agent (never system voice), and the tool name + parameters remain the primary content.
- New `AgentWidgetApprovalConfig` options: `reasonColor`, `reasonLabel`. `formatDescription` now also receives `reason`.
- `runtype-openapi-contract.ts` regenerated from the updated spec.

## Sequencing

`check:runtype-types` fetches the live spec from `api.runtype.com`, so that CI check stays red until core PR runtypelabs/core#4026 deploys to production. Merge after the core deploy.

## Test plan

- 4 new approval-bubble tests (reason renders as plain text + attributed label, omitted when absent, `reasonColor`/`reasonLabel` overrides, `formatDescription` receives `reason`).
- Full widget suite: 1117 tests pass; `tsc --noEmit` and `eslint` clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes human-in-the-loop approval UI and displays untrusted agent text; mitigated by plain-text rendering and explicit attribution, but approvers may over-trust the reason line.
> 
> **Overview**
> Adds support for **agent-supplied approval reasons** from SSE (`agent_approval_start` and approval `step_await`): `client.ts` copies a non-empty `payload.reason` onto `AgentWidgetApproval.reason`.
> 
> The approval bubble shows an attributed **Agent's stated reason** line between the summary and the technical-details toggle. The string is rendered with **`textContent` only** (no HTML/markdown) because it is agent-authored and prompt-injection writable.
> 
> New **`AgentWidgetApprovalConfig`** options: `reasonColor`, `reasonLabel`; **`formatDescription`** also receives `reason`. Types, theme reference, four unit tests, a minor changeset, and small gzip size-limit bumps are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52684e4f17646e33a95951c8f85c0551d935ad9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->