### PR TITLE
docs: fix stale flat-theme guidance across README, llms.txt, and demo assistant prompt

### DIFF
--- a/.changeset/fix-stale-theme-docs.md
+++ b/.changeset/fix-stale-theme-docs.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix outdated theming guidance in the README: all `theme` examples now use the v2 token tree (`semantic.colors.*`) instead of the removed flat v1 shape, the config reference no longer claims flat themes are migrated at runtime, the `copy` option row lists all current keys, and the Theme Configurator link points at this repository.

--- a/examples/embedded-app/llms.txt
+++ b/examples/embedded-app/llms.txt
@@ -47,7 +47,7 @@ const chat = initAgentWidget({
   config: {
     apiUrl: '/api/chat/dispatch',
     launcher: { enabled: true, title: 'AI Assistant' },
-    theme: { accent: '#2563eb' },
+    theme: { semantic: { colors: { accent: '#2563eb' } } },
     postprocessMessage: ({ text }) => markdownPostprocessor(text),
   },
 });

--- a/examples/embedded-app/src/main.ts
+++ b/examples/embedded-app/src/main.ts
@@ -161,6 +161,30 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Artifact Sidebar](/artifact-demo.html) — multi-pane interface with a resizable artifact panel
 - [Fullscreen Assistant](/fullscreen-assistant-demo.html) — dark full-viewport split layout (chat + artifacts)
 - [Voice Integration](/voice-integration-demo.html) — voice input powered by ElevenLabs
