### PR TITLE
feat(examples): WebMCP slide-deck editor demo (Deck Copilot)

### DIFF
--- a/.changeset/webmcp-slides-flow.md
+++ b/.changeset/webmcp-slides-flow.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": minor
+---
+
+Add WEBMCP_SLIDES_FLOW — a Deck Copilot flow for the new slide-deck editor WebMCP demo (`examples/embedded-app/webmcp-slides.html`). Like the other WebMCP flows it owns no tools of its own; the system prompt teaches the model to work with the page's dynamic tool set (selection-scoped tools, presenter-mode swap) and the live `{{slides_context}}` editor state.

--- a/examples/embedded-app/README.md
+++ b/examples/embedded-app/README.md
@@ -157,6 +157,18 @@ To run against your own Runtype flow instead of the in-code definition, set `FLO
 
 > **Note on parallel local tool calls.** "Add SHOE-001 and SHOE-007 at the same time" makes the model emit *parallel* local tool calls in one turn, which depends on **runtypelabs/core#3878** / **#3870** being deployed upstream; single-tool turns work regardless.
 
+### WebMCP Slide-Deck Editor (Deck Copilot)
+- **Slides page**: `http://localhost:5173/webmcp-slides.html` (proxy mode — agent defined in code as `WEBMCP_SLIDES_FLOW`, mounted at `/api/chat/dispatch-slides`)
+  - A Keynote-lite editor (960×540 canvas, slide sorter, themes, presenter mode) where the human and the Persona agent **co-edit the same live canvas** — the richest WebMCP surface in the repo (~20 tools vs. the calendar's ten)
+  - `src/webmcp-slides/tools.ts` registers the tools on `document.modelContext`, and the tool set is **dynamic** — the demo's headline trick:
+    - `style_selection` / `align_selection` exist only while the user has **2+ elements selected** (AbortController re-registration, debounced)
+    - `enter_presenter_mode` **replaces the entire editing set** with show controls (`next_slide`, `prev_slide`, `jump_to_slide`, `exit_presenter_mode`) until the show ends
+  - **Selection as context**: a `contextProviders` + `requestMiddleware` pair ships the live editor state (current slide, mode, selected element ids + bounds) as `{{slides_context}}` with every message — so *"align these"* works without the user describing anything
+  - **Shared undo stack**: agent tools and human gestures commit through the same store, so ⌘Z undoes the agent's edits too
+  - Approval policy by blast radius: reads *and* incremental writes auto-approve (watch the agent assemble a slide live, with an outline pulse on everything it touches); only destructive/deck-wide tools (`delete_slide`, `delete_elements`, `apply_theme`) raise the native approval bubble with friendly copy
+  - Theme tokens (`theme.accent`, `theme.heading`, …) resolve at render time, which is what makes `apply_theme` restyle the whole deck in one call
+  - Try: *"What's in this deck?"* → *"Add a slide about pricing with three tiers"* → drag a box out of place, shift-select two others, *"align these and match their styles"* → *"Apply the Midnight theme"* (approval) → ⌘Z → *"Present the deck"*
+
 ### Custom Components Demo
 - **Components page**: `http://localhost:5173/custom-components.html`
   - Demonstrates custom component rendering from JSON directives

--- a/examples/embedded-app/src/webmcp-slides/canvas.ts
+++ b/examples/embedded-app/src/webmcp-slides/canvas.ts
@@ -1,0 +1,375 @@
+import type { DeckStore } from "./store";
+import type { SlideElement } from "./types";
+import { SLIDE_H, SLIDE_W, clamp } from "./types";
+import { getTheme } from "./themes";
+import { renderSlide } from "./render";
+
+// Editor canvas: renders the current slide at a fixed 960x540 logical size,
+// scaled to fit the available space with a CSS transform, and layers an
+// interaction overlay (selection outlines + resize handles) on top of the
+// pure-rendered slide. Drags and resizes mutate the DOM directly for live
+// feedback and commit ONCE at pointerup — one gesture, one undo step.
+
+type ResizeDir = "nw" | "n" | "ne" | "e" | "se" | "s" | "sw" | "w";
+const RESIZE_DIRS: ResizeDir[] = ["nw", "n", "ne", "e", "se", "s", "sw", "w"];
+const MIN_SIZE = 12;
+const TEXT_TYPES = new Set(["text"]);
+
+export type Canvas = {
+  rerender: () => void;
+};
+
+export const createCanvas = (
+  store: DeckStore,
+  container: HTMLElement,
+): Canvas => {
+  container.classList.add("wm-canvas");
+  const viewport = document.createElement("div");
+  viewport.className = "wm-canvas-viewport";
+  const wrap = document.createElement("div");
+  wrap.className = "wm-stage-wrap";
+  wrap.style.width = `${SLIDE_W}px`;
+  wrap.style.height = `${SLIDE_H}px`;
+  const overlay = document.createElement("div");
+  overlay.className = "wm-overlay";
+  viewport.appendChild(wrap);
+  container.appendChild(viewport);
+
+  let scale = 1;
+  let slideNode: HTMLElement | null = null;
+  let editing: { id: string; node: HTMLElement; original: string } | null = null;
+
+  const fit = (): void => {
+    const rect = container.getBoundingClientRect();
+    const pad = 32;
+    scale = Math.max(
+      0.05,
+      Math.min((rect.width - pad) / SLIDE_W, (rect.height - pad) / SLIDE_H),
+    );
+    viewport.style.width = `${SLIDE_W * scale}px`;
+    viewport.style.height = `${SLIDE_H * scale}px`;
+    wrap.style.transform = `scale(${scale})`;
+  };
+  new ResizeObserver(fit).observe(container);
+
+  const elementNode = (id: string): HTMLElement | null =>
+    wrap.querySelector<HTMLElement>(`[data-element-id="${id}"]`);
+
+  // ---- selection overlay -------------------------------------------------
+
+  const renderOverlay = (): void => {
+    overlay.innerHTML = "";
+    const selected = store.selectedElements();
+    for (const el of selected) {
+      const box = document.createElement("div");
+      box.className = "wm-selection-box";
+      box.style.left = `${el.x}px`;
+      box.style.top = `${el.y}px`;
+      box.style.width = `${el.w}px`;
+      box.style.height = `${el.h}px`;
+      if (el.rotation) box.style.transform = `rotate(${el.rotation}deg)`;
+      // Resize handles only on a single selection — multi-select gets
+      // outlines, and group operations belong to align/style tools.
+      if (selected.length === 1) {
+        for (const dir of RESIZE_DIRS) {
+          const handle = document.createElement("div");
+          handle.className = `wm-handle wm-handle-${dir}`;
+          handle.dataset.dir = dir;
+          handle.dataset.elementId = el.id;
+          box.appendChild(handle);
+        }
+      }
+      overlay.appendChild(box);
+    }
+  };
+
+  // ---- rendering ---------------------------------------------------------
+
+  const render = (): void => {
+    if (editing) return; // modal text session — re-render on commit/cancel
+    const theme = getTheme(store.deck.themeId);
+    const fresh = renderSlide(store.currentSlide, theme);
+    if (slideNode) slideNode.remove();
+    slideNode = fresh;
+    wrap.insertBefore(fresh, wrap.firstChild);
+    if (!overlay.isConnected) wrap.appendChild(overlay);
+    renderOverlay();
+  };
+
+  // ---- inline text editing (modal session, single commit on exit) ---------
+
+  const endEdit = (save: boolean): void => {
+    if (!editing) return;
+    const { id, node, original } = editing;
+    const nextText = node.innerText.replace(/\n+$/, "");
+    node.contentEditable = "false";
+    editing = null;
+    if (save && nextText !== original) {
+      store.commit((deck) => {
+        for (const slide of deck.slides) {
+          const el = slide.elements.find((e) => e.id === id);
+          if (el) el.text = nextText;
+        }
+      });
+    } else {
+      render();
+    }
+  };
+
+  const beginEdit = (id: string): void => {
+    const el = store.currentSlide.elements.find((e) => e.id === id);
+    const node = elementNode(id);
+    if (!el || !node || !TEXT_TYPES.has(el.type)) return;
+    editing = { id, node, original: el.text ?? "" };
+    overlay.innerHTML = "";
+    try {
+      node.contentEditable = "plaintext-only";
+    } catch {
+      node.contentEditable = "true"; // Firefox: no plaintext-only support
+    }
+    node.classList.add("wm-editing");
+    node.focus();
+    const range = document.createRange();
+    range.selectNodeContents(node);
+    window.getSelection()?.removeAllRanges();
+    window.getSelection()?.addRange(range);
+    const onBlur = (): void => endEdit(true);
+    node.addEventListener("blur", onBlur, { once: true });
+    node.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        node.removeEventListener("blur", onBlur);
+        endEdit(false);
+      }
+      event.stopPropagation();
+    });
+  };
+
+  // ---- drag to move / resize ----------------------------------------------
+
+  type DragState =
+    | {
+        kind: "move";
+        startX: number;
+        startY: number;
+        items: { id: string; node: HTMLElement; x: number; y: number }[];
+        moved: boolean;
+      }
+    | {
+        kind: "resize";
+        startX: number;
+        startY: number;
+        dir: ResizeDir;
+        id: string;
+        node: HTMLElement;
+        start: { x: number; y: number; w: number; h: number };
+        moved: boolean;
+      };
+
+  let drag: DragState | null = null;
+
+  const applyResize = (
+    state: Extract<DragState, { kind: "resize" }>,
+    dx: number,
+    dy: number,
+  ): { x: number; y: number; w: number; h: number } => {
+    let { x, y, w, h } = state.start;
+    const { dir } = state;
+    if (dir.includes("e")) w = Math.max(MIN_SIZE, state.start.w + dx);
+    if (dir.includes("s")) h = Math.max(MIN_SIZE, state.start.h + dy);
+    if (dir.includes("w")) {
+      w = Math.max(MIN_SIZE, state.start.w - dx);
+      x = state.start.x + (state.start.w - w);
+    }
+    if (dir.includes("n")) {
+      h = Math.max(MIN_SIZE, state.start.h - dy);
+      y = state.start.y + (state.start.h - h);
+    }
+    return { x, y, w, h };
+  };
+
+  wrap.addEventListener("pointerdown", (event) => {
+    if (editing || store.mode !== "edit") return;
+    const target = event.target as HTMLElement;
+
+    const handle = target.closest<HTMLElement>(".wm-handle");
+    if (handle) {
+      const id = handle.dataset.elementId ?? "";
+      const el = store.currentSlide.elements.find((e) => e.id === id);
+      const node = elementNode(id);
+      if (!el || !node) return;
+      drag = {
+        kind: "resize",
+        startX: event.clientX,
+        startY: event.clientY,
+        dir: handle.dataset.dir as ResizeDir,
+        id,
+        node,
+        start: { x: el.x, y: el.y, w: el.w, h: el.h },
+        moved: false,
+      };
+      wrap.setPointerCapture(event.pointerId);
+      event.preventDefault();
+      return;
+    }
+
+    const elNode = target.closest<HTMLElement>("[data-element-id]");
+    if (!elNode) {
+      store.setSelection([]);
+      return;
+    }
+    const id = elNode.dataset.elementId ?? "";
+    if (event.shiftKey) {
+      store.toggleSelected(id);
+      return;
+    }
+    if (!store.selection.has(id)) store.setSelection([id]);
+
+    drag = {
+      kind: "move",
+      startX: event.clientX,
+      startY: event.clientY,
+      items: store.selectedElements().flatMap((el) => {
+        const node = elementNode(el.id);
+        return node ? [{ id: el.id, node, x: el.x, y: el.y }] : [];
+      }),
+      moved: false,
+    };
+    wrap.setPointerCapture(event.pointerId);
+    event.preventDefault();
+  });
+
+  wrap.addEventListener("pointermove", (event) => {
+    if (!drag) return;
+    const dx = (event.clientX - drag.startX) / scale;
+    const dy = (event.clientY - drag.startY) / scale;
+    if (Math.abs(dx) + Math.abs(dy) > 1) drag.moved = true;
+    overlay.innerHTML = ""; // hide stale selection chrome during the gesture
+    if (drag.kind === "move") {
+      for (const item of drag.items) {
+        item.node.style.left = `${item.x + dx}px`;
+        item.node.style.top = `${item.y + dy}px`;
+      }
+    } else {
+      const next = applyResize(drag, dx, dy);
+      drag.node.style.left = `${next.x}px`;
+      drag.node.style.top = `${next.y}px`;
+      drag.node.style.width = `${next.w}px`;
+      drag.node.style.height = `${next.h}px`;
+    }
+  });
+
+  const finishDrag = (event: PointerEvent): void => {
+    if (!drag) return;
+    const state = drag;
+    drag = null;
+    if (!state.moved) {
+      renderOverlay();
+      return;
+    }
+    const dx = (event.clientX - state.startX) / scale;
+    const dy = (event.clientY - state.startY) / scale;
+    store.commit((deck) => {
+      const slide = deck.slides[store.currentSlideIndex];
+      if (state.kind === "move") {
+        for (const item of state.items) {
+          const el = slide.elements.find((e) => e.id === item.id);
+          if (!el) continue;
+          el.x = Math.round(clamp(item.x + dx, -el.w + 8, SLIDE_W - 8));
+          el.y = Math.round(clamp(item.y + dy, -el.h + 8, SLIDE_H - 8));
+        }
+      } else {
+        const el = slide.elements.find((e) => e.id === state.id);
+        if (!el) return;
+        const next = applyResize(state, dx, dy);
+        el.x = Math.round(next.x);
+        el.y = Math.round(next.y);
+        el.w = Math.round(next.w);
+        el.h = Math.round(next.h);
+      }
+    });
+  };
+
+  wrap.addEventListener("pointerup", finishDrag);
+  wrap.addEventListener("pointercancel", finishDrag);
+
+  wrap.addEventListener("dblclick", (event) => {
+    if (store.mode !== "edit") return;
+    const elNode = (event.target as HTMLElement).closest<HTMLElement>(
+      "[data-element-id]",
+    );
+    if (elNode?.dataset.elementId) beginEdit(elNode.dataset.elementId);
+  });
+
+  // ---- keyboard -----------------------------------------------------------
+
+  const isTypingTarget = (target: EventTarget | null): boolean => {
+    const el = target as HTMLElement | null;
+    if (!el) return false;
+    if (el.isContentEditable) return true;
+    const tag = el.tagName?.toLowerCase();
+    return tag === "input" || tag === "textarea" || tag === "select";
+  };
+
+  document.addEventListener("keydown", (event) => {
+    if (store.mode !== "edit" || editing || isTypingTarget(event.target)) return;
+
+    const meta = event.metaKey || event.ctrlKey;
+    if (meta && event.key.toLowerCase() === "z") {
+      event.preventDefault();
+      if (event.shiftKey) store.redo();
+      else store.undo();
+      return;
+    }
+
+    if (
+      (event.key === "Delete" || event.key === "Backspace") &&
+      store.selection.size > 0
+    ) {
+      event.preventDefault();
+      const ids = new Set(store.selection);
+      store.commit((deck) => {
+        const slide = deck.slides[store.currentSlideIndex];
+        slide.elements = slide.elements.filter((el) => !ids.has(el.id));
+      });
+      return;
+    }
+
+    const nudge: Record<string, [number, number]> = {
+      ArrowLeft: [-1, 0],
+      ArrowRight: [1, 0],
+      ArrowUp: [0, -1],
+      ArrowDown: [0, 1],
+    };
+    if (nudge[event.key] && store.selection.size > 0) {
+      event.preventDefault();
+      const [dx, dy] = nudge[event.key];
+      const step = event.shiftKey ? 10 : 1;
+      const ids = new Set(store.selection);
+      store.commit((deck) => {
+        const slide = deck.slides[store.currentSlideIndex];
+        for (const el of slide.elements) {
+          if (!ids.has(el.id)) continue;
+          el.x += dx * step;
+          el.y += dy * step;
+        }
+      });
+    }
+  });
+
+  store.subscribe(render);
+  fit();
+  render();
+
+  return { rerender: render };
+};
+
+/** Live geometry for one element, used by get_selection / context provider. */
+export const elementBounds = (
+  el: SlideElement,
+): { x: number; y: number; w: number; h: number } => ({
+  x: el.x,
+  y: el.y,
+  w: el.w,
+  h: el.h,
+});

