### PR TITLE
perf(widget): bundle size quick wins — tree-shake package.json, defer WebMCP polyfill

### DIFF
--- a/.changeset/bundle-size-quick-wins.md
+++ b/.changeset/bundle-size-quick-wins.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Reduce bundle sizes: stop inlining the full package.json into every bundle (a named JSON import tree-shakes it down to the version field, ~1.4 kB gzip off each bundle), and stop shipping the WebMCP polyfill inside the CDN bundle (~10 kB gzip off index.global.js). The polyfill now builds as a standalone lazy chunk (`dist/webmcp-polyfill.js`) that the IIFE bundle imports on demand — only when `config.webmcp.enabled` is true and the page has no `document.modelContext` yet — from a URL derived from the widget script's own `src`. npm/bundler consumers are unaffected (their bundlers keep resolving the bare dynamic import). Self-hosted deployments that rename `index.global.js` and rely on Persona to install the polyfill should install `@mcp-b/webmcp-polyfill` on the page themselves. Size budgets ratcheted down accordingly (CDN 180→161 kB, ESM 141→140 kB, CJS 142→141 kB) with a new 11 kB budget for the chunk.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -167,6 +167,7 @@ The widget builds to multiple formats via tsup:
 - `dist/index.global.js` - IIFE (for script tag / CDN usage)
 - `dist/install.global.js` - IIFE installer bootstrap (reads `window.siteAgentConfig`; the script-tag entry point)
 - `dist/launcher.global.js` - IIFE critical launcher bundle (deferred-loading fast path; see "Deferred Launcher Loading")
+- `dist/webmcp-polyfill.js` - Self-contained ESM chunk with `@mcp-b/webmcp-polyfill`; lazy-imported by the IIFE bundle (which marks the polyfill external) only when `config.webmcp.enabled` is true and the page has no `document.modelContext`. URL is derived from the widget script's `src` by the loader registered in `index-global.ts`.
 - `dist/index.d.ts` - TypeScript declarations
 - `dist/widget.css` - Prefixed Tailwind CSS (for consumers who import styles separately)
 

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "⛔ CRITICAL · CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "180 kB",
+    "limit": "161 kB",
     "gzip": true
   },
   {
@@ -20,13 +20,13 @@
   {
     "name": "⛔ CRITICAL · ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "141 kB",
+    "limit": "140 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "142 kB",
+    "limit": "141 kB",
     "gzip": true
   },
   {
@@ -57,6 +57,12 @@
     "name": "Opt-in · plugin-kit subpath (plugin-kit.js)",
     "path": "dist/plugin-kit.js",
     "limit": "2 kB",
+    "gzip": true
+  },
+  {
+    "name": "Lazy · WebMCP polyfill chunk (webmcp-polyfill.js)",
+    "path": "dist/webmcp-polyfill.js",
+    "limit": "11 kB",
     "gzip": true
   }
 ]

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -59,7 +59,7 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && pnpm run build:styles && pnpm run build:client && pnpm run build:installer && pnpm run build:launcher && pnpm run build:theme-ref && pnpm run build:codegen && pnpm run build:theme-editor && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:plugin-kit && pnpm run build:animations",
+    "build": "rimraf dist && pnpm run build:styles && pnpm run build:client && pnpm run build:installer && pnpm run build:launcher && pnpm run build:webmcp-polyfill && pnpm run build:theme-ref && pnpm run build:codegen && pnpm run build:theme-editor && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:plugin-kit && pnpm run build:animations",
     "build:plugin-kit": "tsup src/plugin-kit.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:theme-editor": "tsup src/theme-editor.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:testing": "tsup src/testing.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
@@ -68,7 +68,8 @@
     "build:theme-ref": "tsup src/theme-reference.ts --format esm,cjs --minify --dts",
     "build:codegen": "tsup src/codegen.ts --format esm,cjs --minify --dts",
     "build:styles": "node -e \"const fs=require('fs');fs.mkdirSync('dist',{recursive:true});fs.copyFileSync('src/styles/widget.css','dist/widget.css');\"",
