### PR TITLE
fix: mount dispatch-calendar route in Vercel production entrypoint

### DIFF
--- a/examples/vercel-edge/api/index.ts
+++ b/examples/vercel-edge/api/index.ts
@@ -7,6 +7,7 @@ import {
   BAKERY_ASSISTANT_FLOW,
   STOREFRONT_ASSISTANT_FLOW,
   WEBMCP_STOREFRONT_FLOW,
+  WEBMCP_CALENDAR_FLOW,
   createCheckoutSession,
 } from "@runtypelabs/persona-proxy";
 
@@ -76,12 +77,22 @@ const webmcpApp = createChatProxyApp({
   upstreamUrl,
 });
 
+// WebMCP calendar proxy - for the chrome-devtools-quickstart calendar copilot demo.
+const webmcpCalendarApp = createChatProxyApp({
+  path: "/api/chat/dispatch-calendar",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_CALENDAR || undefined,
+  flowConfig: process.env.FLOW_ID_CALENDAR ? undefined : WEBMCP_CALENDAR_FLOW,
+  upstreamUrl,
+});
+
 app.route("/", directiveApp);
 app.route("/", actionApp);
 app.route("/", componentApp);
 app.route("/", bakeryApp);
 app.route("/", storefrontApp);
 app.route("/", webmcpApp);
+app.route("/", webmcpCalendarApp);
 
 app.post("/api/checkout", async (c) => {
   const origin = c.req.header("origin");


### PR DESCRIPTION
## Summary

- Adds `WEBMCP_CALENDAR_FLOW` to the import in `examples/vercel-edge/api/index.ts`
- Creates `webmcpCalendarApp` at `/api/chat/dispatch-calendar` with the standard `FLOW_ID_CALENDAR` env-override pattern
- Mounts it alongside the other demo apps

## Why

The route was only present in `src/server.ts` (local dev entrypoint). The production Vercel deployment is served by `api/index.ts` via the `vercel.json` rewrite, which was missing the route — causing `POST /api/chat/dispatch-calendar` to return 404 in production.

The cloudflare-workers example is unchanged (it doesn't mount any per-demo WebMCP flows).

## Test plan

- [ ] `pnpm --filter vercel-edge dev` + `curl -X POST -H "Origin: http://localhost:5173" -H "Content-Type: application/json" -d '{}' http://localhost:<port>/api/chat/dispatch-calendar` → 401 (not 404)
- [ ] After deploy: `POST https://proxy.persona-chat.dev/api/chat/dispatch-calendar` → anything but 404

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing parity fix in the Vercel example; mirrors an existing local-dev pattern with no auth or data-model changes.
> 
> **Overview**
> **Mounts the WebMCP calendar chat proxy on the Vercel production entrypoint** so `POST /api/chat/dispatch-calendar` works in deployed environments, not only in local dev (`src/server.ts`).
> 
> The change imports `WEBMCP_CALENDAR_FLOW`, adds a `webmcpCalendarApp` via `createChatProxyApp` at `/api/chat/dispatch-calendar` (with the same `FLOW_ID_CALENDAR` env override pattern as other demos), and routes it on the main Hono app alongside the existing WebMCP storefront proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7101ad3ce352a0e3610842d212bee5ba952dafd5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->