--- a/examples/embedded-app/src/webmcp-slides/main.ts
+++ b/examples/embedded-app/src/webmcp-slides/main.ts
@@ -1,0 +1,325 @@
+// WebMCP slide-deck editor ("Deckmate") — a Keynote-lite editor where the
+// embedded Persona widget and the human co-edit the same live canvas through
+// the page's WebMCP tools. See tools.ts for the tool surface (static editing
+// set, selection-scoped dynamic set, presenter-mode swap).
+import "@runtypelabs/persona/widget.css";
+import "./slides.css";
+
+import {
+  DEFAULT_WIDGET_CONFIG,
+  createLocalStorageAdapter,
+  initAgentWidget,
+  markdownPostprocessor,
+} from "@runtypelabs/persona";
+// `@mcp-b/webmcp-polyfill` polyfills the strict standard surface on
+// `document.modelContext`; it must be initialized before tools register.
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+
+import { DeckStore, createSeedDeck } from "./store";
+import { THEMES, getTheme } from "./themes";
+import { createCanvas } from "./canvas";
+import { createSorter } from "./sorter";
+import { createPresenter } from "./presenter";
+import {
+  APPROVAL_REQUIRED_TOOL_NAMES,
+  setupSlidesTools,
+} from "./tools";
+
+initializeWebMCPPolyfill();
+
+const store = new DeckStore(createSeedDeck);
+
+// ---- editor chrome --------------------------------------------------------
+
+const canvasHost = document.querySelector<HTMLElement>("#slides-canvas");
+const sorterHost = document.querySelector<HTMLElement>("#slides-sorter");
+const titleInput = document.querySelector<HTMLInputElement>("#deck-title");
+const themeSelect = document.querySelector<HTMLSelectElement>("#theme-select");
+const undoButton = document.querySelector<HTMLButtonElement>("#undo-button");
+const redoButton = document.querySelector<HTMLButtonElement>("#redo-button");
+const presentButton = document.querySelector<HTMLButtonElement>("#present-button");
+const resetButton = document.querySelector<HTMLButtonElement>("#reset-button");
+
+if (!canvasHost || !sorterHost) {
+  throw new Error("[Slides] Missing editor mount points in webmcp-slides.html");
+}
+
+createCanvas(store, canvasHost);
+createSorter(store, sorterHost);
+createPresenter(store);
+
+if (themeSelect) {
+  for (const theme of THEMES) {
+    const option = document.createElement("option");
+    option.value = theme.id;
+    option.textContent = theme.name;
+    themeSelect.appendChild(option);
+  }
+  themeSelect.addEventListener("change", () => {
+    store.commit((deck) => {
+      deck.themeId = themeSelect.value;
+    });
+  });
+}
+
+titleInput?.addEventListener("change", () => {
+  const title = titleInput.value.trim();
+  if (!title) return;
+  store.commit((deck) => {
+    deck.title = title;
+  });
+});
+
+undoButton?.addEventListener("click", () => store.undo());
+redoButton?.addEventListener("click", () => store.redo());
+presentButton?.addEventListener("click", () => {
+  store.setCurrentSlide(0);
+  store.setMode("present");
+});
+resetButton?.addEventListener("click", () => store.resetDeck(createSeedDeck));
+
+const syncChrome = (): void => {
+  if (titleInput && document.activeElement !== titleInput) {
+    titleInput.value = store.deck.title;
+  }
+  if (themeSelect && document.activeElement !== themeSelect) {
+    themeSelect.value = store.deck.themeId;
+  }
+  if (undoButton) undoButton.disabled = !store.canUndo;
+  if (redoButton) redoButton.disabled = !store.canRedo;
+  document.title = `${store.deck.title} — WebMCP Slides`;
+};
+store.subscribe(syncChrome);
+syncChrome();
+
+// ---- WebMCP tools ----------------------------------------------------------
+
+setupSlidesTools(store);
+
+// ---- Persona widget --------------------------------------------------------
+
+// Proxy mode, like the other example demos — the agent is defined in code as
+// WEBMCP_SLIDES_FLOW (packages/proxy/src/flows/webmcp-slides.ts) and the local
+// proxy mounts it at /api/chat/dispatch-slides (see
+// examples/vercel-edge/src/server.ts). No hosted agent or client token needed.
+const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+const proxyApiUrl = import.meta.env.VITE_PROXY_URL
+  ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-slides`
+  : `http://localhost:${proxyPort}/api/chat/dispatch-slides`;
+
+// User-facing summary copy for tool approval bubbles. Returning undefined
+// falls back to Persona's humanized default ("The assistant wants to use …").
+const describeSlidesApproval = ({
+  toolName,
+  parameters,
+}: {
+  toolName?: string;
+  parameters?: unknown;
+}): string | undefined => {
+  const params = (
+    parameters && typeof parameters === "object" ? parameters : {}
+  ) as Record<string, unknown>;
+  const name = String(toolName ?? "").replace(/^webmcp[:_]/, "");
+
+  switch (name) {
+    case "delete_slide": {
+      const slide =
+        typeof params.slideId === "string"
+          ? store.findSlide(params.slideId)
+          : typeof params.position === "number"
+            ? store.deck.slides[params.position - 1]
+            : undefined;
+      return slide
+        ? `Delete slide ${store.deck.slides.indexOf(slide) + 1} (“${slide.title ?? "Untitled"}”)? This can be undone with ⌘Z.`
+        : "Delete this slide? This can be undone with ⌘Z.";
+    }
+    case "delete_elements": {
+      const count = Array.isArray(params.elementIds)
+        ? params.elementIds.length
+        : 0;
+      return count
+        ? `Delete ${count} element${count === 1 ? "" : "s"} from the deck?`
+        : "Delete the selected elements?";
+    }
+    case "apply_theme": {
+      const theme =
+        typeof params.themeId === "string" ? getTheme(params.themeId) : null;
+      return theme
+        ? `Apply the ${theme.name} theme to all ${store.deck.slides.length} slides?`
+        : "Restyle the whole deck with a new theme?";
+    }
+    default:
+      return undefined;
+  }
+};
+
+const deckmateTheme = {
+  semantic: {
+    colors: {
+      primary: "#1f2933",
+      accent: "#c2410c",
+      surface: "#ffffff",
+      background: "#ffffff",
+      container: "#f8f7f4",
+      text: "#1f2933",
+      textMuted: "#6b7280",
+      textInverse: "#ffffff",
+      border: "#e7e5e0",
+      divider: "#e7e5e0",
+    },
+  },
+  components: {
+    panel: { borderRadius: "0", border: "none", shadow: "none" },
+    header: {
+      borderRadius: "0",
+      background: "#ffffff",
+      titleForeground: "#1f2933",
+      subtitleForeground: "#6b7280",
+      iconBackground: "#c2410c",
+      iconForeground: "#ffffff",
+      borderBottom: "1px solid #e7e5e0",
+    },
+    message: {
+      user: {
+        background: "#1f2933",
+        text: "#ffffff",
+        borderRadius: "16px",
+        shadow: "none",
+      },
+      assistant: {
+        background: "#f8f7f4",
+        text: "#1f2933",
+        border: "#e7e5e0",
+        borderRadius: "16px",
+        shadow: "none",
+      },
+    },
+    approval: {
+      approve: {
+        background: "#1f2933",
+        foreground: "#ffffff",
+        border: "#1f2933",
+        borderRadius: "999px",
+      },
+      deny: {
+        background: "#ffffff",
+        foreground: "#b91c1c",
+        border: "#e7e5e0",
+        borderRadius: "999px",
+      },
+    },
+    toolBubble: { shadow: "none" },
+  },
+};
+
+const dockTarget = document.querySelector<HTMLElement>("#editor-dock-target");
+
+if (dockTarget) {
+  const widget = initAgentWidget({
+    target: dockTarget,
+    useShadowDom: false,
+    config: {
+      ...DEFAULT_WIDGET_CONFIG,
+      apiUrl: proxyApiUrl,
+      storageAdapter: createLocalStorageAdapter("persona-state-webmcp-slides"),
+      postprocessMessage: ({ text }) => markdownPostprocessor(text),
+      colorScheme: "light",
+      theme: deckmateTheme,
+      copy: {
+        ...DEFAULT_WIDGET_CONFIG.copy,
+        welcomeTitle: "Ask Deck Copilot",
+        welcomeSubtitle:
+          "I edit this deck live through the page's WebMCP tools — slides, elements, alignment, themes, even presenting.",
+        inputPlaceholder: "Ask Copilot to build, restyle, or align slides…",
+      },
+      suggestionChips: [
+        "What's in this deck?",
+        "Add a slide about pricing with three tiers",
+        "Make the title slide pop",
+        "Apply the Midnight theme",
+      ],
+      launcher: {
+        ...DEFAULT_WIDGET_CONFIG.launcher,
+        mountMode: "docked",
+        dock: {
+          side: "right",
+          width: "420px",
+          reveal: "emerge",
+          animate: true,
+        },
+        autoExpand: true,
+        mobileBreakpoint: 1080,
+        title: "Deck Copilot",
+        subtitle: "Slide editing assistant",
+      },
+      webmcp: {
+        enabled: true,
+        // Destructive / deck-wide tools confirm; reads and incremental writes
+        // auto-approve so the user can watch the agent assemble slides live.
+        autoApprove: (info) => !APPROVAL_REQUIRED_TOOL_NAMES.has(info.toolName),
+      },
+      approval: {
+        ...DEFAULT_WIDGET_CONFIG.approval,
+        title: "Run deck tool?",
+        approveLabel: "Run tool",
+        denyLabel: "Cancel",
+        detailsDisplay: "collapsed",
+        formatDescription: describeSlidesApproval,
+      },
+      // Fresh editor state rides along with every message: current slide,
+      // mode, and the user's live selection (ids + bounds). The flow prompt
+      // interpolates {{slides_context}}, so "align these" needs no guessing.
+      contextProviders: [
+        () => ({
+          slides_context: JSON.stringify({
+            mode: store.mode,
+            deckTitle: store.deck.title,
+            themeId: store.deck.themeId,
+            slideCount: store.deck.slides.length,
+            currentSlide: {
+              id: store.currentSlide.id,
+              position: store.currentSlideIndex + 1,
+              title: store.currentSlide.title ?? null,
+            },
+            selection: store.selectedElements().map((el) => ({
+              id: el.id,
+              type: el.type,
+              x: el.x,
+              y: el.y,
+              w: el.w,
+              h: el.h,
+            })),
+          }),
+        }),
+      ],
+      // The provider's output lands in `payload.context`, but the proxy only
+      // forwards `inputs`/`metadata` to the flow. Move it into `inputs` so
+      // {{slides_context}} resolves in WEBMCP_SLIDES_FLOW's prompt.
+      requestMiddleware: ({ payload }) => {
+        const ctx = payload.context;
+        if (!ctx) return payload;
+        return {
+          ...payload,
+          inputs: { ...payload.inputs, ...ctx },
+          context: undefined,
+        };
+      },
+      statusIndicator: {
+        ...DEFAULT_WIDGET_CONFIG.statusIndicator,
+        visible: true,
+        idleText: "Copilot can make mistakes. ⌘Z undoes its edits too.",
+        connectedText: "Copilot can make mistakes. ⌘Z undoes its edits too.",
+        connectingText: "Connecting Deck Copilot…",
+        errorText: "Deck Copilot connection error",
+      },
+    },
+  });
+
+  window.personaSlidesWidget = widget;
+}
+
+declare global {
+  interface Window {
+    personaSlidesWidget?: unknown;
+  }
+}

--- a/examples/embedded-app/src/webmcp-slides/presenter.ts
+++ b/examples/embedded-app/src/webmcp-slides/presenter.ts
@@ -1,0 +1,80 @@
+import type { DeckStore } from "./store";
+import { SLIDE_H, SLIDE_W } from "./types";
+import { getTheme } from "./themes";
+import { renderSlide } from "./render";
+
+// Presenter mode: a full-viewport overlay reusing the pure renderSlide().
+// Entering/leaving flips store.mode, which also swaps the WebMCP tool set
+// (see tools.ts) — the agent can drive the show with next/prev/jump tools.
+
+export const createPresenter = (store: DeckStore): void => {
+  let overlay: HTMLElement | null = null;
+
+  const renderCurrent = (): void => {
+    if (!overlay) return;
+    const frame = overlay.querySelector<HTMLElement>(".wm-present-frame");
+    const counter = overlay.querySelector<HTMLElement>(".wm-present-counter");
+    if (!frame || !counter) return;
+    frame.innerHTML = "";
+    const slide = renderSlide(store.currentSlide, getTheme(store.deck.themeId));
+    const scale = Math.min(
+      window.innerWidth / SLIDE_W,
+      window.innerHeight / SLIDE_H,
+    );
+    slide.style.transform = `scale(${scale})`;
+    slide.style.transformOrigin = "center center";
+    frame.appendChild(slide);
+    counter.textContent = `${store.currentSlideIndex + 1} / ${store.deck.slides.length}`;
+  };
+
+  const onKey = (event: KeyboardEvent): void => {
+    if (store.mode !== "present") return;
+    if (event.key === "ArrowRight" || event.key === " " || event.key === "PageDown") {
+      event.preventDefault();
+      store.setCurrentSlide(store.currentSlideIndex + 1);
+    } else if (event.key === "ArrowLeft" || event.key === "PageUp") {
+      event.preventDefault();
+      store.setCurrentSlide(store.currentSlideIndex - 1);
+    } else if (event.key === "Escape") {
+      event.preventDefault();
+      store.setMode("edit");
+    }
+  };
+
+  const open = (): void => {
+    if (overlay) return;
+    overlay = document.createElement("div");
+    overlay.className = "wm-present-overlay";
+    overlay.innerHTML = `
+      <div class="wm-present-frame"></div>
+      <div class="wm-present-bar">
+        <span class="wm-present-counter"></span>
+        <span class="wm-present-hint">← → to navigate · Esc to exit</span>
+        <button type="button" class="wm-present-exit">Exit</button>
+      </div>`;
+    overlay
+      .querySelector(".wm-present-exit")
+      ?.addEventListener("click", () => store.setMode("edit"));
+    document.body.appendChild(overlay);
+    document.addEventListener("keydown", onKey);
+    window.addEventListener("resize", renderCurrent);
+    renderCurrent();
+  };
+
+  const close = (): void => {
+    if (!overlay) return;
+    overlay.remove();
+    overlay = null;
+    document.removeEventListener("keydown", onKey);
+    window.removeEventListener("resize", renderCurrent);
+  };
+
+  store.subscribe(() => {
+    if (store.mode === "present") {
+      open();
+      renderCurrent();
+    } else {
+      close();
+    }
+  });
+};