-    "build:client": "tsup src/index.ts --format esm,cjs --minify --sourcemap --splitting false --dts --loader \".css=text\" && tsup src/index-global.ts --format iife --global-name AgentWidget --minify --sourcemap --splitting false --out-dir dist --loader \".css=text\" && node -e \"const fs=require('fs');for(const ext of ['.global.js','.global.js.map']){const from='dist/index-global'+ext;if(fs.existsSync(from))fs.renameSync(from,'dist/index'+ext);}\"",
+    "build:client": "tsup src/index.ts --format esm,cjs --minify --sourcemap --splitting false --dts --loader \".css=text\" && tsup --config tsup.global.config.ts && node -e \"const fs=require('fs');for(const ext of ['.global.js','.global.js.map']){const from='dist/index-global'+ext;if(fs.existsSync(from))fs.renameSync(from,'dist/index'+ext);}\"",
+    "build:webmcp-polyfill": "tsup --config tsup.webmcp-polyfill.config.ts",
     "build:installer": "tsup src/install.ts --format iife --global-name SiteAgentInstaller --out-dir dist --minify --sourcemap --no-splitting",
     "build:launcher": "tsup src/launcher-global.ts --format iife --global-name AgentWidgetLauncher --minify --sourcemap --splitting false --out-dir dist && node -e \"const fs=require('fs');for(const ext of ['.global.js','.global.js.map']){const from='dist/launcher-global'+ext;if(fs.existsSync(from))fs.renameSync(from,'dist/launcher'+ext);}\"",
     "lint": "eslint . --ext .ts",

--- a/packages/widget/src/index-global.ts
+++ b/packages/widget/src/index-global.ts
@@ -31,3 +31,42 @@ export {
   listRegisteredStreamAnimations,
 } from "./utils/stream-animation";
 export type { StreamAnimationPlugin, StreamAnimationContext } from "./types";
+
+// ---------------------------------------------------------------------------
+// Deferred WebMCP polyfill loading.
+//
+// This bundle is built with `@mcp-b/webmcp-polyfill` external — the bridge's
+// default `import("@mcp-b/webmcp-polyfill")` is a bare specifier no browser
+// can resolve, so register a loader that imports the self-contained
+// `webmcp-polyfill.js` chunk from a sibling URL instead. Mirrors how
+// `install.ts` derives `launcher.global.js` from a `jsUrl` override.
+// ---------------------------------------------------------------------------
+
+import { setWebMcpPolyfillLoader } from "./webmcp-bridge";
+
+// Capture at module-evaluation time — `document.currentScript` is null once
+// execution leaves the script's initial synchronous run.
+const widgetScriptSrc: string | null =
+  typeof document !== "undefined"
+    ? ((document.currentScript as HTMLScriptElement | null)?.src ?? null)
+    : null;
+
+setWebMcpPolyfillLoader(() => {
+  const chunkUrl = widgetScriptSrc?.replace(
+    /index\.global\.js($|\?)/,
+    "webmcp-polyfill.js$1",
+  );
+  if (!chunkUrl || chunkUrl === widgetScriptSrc) {
+    return Promise.reject(
+      new Error(
+        "Could not derive the webmcp-polyfill.js URL from the widget script URL " +
+          `(${widgetScriptSrc ?? "unavailable"}). Self-hosted deployments that ` +
+          "rename index.global.js should install @mcp-b/webmcp-polyfill on the " +
+          "page themselves before enabling config.webmcp.",
+      ),
+    );
+  }
+  // Runtime-only dynamic import; the specifier is a computed URL, so esbuild
+  // leaves it untouched (and must not try to bundle it).
+  return import(/* @vite-ignore */ chunkUrl);
+});

--- a/packages/widget/src/version.ts
+++ b/packages/widget/src/version.ts
@@ -1,7 +1,10 @@
-import packageJson from "../package.json";
+// Named import (not default) so esbuild tree-shakes the JSON module down to
+// the one field we read — a default import inlines the entire package.json
+// (~4.8 kB minified) into every bundle.
+import { version } from "../package.json";
 
 /**
  * The current version of the @runtypelabs/persona package.
  * This is automatically derived from package.json.
  */
-export const VERSION = packageJson.version;
+export const VERSION = version;

--- a/packages/widget/src/webmcp-bridge.test.ts
+++ b/packages/widget/src/webmcp-bridge.test.ts
@@ -31,6 +31,7 @@ import {
   isWebMcpToolName,
   stripWebMcpPrefix,
   computeClientToolsFingerprint,
+  setWebMcpPolyfillLoader,
 } from "./webmcp-bridge";
 import type { ClientToolDefinition } from "./types";
 
