### PR TITLE
fix(widget): preserve approval context across agent_approval_complete

### DIFF
--- a/.changeset/approval-complete-preserves-context.md
+++ b/.changeset/approval-complete-preserves-context.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Preserve approval context (tool name, description, tool type, agent-stated reason, parameters) when `agent_approval_complete` resolves an approval bubble. The complete event only carries the decision, so the session now merges it field-wise into the existing approval instead of replacing it — resolved bubbles no longer lose their context on a full re-render.

--- a/packages/widget/src/session.test.ts
+++ b/packages/widget/src/session.test.ts
@@ -894,6 +894,68 @@ describe('AgentWidgetSession.resolveApproval', () => {
   });
 });
 
+describe('AgentWidgetSession - approval context across agent_approval_complete', () => {
+  const sseStream = (events: Array<Record<string, unknown>>): ReadableStream<Uint8Array> => {
+    const encoder = new TextEncoder();
+    const body = events
+      .map((e) => `event: ${e.type}\ndata: ${JSON.stringify(e)}\n\n`)
+      .join('');
+    return new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(body));
+        controller.close();
+      },
+    });
+  };
+
+  it('keeps toolName/description/toolType/reason/parameters when the sparse complete event resolves the bubble', async () => {
+    let messages: AgentWidgetMessage[] = [];
+    const session = new AgentWidgetSession(
+      { apiUrl: 'http://localhost:8000' },
+      {
+        onMessagesChanged: (m) => { messages = m; },
+        onStatusChanged: () => {},
+        onStreamingChanged: () => {},
+        onError: () => {},
+      }
+    );
+
+    // `agent_approval_complete` carries only the resolution — none of the
+    // context fields from `agent_approval_start`. The session merge must keep
+    // them so a full re-render of the resolved bubble (morph, virtual-scroll
+    // re-mount, storage restore) still shows the tool, description, and the
+    // agent's stated reason.
+    await session.connectStream(sseStream([
+      {
+        type: 'agent_approval_start',
+        executionId: 'exec_abc',
+        approvalId: 'appr_1',
+        toolName: 'send_email',
+        toolType: 'external',
+        description: 'Send an email to the customer',
+        reason: 'The user asked me to notify the customer.',
+        parameters: { to: 'customer@example.com' },
+      },
+      {
+        type: 'agent_approval_complete',
+        executionId: 'exec_abc',
+        approvalId: 'appr_1',
+        decision: 'approved',
+        resolvedBy: 'user',
+      },
+    ]));
+
+    const bubble = messages.find((m) => m.id === 'approval-appr_1');
+    expect(bubble?.approval?.status).toBe('approved');
+    expect(bubble?.approval?.resolvedAt).toBeDefined();
+    expect(bubble?.approval?.toolName).toBe('send_email');
+    expect(bubble?.approval?.toolType).toBe('external');
+    expect(bubble?.approval?.description).toBe('Send an email to the customer');
+    expect(bubble?.approval?.reason).toBe('The user asked me to notify the customer.');
+    expect(bubble?.approval?.parameters).toEqual({ to: 'customer@example.com' });
+  });
+});
+
 describe('AgentWidgetSession - dispatch error fallback', () => {
   const originalFetch = global.fetch;
 

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -2659,6 +2659,33 @@ export class AgentWidgetSession {
           awaitingLocalTool: false,
         };
       }
+      // Approval equivalent: `agent_approval_complete` carries only the
+      // resolution (approvalId, decision, resolvedBy) — the runtime does not
+      // re-send toolName/description/toolType/reason/parameters, so client.ts
+      // rebuilds the approval with empty required fields and the optional
+      // ones absent. A wholesale `approval` replacement would wipe that
+      // context from the resolved bubble on the next full re-render (morph,
+      // virtual-scroll re-mount, storage restore). Merge field-wise instead:
+      // take the resolution from the incoming event, keep existing context
+      // wherever the event is silent or empty.
+      if (
+        existing.approval &&
+        withSequence.approval &&
+        existing.approval.id === withSequence.approval.id
+      ) {
+        const prior = existing.approval;
+        const incoming = withSequence.approval;
+        merged.approval = {
+          ...prior,
+          ...incoming,
+          executionId: incoming.executionId || prior.executionId,
+          toolName: incoming.toolName || prior.toolName,
+          description: incoming.description || prior.description,
+          toolType: incoming.toolType ?? prior.toolType,
+          reason: incoming.reason ?? prior.reason,
+          parameters: incoming.parameters ?? prior.parameters,
+        };
+      }
       // WebMCP equivalent: once a `webmcp:*` tool has started resolving
       // (inflight) or resolved, a duplicate `step_await` re-emit must not
       // flip `awaitingLocalTool` back to true and resurrect the "waiting on


### PR DESCRIPTION
## Summary

Fixes the BugBot finding on #250 (posted just after merge): `agent_approval_complete` carries only the resolution (`approvalId`, `decision`, `resolvedBy`) — none of the context from `agent_approval_start`. The client rebuilds the approval object with empty required fields and the optional ones absent, and `session.upsertMessage`'s top-level merge replaced the whole `approval` object, wiping `toolName`, `description`, `toolType`, **`reason`**, and `parameters` from the resolved bubble. The loss shows up on any full re-render (idiomorph morph, virtual-scroll re-mount, storage restore).

## Fix

`upsertMessage` now merges approvals field-wise (same pattern as the existing ask-user-question and WebMCP preservation blocks): the incoming event wins for the resolution fields, existing context is kept wherever the event is silent or empty.

## Testing

- New regression test drives the real SSE pipeline via `session.connectStream` (`agent_approval_start` with reason/parameters → sparse `agent_approval_complete`) and asserts all context fields survive with `status: approved`.
- Verified the test fails without the fix (`expected '' to be 'send_email'`).
- Full suite: 1129/1129 passing, tsc clean, lint clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized merge logic in `upsertMessage` with a targeted regression test; no auth or API contract changes.
> 
> **Overview**
> Fixes resolved **approval bubbles** losing display context after `agent_approval_complete`. That SSE event only carries resolution fields (`decision`, `resolvedBy`, etc.), while `upsertMessage` used to replace the whole `approval` object—wiping `toolName`, `description`, `toolType`, `reason`, and `parameters` from `agent_approval_start` on morph, virtual-scroll remount, or storage restore.
> 
> **`AgentWidgetSession.upsertMessage`** now **field-wise merges** approvals with the same `id` (same pattern as ask-user-question / WebMCP): incoming resolution wins; prior context is kept when the event is silent or empty.
> 
> A **regression test** drives `agent_approval_start` → sparse `agent_approval_complete` through `connectStream` and asserts all context survives with `status: approved`. A **changeset** documents the `@runtypelabs/persona` patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81ba40a7d1ac2614a521babc15fc9281a989c900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->