### PR TITLE
fix(vercel): add missing /api/chat/dispatch-slides and /dispatch-page-context routes

### DIFF
--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -449,11 +449,18 @@ export default defineConfig({
     port: 5173,
     proxy: {
       "/api/chat/dispatch": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-directive": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-action": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-component": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-bakery": `http://localhost:${proxyPort}`,
       "/api/chat/dispatch-storefront": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-webmcp": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-calendar": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-slides": `http://localhost:${proxyPort}`,
+      "/api/chat/dispatch-page-context": `http://localhost:${proxyPort}`,
       "/api/checkout": `http://localhost:${proxyPort}`,
+      "/api/checkout/bakery": `http://localhost:${proxyPort}`,
+      "/api/checkout/storefront": `http://localhost:${proxyPort}`,
       "/form": `http://localhost:${proxyPort}`
     }
   }

--- a/examples/vercel-edge/api/index.ts
+++ b/examples/vercel-edge/api/index.ts
@@ -8,6 +8,8 @@ import {
   STOREFRONT_ASSISTANT_FLOW,
   WEBMCP_STOREFRONT_FLOW,
   WEBMCP_CALENDAR_FLOW,
+  WEBMCP_SLIDES_FLOW,
+  PAGE_CONTEXT_FLOW,
   createCheckoutSession,
 } from "@runtypelabs/persona-proxy";
 
@@ -86,6 +88,24 @@ const webmcpCalendarApp = createChatProxyApp({
   upstreamUrl,
 });
 
+// WebMCP slides proxy - for the Deck Copilot slide-editor demo.
+const webmcpSlidesApp = createChatProxyApp({
+  path: "/api/chat/dispatch-slides",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_SLIDES || undefined,
+  flowConfig: process.env.FLOW_ID_SLIDES ? undefined : WEBMCP_SLIDES_FLOW,
+  upstreamUrl,
+});
+
+// Page-context proxy - read-only, markdown answers about the current page.
+const pageContextApp = createChatProxyApp({
+  path: "/api/chat/dispatch-page-context",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_PAGE_CONTEXT || undefined,
+  flowConfig: process.env.FLOW_ID_PAGE_CONTEXT ? undefined : PAGE_CONTEXT_FLOW,
+  upstreamUrl,
+});
+
 app.route("/", directiveApp);
 app.route("/", actionApp);
 app.route("/", componentApp);
@@ -93,6 +113,8 @@ app.route("/", bakeryApp);
 app.route("/", storefrontApp);
 app.route("/", webmcpApp);
 app.route("/", webmcpCalendarApp);
+app.route("/", webmcpSlidesApp);
+app.route("/", pageContextApp);
 
 app.post("/api/checkout", async (c) => {
   const origin = c.req.header("origin");


### PR DESCRIPTION
Fixes 404 errors when the slides demo (and other demos) try to connect to their proxy endpoints.

## Changes

### Local dev server (vite.config.ts)
Added missing Vite dev server proxy routes:
- /api/chat/dispatch-directive (dynamic form demos)
- /api/chat/dispatch-webmcp (WebMCP demo)
- /api/chat/dispatch-calendar (calendar copilot demo)
- /api/chat/dispatch-slides (Deck Copilot demo) - fixes the reported issue
- /api/chat/dispatch-page-context (smart-dom-reader demo)
- /api/checkout/bakery (bakery checkout)
- /api/checkout/storefront (storefront checkout)

### Vercel production proxy (api/index.ts)
Added missing routes for production deployment at proxy.persona-chat.dev:
- /api/chat/dispatch-slides (Deck Copilot demo)
- /api/chat/dispatch-page-context (smart-dom-reader demo)

## Testing
- Local: Run pnpm dev and open http://localhost:5173/webmcp-slides.html
- Production: Visit the deployed slides demo and verify the chat widget connects without 404 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Proxy route registration only; no changes to auth, checkout logic, or upstream flow behavior beyond exposing existing flow configs on new paths.
> 
> **Overview**
> Fixes **404s** when Deck Copilot (`webmcp-slides`) and the smart-dom-reader demo call their chat proxy URLs in production, and aligns **local dev** with the same dispatch/checkout paths other demos already expect.
> 
> **Vite (`vite.config.ts`)** forwards additional paths to the local persona proxy (`PROXY_PORT`, default 43111): `dispatch-directive`, `dispatch-webmcp`, `dispatch-calendar`, **`dispatch-slides`**, **`dispatch-page-context`**, plus `checkout/bakery` and `checkout/storefront`.
> 
> **Vercel edge (`api/index.ts`)** mounts two new `createChatProxyApp` apps on `/api/chat/dispatch-slides` (`WEBMCP_SLIDES_FLOW` / `FLOW_ID_SLIDES`) and `/api/chat/dispatch-page-context` (`PAGE_CONTEXT_FLOW` / `FLOW_ID_PAGE_CONTEXT`), wired into the existing Hono route tree like the other dispatch apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c037d22916df7e71c0cd66169de91faa29f66040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->