--- a/examples/embedded-app/src/webmcp-slides/render.ts
+++ b/examples/embedded-app/src/webmcp-slides/render.ts
@@ -1,0 +1,113 @@
+import type { Slide, SlideElement, Theme } from "./types";
+import { SLIDE_H, SLIDE_W } from "./types";
+import { resolveColor, resolveFont } from "./themes";
+
+// Pure slide rendering — no event listeners, no store access. Reused by three
+// consumers: the editor canvas (which layers an interaction overlay on top),
+// the sorter rail (scaled down with a CSS transform), and presenter mode
+// (scaled to the viewport). Full re-render on every store change is cheap:
+// decks are a handful of slides with tens of elements.
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+
+const IMAGE_PLACEHOLDER_SVG = encodeURIComponent(
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 4 3"><rect width="4" height="3" fill="#cbd5e1"/><path d="M0.5 2.4 1.5 1.3 2.3 2 2.9 1.4 3.5 2.4z" fill="#64748b"/><circle cx="1.1" cy="0.8" r="0.3" fill="#64748b"/></svg>`,
+);
+
+export const renderElement = (
+  element: SlideElement,
+  theme: Theme,
+): HTMLElement => {
+  const node = document.createElement(element.type === "image" ? "div" : "div");
+  node.className = `wm-element wm-element-${element.type}`;
+  node.dataset.elementId = element.id;
+  node.style.left = `${element.x}px`;
+  node.style.top = `${element.y}px`;
+  node.style.width = `${element.w}px`;
+  node.style.height = `${element.h}px`;
+  node.style.zIndex = String(element.z);
+  if (element.rotation) {
+    node.style.transform = `rotate(${element.rotation}deg)`;
+  }
+
+  switch (element.type) {
+    case "text": {
+      node.textContent = element.text ?? "";
+      node.style.fontSize = `${element.fontSize ?? 18}px`;
+      node.style.fontFamily = resolveFont(element.fontFamily, theme) ?? theme.fonts.body;
+      node.style.fontWeight = String(element.fontWeight ?? 400);
+      node.style.color = resolveColor(element.color, theme) ?? theme.colors.text;
+      node.style.textAlign = element.align ?? "left";
+      break;
+    }
+    case "rect":
+    case "ellipse": {
+      const fill = resolveColor(element.fill, theme);
+      if (fill) node.style.background = fill;
+      const stroke = resolveColor(element.stroke, theme);
+      if (stroke) {
+        node.style.border = `${element.strokeWidth ?? 1}px solid ${stroke}`;
+      }
+      if (element.type === "ellipse") node.style.borderRadius = "50%";
+      break;
+    }
+    case "line": {
+      // Lines draw from the top-left to the bottom-right corner of their
+      // bounding box (an SVG keeps stroke endpoints exact at any angle).
+      const svg = document.createElementNS(SVG_NS, "svg");
+      svg.setAttribute("width", "100%");
+      svg.setAttribute("height", "100%");
+      svg.setAttribute(
+        "viewBox",
+        `0 0 ${Math.max(element.w, 1)} ${Math.max(element.h, 1)}`,
+      );
+      svg.setAttribute("preserveAspectRatio", "none");
+      const line = document.createElementNS(SVG_NS, "line");
+      line.setAttribute("x1", "0");
+      line.setAttribute("y1", "0");
+      line.setAttribute("x2", String(Math.max(element.w, 1)));
+      line.setAttribute("y2", String(Math.max(element.h, 1)));
+      line.setAttribute(
+        "stroke",
+        resolveColor(element.stroke, theme) ?? theme.colors.text,
+      );
+      line.setAttribute("stroke-width", String(element.strokeWidth ?? 2));
+      svg.appendChild(line);
+      node.appendChild(svg);
+      break;
+    }
+    case "image": {
+      const img = document.createElement("img");
+      img.alt = "";
+      img.draggable = false;
+      img.src =
+        !element.src || element.src === "placeholder"
+          ? `data:image/svg+xml,${IMAGE_PLACEHOLDER_SVG}`
+          : element.src;
+      img.onerror = () => {
+        img.onerror = null;
+        img.src = `data:image/svg+xml,${IMAGE_PLACEHOLDER_SVG}`;
+      };
+      node.appendChild(img);
+      break;
+    }
+  }
+
+  return node;
+};
+
+export const renderSlide = (slide: Slide, theme: Theme): HTMLElement => {
+  const stage = document.createElement("div");
+  stage.className = "wm-slide";
+  stage.dataset.slideId = slide.id;
+  stage.style.width = `${SLIDE_W}px`;
+  stage.style.height = `${SLIDE_H}px`;
+  stage.style.background =
+    resolveColor(slide.background, theme) ?? theme.colors.background;
+  stage.style.fontFamily = theme.fonts.body;
+
+  for (const element of [...slide.elements].sort((a, b) => a.z - b.z)) {
+    stage.appendChild(renderElement(element, theme));
+  }
+  return stage;
+};

--- a/examples/embedded-app/src/webmcp-slides/slides.css
+++ b/examples/embedded-app/src/webmcp-slides/slides.css
@@ -1,0 +1,474 @@
+/* WebMCP slide-deck editor — page chrome + editor surfaces.
+   Slide CONTENT styles must stay in sync between the canvas, the sorter
+   thumbnails, and presenter mode; they all share .wm-slide / .wm-element. */
+
+:root {
+  --wm-chrome-bg: #f4f3ef;
+  --wm-surface: #ffffff;
+  --wm-border: #e7e5e0;
+  --wm-text: #1f2933;
+  --wm-text-muted: #6b7280;
+  --wm-accent: #c2410c;
+  --wm-selection: #2563eb;
+  --wm-agent: #c2410c;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.wm-body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--wm-chrome-bg);
+  color: var(--wm-text);
+  font-family:
+    Inter,
+    "Segoe UI",
+    system-ui,
+    -apple-system,
+    sans-serif;
+}
+
+/* ---- toolbar ---- */
+
+.wm-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 10px 16px;
+  background: var(--wm-surface);
+  border-bottom: 1px solid var(--wm-border);
+  flex: 0 0 auto;
+}
+
+.wm-toolbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wm-logo {
+  font-weight: 800;
+  font-size: 17px;
+  letter-spacing: -0.02em;
+}
+
+.wm-badge {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--wm-accent);
+  background: rgba(194, 65, 12, 0.08);
+  border: 1px solid rgba(194, 65, 12, 0.25);
+  border-radius: 999px;
+  padding: 2px 8px;
+}
+
+.wm-deck-title {
+  flex: 1;
+  min-width: 120px;
+  max-width: 420px;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--wm-text);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  padding: 6px 10px;
+}
+
+.wm-deck-title:hover {
+  border-color: var(--wm-border);
+}
+
+.wm-deck-title:focus {
+  outline: none;
+  border-color: var(--wm-selection);
+  background: var(--wm-surface);
+}
+
+.wm-toolbar-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.wm-toolbar-actions button {
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wm-text);
+  background: var(--wm-surface);
+  border: 1px solid var(--wm-border);
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+}
+
+.wm-toolbar-actions button:hover:not(:disabled) {
+  border-color: var(--wm-text-muted);
+}
+
+.wm-toolbar-actions button:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.wm-toolbar-actions .wm-present-button {
+  background: var(--wm-text);
+  border-color: var(--wm-text);
+  color: #ffffff;
+}
+
+.wm-theme-label {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--wm-text-muted);
+}
+
+.wm-theme-label select {
+  font: inherit;
+  font-size: 13px;
+  padding: 5px 8px;
+  border: 1px solid var(--wm-border);
+  border-radius: 8px;
+  background: var(--wm-surface);
+  color: var(--wm-text);
+}
+
+/* ---- main layout ---- */
+
+.wm-main {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+#slides-sorter {
+  flex: 0 0 200px;
+  overflow-y: auto;
+  border-right: 1px solid var(--wm-border);
+  background: var(--wm-surface);
+}
+
+#slides-canvas {
+  flex: 1;
+  min-width: 0;
+}
+
+/* Persona's docked mount wraps #editor-dock-target in a generated
+   [data-persona-host-layout="docked"] flex row and docks the panel beside
+   it — the editor shrinks to make room (same pattern as webmcp-calendar). */
+.wm-editor {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+}
+
+[data-persona-host-layout="docked"] {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  border: none;
+}
+
+/* The wrapper's generated children (content area + panel) must be allowed to
+   shrink below their content size, or the canvas's fixed-width viewport
+   pushes the docked panel off-screen. */
+[data-persona-host-layout="docked"] > * {
+  min-width: 0;
+  min-height: 0;
+}
+
+.wm-footer {
+  flex: 0 0 auto;
+  padding: 8px 16px;
+  border-top: 1px solid var(--wm-border);
+  background: var(--wm-surface);
+}
+
+.wm-footer p {
+  margin: 0;
+  font-size: 12px;
+  color: var(--wm-text-muted);
+}
+
+.wm-footer kbd {
+  font-family: inherit;
+  border: 1px solid var(--wm-border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 0 4px;
+  font-size: 11px;
+}
+
+/* ---- canvas ---- */
+
+.wm-canvas {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.wm-canvas-viewport {
+  position: relative;
+  flex: 0 0 auto;
+  box-shadow: 0 18px 50px rgba(31, 41, 51, 0.18);
+  border-radius: 4px;
+}
+
+.wm-stage-wrap {
+  position: absolute;
+  top: 0;
+  left: 0;
+  transform-origin: top left;
+}
+
+.wm-slide {
+  position: relative;
+  overflow: hidden;
+  user-select: none;
+}
+
+.wm-element {
+  position: absolute;
+}
+
+.wm-element-text {
+  white-space: pre-wrap;
+  line-height: 1.3;
+  overflow: hidden;
+  cursor: default;
+}
+
+.wm-element-text.wm-editing {
+  outline: 2px solid var(--wm-selection);
+  cursor: text;
+  user-select: text;
+}
+
+.wm-element-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.wm-element-line svg {
+  display: block;
+  overflow: visible;
+}
+
+/* ---- selection overlay ---- */
+
+.wm-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 1000;
+}
+
+.wm-selection-box {
+  position: absolute;
+  border: 2px solid var(--wm-selection);
+  pointer-events: none;
+}
+
+.wm-handle {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  background: #ffffff;
+  border: 2px solid var(--wm-selection);
+  border-radius: 2px;
+  pointer-events: auto;
+}
+
+.wm-handle-nw { top: -6px; left: -6px; cursor: nwse-resize; }
+.wm-handle-n  { top: -6px; left: calc(50% - 5px); cursor: ns-resize; }
+.wm-handle-ne { top: -6px; right: -6px; cursor: nesw-resize; }
+.wm-handle-e  { top: calc(50% - 5px); right: -6px; cursor: ew-resize; }
+.wm-handle-se { bottom: -6px; right: -6px; cursor: nwse-resize; }
+.wm-handle-s  { bottom: -6px; left: calc(50% - 5px); cursor: ns-resize; }
+.wm-handle-sw { bottom: -6px; left: -6px; cursor: nesw-resize; }
+.wm-handle-w  { top: calc(50% - 5px); left: -6px; cursor: ew-resize; }
+
+/* ---- agent-touch flash ---- */
+
+@keyframes wm-agent-pulse {
+  0% {
+    outline-color: rgba(194, 65, 12, 0.9);
+    outline-offset: 2px;
+  }
+  100% {
+    outline-color: rgba(194, 65, 12, 0);
+    outline-offset: 8px;
+  }
+}
+
+.wm-agent-flash {
+  outline: 3px solid rgba(194, 65, 12, 0.9);
+  animation: wm-agent-pulse 1.2s ease-out forwards;
+}
+
+/* ---- sorter ---- */
+
+.wm-sorter {
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.wm-thumb {
+  position: relative;
+  cursor: pointer;
+  border-radius: 8px;
+  padding: 6px;
+  border: 2px solid transparent;
+}
+
+.wm-thumb:hover {
+  background: var(--wm-chrome-bg);
+}
+
+.wm-thumb.is-current {
+  border-color: var(--wm-selection);
+  background: rgba(37, 99, 235, 0.06);
+}
+
+.wm-thumb-frame {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--wm-border);
+  border-radius: 4px;
+  pointer-events: none;
+}
+
+.wm-thumb-label {
+  margin-top: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--wm-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.wm-thumb-actions {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  display: none;
+  gap: 4px;
+}
+
+.wm-thumb:hover .wm-thumb-actions {
+  display: flex;
+}
+
+.wm-thumb-actions button {
+  font-size: 11px;
+  width: 22px;
+  height: 22px;
+  border: 1px solid var(--wm-border);
+  border-radius: 4px;
+  background: var(--wm-surface);
+  cursor: pointer;
+}
+
+.wm-thumb-actions button:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.wm-thumb-add {
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--wm-text-muted);
+  background: transparent;
+  border: 1px dashed var(--wm-border);
+  border-radius: 8px;
+  padding: 10px;
+  cursor: pointer;
+}
+
+.wm-thumb-add:hover {
+  color: var(--wm-text);
+  border-color: var(--wm-text-muted);
+}
+
+/* ---- presenter mode ---- */
+
+.wm-present-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 99990;
+  background: #0b0f14;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.wm-present-frame {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+
+.wm-present-frame .wm-slide {
+  flex: 0 0 auto;
+}
+
+.wm-present-bar {
+  position: fixed;
+  bottom: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 8px 16px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.85);
+  color: #e2e8f0;
+  font-size: 13px;
+}
+
+.wm-present-hint {
+  color: #94a3b8;
+}
+
+.wm-present-exit {
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  color: #0f172a;
+  background: #e2e8f0;
+  border: none;
+  border-radius: 999px;
+  padding: 4px 12px;
+  cursor: pointer;
+}
+
+@media (max-width: 1080px) {
+  #slides-sorter {
+    display: none;
+  }
+}

