### PR TITLE
refactor: use wildcard proxy patterns for /api/chat/* and /api/checkout/*

### DIFF
--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -448,19 +448,11 @@ export default defineConfig({
   server: {
     port: 5173,
     proxy: {
-      "/api/chat/dispatch": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-directive": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-action": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-component": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-bakery": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-storefront": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-webmcp": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-calendar": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-slides": `http://localhost:${proxyPort}`,
-      "/api/chat/dispatch-page-context": `http://localhost:${proxyPort}`,
+      // Wildcard: forward all /api/chat/* and /api/checkout/* to the proxy
+      // This prevents 404s when new demo endpoints are added
+      "^/api/chat/.*": `http://localhost:${proxyPort}`,
+      "^/api/checkout/.*": `http://localhost:${proxyPort}`,
       "/api/checkout": `http://localhost:${proxyPort}`,
-      "/api/checkout/bakery": `http://localhost:${proxyPort}`,
-      "/api/checkout/storefront": `http://localhost:${proxyPort}`,
       "/form": `http://localhost:${proxyPort}`
     }
   }


### PR DESCRIPTION
Instead of enumerating every dispatch endpoint, use regex patterns to forward all chat and checkout paths to the proxy. This prevents 404s when new demo endpoints are added without requiring config changes.

## Changes

**Vite dev server (examples/embedded-app/vite.config.ts)**
- `^/api/chat/.*` → forwards to proxy (covers dispatch, dispatch-*, etc.)
- `^/api/checkout/.*` → forwards to proxy (covers checkout subpaths)
- `/api/checkout` → explicit match for root checkout endpoint
- `/form` → explicit match for form endpoint

## Benefits
- No more 404s when adding new demo endpoints
- Simpler, more maintainable config
- Future-proof for new dispatch variants

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only Vite proxy config in the embedded-app example; no production or auth behavior changes.
> 
> **Overview**
> The embedded-app **Vite dev server** proxy no longer lists each chat/checkout route by hand. It now forwards **`^/api/chat/.*`** and **`^/api/checkout/.*`** to the local proxy (`PROXY_PORT`), so new demo dispatch paths (e.g. `dispatch-webmcp`, `dispatch-calendar`) work without editing `vite.config.ts`.
> 
> **`/api/checkout`** (root) and **`/form`** stay as explicit proxy targets. Per-path checkout entries like `/api/checkout/bakery` are removed in favor of the checkout wildcard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d16717182bac9f41822300d57111508cd033c4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->