@@ -114,6 +115,9 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  // The loader is module-global (page-global in production); reset so a test
+  // that registers one can't leak into the default-import tests.
+  setWebMcpPolyfillLoader(null);
 });
 
 describe("stripWebMcpPrefix", () => {
@@ -150,6 +154,9 @@ describe("WebMcpBridge.snapshotForDispatch", () => {
   });
 
   it("returns empty when initializeWebMCPPolyfill() throws", async () => {
+    // No pre-existing modelContext — otherwise install() short-circuits
+    // before importing the polyfill and the throwing init never runs.
+    vi.stubGlobal("document", {});
     polyfillMock.initThrows = true;
     const bridge = new WebMcpBridge({ enabled: true });
     expect(await bridge.snapshotForDispatch()).toEqual([]);
@@ -201,6 +208,59 @@ describe("WebMcpBridge.snapshotForDispatch", () => {
       "foo",
       "bar",
     ]);
+  });
+});
+
+describe("setWebMcpPolyfillLoader", () => {
+  it("uses the registered loader instead of the bare import when no modelContext exists", async () => {
+    // Start with no modelContext so install() actually loads the polyfill;
+    // the loader's init then installs the registry, like the real one would.
+    const doc: { modelContext?: ReturnType<typeof makeModelContext> } = {};
+    vi.stubGlobal("document", doc);
+    registry.tools = [fakeTool({ name: "search" })];
+    const loader = vi.fn(async () => ({
+      initializeWebMCPPolyfill: () => {
+        doc.modelContext = makeModelContext();
+      },
+    }));
+    setWebMcpPolyfillLoader(loader);
+
+    const bridge = new WebMcpBridge({ enabled: true });
+    const snap = await bridge.snapshotForDispatch();
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(snap.map((t) => t.name)).toEqual(["search"]);
+    expect(bridge.isOperational()).toBe(true);
+  });
+
+  it("disables WebMCP (with a warning) when the loader rejects", async () => {
+    vi.stubGlobal("document", {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    setWebMcpPolyfillLoader(() => Promise.reject(new Error("chunk 404")));
+
+    const bridge = new WebMcpBridge({ enabled: true });
+    expect(await bridge.snapshotForDispatch()).toEqual([]);
+    expect(bridge.isOperational()).toBe(false);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to load @mcp-b/webmcp-polyfill"),
+      expect.any(Error),
+    );
+    warn.mockRestore();
+  });
+
+  it("never invokes the loader when a compatible modelContext is already present", async () => {
+    // beforeEach stubs a compatible document.modelContext — the install
+    // short-circuit must win, so a failing loader is irrelevant.
+    registry.tools = [fakeTool({ name: "search" })];
+    const loader = vi.fn(() => Promise.reject(new Error("should not load")));
+    setWebMcpPolyfillLoader(loader);
+
+    const bridge = new WebMcpBridge({ enabled: true });
+    const snap = await bridge.snapshotForDispatch();
+
+    expect(loader).not.toHaveBeenCalled();
+    expect(snap.map((t) => t.name)).toEqual(["search"]);
+    expect(bridge.isOperational()).toBe(true);
   });
 });
 

--- a/packages/widget/src/webmcp-bridge.ts
+++ b/packages/widget/src/webmcp-bridge.ts
@@ -131,6 +131,28 @@ const log = {
   },
 };
 