--- a/examples/embedded-app/src/webmcp-slides/sorter.ts
+++ b/examples/embedded-app/src/webmcp-slides/sorter.ts
@@ -1,0 +1,97 @@
+import type { DeckStore } from "./store";
+import { SLIDE_H, SLIDE_W, makeId } from "./types";
+import { getTheme } from "./themes";
+import { renderSlide } from "./render";
+
+// Slide sorter rail: scaled-down thumbnails rendered with the same pure
+// renderSlide() the canvas uses, so thumbnails are always pixel-faithful.
+// Reordering is via per-slide up/down buttons (drag-reorder is intentionally
+// out of scope — the agent's reorder_slides tool covers the rich case).
+
+const THUMB_SCALE = 0.16;
+
+export const createSorter = (
+  store: DeckStore,
+  container: HTMLElement,
+): void => {
+  container.classList.add("wm-sorter");
+
+  const moveSlide = (from: number, to: number): void => {
+    if (to < 0 || to >= store.deck.slides.length) return;
+    store.commit((deck) => {
+      const [slide] = deck.slides.splice(from, 1);
+      deck.slides.splice(to, 0, slide);
+    });
+    store.setCurrentSlide(to);
+  };
+
+  const render = (): void => {
+    const theme = getTheme(store.deck.themeId);
+    container.innerHTML = "";
+
+    store.deck.slides.forEach((slide, index) => {
+      const item = document.createElement("div");
+      item.className = "wm-thumb";
+      item.dataset.slideId = slide.id;
+      if (index === store.currentSlideIndex) item.classList.add("is-current");
+
+      const frame = document.createElement("div");
+      frame.className = "wm-thumb-frame";
+      frame.style.width = `${SLIDE_W * THUMB_SCALE}px`;
+      frame.style.height = `${SLIDE_H * THUMB_SCALE}px`;
+      const inner = renderSlide(slide, theme);
+      inner.style.transform = `scale(${THUMB_SCALE})`;
+      inner.style.transformOrigin = "top left";
+      frame.appendChild(inner);
+
+      const label = document.createElement("div");
+      label.className = "wm-thumb-label";
+      label.textContent = `${index + 1}. ${slide.title ?? "Untitled"}`;
+
+      const actions = document.createElement("div");
+      actions.className = "wm-thumb-actions";
+      const up = document.createElement("button");
+      up.type = "button";
+      up.textContent = "↑";
+      up.title = "Move slide up";
+      up.disabled = index === 0;
+      up.addEventListener("click", (event) => {
+        event.stopPropagation();
+        moveSlide(index, index - 1);
+      });
+      const down = document.createElement("button");
+      down.type = "button";
+      down.textContent = "↓";
+      down.title = "Move slide down";
+      down.disabled = index === store.deck.slides.length - 1;
+      down.addEventListener("click", (event) => {
+        event.stopPropagation();
+        moveSlide(index, index + 1);
+      });
+      actions.append(up, down);
+
+      item.append(frame, label, actions);
+      item.addEventListener("click", () => store.setCurrentSlide(index));
+      container.appendChild(item);
+    });
+
+    const add = document.createElement("button");
+    add.type = "button";
+    add.className = "wm-thumb-add";
+    add.textContent = "+ New slide";
+    add.addEventListener("click", () => {
+      store.commit((deck) => {
+        deck.slides.push({
+          id: makeId("slide"),
+          title: `Slide ${deck.slides.length + 1}`,
+          elements: [],
+        });
+      });
+      store.setCurrentSlide(store.deck.slides.length - 1);
+    });
+    container.appendChild(add);
+  };
+
+  store.subscribe(render);
+  render();
+};