+- [Custom Components](/custom-components.html) — render your own interactive components inside assistant messages
+- [Layout Configuration](/layout-config-demo.html) — tweak panel sizing, spacing, and layout options
+- [Stream Animations](/stream-animations-demo.html) — customize how streamed text animates in
+- [Persistent Composer](/persistent-composer.html) — always-visible composer bar layout
+- [WebMCP Storefront](/webmcp-demo.html) — expose page tools to the agent via WebMCP
+
+## Customization
+
+When a user asks what they can customize, cover these areas (all set via the config object passed to \`initAgentWidget\` / \`createAgentExperience\`):
+
+- **Theme** — \`theme\` accepts a token tree with three layers: \`palette\` (raw color scales, spacing, typography, shadows, radii), \`semantic\` (intent tokens like \`colors.primary\`, \`colors.surface\` that reference palette values), and \`components\` (per-component tokens like \`launcher.size\`, \`panel.borderRadius\`). Simplest override:
+  \`\`\`js
+  theme: { palette: { colors: { primary: { 500: '#7c3aed', 600: '#6d28d9' } } } }
+  \`\`\`
+  IMPORTANT: the old flat v1 shape (\`theme: { primary, accent, surface, ... }\`) was removed and is NOT supported — always show the token tree. A \`createTheme()\` helper with plugins (e.g. \`brandPlugin\`, \`accessibilityPlugin\`) is also exported. Point users at the [Theme Editor](/theme.html) demo and the THEME-CONFIG.md reference in the repo.
+- **Dark mode** — \`darkTheme\` (token overrides merged over \`theme\` when dark) and \`colorScheme: 'light' | 'dark' | 'auto'\` (auto detects the \`dark\` class on \`<html>\`, then \`prefers-color-scheme\`).
+- **Copy** — \`copy: { welcomeTitle, welcomeSubtitle, inputPlaceholder, sendButtonLabel, stopButtonLabel, showWelcomeCard, stopReasonNotice }\`.
+- **Launcher & layout** — \`launcher\` config (floating launcher vs inline embed via \`enabled: false\`, width, fullHeight), docked panel mode, artifact sidebar.
+- **Suggestion chips** — \`suggestionChips: [...]\` for starter prompts, plus \`suggestionChipsConfig\` for behavior/appearance.
+- **Composer & buttons** — \`sendButton\`, \`statusIndicator\` (idle text/link/alignment), \`autoFocusInput\`.
+- **Message rendering** — \`postprocessMessage\` hook to transform rendered HTML (e.g. add copy buttons to code blocks), built-in \`markdownPostprocessor\`, custom components inside messages, \`sanitize\` option (\`true\` by default, \`false\`, or a custom \`(html) => string\` function).
+- **Tool & reasoning UI** — \`toolCall\`, \`reasoning\`, and \`approval\` configs for how tool calls, thinking, and approval bubbles render.
+- **Voice & speech** — \`voiceRecognition\` (browser or ElevenLabs-powered providers) and \`textToSpeech\` (Web Speech API: voice, rate, pitch).
+- **Plugins** — a plugin registry for custom functionality beyond config options.
 
 ## Setting Up Persona With an AI Coding Agent
 
@@ -197,7 +221,8 @@ Add the Persona chat widget (@runtypelabs/persona) to this project.
    - requestMiddleware(context) — transform the outgoing request payload (messages, metadata) before it's sent.
 
 5. Customize appearance:
-   - theme: { primary, accent, surface, container, muted } to match site colors
+   - theme: a token tree, e.g. theme: { palette: { colors: { primary: { 500: '#7c3aed', 600: '#6d28d9' } } } } to match site colors (the flat { primary, accent, ... } shape is not supported)
+   - colorScheme: 'light' | 'dark' | 'auto', with optional darkTheme token overrides
    - copy: { welcomeTitle, welcomeSubtitle, inputPlaceholder }
    - suggestionChips: ['Question 1', 'Question 2'] for starter prompts
 

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -38,8 +38,7 @@ createAgentExperience(inlineHost, {
   apiUrl: proxyUrl,
   launcher: { enabled: false },
   theme: {
-    ...DEFAULT_WIDGET_CONFIG.theme,
-    accent: '#2563eb'
+    semantic: { colors: { accent: '#2563eb' } }
   },
   suggestionChips: ['What can you do?', 'Show API docs'],
   postprocessMessage: ({ text }) => markdownPostprocessor(text)
@@ -62,7 +61,9 @@ const controller = initAgentWidget({
 
 // Runtime theme update
 document.querySelector('#dark-mode')?.addEventListener('click', () => {
-  controller.update({ theme: { surface: '#0f172a', primary: '#f8fafc' } });
+  controller.update({
+    theme: { semantic: { colors: { surface: '#0f172a', primary: '#f8fafc' } } }
+  });
 });
 
 // Docked panel that wraps a concrete workspace container
@@ -1562,8 +1563,9 @@ The easiest way is to use the automatic installer script. It handles loading CSS
         subtitle: 'How can I help you?'
       },
       theme: {
-        accent: '#2563eb',
-        surface: '#ffffff'
+        semantic: {
+          colors: { accent: '#2563eb', surface: '#ffffff' }
+        }
       },
       // Optional: configure stream parser for JSON/XML responses
       // streamParser: () => window.AgentWidget.createJsonStreamParser()
@@ -1689,8 +1691,9 @@ For more control, manually load CSS and JavaScript:
         subtitle: 'Here to help'
       },
       theme: {
-        accent: '#111827',
-        surface: '#f5f5f5'
+        semantic: {
+          colors: { accent: '#111827', surface: '#f5f5f5' }
+        }
       },
       // Optional: configure stream parser for JSON/XML responses
       streamParser: window.AgentWidget.createJsonStreamParser // or createXmlParser, createPlainTextParser
@@ -1760,8 +1763,9 @@ export function ChatWidget() {
       config: {
         apiUrl: "/api/chat/dispatch",
         theme: {
-          primary: "#111827",
-          accent: "#1d4ed8",
+          semantic: {
+            colors: { primary: "#111827", accent: "#1d4ed8" }
+          }
         },
         launcher: {
           enabled: true,
@@ -1951,7 +1955,7 @@ import { ChatWidget } from './ChatWidget.tsx';
 
 #### Using the Theme Configurator
 
-For easy configuration generation, use the [Theme Configurator](https://github.com/becomevocal/chaty/tree/main/examples/embedded-app) which includes a "React (Client Component)" export option. It generates a complete React component with your custom theme, launcher settings, and all configuration options.
+For easy configuration generation, use the [Theme Editor demo](https://github.com/runtypelabs/persona/tree/main/examples/embedded-app) (`theme.html` in the embedded-app example) which includes a "React (Client Component)" export option. It generates a complete React component with your custom theme, launcher settings, and all configuration options.
 
 #### Installation
 
@@ -1985,8 +1989,7 @@ const controller = initAgentWidget({
     ...DEFAULT_WIDGET_CONFIG,
     apiUrl: '/api/chat/dispatch',
     theme: {
-      ...DEFAULT_WIDGET_CONFIG.theme,
-      accent: '#custom-color'  // Override only what you need
+      semantic: { colors: { accent: '#2563eb' } }  // Override only what you need
     }
   }
 });
@@ -1996,7 +1999,7 @@ const controller = initAgentWidget({
   target: '#app',
   config: mergeWithDefaults({
     apiUrl: '/api/chat/dispatch',
-    theme: { accent: '#custom-color' }
+    theme: { semantic: { colors: { accent: '#2563eb' } } }
   })
 });
 ```
@@ -2110,10 +2113,10 @@ config: {
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `theme` | `DeepPartial<PersonaTheme>` | Semantic tokens (`palette`, `semantic`, `components`). See [THEME-CONFIG.md](./THEME-CONFIG.md). Flat v1-style objects are still accepted at runtime (with a console warning) and migrated internally. |
+| `theme` | `DeepPartial<PersonaTheme>` | Semantic tokens (`palette`, `semantic`, `components`). See [THEME-CONFIG.md](./THEME-CONFIG.md). The flat v1 shape (`{ primary, accent, surface, ... }`) is **not** supported — there is no runtime migration; port themes to the token tree. |
 | `darkTheme` | `DeepPartial<PersonaTheme>` | Dark-mode token overrides, merged over `theme` when the active scheme is dark. |
 | `colorScheme` | `'light' \| 'dark' \| 'auto'` | Color scheme mode. `'auto'` detects from `<html class="dark">` or `prefers-color-scheme`. Default: `'light'`. |
-| `copy` | `{ welcomeTitle?, welcomeSubtitle?, inputPlaceholder?, sendButtonLabel? }` | Customize user-facing text strings. |
+| `copy` | `{ welcomeTitle?, welcomeSubtitle?, inputPlaceholder?, sendButtonLabel?, stopButtonLabel?, showWelcomeCard?, stopReasonNotice? }` | Customize user-facing text strings, hide the welcome card, or override per-stop-reason notices. |
 | `autoFocusInput` | `boolean` | Focus the chat input after the panel opens. Skips when voice is active. Default: `false`. |
 | `launcherWidth` | `string` | CSS width for the floating launcher panel (e.g. `'320px'`). Default: `'min(440px, calc(100vw - 24px))'`. |
 


### PR DESCRIPTION
## Summary

The flat v1 theme shape (`theme: { primary, accent, surface, ... }`) was removed with no runtime migration (per THEME-CONFIG.md), but several doc surfaces still taught it:

- **`packages/widget/README.md`** — all seven `theme:` examples used the flat shape; now use the v2 token tree (`semantic.colors.*`). The `...DEFAULT_WIDGET_CONFIG.theme` spreads were dropped too (`DEFAULT_WIDGET_CONFIG.theme` is `undefined`; user themes deep-merge over library defaults internally).
- **Config reference ("UI & Theme")** — removed the false claim that flat v1 themes are "accepted at runtime (with a console warning) and migrated internally" — no such code exists in `theme.ts`/`tokens.ts`. Also expanded the `copy` row to list all current keys (`stopButtonLabel`, `showWelcomeCard`, `stopReasonNotice`).
- **Theme Configurator link** — pointed at the pre-rename `becomevocal/chaty` repo; now points here.
- **`examples/embedded-app/llms.txt`** — quick-start snippet used a flat theme. (This also fixes the generated `llms-full.txt`, which concatenates llms.txt + the widget README + THEME-CONFIG.md.)
- **Home page assistant prompt (`examples/embedded-app/src/main.ts`)** — the docs assistant's system prompt told users to theme via flat keys; it now teaches the token tree, gains a dedicated Customization section (theme/dark mode/copy/launcher/chips/rendering/tool UI/voice/plugins, verified against `types.ts`), and lists newer demos (Custom Components, Layout Configuration, Stream Animations, Persistent Composer, WebMCP Storefront).

Includes a patch changeset so the corrected README ships to npm.

## Test plan

- `grep` confirms no flat `theme: {` examples remain in README/llms.txt
- Verified raw hex values pass through `resolveTokenValue()` (values not starting with `palette.`/`semantic.`/`components.` are returned verbatim), so `semantic: { colors: { accent: '#2563eb' } }` is valid
- Docs-only change; no source code touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and changeset only; no runtime or API code changes.
> 
> **Overview**
> Documentation-only fix so Persona theming guidance matches **v2** (`palette` / `semantic` / `components`) after flat v1 `theme: { primary, accent, surface, ... }` was removed with **no** runtime migration.
> 
> **`packages/widget/README.md`** — All `theme` snippets and `controller.update` examples now use `semantic.colors.*`; misleading `...DEFAULT_WIDGET_CONFIG.theme` spreads are dropped. The config table states flat v1 is unsupported, expands the `copy` option keys, and the Theme Configurator link targets this repo’s embedded-app Theme Editor (`theme.html`).
> 
> **`examples/embedded-app/llms.txt`** — Quick-start `theme` uses the token tree (feeds generated `llms-full.txt`).
> 
> **`examples/embedded-app/src/main.ts`** — The home docs assistant prompt adds a **Customization** section (theme, dark mode, copy, launcher, chips, rendering, tool UI, voice, plugins), lists newer demos, and replaces flat-theme instructions in the AI-agent setup template with token-tree + `colorScheme` guidance.
> 
> Patch **changeset** so the corrected README ships on the next npm release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f023f575fca2b99323a3f41213241945b906c77f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->