+/** The slice of `@mcp-b/webmcp-polyfill` the bridge consumes on install. */
+export type WebMcpPolyfillModule = {
+  initializeWebMCPPolyfill: () => void;
+};
+
+/**
+ * Override how the polyfill module is obtained. By default the bridge does
+ * `import("@mcp-b/webmcp-polyfill")`, which bundlers resolve for npm
+ * consumers. The IIFE/CDN build can't resolve a bare specifier at runtime, so
+ * its entry (`index-global.ts`) registers a loader that imports the
+ * self-contained `webmcp-polyfill.js` chunk from a URL derived from the
+ * widget script's own `src`. Page-global, like `document.modelContext`
+ * itself. Pass `null` to restore the default (used by tests).
+ */
+let polyfillLoader: (() => Promise<WebMcpPolyfillModule>) | null = null;
+
+export const setWebMcpPolyfillLoader = (
+  loader: (() => Promise<WebMcpPolyfillModule>) | null,
+): void => {
+  polyfillLoader = loader;
+};
+
 /**
  * Compute a stable, order-independent fingerprint of a `ClientToolDefinition[]`
  * snapshot, for the diff-only / send-once dispatch path (client-token mode).
@@ -449,7 +471,18 @@ export class WebMcpBridge {
 
   private async install(): Promise<void> {
     try {
-      const mod = await import("@mcp-b/webmcp-polyfill");
+      // A compatible registry is already on the page (the host installed the
+      // polyfill, or a native impl) — initialize would no-op against it, so
+      // skip loading the module entirely. Pages that register tools before
+      // Persona's first dispatch always land here, because registering
+      // requires `document.modelContext` to exist.
+      if (this.getModelContext()) {
+        this.installed = true;
+        return;
+      }
+      const mod = polyfillLoader
+        ? await polyfillLoader()
+        : await import("@mcp-b/webmcp-polyfill");
       // Idempotent: no-ops if `document.modelContext` already exists (native or
       // a prior install by the host page).
       mod.initializeWebMCPPolyfill();

--- a/packages/widget/src/webmcp-polyfill.ts
+++ b/packages/widget/src/webmcp-polyfill.ts
@@ -1,0 +1,16 @@
+/**
+ * Standalone WebMCP polyfill chunk (`dist/webmcp-polyfill.js`).
+ *
+ * The IIFE/CDN widget bundle marks `@mcp-b/webmcp-polyfill` external so the
+ * ~35 kB (minified) polyfill + its transitive `@cfworker/json-schema` never
+ * ship to consumers who don't enable WebMCP. When `config.webmcp.enabled` is
+ * true and no `document.modelContext` exists yet, the bridge dynamically
+ * imports this chunk from a URL derived from the widget script's own `src`
+ * (see the loader registered in `index-global.ts`).
+ *
+ * Built self-contained (`--no-external`) — it must work standalone on a CDN
+ * with no module resolution. npm/bundler consumers never load this file;
+ * their bundlers resolve the bare `import("@mcp-b/webmcp-polyfill")` in
+ * `webmcp-bridge.ts` directly.
+ */
+export { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";

--- a/packages/widget/tsup.global.config.ts
+++ b/packages/widget/tsup.global.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig } from "tsup";
+
+/**
+ * Config for the IIFE/CDN widget bundle (`dist/index.global.js`, built from
+ * `src/index-global.ts` then renamed by the `build:client` script).
+ *
+ * Lives in a config file rather than CLI flags because of the external
+ * `@mcp-b/webmcp-polyfill`: tsup never applies its `external` option to IIFE
+ * builds (its external plugin is gated on `format !== "iife"`), so the
+ * exclusion must go through esbuild's native `external` list via
+ * `esbuildOptions`. Named distinctly so the other CLI-driven build scripts
+ * don't auto-load it the way they would a `tsup.config.ts`.
+ */
+export default defineConfig({
+  entry: ["src/index-global.ts"],
+  format: ["iife"],
+  globalName: "AgentWidget",
+  minify: true,
+  sourcemap: true,
+  splitting: false,
+  outDir: "dist",
+  loader: { ".css": "text" },
+  esbuildOptions(options) {
+    // Keep the WebMCP polyfill (and its ~22 kB transitive
+    // @cfworker/json-schema) out of the CDN bundle. esbuild leaves the
+    // bridge's bare `import("@mcp-b/webmcp-polyfill")` in place as a runtime
+    // dynamic import; it is never invoked in this bundle because
+    // `index-global.ts` registers a loader that imports the standalone
+    // `webmcp-polyfill.js` chunk instead.
+    options.external = [...(options.external ?? []), "@mcp-b/webmcp-polyfill"];
+  },
+});

--- a/packages/widget/tsup.webmcp-polyfill.config.ts
+++ b/packages/widget/tsup.webmcp-polyfill.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "tsup";
+
+/**
+ * Dedicated config for the standalone WebMCP polyfill chunk
+ * (`dist/webmcp-polyfill.js`). Lives in its own file (loaded via
+ * `--config`) because:
+ *   - the chunk must bundle its dependencies (`noExternal`), and tsup's CLI
+ *     has no `--no-external` flag;
+ *   - a file named `tsup.config.ts` would be auto-loaded by every other
+ *     CLI-driven build script in package.json.
+ *
+ * See `src/webmcp-polyfill.ts` for why this chunk exists.
+ */
+export default defineConfig({
+  entry: ["src/webmcp-polyfill.ts"],
+  format: ["esm"],
+  minify: true,
+  splitting: false,
+  outDir: "dist",
+  // Self-contained: inline @mcp-b/webmcp-polyfill and its transitive deps so
+  // the file works standalone from a CDN with no module resolution.
+  noExternal: [/.*/],
+});


### PR DESCRIPTION
## Summary

We've been bumping the size budgets 1 kB at a time as features land. This PR claws back ~10.6 kB gzip on the CDN bundle and ~1.4 kB gzip on the npm bundles via two changes identified from esbuild metafile analysis, and ratchets the budgets down to lock the savings in.

### 1. Tree-shake `package.json` out of every bundle

`src/version.ts` used a default import of `package.json`, which inlines the **entire file** (~4.8 kB minified — keywords, scripts, dependency lists) into every bundle just to read `.version`. A named import (`import { version }`) lets esbuild tree-shake the JSON module down to the one field. Verified: 4.8 kB → 35 bytes.

