### PR TITLE
fix: add missing proxy routes for all demo endpoints

### DIFF
--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -449,11 +449,18 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api/chat/dispatch": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-directive": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-action": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-component": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-bakery": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-storefront": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-webmcp": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-calendar": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-slides": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-page-context": `http://localhost:${proxyPort}`,
       "/api/checkout": `http://localhost:${proxyPort}`,
+      "/api/checkout/bakery": `http://localhost:${proxyPort}`,
+      "/api/checkout/storefront": `http://localhost:${proxyPort}`,
       "/form": `http://localhost:${proxyPort}`
     }
   }


### PR DESCRIPTION
Fixes 404 errors when demos try to connect to their respective proxy endpoints.

## Changes
Added missing Vite dev server proxy routes in `examples/embedded-app/vite.config.ts`:

- `/api/chat/dispatch-directive` (dynamic form demos)
- `/api/chat/dispatch-webmcp` (WebMCP demo)
- `/api/chat/dispatch-calendar` (calendar copilot demo)
- `/api/chat/dispatch-slides` (Deck Copilot demo) ← **fixes the reported issue**
- `/api/chat/dispatch-page-context` (smart-dom-reader demo)
- `/api/checkout/bakery` (bakery checkout)
- `/api/checkout/storefront` (storefront checkout)

## Testing
Run `pnpm dev` and open the slides demo at `http://localhost:5173/webmcp-slides.html`. The chat widget should now connect successfully without the 404 error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only Vite proxy configuration; no production or runtime behavior changes.
> 
> **Overview**
> Fixes **404s in local dev** when embedded demos call chat dispatch and checkout APIs through **relative URLs** on the Vite server (`pnpm dev` on port 5173).
> 
> The Vite `server.proxy` block in `vite.config.ts` now forwards seven additional paths to the same local backend as the existing routes (`localhost:${PROXY_PORT}`, default 43111): chat dispatch variants (`dispatch-directive`, `dispatch-webmcp`, `dispatch-calendar`, `dispatch-slides`, `dispatch-page-context`) and checkout subpaths (`/api/checkout/bakery`, `/api/checkout/storefront`). Demos that already pointed at those endpoints (e.g. Deck Copilot at `/api/chat/dispatch-slides`, bakery at `/api/checkout/bakery`) can reach the proxy without changing app code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 718135c7611340dee7f5d380c002117cd8a64b55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->