--- a/examples/embedded-app/src/webmcp-slides/store.ts
+++ b/examples/embedded-app/src/webmcp-slides/store.ts
@@ -1,0 +1,319 @@
+import type { Deck, Slide, SlideElement } from "./types";
+import { clamp, makeId } from "./types";
+
+const STORAGE_KEY = "persona-webmcp-slides-v1";
+const UNDO_CAP = 100;
+const PERSIST_DEBOUNCE_MS = 400;
+
+export type EditorMode = "edit" | "present";
+
+export type FindElementResult = { slide: Slide; element: SlideElement };
+
+/**
+ * Single source of truth for the deck, shared by human gestures and agent
+ * tools. Undo is a snapshot stack: `commit()` clones the deck, applies the
+ * mutator, and pushes the previous deck — decks are a few KB of JSON so
+ * snapshots are effectively free and trivially correct, and because tools and
+ * UI handlers go through the same `commit()`, Cmd+Z reverses agent edits too.
+ *
+ * Selection, current slide, and mode are UI state outside the undo stack;
+ * they're re-clamped after undo/redo so they never dangle.
+ */
+export class DeckStore {
+  deck: Deck;
+  currentSlideIndex = 0;
+  selection = new Set<string>();
+  mode: EditorMode = "edit";
+
+  private undoStack: Deck[] = [];
+  private redoStack: Deck[] = [];
+  private listeners = new Set<(store: DeckStore) => void>();
+  private persistTimer: number | undefined;
+
+  constructor(seed: () => Deck) {
+    this.deck = loadDeck() ?? seed();
+  }
+
+  get currentSlide(): Slide {
+    return this.deck.slides[this.currentSlideIndex];
+  }
+
+  subscribe(listener: (store: DeckStore) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** All mutations — human or agent — enter here. One call = one undo step. */
+  commit(mutate: (deck: Deck) => void): void {
+    const previous = structuredClone(this.deck);
+    const next = structuredClone(this.deck);
+    mutate(next);
+    this.undoStack.push(previous);
+    if (this.undoStack.length > UNDO_CAP) this.undoStack.shift();
+    this.redoStack = [];
+    this.deck = next;
+    this.afterChange();
+  }
+
+  undo(): boolean {
+    const previous = this.undoStack.pop();
+    if (!previous) return false;
+    this.redoStack.push(this.deck);
+    this.deck = previous;
+    this.afterChange();
+    return true;
+  }
+
+  redo(): boolean {
+    const next = this.redoStack.pop();
+    if (!next) return false;
+    this.undoStack.push(this.deck);
+    this.deck = next;
+    this.afterChange();
+    return true;
+  }
+
+  get canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  get canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  setSelection(ids: string[]): void {
+    const valid = new Set(this.currentSlide.elements.map((el) => el.id));
+    this.selection = new Set(ids.filter((id) => valid.has(id)));
+    this.notify();
+  }
+
+  toggleSelected(id: string): void {
+    if (this.selection.has(id)) {
+      this.selection.delete(id);
+    } else if (this.currentSlide.elements.some((el) => el.id === id)) {
+      this.selection.add(id);
+    }
+    this.notify();
+  }
+
+  setCurrentSlide(index: number): void {
+    const next = clamp(index, 0, this.deck.slides.length - 1);
+    if (next === this.currentSlideIndex) return;
+    this.currentSlideIndex = next;
+    this.selection.clear();
+    this.notify();
+  }
+
+  setMode(mode: EditorMode): void {
+    if (this.mode === mode) return;
+    this.mode = mode;
+    if (mode === "present") this.selection.clear();
+    this.notify();
+  }
+
+  findSlide(slideId: string): Slide | undefined {
+    return this.deck.slides.find((s) => s.id === slideId);
+  }
+
+  findElement(elementId: string): FindElementResult | undefined {
+    for (const slide of this.deck.slides) {
+      const element = slide.elements.find((el) => el.id === elementId);
+      if (element) return { slide, element };
+    }
+    return undefined;
+  }
+
+  selectedElements(): SlideElement[] {
+    return this.currentSlide.elements.filter((el) => this.selection.has(el.id));
+  }
+
+  nextZ(slide: Slide): number {
+    return slide.elements.reduce((max, el) => Math.max(max, el.z), 0) + 1;
+  }
+
+  resetDeck(seed: () => Deck): void {
+    this.deck = seed();
+    this.undoStack = [];
+    this.redoStack = [];
+    this.currentSlideIndex = 0;
+    this.selection.clear();
+    this.afterChange();
+  }
+
+  private afterChange(): void {
+    this.currentSlideIndex = clamp(
+      this.currentSlideIndex,
+      0,
+      this.deck.slides.length - 1,
+    );
+    const valid = new Set(this.currentSlide.elements.map((el) => el.id));
+    this.selection = new Set([...this.selection].filter((id) => valid.has(id)));
+    this.schedulePersist();
+    this.notify();
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener(this));
+  }
+
+  private schedulePersist(): void {
+    window.clearTimeout(this.persistTimer);
+    this.persistTimer = window.setTimeout(() => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(this.deck));
+      } catch {
+        // Storage may be unavailable (private mode, quota) — demo keeps working.
+      }
+    }, PERSIST_DEBOUNCE_MS);
+  }
+}
+
+const loadDeck = (): Deck | null => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const deck = JSON.parse(raw) as Deck;
+    if (!deck?.slides?.length) return null;
+    return deck;
+  } catch {
+    return null;
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Seed deck — a fictional startup pitch so demo prompts have material.
+
+const text = (
+  props: Partial<SlideElement> & Pick<SlideElement, "x" | "y" | "w" | "h">,
+): SlideElement => ({
+  id: makeId("el"),
+  type: "text",
+  rotation: 0,
+  z: 1,
+  fontSize: 18,
+  fontFamily: "theme.body",
+  color: "theme.text",
+  align: "left",
+  text: "",
+  ...props,
+});
+
+const shape = (
+  type: SlideElement["type"],
+  props: Partial<SlideElement> & Pick<SlideElement, "x" | "y" | "w" | "h">,
+): SlideElement => ({
+  id: makeId("el"),
+  type,
+  rotation: 0,
+  z: 0,
+  fill: "theme.accent",
+  ...props,
+});
+
+export const createSeedDeck = (): Deck => ({
+  id: makeId("deck"),
+  title: "Lumen Labs — Seed Pitch",
+  themeId: "paper",
+  slides: [
+    {
+      id: makeId("slide"),
+      title: "Title",
+      elements: [
+        shape("rect", { x: 0, y: 430, w: 960, h: 110, fill: "theme.accent", z: 0 }),
+        text({
+          x: 80, y: 170, w: 800, h: 90,
+          text: "Lumen Labs",
+          fontSize: 64, fontFamily: "theme.heading", fontWeight: 700, align: "center",
+        }),
+        text({
+          x: 160, y: 280, w: 640, h: 40,
+          text: "Daylight analytics for commercial buildings",
+          fontSize: 24, color: "theme.accent", align: "center",
+        }),
+      ],
+    },
+    {
+      id: makeId("slide"),
+      title: "Problem",
+      elements: [
+        text({
+          x: 60, y: 50, w: 840, h: 60,
+          text: "Buildings waste light",
+          fontSize: 40, fontFamily: "theme.heading", fontWeight: 700,
+        }),
+        text({
+          x: 60, y: 150, w: 500, h: 280, fontSize: 20,
+          text: "Commercial buildings spend 17% of their energy budget on lighting — most of it during daylight hours.\n\nFacility teams have no per-room visibility into natural light, so fixtures run at full power all day.",
+        }),
+        shape("ellipse", { x: 640, y: 170, w: 240, h: 240, fill: "theme.accent" }),
+        text({
+          x: 640, y: 260, w: 240, h: 60,
+          text: "17%", fontSize: 48, fontWeight: 700,
+          color: "theme.accentText", align: "center", z: 2,
+        }),
+      ],
+    },
+    {
+      id: makeId("slide"),
+      title: "Solution",
+      elements: [
+        text({
+          x: 60, y: 50, w: 840, h: 60,
+          text: "Sense the daylight, dim the grid",
+          fontSize: 40, fontFamily: "theme.heading", fontWeight: 700,
+        }),
+        shape("rect", { x: 60, y: 160, w: 260, h: 240, fill: "theme.surface", stroke: "theme.accent", strokeWidth: 2 }),
+        text({ x: 80, y: 180, w: 220, h: 40, text: "Sensors", fontSize: 22, fontWeight: 700, color: "theme.accent", z: 2 }),
+        text({ x: 80, y: 230, w: 220, h: 150, fontSize: 16, text: "Peel-and-stick lux sensors, 5-year battery, zero wiring.", z: 2 }),
+        shape("rect", { x: 350, y: 160, w: 260, h: 240, fill: "theme.surface", stroke: "theme.accent", strokeWidth: 2 }),
+        text({ x: 370, y: 180, w: 220, h: 40, text: "Platform", fontSize: 22, fontWeight: 700, color: "theme.accent", z: 2 }),
+        text({ x: 370, y: 230, w: 220, h: 150, fontSize: 16, text: "Room-level daylight maps with dimming recommendations.", z: 2 }),
+        shape("rect", { x: 640, y: 160, w: 260, h: 240, fill: "theme.surface", stroke: "theme.accent", strokeWidth: 2 }),
+        text({ x: 660, y: 180, w: 220, h: 40, text: "Savings", fontSize: 22, fontWeight: 700, color: "theme.accent", z: 2 }),
+        text({ x: 660, y: 230, w: 220, h: 150, fontSize: 16, text: "Cuts lighting spend 30-40% with no fixture replacement.", z: 2 }),
+      ],
+    },
+    {
+      id: makeId("slide"),
+      title: "Market",
+      elements: [
+        text({
+          x: 60, y: 50, w: 840, h: 60,
+          text: "A $14B retrofit market",
+          fontSize: 40, fontFamily: "theme.heading", fontWeight: 700,
+        }),
+        shape("rect", { x: 100, y: 360, w: 140, h: 80, fill: "theme.accent" }),
+        shape("rect", { x: 300, y: 280, w: 140, h: 160, fill: "theme.accent" }),
+        shape("rect", { x: 500, y: 200, w: 140, h: 240, fill: "theme.accent" }),
+        text({ x: 100, y: 460, w: 140, h: 30, text: "2024", fontSize: 16, align: "center" }),
+        text({ x: 300, y: 460, w: 140, h: 30, text: "2026", fontSize: 16, align: "center" }),
+        text({ x: 500, y: 460, w: 140, h: 30, text: "2028", fontSize: 16, align: "center" }),
+        text({
+          x: 680, y: 220, w: 220, h: 180, fontSize: 18,
+          text: "Lighting retrofits grow 18% YoY as energy codes tighten across the US and EU.",
+        }),
+      ],
+    },
+    {
+      id: makeId("slide"),
+      title: "The Ask",
+      elements: [
+        text({
+          x: 60, y: 50, w: 840, h: 60,
+          text: "Raising $2.5M seed",
+          fontSize: 40, fontFamily: "theme.heading", fontWeight: 700,
+        }),
+        text({
+          x: 60, y: 160, w: 520, h: 240, fontSize: 20,
+          text: "• 12 pilot buildings signed, 3 paying\n• $180k ARR, 9 months runway\n• Funds: 2 firmware engineers, UL certification, 50-building rollout",
+        }),
+        shape("rect", { x: 640, y: 160, w: 260, h: 240, fill: "theme.accent" }),
+        text({
+          x: 660, y: 230, w: 220, h: 110,
+          text: "hello@lumenlabs.example", fontSize: 18,
+          color: "theme.accentText", align: "center", z: 2,
+        }),
+      ],
+    },
+  ],
+});

--- a/examples/embedded-app/src/webmcp-slides/themes.ts
+++ b/examples/embedded-app/src/webmcp-slides/themes.ts
@@ -1,0 +1,105 @@
+import type { Theme } from "./types";
+
+// Element color/font props may hold theme tokens ('theme.accent',
+// 'theme.heading') instead of literals. Tokens resolve at render time, so
+// `apply_theme` restyles every token-colored element across the deck — the
+// system prompt tells the model to prefer tokens for exactly this reason.
+
+export const THEMES: Theme[] = [
+  {
+    id: "paper",
+    name: "Paper",
+    fonts: {
+      heading: "'Avenir Next', 'Segoe UI', system-ui, sans-serif",
+      body: "'Avenir Next', 'Segoe UI', system-ui, sans-serif",
+    },
+    colors: {
+      background: "#fafaf7",
+      surface: "#ffffff",
+      text: "#1f2933",
+      accent: "#c2410c",
+      accentText: "#ffffff",
+    },
+  },
+  {
+    id: "midnight",
+    name: "Midnight",
+    fonts: {
+      heading: "'Avenir Next', 'Segoe UI', system-ui, sans-serif",
+      body: "Georgia, 'Times New Roman', serif",
+    },
+    colors: {
+      background: "#0f172a",
+      surface: "#1e293b",
+      text: "#e2e8f0",
+      accent: "#38bdf8",
+      accentText: "#0f172a",
+    },
+  },
+  {
+    id: "terracotta",
+    name: "Terracotta",
+    fonts: {
+      heading: "Georgia, 'Times New Roman', serif",
+      body: "'Segoe UI', system-ui, sans-serif",
+    },
+    colors: {
+      background: "#fdf6f0",
+      surface: "#ffffff",
+      text: "#43302b",
+      accent: "#9a3412",
+      accentText: "#fff7ed",
+    },
+  },
+  {
+    id: "mint",
+    name: "Mint",
+    fonts: {
+      heading: "'Trebuchet MS', 'Segoe UI', system-ui, sans-serif",
+      body: "'Segoe UI', system-ui, sans-serif",
+    },
+    colors: {
+      background: "#f0fdf4",
+      surface: "#ffffff",
+      text: "#14532d",
+      accent: "#059669",
+      accentText: "#ffffff",
+    },
+  },
+];
+
+export const getTheme = (themeId: string): Theme =>
+  THEMES.find((t) => t.id === themeId) ?? THEMES[0];
+
+const COLOR_TOKENS = new Set([
+  "background",
+  "surface",
+  "text",
+  "accent",
+  "accentText",
+]);
+
+/** Resolve 'theme.accent' → the active theme's accent; pass literals through. */
+export const resolveColor = (
+  value: string | undefined,
+  theme: Theme,
+): string | undefined => {
+  if (!value) return value;
+  if (!value.startsWith("theme.")) return value;
+  const key = value.slice("theme.".length);
+  if (COLOR_TOKENS.has(key)) {
+    return theme.colors[key as keyof Theme["colors"]];
+  }
+  return undefined;
+};
+
+/** Resolve 'theme.heading' / 'theme.body' → font stack; pass literals through. */
+export const resolveFont = (
+  value: string | undefined,
+  theme: Theme,
+): string | undefined => {
+  if (!value) return value;
+  if (value === "theme.heading") return theme.fonts.heading;
+  if (value === "theme.body") return theme.fonts.body;
+  return value;
+};

--- a/examples/embedded-app/src/webmcp-slides/tools.ts
+++ b/examples/embedded-app/src/webmcp-slides/tools.ts
@@ -1,0 +1,1141 @@
+import type { DeckStore } from "./store";
+import type { Deck, Slide, SlideElement, SlideLayout } from "./types";
+import { SLIDE_H, SLIDE_W, clamp, makeId } from "./types";
+import { THEMES, getTheme } from "./themes";
+
+// WebMCP tool surface for the slide editor. Three tool sets share two
+// AbortController owners (the calendar demo's re-registration pattern):
+//
+//   1. the static editing set (18 tools) — registered while mode === 'edit';
+//   2. the presenter set (4 tools) — replaces the editing set wholesale while
+//      mode === 'present', so the agent only sees show controls mid-show;
+//   3. the selection-scoped set (2 tools) — registered only while 2+ elements
+//      are selected, debounced so shift-click sprees don't thrash the registry.
+//
+// Every tool returns structured JSON including the ids it created or touched,
+// so the model can chain calls without re-reading the deck.
+
+const EDIT_OWNER = "__webmcpSlidesEditAbort";
+const SELECTION_OWNER = "__webmcpSlidesSelectionAbort";
+const SELECTION_DEBOUNCE_MS = 150;
+const FLASH_MS = 1200;
+
+declare global {
+  interface Window {
+    [EDIT_OWNER]?: AbortController;
+    [SELECTION_OWNER]?: AbortController;
+  }
+}
+
+// Only destructive or deck-wide tools raise Persona's approval bubble —
+// ordinary writes (add_element, update_element, …) auto-approve so the user
+// can watch the agent build slides without clicking through every step.
+export const APPROVAL_REQUIRED_TOOL_NAMES = new Set([
+  "delete_slide",
+  "delete_elements",
+  "apply_theme",
+]);
+
+export const READ_ONLY_TOOL_NAMES = new Set([
+  "get_deck_overview",
+  "get_slide",
+  "get_selection",
+  "list_themes",
+  "goto_slide",
+  "enter_presenter_mode",
+  "next_slide",
+  "prev_slide",
+  "jump_to_slide",
+  "exit_presenter_mode",
+]);
+
+type ToolDescriptor = {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: object;
+  annotations?: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => unknown | Promise<unknown>;
+};
+
+type RegisterableModelContext = {
+  registerTool: (
+    tool: ToolDescriptor & { annotations?: Record<string, unknown> },
+    options?: { signal?: AbortSignal },
+  ) => void;
+};
+
+const getModelContext = (): RegisterableModelContext | undefined =>
+  (document as unknown as { modelContext?: RegisterableModelContext })
+    .modelContext ??
+  (navigator as unknown as { modelContext?: RegisterableModelContext })
+    .modelContext;
+
+const toolResult = (data: unknown, summary?: string): unknown => ({
+  content: [
+    {
+      type: "text",
+      text: `${summary ? `${summary}\n\n` : ""}${JSON.stringify(data, null, 2)}`,
+    },
+  ],
+  structuredContent: data,
+});
+
+const registerTool = (
+  modelContext: RegisterableModelContext,
+  tool: ToolDescriptor,
+  signal: AbortSignal,
+): void => {
+  try {
+    // The WebMCP spec carries the display title on the descriptor itself, but
+    // the current @mcp-b SDK only surfaces annotations.title to consumers
+    // (Persona approval bubbles, Chrome DevTools MCP) — mirror it there.
+    const descriptor = tool.title
+      ? { ...tool, annotations: { title: tool.title, ...tool.annotations } }
+      : tool;
+    modelContext.registerTool(descriptor, { signal });
+  } catch (error) {
+    console.warn(`[Slides] Failed to register ${tool.name}`, error);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Lookup + serialization helpers
+
+const slidePosition = (deck: Deck, slideId: string): number =>
+  deck.slides.findIndex((s) => s.id === slideId) + 1;
+
+/** Resolve a slide from `slideId` or 1-based `position`; default current. */
+const resolveSlide = (
+  store: DeckStore,
+  args: Record<string, unknown>,
+): Slide => {
+  if (typeof args.slideId === "string" && args.slideId) {
+    const slide = store.findSlide(args.slideId);
+    if (!slide) throw new Error(`No slide with id "${args.slideId}". Call get_deck_overview for valid ids.`);
+    return slide;
+  }
+  if (typeof args.position === "number") {
+    const slide = store.deck.slides[args.position - 1];
+    if (!slide) throw new Error(`No slide at position ${args.position} (deck has ${store.deck.slides.length} slides).`);
+    return slide;
+  }
+  return store.currentSlide;
+};
+
+const publicElement = (el: SlideElement): Record<string, unknown> => {
+  const out: Record<string, unknown> = {
+    id: el.id,
+    type: el.type,
+    x: el.x,
+    y: el.y,
+    w: el.w,
+    h: el.h,
+    rotation: el.rotation,
+    z: el.z,
+  };
+  for (const key of [
+    "text",
+    "fontSize",
+    "fontFamily",
+    "fontWeight",
+    "color",
+    "align",
+    "fill",
+    "stroke",
+    "strokeWidth",
+    "src",
+  ] as const) {
+    if (el[key] !== undefined) out[key] = el[key];
+  }
+  return out;
+};
+
+const publicSlide = (deck: Deck, slide: Slide): Record<string, unknown> => ({
+  id: slide.id,
+  position: slidePosition(deck, slide.id),
+  title: slide.title ?? null,
+  background: slide.background ?? null,
+  elements: [...slide.elements]
+    .sort((a, b) => a.z - b.z)
+    .map(publicElement),
+});
+
+const NUMERIC_PROPS = new Set(["x", "y", "w", "h", "rotation", "z", "fontSize", "fontWeight", "strokeWidth"]);
+const STRING_PROPS = new Set(["text", "fontFamily", "color", "align", "fill", "stroke", "src"]);
+
+const applyElementPatch = (
+  el: SlideElement,
+  patch: Record<string, unknown>,
+): void => {
+  const target = el as unknown as Record<string, unknown>;
+  for (const [key, value] of Object.entries(patch)) {
+    if (value === undefined || value === null) continue;
+    if (NUMERIC_PROPS.has(key) && typeof value === "number") {
+      target[key] = value;
+    } else if (STRING_PROPS.has(key) && typeof value === "string") {
+      target[key] = value;
+    }
+  }
+  el.x = clamp(Math.round(el.x), -el.w + 8, SLIDE_W - 8);
+  el.y = clamp(Math.round(el.y), -el.h + 8, SLIDE_H - 8);
+  el.w = Math.max(4, Math.round(el.w));
+  el.h = Math.max(4, Math.round(el.h));
+};
+
+// ---------------------------------------------------------------------------
+// Agent-touch affordance: the user should SEE what the agent changed. After a
+// mutation we jump to the touched slide (if needed) and pulse an outline on
+// the touched elements + the slide's sorter thumbnail.
+
+const flashAgentTouch = (
+  store: DeckStore,
+  slideId: string,
+  elementIds: string[] = [],
+): void => {
+  const index = store.deck.slides.findIndex((s) => s.id === slideId);
+  if (index >= 0 && store.mode === "edit") store.setCurrentSlide(index);
+
+  // Subscribers re-render synchronously inside commit()/setCurrentSlide(),
+  // so the fresh nodes are already in the DOM.
+  const targets: Element[] = [];
+  const thumb = document.querySelector(`.wm-thumb[data-slide-id="${slideId}"]`);
+  if (thumb) targets.push(thumb);
+  for (const id of elementIds) {
+    document
+      .querySelectorAll(`.wm-canvas [data-element-id="${id}"]`)
+      .forEach((node) => targets.push(node));
+  }
+  for (const node of targets) {
+    node.classList.add("wm-agent-flash");
+    window.setTimeout(() => node.classList.remove("wm-agent-flash"), FLASH_MS);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Slide layouts for add_slide
+
+const layoutElements = (
+  layout: SlideLayout,
+  title: string,
+  body: string,
+): SlideElement[] => {
+  const base = (overrides: Partial<SlideElement>): SlideElement => ({
+    id: makeId("el"),
+    type: "text",
+    x: 60,
+    y: 50,
+    w: 840,
+    h: 60,
+    rotation: 0,
+    z: 1,
+    fontSize: 40,
+    fontFamily: "theme.heading",
+    fontWeight: 700,
+    color: "theme.text",
+    align: "left",
+    text: title,
+    ...overrides,
+  });
+
+  switch (layout) {
+    case "title":
+      return [
+        base({ y: 190, h: 90, fontSize: 56, align: "center" }),
+        base({
+          y: 300, h: 50, fontSize: 24, fontWeight: 400,
+          fontFamily: "theme.body", color: "theme.accent", align: "center",
+          text: body,
+        }),
+      ];
+    case "title-body":
+      return [
+        base({}),
+        base({
+          y: 150, h: 330, fontSize: 20, fontWeight: 400,
+          fontFamily: "theme.body", text: body,
+        }),
+      ];
+    case "two-col":
+      return [
+        base({}),
+        base({
+          y: 150, w: 400, h: 330, fontSize: 18, fontWeight: 400,
+          fontFamily: "theme.body", text: body,
+        }),
+        base({
+          x: 500, y: 150, w: 400, h: 330, fontSize: 18, fontWeight: 400,
+          fontFamily: "theme.body", text: "",
+        }),
+      ];
+    case "blank":
+    default:
+      return [];
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Shared geometry for align/distribute (used by both the static id-based
+// tools and the selection-scoped dynamic ones)
+
+type Alignment = "left" | "center-x" | "right" | "top" | "center-y" | "bottom";
+
+const alignElements = (
+  elements: SlideElement[],
+  alignment: Alignment,
+  relativeTo: "slide" | "selection-bounds",
+): void => {
+  let minX = 0;
+  let minY = 0;
+  let maxX = SLIDE_W;
+  let maxY = SLIDE_H;
+  if (relativeTo === "selection-bounds") {
+    minX = Math.min(...elements.map((el) => el.x));
+    minY = Math.min(...elements.map((el) => el.y));
+    maxX = Math.max(...elements.map((el) => el.x + el.w));
+    maxY = Math.max(...elements.map((el) => el.y + el.h));
+  }
+  for (const el of elements) {
+    switch (alignment) {
+      case "left": el.x = minX; break;
+      case "center-x": el.x = Math.round(minX + (maxX - minX - el.w) / 2); break;
+      case "right": el.x = maxX - el.w; break;
+      case "top": el.y = minY; break;
+      case "center-y": el.y = Math.round(minY + (maxY - minY - el.h) / 2); break;
+      case "bottom": el.y = maxY - el.h; break;
+    }
+  }
+};
+
+const distributeElements = (
+  elements: SlideElement[],
+  axis: "horizontal" | "vertical",
+): void => {
+  if (elements.length < 3) {
+    throw new Error("distribute needs at least 3 elements.");
+  }
+  const horizontal = axis === "horizontal";
+  const sorted = [...elements].sort((a, b) =>
+    horizontal ? a.x - b.x : a.y - b.y,
+  );
+  const first = sorted[0];
+  const last = sorted[sorted.length - 1];
+  const start = horizontal ? first.x + first.w / 2 : first.y + first.h / 2;
+  const end = horizontal ? last.x + last.w / 2 : last.y + last.h / 2;
+  const step = (end - start) / (sorted.length - 1);
+  sorted.forEach((el, i) => {
+    const center = start + step * i;
+    if (horizontal) el.x = Math.round(center - el.w / 2);
+    else el.y = Math.round(center - el.h / 2);
+  });
+};
+
+const positionsOf = (
+  elements: SlideElement[],
+): { elementId: string; x: number; y: number }[] =>
+  elements.map((el) => ({ elementId: el.id, x: el.x, y: el.y }));
+
+// ---------------------------------------------------------------------------
+// Schema fragments
+
+const COLOR_DESC =
+  "CSS color (e.g. '#0f172a') or a theme token: 'theme.background', 'theme.surface', 'theme.text', 'theme.accent', 'theme.accentText'. Prefer tokens so the deck restyles when the theme changes.";
+const FONT_DESC =
+  "Font stack, or a theme token: 'theme.heading' / 'theme.body'. Prefer tokens.";
+const GEOMETRY_DESC =
+  "Slide units; the canvas is 960 wide x 540 tall, origin at the top-left.";
+
+const ELEMENT_PATCH_PROPS = {
+  x: { type: "number", description: GEOMETRY_DESC },
+  y: { type: "number" },
+  w: { type: "number" },
+  h: { type: "number" },
+  rotation: { type: "number", description: "Degrees clockwise." },
+  z: { type: "number", description: "Stacking order; higher renders on top." },
+  text: { type: "string", description: "Text elements only. Use \\n for line breaks." },
+  fontSize: { type: "number" },
+  fontFamily: { type: "string", description: FONT_DESC },
+  fontWeight: { type: "number", description: "400 normal, 700 bold." },
+  color: { type: "string", description: COLOR_DESC },
+  align: { type: "string", enum: ["left", "center", "right"] },
+  fill: { type: "string", description: COLOR_DESC },
+  stroke: { type: "string", description: COLOR_DESC },
+  strokeWidth: { type: "number" },
+  src: { type: "string", description: "Image URL, or 'placeholder' for a styled placeholder block." },
+} as const;
+
+// ---------------------------------------------------------------------------
+// Static editing tool set
+
+const buildEditingTools = (store: DeckStore): ToolDescriptor[] => [
+  {
+    name: "get_deck_overview",
+    title: "Read deck overview",
+    description:
+      "Read the deck: title, active theme, slide count, and per-slide {id, position, title, elementCount}. Call this first to orient yourself; positions are 1-based.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute() {
+      const data = {
+        deckTitle: store.deck.title,
+        themeId: store.deck.themeId,
+        slideCount: store.deck.slides.length,
+        currentSlide: {
+          id: store.currentSlide.id,
+          position: store.currentSlideIndex + 1,
+        },
+        slides: store.deck.slides.map((slide, i) => ({
+          id: slide.id,
+          position: i + 1,
+          title: slide.title ?? null,
+          elementCount: slide.elements.length,
+        })),
+      };
+      return toolResult(data, `Deck "${store.deck.title}" — ${data.slideCount} slides.`);
+    },
+  },
+  {
+    name: "get_slide",
+    title: "Read a slide",
+    description:
+      "Read one slide's full contents — every element with its id, geometry, and style. Call this before editing a slide's elements. Defaults to the slide open in the editor.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slideId: { type: "string", description: "Slide id from get_deck_overview." },
+        position: { type: "number", description: "1-based slide position (alternative to slideId)." },
+      },
+    },
+    annotations: { readOnlyHint: true },
+    execute(args) {
+      const slide = resolveSlide(store, args);
+      return toolResult(publicSlide(store.deck, slide));
+    },
+  },
+  {
+    name: "get_selection",
+    title: "Read the user's selection",
+    description:
+      "Read the elements the user currently has selected on the canvas: ids, types, geometry, and styles. Use this whenever the user says 'this', 'these', or refers to something they clicked.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute() {
+      const selected = store.selectedElements();
+      return toolResult(
+        {
+          slideId: store.currentSlide.id,
+          slidePosition: store.currentSlideIndex + 1,
+          count: selected.length,
+          elements: selected.map(publicElement),
+        },
+        selected.length
+          ? `${selected.length} element(s) selected.`
+          : "Nothing is selected.",
+      );
+    },
+  },
+  {
+    name: "list_themes",
+    title: "List themes",
+    description: "List the available deck themes with their palettes and fonts.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute() {
+      return toolResult({
+        activeThemeId: store.deck.themeId,
+        themes: THEMES.map((t) => ({
+          id: t.id,
+          name: t.name,
+          fonts: t.fonts,
+          colors: t.colors,
+        })),
+      });
+    },
+  },
+  {
+    name: "goto_slide",
+    title: "Go to a slide",
+    description: "Open a slide in the editor (navigation only — changes nothing).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slideId: { type: "string" },
+        position: { type: "number", description: "1-based slide position." },
+      },
+    },
+    annotations: { readOnlyHint: true },
+    execute(args) {
+      const slide = resolveSlide(store, args);
+      store.setCurrentSlide(store.deck.slides.indexOf(slide));
+      return toolResult({
+        slideId: slide.id,
+        position: slidePosition(store.deck, slide.id),
+      });
+    },
+  },
+  {
+    name: "add_slide",
+    title: "Add a slide",
+    description:
+      "Insert a new slide from a layout. 'title' = centered title + subtitle; 'title-body' = heading + body text; 'two-col' = heading + two text columns (body fills the left, right starts empty); 'blank' = empty. Returns the new slide id and its element ids so you can refine them with update_element.",
+    inputSchema: {
+      type: "object",
+      required: ["layout"],
+      properties: {
+        layout: { type: "string", enum: ["title", "title-body", "two-col", "blank"] },
+        title: { type: "string", description: "Slide heading text." },
+        body: { type: "string", description: "Body text. Use \\n for line breaks, • for bullets." },
+        position: {
+          type: "number",
+          description: "1-based position to insert at; defaults to the end of the deck.",
+        },
+      },
+    },
+    execute(args) {
+      const layout = String(args.layout ?? "blank") as SlideLayout;
+      const title = typeof args.title === "string" ? args.title : "";
+      const body = typeof args.body === "string" ? args.body : "";
+      const slide: Slide = {
+        id: makeId("slide"),
+        title: title || `Slide ${store.deck.slides.length + 1}`,
+        elements: layoutElements(layout, title, body),
+      };
+      const index =
+        typeof args.position === "number"
+          ? clamp(Math.round(args.position) - 1, 0, store.deck.slides.length)
+          : store.deck.slides.length;
+      store.commit((deck) => {
+        deck.slides.splice(index, 0, structuredClone(slide));
+      });
+      flashAgentTouch(store, slide.id, slide.elements.map((el) => el.id));
+      return toolResult({
+        slideId: slide.id,
+        position: index + 1,
+        elementIds: slide.elements.map((el) => el.id),
+      }, `Added slide ${index + 1} ("${slide.title}").`);
+    },
+  },
+  {
+    name: "duplicate_slide",
+    title: "Duplicate a slide",
+    description: "Copy a slide (and all its elements) right after the original. Returns the new slide id.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slideId: { type: "string" },
+        position: { type: "number", description: "1-based position of the slide to copy." },
+      },
+    },
+    execute(args) {
+      const source = resolveSlide(store, args);
+      const copy: Slide = structuredClone(source);
+      copy.id = makeId("slide");
+      copy.title = `${source.title ?? "Untitled"} (copy)`;
+      copy.elements = copy.elements.map((el) => ({ ...el, id: makeId("el") }));
+      const at = store.deck.slides.indexOf(source) + 1;
+      store.commit((deck) => {
+        deck.slides.splice(at, 0, structuredClone(copy));
+      });
+      flashAgentTouch(store, copy.id);
+      return toolResult({ slideId: copy.id, position: at + 1 });
+    },
+  },
+  {
+    name: "delete_slide",
+    title: "Delete a slide",
+    description: "Permanently remove a slide and all its elements.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slideId: { type: "string" },
+        position: { type: "number", description: "1-based slide position." },
+      },
+    },
+    annotations: { destructiveHint: true },
+    execute(args) {
+      const slide = resolveSlide(store, args);
+      if (store.deck.slides.length === 1) {
+        throw new Error("Cannot delete the only slide in the deck.");
+      }
+      const position = slidePosition(store.deck, slide.id);
+      store.commit((deck) => {
+        deck.slides = deck.slides.filter((s) => s.id !== slide.id);
+      });
+      return toolResult(
+        { deletedSlideId: slide.id, slideCount: store.deck.slides.length },
+        `Deleted slide ${position} ("${slide.title ?? "Untitled"}").`,
+      );
+    },
+  },
+  {
+    name: "reorder_slides",
+    title: "Reorder slides",
+    description: "Move a slide to a new 1-based position. Returns the resulting slide order.",
+    inputSchema: {
+      type: "object",
+      required: ["slideId", "position"],
+      properties: {
+        slideId: { type: "string" },
+        position: { type: "number", description: "1-based target position." },
+      },
+    },
+    execute(args) {
+      const slide = resolveSlide(store, { slideId: args.slideId });
+      const to = clamp(
+        Math.round(Number(args.position)) - 1,
+        0,
+        store.deck.slides.length - 1,
+      );
+      store.commit((deck) => {
+        const from = deck.slides.findIndex((s) => s.id === slide.id);
+        const [moved] = deck.slides.splice(from, 1);
+        deck.slides.splice(to, 0, moved);
+      });
+      flashAgentTouch(store, slide.id);
+      return toolResult({
+        order: store.deck.slides.map((s, i) => ({
+          id: s.id,
+          position: i + 1,
+          title: s.title ?? null,
+        })),
+      });
+    },
+  },
+  {
+    name: "set_slide_props",
+    title: "Update slide settings",
+    description: "Update a slide's title and/or background color.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        slideId: { type: "string" },
+        position: { type: "number", description: "1-based slide position." },
+        title: { type: "string" },
+        background: { type: "string", description: COLOR_DESC },
+      },
+    },
+    execute(args) {
+      const slide = resolveSlide(store, args);
+      store.commit((deck) => {
+        const target = deck.slides.find((s) => s.id === slide.id);
+        if (!target) return;
+        if (typeof args.title === "string") target.title = args.title;
+        if (typeof args.background === "string") target.background = args.background;
+      });
+      flashAgentTouch(store, slide.id);
+      const fresh = store.findSlide(slide.id);
+      return toolResult({
+        slideId: slide.id,
+        title: fresh?.title ?? null,
+        background: fresh?.background ?? null,
+      });
+    },
+  },
+  {
+    name: "add_element",
+    title: "Add an element",
+    description:
+      "Add one element (text box, rectangle, ellipse, line, or image) to a slide. Lines draw from the top-left to the bottom-right corner of their bounding box. Returns the new element id.",
+    inputSchema: {
+      type: "object",
+      required: ["type"],
+      properties: {
+        slideId: {
+          type: "string",
+          description: "Target slide id; defaults to the slide open in the editor.",
+        },
+        type: { type: "string", enum: ["text", "rect", "ellipse", "line", "image"] },
+        ...ELEMENT_PATCH_PROPS,
+      },
+    },
+    execute(args) {
+      const slide = resolveSlide(store, args);
+      const type = String(args.type) as SlideElement["type"];
+      if (!["text", "rect", "ellipse", "line", "image"].includes(type)) {
+        throw new Error(`Unknown element type "${type}".`);
+      }
+      const el: SlideElement = {
+        id: makeId("el"),
+        type,
+        x: 80,
+        y: 80,
+        w: type === "text" ? 400 : 200,
+        h: type === "text" ? 50 : type === "line" ? 4 : 120,
+        rotation: 0,
+        z: store.nextZ(slide),
+        ...(type === "text"
+          ? { text: "", fontSize: 18, fontFamily: "theme.body", color: "theme.text", align: "left" as const }
+          : {}),
+        ...(type === "rect" || type === "ellipse" ? { fill: "theme.accent" } : {}),
+        ...(type === "line" ? { stroke: "theme.text", strokeWidth: 2 } : {}),
+        ...(type === "image" ? { src: "placeholder" } : {}),
+      };
+      applyElementPatch(el, args);
+      store.commit((deck) => {
+        const target = deck.slides.find((s) => s.id === slide.id);
+        target?.elements.push(structuredClone(el));
+      });
+      flashAgentTouch(store, slide.id, [el.id]);
+      return toolResult(
+        {
+          elementId: el.id,
+          slideId: slide.id,
+          bounds: { x: el.x, y: el.y, w: el.w, h: el.h },
+        },
+        `Added ${type} to slide ${slidePosition(store.deck, slide.id)}.`,
+      );
+    },
+  },
+  {
+    name: "update_element",
+    title: "Update an element",
+    description:
+      "Merge a partial patch into one element — position, size, text, and style in a single call. Omitted keys are unchanged. Returns the updated element.",
+    inputSchema: {
+      type: "object",
+      required: ["elementId", "patch"],
+      properties: {
+        elementId: { type: "string" },
+        patch: {
+          type: "object",
+          description: "Partial element properties to merge; omitted keys are unchanged.",
+          properties: ELEMENT_PATCH_PROPS,
+        },
+      },
+    },
+    execute(args) {
+      const elementId = String(args.elementId ?? "");
+      const found = store.findElement(elementId);
+      if (!found) {
+        throw new Error(`No element with id "${elementId}". Call get_slide to list element ids.`);
+      }
+      const patch = (args.patch ?? {}) as Record<string, unknown>;
+      store.commit((deck) => {
+        for (const slide of deck.slides) {
+          const el = slide.elements.find((e) => e.id === elementId);
+          if (el) applyElementPatch(el, patch);
+        }
+      });
+      flashAgentTouch(store, found.slide.id, [elementId]);
+      const fresh = store.findElement(elementId);
+      return toolResult(fresh ? publicElement(fresh.element) : { elementId });
+    },
+  },
+  {
+    name: "delete_elements",
+    title: "Delete elements",
+    description: "Permanently remove one or more elements by id.",
+    inputSchema: {
+      type: "object",
+      required: ["elementIds"],
+      properties: {
+        elementIds: { type: "array", items: { type: "string" }, minItems: 1 },
+      },
+    },
+    annotations: { destructiveHint: true },
+    execute(args) {
+      const ids = Array.isArray(args.elementIds)
+        ? args.elementIds.map(String)
+        : [];
+      if (!ids.length) throw new Error("elementIds is required.");
+      const touched = new Set<string>();
+      store.commit((deck) => {
+        for (const slide of deck.slides) {
+          const before = slide.elements.length;
+          slide.elements = slide.elements.filter((el) => !ids.includes(el.id));
+          if (slide.elements.length !== before) touched.add(slide.id);
+        }
+      });
+      return toolResult(
+        { deletedElementIds: ids, slideIds: [...touched] },
+        `Deleted ${ids.length} element(s).`,
+      );
+    },
+  },
+  {
+    name: "align_elements",
+    title: "Align elements",
+    description:
+      "Align elements to the slide or to their shared bounding box. Returns the new positions.",
+    inputSchema: {
+      type: "object",
+      required: ["elementIds", "alignment"],
+      properties: {
+        elementIds: { type: "array", items: { type: "string" }, minItems: 1 },
+        alignment: {
+          type: "string",
+          enum: ["left", "center-x", "right", "top", "center-y", "bottom"],
+        },
+        relativeTo: {
+          type: "string",
+          enum: ["slide", "selection-bounds"],
+          description:
+            "Default 'slide'. 'selection-bounds' aligns within the group's own bounding box.",
+        },
+      },
+    },
+    execute(args) {
+      const ids = Array.isArray(args.elementIds) ? args.elementIds.map(String) : [];
+      if (!ids.length) throw new Error("elementIds is required.");
+      const first = store.findElement(ids[0]);
+      if (!first) throw new Error(`No element with id "${ids[0]}".`);
+      store.commit((deck) => {
+        const slide = deck.slides.find((s) => s.id === first.slide.id);
+        if (!slide) return;
+        const targets = slide.elements.filter((el) => ids.includes(el.id));
+        alignElements(
+          targets,
+          String(args.alignment) as Alignment,
+          args.relativeTo === "selection-bounds" ? "selection-bounds" : "slide",
+        );
+      });
+      flashAgentTouch(store, first.slide.id, ids);
+      const fresh = store.findSlide(first.slide.id);
+      return toolResult({
+        positions: positionsOf(
+          fresh?.elements.filter((el) => ids.includes(el.id)) ?? [],
+        ),
+      });
+    },
+  },
+  {
+    name: "distribute_elements",
+    title: "Distribute elements",
+    description:
+      "Space three or more elements evenly along an axis (their first/last stay put). Returns the new positions.",
+    inputSchema: {
+      type: "object",
+      required: ["elementIds", "axis"],
+      properties: {
+        elementIds: { type: "array", items: { type: "string" }, minItems: 3 },
+        axis: { type: "string", enum: ["horizontal", "vertical"] },
+      },
+    },
+    execute(args) {
+      const ids = Array.isArray(args.elementIds) ? args.elementIds.map(String) : [];
+      const first = store.findElement(ids[0] ?? "");
+      if (!first) throw new Error("elementIds must reference existing elements.");
+      store.commit((deck) => {
+        const slide = deck.slides.find((s) => s.id === first.slide.id);
+        if (!slide) return;
+        const targets = slide.elements.filter((el) => ids.includes(el.id));
+        distributeElements(
+          targets,
+          args.axis === "vertical" ? "vertical" : "horizontal",
+        );
+      });
+      flashAgentTouch(store, first.slide.id, ids);
+      const fresh = store.findSlide(first.slide.id);
+      return toolResult({
+        positions: positionsOf(
+          fresh?.elements.filter((el) => ids.includes(el.id)) ?? [],
+        ),
+      });
+    },
+  },
+  {
+    name: "set_deck_title",
+    title: "Rename the deck",
+    description: "Set the deck's title.",
+    inputSchema: {
+      type: "object",
+      required: ["title"],
+      properties: { title: { type: "string" } },
+    },
+    execute(args) {
+      const title = String(args.title ?? "").trim();
+      if (!title) throw new Error("title is required.");
+      store.commit((deck) => {
+        deck.title = title;
+      });
+      return toolResult({ deckTitle: title });
+    },
+  },
+  {
+    name: "apply_theme",
+    title: "Apply a theme to the whole deck",
+    description:
+      "Switch the deck's theme. Every element using theme tokens ('theme.accent', 'theme.heading', …) restyles across ALL slides.",
+    inputSchema: {
+      type: "object",
+      required: ["themeId"],
+      properties: {
+        themeId: { type: "string", description: "A theme id from list_themes." },
+      },
+    },
+    execute(args) {
+      const themeId = String(args.themeId ?? "");
+      if (!THEMES.some((t) => t.id === themeId)) {
+        throw new Error(
+          `Unknown theme "${themeId}". Valid: ${THEMES.map((t) => t.id).join(", ")}.`,
+        );
+      }
+      store.commit((deck) => {
+        deck.themeId = themeId;
+      });
+      flashAgentTouch(store, store.currentSlide.id);
+      return toolResult(
+        { themeId, theme: getTheme(themeId).name },
+        `Applied the ${getTheme(themeId).name} theme to all ${store.deck.slides.length} slides.`,
+      );
+    },
+  },
+  {
+    name: "enter_presenter_mode",
+    title: "Start presenting",
+    description:
+      "Enter full-screen presenter mode. NOTE: this replaces your editing tools with presentation controls (next_slide, prev_slide, jump_to_slide, exit_presenter_mode) until the show ends.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        position: { type: "number", description: "1-based slide to start from; defaults to slide 1." },
+      },
+    },
+    execute(args) {
+      if (typeof args.position === "number") {
+        store.setCurrentSlide(Math.round(args.position) - 1);
+      } else {
+        store.setCurrentSlide(0);
+      }
+      store.setMode("present");
+      return toolResult({
+        mode: "present",
+        slidePosition: store.currentSlideIndex + 1,
+        slideCount: store.deck.slides.length,
+      });
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Presenter tool set (replaces the editing set while presenting)
+
+const buildPresenterTools = (store: DeckStore): ToolDescriptor[] => {
+  const state = (): Record<string, unknown> => ({
+    mode: store.mode,
+    slidePosition: store.currentSlideIndex + 1,
+    slideCount: store.deck.slides.length,
+    slideTitle: store.currentSlide.title ?? null,
+  });
+  return [
+    {
+      name: "next_slide",
+      title: "Next slide",
+      description: "Advance the presentation to the next slide.",
+      inputSchema: { type: "object", properties: {} },
+      annotations: { readOnlyHint: true },
+      execute() {
+        store.setCurrentSlide(store.currentSlideIndex + 1);
+        return toolResult(state());
+      },
+    },
+    {
+      name: "prev_slide",
+      title: "Previous slide",
+      description: "Go back to the previous slide.",
+      inputSchema: { type: "object", properties: {} },
+      annotations: { readOnlyHint: true },
+      execute() {
+        store.setCurrentSlide(store.currentSlideIndex - 1);
+        return toolResult(state());
+      },
+    },
+    {
+      name: "jump_to_slide",
+      title: "Jump to a slide",
+      description: "Jump to a 1-based slide position.",
+      inputSchema: {
+        type: "object",
+        required: ["position"],
+        properties: { position: { type: "number" } },
+      },
+      annotations: { readOnlyHint: true },
+      execute(args) {
+        store.setCurrentSlide(Math.round(Number(args.position)) - 1);
+        return toolResult(state());
+      },
+    },
+    {
+      name: "exit_presenter_mode",
+      title: "End the show",
+      description: "Leave presenter mode and return to the editor (restores the editing tools).",
+      inputSchema: { type: "object", properties: {} },
+      annotations: { readOnlyHint: true },
+      execute() {
+        store.setMode("edit");
+        return toolResult({ mode: "edit" });
+      },
+    },
+  ];
+};
+
+// ---------------------------------------------------------------------------
+// Selection-scoped dynamic tool set — exists only while 2+ elements are
+// selected. These act on the LIVE selection, so no ids are needed.
+
+const buildSelectionTools = (store: DeckStore): ToolDescriptor[] => [
+  {
+    name: "style_selection",
+    title: "Style the selected elements",
+    description:
+      "Apply shared style properties to every element the user has selected. Acts on the live selection — no ids needed.",
+    inputSchema: {
+      type: "object",
+      required: ["patch"],
+      properties: {
+        patch: {
+          type: "object",
+          description: "Style properties to apply to all selected elements.",
+          properties: {
+            fontSize: { type: "number" },
+            fontFamily: { type: "string", description: FONT_DESC },
+            fontWeight: { type: "number" },
+            color: { type: "string", description: COLOR_DESC },
+            align: { type: "string", enum: ["left", "center", "right"] },
+            fill: { type: "string", description: COLOR_DESC },
+            stroke: { type: "string", description: COLOR_DESC },
+            strokeWidth: { type: "number" },
+            w: { type: "number" },
+            h: { type: "number" },
+          },
+        },
+      },
+    },
+    execute(args) {
+      const ids = [...store.selection];
+      if (ids.length < 2) throw new Error("Fewer than 2 elements are selected now.");
+      const slideId = store.currentSlide.id;
+      const patch = (args.patch ?? {}) as Record<string, unknown>;
+      store.commit((deck) => {
+        const slide = deck.slides.find((s) => s.id === slideId);
+        for (const el of slide?.elements ?? []) {
+          if (ids.includes(el.id)) applyElementPatch(el, patch);
+        }
+      });
+      flashAgentTouch(store, slideId, ids);
+      const fresh = store.findSlide(slideId);
+      return toolResult({
+        styled: fresh?.elements.filter((el) => ids.includes(el.id)).map(publicElement) ?? [],
+      });
+    },
+  },
+  {
+    name: "align_selection",
+    title: "Align the selected elements",
+    description:
+      "Align or distribute the elements the user has selected. Acts on the live selection — no ids needed.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        alignment: {
+          type: "string",
+          enum: ["left", "center-x", "right", "top", "center-y", "bottom"],
+        },
+        distribute: { type: "string", enum: ["horizontal", "vertical"] },
+        relativeTo: {
+          type: "string",
+          enum: ["slide", "selection-bounds"],
+          description: "Default 'selection-bounds' (line the group up with itself).",
+        },
+      },
+    },
+    execute(args) {
+      const ids = [...store.selection];
+      if (ids.length < 2) throw new Error("Fewer than 2 elements are selected now.");
+      if (!args.alignment && !args.distribute) {
+        throw new Error("Provide alignment and/or distribute.");
+      }
+      const slideId = store.currentSlide.id;
+      store.commit((deck) => {
+        const slide = deck.slides.find((s) => s.id === slideId);
+        if (!slide) return;
+        const targets = slide.elements.filter((el) => ids.includes(el.id));
+        if (args.alignment) {
+          alignElements(
+            targets,
+            String(args.alignment) as Alignment,
+            args.relativeTo === "slide" ? "slide" : "selection-bounds",
+          );
+        }
+        if (args.distribute) {
+          distributeElements(
+            targets,
+            args.distribute === "vertical" ? "vertical" : "horizontal",
+          );
+        }
+      });
+      flashAgentTouch(store, slideId, ids);
+      const fresh = store.findSlide(slideId);
+      return toolResult({
+        positions: positionsOf(
+          fresh?.elements.filter((el) => ids.includes(el.id)) ?? [],
+        ),
+      });
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Registration lifecycle
+
+export const setupSlidesTools = (store: DeckStore): boolean => {
+  const modelContext = getModelContext();
+  if (!modelContext?.registerTool) {
+    console.warn("[Slides] WebMCP unavailable — no modelContext found on this page.");
+    return false;
+  }
+
+  const registerSet = (
+    owner: typeof EDIT_OWNER | typeof SELECTION_OWNER,
+    tools: ToolDescriptor[],
+  ): void => {
+    window[owner]?.abort?.();
+    const controller = new AbortController();
+    window[owner] = controller;
+    for (const tool of tools) {
+      registerTool(modelContext, tool, controller.signal);
+    }
+  };
+
+  let registeredMode: "edit" | "present" | null = null;
+  let selectionRegistered = false;
+  let selectionTimer: number | undefined;
+
+  const syncSelectionTools = (): void => {
+    const want = store.mode === "edit" && store.selection.size >= 2;
+    if (want === selectionRegistered) return;
+    // Debounced: shift-click sprees and marquee-style adjustments shouldn't
+    // thrash the registry (the widget re-snapshots tools every turn anyway).
+    window.clearTimeout(selectionTimer);
+    selectionTimer = window.setTimeout(() => {
+      const stillWant = store.mode === "edit" && store.selection.size >= 2;
+      if (stillWant === selectionRegistered) return;
+      selectionRegistered = stillWant;
+      if (stillWant) {
+        registerSet(SELECTION_OWNER, buildSelectionTools(store));
+      } else {
+        window[SELECTION_OWNER]?.abort?.();
+      }
+    }, SELECTION_DEBOUNCE_MS);
+  };
+
+  const syncModeTools = (): void => {
+    if (store.mode === registeredMode) return;
+    registeredMode = store.mode;
+    if (store.mode === "present") {
+      window[SELECTION_OWNER]?.abort?.();
+      selectionRegistered = false;
+      registerSet(EDIT_OWNER, buildPresenterTools(store));
+    } else {
+      registerSet(EDIT_OWNER, buildEditingTools(store));
+    }
+  };
+
+  store.subscribe(() => {
+    syncModeTools();
+    syncSelectionTools();
+  });
+  syncModeTools();
+  syncSelectionTools();
+  return true;
+};

--- a/examples/embedded-app/src/webmcp-slides/types.ts
+++ b/examples/embedded-app/src/webmcp-slides/types.ts
@@ -1,0 +1,75 @@
+// Data model for the WebMCP slide-deck editor demo. All element geometry is in
+// logical slide units on a fixed 960x540 stage — the canvas scales the stage
+// with a CSS transform, so coordinates never depend on viewport size.
+
+export const SLIDE_W = 960;
+export const SLIDE_H = 540;
+
+export type ElementType = "text" | "rect" | "ellipse" | "line" | "image";
+
+export type SlideElement = {
+  id: string;
+  type: ElementType;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  /** Degrees clockwise. */
+  rotation: number;
+  z: number;
+  // Text props
+  text?: string;
+  fontSize?: number;
+  /** Literal font stack or a theme token: 'theme.heading' | 'theme.body'. */
+  fontFamily?: string;
+  fontWeight?: number;
+  /** Literal CSS color or a theme token like 'theme.text' / 'theme.accent'. */
+  color?: string;
+  align?: "left" | "center" | "right";
+  // Shape props (rect/ellipse/line)
+  fill?: string;
+  stroke?: string;
+  strokeWidth?: number;
+  // Image props
+  /** Image URL, or 'placeholder' for a styled placeholder block. */
+  src?: string;
+};
+
+export type Slide = {
+  id: string;
+  title?: string;
+  /** Literal CSS color or theme token; defaults to 'theme.background'. */
+  background?: string;
+  elements: SlideElement[];
+};
+
+export type Deck = {
+  id: string;
+  title: string;
+  themeId: string;
+  slides: Slide[];
+};
+
+export type Theme = {
+  id: string;
+  name: string;
+  fonts: { heading: string; body: string };
+  colors: {
+    background: string;
+    surface: string;
+    text: string;
+    accent: string;
+    accentText: string;
+  };
+};
+
+export type SlideLayout = "title" | "title-body" | "two-col" | "blank";
+
+let idCounter = 0;
+
+/** Short unique id, readable in tool output (e.g. "el-kf3a9x-7"). */
+export const makeId = (prefix: string): string =>
+  `${prefix}-${Date.now().toString(36)}-${(idCounter++).toString(36)}`;
+
+export const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -407,6 +407,8 @@ export default defineConfig({
         'webmcp-demo': path.resolve(__dirname, 'webmcp-demo.html'),
         // WebMCP — calendar copilot (client-token mode)
         'webmcp-calendar': path.resolve(__dirname, 'webmcp-calendar.html'),
+        // WebMCP — slide-deck editor (dynamic tool sets, selection context)
+        'webmcp-slides': path.resolve(__dirname, 'webmcp-slides.html'),
         // Bakery demo pages
         'bakery': path.resolve(__dirname, 'bakery.html'),
         'bakery-story': path.resolve(__dirname, 'bakery-story.html'),

--- a/examples/embedded-app/webmcp-slides.html
+++ b/examples/embedded-app/webmcp-slides.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" />
+    <title>WebMCP Slides — Deck Copilot</title>
+  </head>
+  <body class="wm-body">
+    <header class="wm-toolbar">
+      <div class="wm-toolbar-brand">
+        <span class="wm-logo">Deckmate</span>
+        <span class="wm-badge">WebMCP demo</span>
+      </div>
+      <input id="deck-title" class="wm-deck-title" type="text" aria-label="Deck title" />
+      <div class="wm-toolbar-actions">
+        <label class="wm-theme-label">
+          Theme
+          <select id="theme-select" aria-label="Deck theme"></select>
+        </label>
+        <button id="undo-button" type="button" title="Undo (⌘Z)">↺ Undo</button>
+        <button id="redo-button" type="button" title="Redo (⇧⌘Z)">↻ Redo</button>
+        <button id="reset-button" type="button" title="Reset to the sample deck">Reset deck</button>
+        <button id="present-button" type="button" class="wm-present-button">▶ Present</button>
+      </div>
+    </header>
+
+    <main class="wm-main">
+      <!-- The docked Persona panel wraps this target and docks beside it,
+           shrinking the editor — same pattern as webmcp-calendar. -->
+      <div id="editor-dock-target" class="wm-editor">
+        <aside id="slides-sorter" aria-label="Slides"></aside>
+        <section id="slides-canvas" aria-label="Slide canvas"></section>
+      </div>
+    </main>
+
+    <footer class="wm-footer">
+      <p>
+        Every edit — yours or the Copilot's — goes through the same store, so
+        <kbd>⌘Z</kbd> undoes both. Select two or more elements to unlock the
+        Copilot's selection tools; press <strong>Present</strong> to swap its
+        tool set for show controls.
+      </p>
+    </footer>
+
+    <script type="module" src="/src/webmcp-slides/main.ts"></script>
+  </body>
+</html>

--- a/examples/vercel-edge/src/server.ts
+++ b/examples/vercel-edge/src/server.ts
@@ -10,6 +10,7 @@ import {
   STOREFRONT_ASSISTANT_FLOW,
   WEBMCP_STOREFRONT_FLOW,
   WEBMCP_CALENDAR_FLOW,
+  WEBMCP_SLIDES_FLOW,
   PAGE_CONTEXT_FLOW,
   createCheckoutSession
 } from "@runtypelabs/persona-proxy";
@@ -111,6 +112,18 @@ const webmcpCalendarApp = createChatProxyApp({
   upstreamUrl
 });
 
+// WebMCP slides proxy - for the Deck Copilot slide-editor demo. Same pattern,
+// with a twist: the page's tool set is dynamic (selection-scoped tools appear
+// with multi-select; presenter mode swaps the editing set for show controls),
+// and the widget ships live editor state as {{slides_context}} via inputs.
+const webmcpSlidesApp = createChatProxyApp({
+  path: "/api/chat/dispatch-slides",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_SLIDES || undefined,
+  flowConfig: process.env.FLOW_ID_SLIDES ? undefined : WEBMCP_SLIDES_FLOW,
+  upstreamUrl
+});
+
 // Page-context proxy - read-only, markdown answers about the current page.
 // Used by the smart-dom-reader demo: the widget sends live page context (including
 // shadow-DOM elements) as `inputs`, and this flow injects it via {{pageContext}}.
@@ -130,6 +143,7 @@ app.route("/", bakeryApp);
 app.route("/", storefrontApp);
 app.route("/", webmcpApp);
 app.route("/", webmcpCalendarApp);
+app.route("/", webmcpSlidesApp);
 app.route("/", pageContextApp);
 
 // Stripe checkout endpoint

--- a/packages/proxy/src/flows/index.ts
+++ b/packages/proxy/src/flows/index.ts
@@ -13,4 +13,5 @@ export { BAKERY_ASSISTANT_FLOW } from "./bakery-assistant.js";
 export { STOREFRONT_ASSISTANT_FLOW } from "./storefront-assistant.js";
 export { WEBMCP_STOREFRONT_FLOW } from "./webmcp-storefront.js";
 export { WEBMCP_CALENDAR_FLOW } from "./webmcp-calendar.js";
+export { WEBMCP_SLIDES_FLOW } from "./webmcp-slides.js";
 export { PAGE_CONTEXT_FLOW } from "./page-context.js";

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -1,0 +1,78 @@
+import type { RuntypeFlowConfig } from "../index.js";
+
+/**
+ * WebMCP slide-editor flow for the Deck Copilot demo
+ * (`examples/embedded-app/webmcp-slides.html`).
+ *
+ * Like the other WebMCP flows, this agent owns **no** tools of its own — the
+ * demo page registers them on `document.modelContext` and the widget snapshots
+ * them every turn into `clientTools[]`. What makes this flow different is that
+ * the page's tool set is *dynamic*: selection-scoped tools
+ * (`style_selection`, `align_selection`) only exist while the user has 2+
+ * elements selected, and entering presenter mode replaces the entire editing
+ * set with show controls (`next_slide`, `prev_slide`, `jump_to_slide`,
+ * `exit_presenter_mode`). The system prompt teaches the model to treat the
+ * current tool list as authoritative rather than assuming a fixed catalog.
+ *
+ * The page also ships live editor state as `{{slides_context}}` via the
+ * widget's `contextProviders` + `requestMiddleware` (moved from
+ * `payload.context` into `inputs`): current slide, mode, and the user's
+ * selection with ids and bounding boxes — so "align these" resolves without a
+ * round-trip.
+ */
+export const WEBMCP_SLIDES_FLOW: RuntypeFlowConfig = {
+  name: "WebMCP Slides Flow",
+  description:
+    "Deck Copilot — drives a slide editor's page-provided WebMCP tools (clientTools[])",
+  steps: [
+    {
+      id: "webmcp_slides_prompt",
+      name: "WebMCP Slides Prompt",
+      type: "prompt",
+      enabled: true,
+      config: {
+        model: "nemotron-3-ultra-550b-a55b",
+        reasoning: false,
+        responseFormat: "markdown",
+        outputVariable: "prompt_result",
+        userPrompt: "{{user_message}}",
+        systemPrompt: `You are the Deck Copilot inside a live slide-deck editor. You build, restyle, align, and present slides — the canvas on the page updates instantly as your tools run, and the user is watching.
+
+Voice: concise and design-literate. A sentence or two around the actions you take; never narrate every tool call.
+
+## Your tools come from the page — and they change
+
+The editor exposes its own tools to you, and the set is dynamic:
+- While the user has 2 or more elements selected, extra selection tools appear (style_selection, align_selection) that act on the live selection without needing ids.
+- When the show starts (enter_presenter_mode), your editing tools are REPLACED by presentation controls (next_slide, prev_slide, jump_to_slide, exit_presenter_mode) until the show ends.
+
+Treat the tool list you currently see as authoritative. Never invent slide ids, element ids, or theme ids — read them from tool results.
+
+## Read before you write
+
+- Call get_deck_overview to orient yourself when you need the deck's shape; call get_slide before editing a slide's elements.
+- Mutations return the ids they created or touched — chain on those instead of re-reading the deck.
+- A {{slides_context}} block rides along with every message: the current slide, the editor mode, and the user's live selection (ids + bounding boxes). When the user says "this", "these", or "the selected boxes", use that context (or get_selection) — do not guess.
+
+## Geometry and style conventions
+
+- The canvas is 960 wide x 540 tall, origin at the top-left. Keep ~40px margins; slide titles sit around y 40-60 at fontSize 36-48.
+- Prefer theme tokens over literal colors and fonts: 'theme.text', 'theme.accent', 'theme.background', 'theme.surface', 'theme.accentText' for colors, 'theme.heading' / 'theme.body' for fonts. Token-styled elements restyle automatically when apply_theme runs — hex values do not.
+- Build slides with add_slide layouts first, then refine with update_element patches (one patch can move, resize, and restyle at once). Use align_elements / distribute_elements for clean composition instead of eyeballing coordinates.
+
+## Etiquette
+
+- Destructive or deck-wide tools (delete_slide, delete_elements, apply_theme) ask the user for confirmation — if the user declines, accept it and move on.
+- Every change you make lands on the editor's undo stack; the user can reverse you with Cmd+Z. Don't be precious about edits.
+- After mutations, confirm briefly what changed — the user can see the canvas, so don't re-describe slides in detail.
+- If a tool reports an error (unknown id, too few elements selected), relay it plainly and suggest the fix.
+- Never mention JSON, ids, tool schemas, or the WebMCP mechanism unless the user asks.
+
+## Live editor state
+
+{{slides_context}}`,
+        previousMessages: "{{messages}}"
+      }
+    }
+  ]
+};


### PR DESCRIPTION
## Summary

Adds a new WebMCP example — a **Keynote-lite slide-deck editor** (`webmcp-slides.html`) where the human and the Persona agent co-edit the same live canvas. The existing WebMCP demos (storefront, calendar) are CRUD-over-a-list apps; this one exercises the WebMCP capabilities none of them touch:

- **Dynamic tool registration** — the demo's headline trick, shown twice:
  - `style_selection` / `align_selection` exist only while the user has **2+ elements selected** (AbortController re-registration, debounced)
  - `enter_presenter_mode` **replaces the entire editing set** (18 tools) with show controls (`next_slide`, `prev_slide`, `jump_to_slide`, `exit_presenter_mode`) until the show ends
- **Selection as context** — `contextProviders` + `requestMiddleware` ship live editor state (current slide, mode, selected element ids + bounding boxes) as `{{slides_context}}` with every message, so *"align these"* works without the user describing anything
- **Shared undo stack** — agent tools and human gestures commit through the same snapshot-stack store, so ⌘Z reverses the agent's edits too
- **Approval by blast radius** — reads and incremental writes auto-approve (watch the agent assemble a slide live, with an outline pulse on everything it touches); only `delete_slide` / `delete_elements` / `apply_theme` raise the native approval bubble, with friendly copy via `approval.formatDescription`
- **Theme tokens** — `theme.accent` / `theme.heading` etc. resolve at render time, so `apply_theme` restyles all slides in one call

### The editor itself (dependency-free vanilla TS)

960×540 logical canvas scaled with a CSS transform; absolutely-positioned DOM elements (text/rect/ellipse/line/image); click + shift-click multi-select, drag-move, 8-handle resize, double-click inline text editing; slide sorter rail with pixel-faithful scaled thumbnails (same pure `renderSlide()` as the canvas and presenter); 4 named themes; localStorage persistence; seeded 5-slide startup pitch.

### Proxy

New `WEBMCP_SLIDES_FLOW` in `@runtypelabs/persona-proxy` (changeset included), mounted at `/api/chat/dispatch-slides` in the vercel-edge example server. Tool-passthrough like the other WebMCP flows; the system prompt teaches the model that the tool list changes between turns.

## Test plan

- [x] `pnpm build`, `pnpm lint`, `pnpm typecheck` green; widget tests 1132/1132 pass; embedded-app `vite build` succeeds
- [x] Browser-verified standalone editor: select/drag/resize/inline-edit, sorter reorder, theme switch, undo/redo, localStorage persistence, reset
- [x] Browser-verified WebMCP surface via `document.modelContext.getTools()/executeTool()` (the exact path the widget uses): 18 editing tools; `add_slide` → live slide + flash + chained ids; `get_selection` reflects shift-click multi-select; selection tools appear (18→20) and `style_selection` patches the live selection; presenter swap (18→4→18); `apply_theme` restyles all slides
- [ ] Live LLM round-trip not verified locally — requires upstream proxy credentials (`.env`) that aren't present in this checkout; the flow mirrors `WEBMCP_CALENDAR_FLOW`'s wiring exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Example-only editor and proxy flow wiring; no changes to core widget auth or production paths beyond a minor persona-proxy export.
> 
> **Overview**
> Adds a **Deck Copilot** WebMCP demo: `webmcp-slides.html` plus a vanilla TS slide editor (canvas, sorter, presenter, shared `DeckStore` with undo + localStorage) where humans and Persona co-edit the same deck.
> 
> **WebMCP surface** (`tools.ts`): ~18 editing tools on `document.modelContext`, with **dynamic registration** — selection-only `style_selection` / `align_selection` when 2+ elements are selected (debounced AbortController), and a full swap to presenter controls in present mode. Destructive/deck-wide tools use approval; incremental writes auto-approve with agent-touch flashes.
> 
> **Persona wiring** (`main.ts`): docked widget → `/api/chat/dispatch-slides`; `contextProviders` + `requestMiddleware` move live `slides_context` (mode, slide, selection bounds) into `inputs` for `{{slides_context}}`.
> 
> **Proxy / package**: new `WEBMCP_SLIDES_FLOW` in `@runtypelabs/persona-proxy` (minor changeset), exported and mounted in `examples/vercel-edge/src/server.ts` with optional `FLOW_ID_SLIDES`. Vite entry and README section document the demo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b089401587cb13e0769af6e900b1b62edef582ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->