### 2. Defer the WebMCP polyfill out of the CDN bundle

`webmcp-bridge.ts` already dynamic-imports `@mcp-b/webmcp-polyfill` with the intent of keeping it out of the main bundle — but tsup **never applies `external` to IIFE builds** (its external plugin is gated on `format !== "iife"`, see `tsup/dist/index.js:506`), so the polyfill plus its transitive `@cfworker/json-schema` (~35 kB minified combined) shipped to every CDN consumer, including the vast majority who never enable WebMCP.

Now:
- The IIFE build moves from CLI flags to `tsup.global.config.ts`, which sets esbuild's **native** `external` list (esbuild handles external dynamic imports in IIFE correctly).
- The polyfill builds as a self-contained lazy ESM chunk, `dist/webmcp-polyfill.js` (10 kB gzip), published alongside the other dist files (R2 + jsdelivr/unpkg pick it up automatically since both ship the whole `dist/`).
- `index-global.ts` registers a loader that imports the chunk from a URL derived from the widget script's own `src` (same derivation pattern `install.ts` uses for `launcher.global.js`). It runs only when `config.webmcp.enabled` is true **and** the page has no `document.modelContext` yet.
- The bridge short-circuits when a compatible `document.modelContext` already exists — initialize would no-op against it anyway, so pages that install the polyfill themselves never fetch the chunk.
- npm/bundler consumers are unaffected: the bare `import("@mcp-b/webmcp-polyfill")` stays in the ESM/CJS builds and their bundler resolves it as before.

**Behavior note:** a self-hosted deployment that (a) renames `index.global.js`, (b) enables `config.webmcp`, and (c) relies on Persona to install the polyfill before the page registers tools will now get a console warning telling it to install the polyfill itself. Pages that register tools before Persona's first dispatch are unaffected (registering requires `document.modelContext`, which triggers the short-circuit).

## Results (size-limit, gzip)

| Bundle | Before | After | Budget |
|---|---|---|---|
| `index.global.js` (CDN) | 169.9 kB | **159.3 kB** | 180 → **161 kB** |
| `index.js` (ESM) | 140.0 kB | **138.6 kB** | 141 → **140 kB** |
| `index.cjs` | 141.0 kB | **139.3 kB** | 142 → **141 kB** |
| `webmcp-polyfill.js` (lazy, new) | — | 10.0 kB | **11 kB** (new) |

## Testing

- 70 test files / 1131 tests pass, including three new tests covering the loader override, loader rejection (WebMCP disabled with a warning), and the already-present-modelContext short-circuit.
- `pnpm build`, `pnpm lint`, `tsc --noEmit`, and `pnpm size` all green.
- Verified in the built output: the polyfill and `@cfworker/json-schema` are absent from `index.global.js`, the runtime `import()` of the derived chunk URL survives minification, and the chunk exports `initializeWebMCPPolyfill`.

## Not in this PR

The other findings from the analysis (dropping `code-generators`/`demo-carousel` from the npm barrel — breaking; splitting the 8,000-line `ui.ts`) need API-deprecation decisions and are left for follow-ups.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CDN WebMCP loading and self-hosted URL derivation edge cases; core npm bundler path is unchanged but WebMCP enablement behavior on custom script URLs needs verification.
> 
> **Overview**
> Shrinks widget bundles by **tree-shaking `package.json`** in `version.ts` (named `version` import instead of default) and by **removing the WebMCP polyfill from the CDN IIFE**.
> 
> The IIFE build now uses `tsup.global.config.ts` with esbuild `external` for `@mcp-b/webmcp-polyfill`, adds `dist/webmcp-polyfill.js` as a self-contained lazy ESM chunk, and registers `setWebMcpPolyfillLoader` in `index-global.ts` to load it from a URL derived from `index.global.js` (same pattern as `launcher.global.js` in `install.ts`). `WebMcpBridge` skips polyfill import when `document.modelContext` already exists; npm ESM/CJS still use the bare dynamic import.
> 
> **size-limit** budgets are tightened (CDN 180→161 kB, ESM/CJS −1 kB) and a new 11 kB budget covers the polyfill chunk. Tests cover loader override, rejection, and the modelContext short-circuit.
> 
> **Note for self-hosters:** renamed `index.global.js` + WebMCP enabled without pre-installed polyfill now fails with a clear error unless they load `@mcp-b/webmcp-polyfill` themselves.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c28faf19c20161d5f690fd2fc8c593e0de318e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->