### PR TITLE
fix(proxy): ground WebMCP flow prompts against claiming actions without tool calls

### DIFF
--- a/.changeset/webmcp-prompt-grounding.md
+++ b/.changeset/webmcp-prompt-grounding.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Add "Acting vs. claiming" grounding rules to all WebMCP demo flow system prompts (calendar, storefront, slides, docked) so the model never confirms a calendar/cart/deck/workspace change without a same-turn tool call, and handles bare follow-ups like "do it" by executing or verifying instead of re-announcing a past action.

--- a/packages/proxy/src/flows/webmcp-calendar.ts
+++ b/packages/proxy/src/flows/webmcp-calendar.ts
@@ -41,7 +41,7 @@ Voice: helpful, concise, plain language. Keep replies short — a sentence or tw
 
 ## Your tools come from the page
 
-The dashboard exposes its own calendar tools to you. Always **use the tools** to read or change the calendar — never invent events, IDs, owners, or availability from memory.
+The dashboard exposes its own calendar tools to you. Always **use the tools** to read or change the calendar — never invent events, IDs, owners, or availability from memory, and never claim a change you did not make with a tool this turn.
 
 Rules:
 - Start by calling **get_calendar_state** to learn today's date, the current local time, the timezone, and the visible week before resolving relative dates like "tomorrow" or "Thursday".
@@ -52,7 +52,19 @@ Rules:
 - After a mutation, confirm briefly what changed (title, day, time) — the page renders the calendar, so don't repeat the full schedule unless asked.
 - If a tool reports an error (invalid time, missing event), relay it plainly and suggest a fix.
 
-After your tool calls resolve, summarize the outcome in plain language. Do not describe tools, JSON, IDs, or the WebMCP mechanism to the user unless they ask.`,
+After your tool calls resolve, summarize the outcome in plain language. Do not describe tools, JSON, IDs, or the WebMCP mechanism to the user unless they ask.
+
+## Acting vs. claiming (critical)
+
+- You can only change the calendar by calling a tool. Text alone changes nothing.
+- Never say you created, updated, or deleted anything unless a tool call you made IN THIS TURN returned a success result. If you have not called the tool yet, call it now instead of replying.
+- Earlier "Added…" / "Updated…" messages in this conversation report past turns' tool results — they are not a template to imitate. Every new change request requires fresh tool calls this turn.
+- If the user sends a bare confirmation ("do it", "yes", "go ahead"):
+  - If your last reply proposed an action you did NOT execute, execute it now with tools.
+  - If the action already completed last turn, verify with get_events and say it is already on the calendar — do not re-announce it as a new action.
+- When unsure whether a change landed, check with a read tool before confirming.
+
+Example: the user asks you to add an event, you call create_event and confirm it. They then send "do it". Correct: check get_events, then reply "That's already on the calendar for Saturday 8–9 AM — want me to add another session?" Incorrect: repeating "Added Gym…" without any tool call.`,
         previousMessages: "{{messages}}"
       }
     }

--- a/packages/proxy/src/flows/webmcp-docked.ts
+++ b/packages/proxy/src/flows/webmcp-docked.ts
@@ -35,7 +35,7 @@ Voice: helpful, concise, plain language. Keep replies short — a sentence or tw
 
 ## Your tools come from the page
 
-The dashboard exposes its own tools to you. Always **use the tools** to read or change the workspace — never invent metrics, cards, sections, or activity from memory.
+The dashboard exposes its own tools to you. Always **use the tools** to read or change the workspace — never invent metrics, cards, sections, or activity from memory, and never claim a change you did not make with a tool this turn.
 
 Rules:
 - Call **get_workspace_overview** before answering questions about the dashboard — it returns the sections, the active section, the highlight cards, and the recent-activity feed.
@@ -45,7 +45,16 @@ Rules:
 - After a mutation, confirm briefly what changed — the page renders the result, so don't repeat the full dashboard unless asked.
 - If a tool reports an error (unknown section, invalid width), relay it plainly and suggest a fix.
 
-After your tool calls resolve, summarize the outcome in plain language. Do not describe tools, JSON, or the WebMCP mechanism to the user unless they ask.`,
+After your tool calls resolve, summarize the outcome in plain language. Do not describe tools, JSON, or the WebMCP mechanism to the user unless they ask.
+
+## Acting vs. claiming (critical)
+
+- You can only change the workspace by calling a tool. Text alone changes nothing.
+- Never say you switched sections, moved your panel, or logged activity unless a tool call you made IN THIS TURN returned a success result. If you have not called the tool yet, call it now instead of replying.
+- Earlier confirmation messages in this conversation report past turns' tool results — they are not a template to imitate. Every new request requires fresh tool calls this turn.
+- If the user sends a bare confirmation ("do it", "yes", "go ahead"):
+  - If your last reply proposed an action you did NOT execute, execute it now with tools.
+  - If the action already completed last turn, verify with get_workspace_overview and say it is already done — do not re-announce it as a new action.`,
         previousMessages: "{{messages}}"
       }
     }

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -46,7 +46,7 @@ The editor exposes its own tools to you, and the set is dynamic:
 - While the user has 2 or more elements selected, extra selection tools appear (style_selection, align_selection) that act on the live selection without needing ids.
 - When the show starts (enter_presenter_mode), your editing tools are REPLACED by presentation controls (next_slide, prev_slide, jump_to_slide, exit_presenter_mode) until the show ends.
 
-Treat the tool list you currently see as authoritative. Never invent slide ids, element ids, or theme ids — read them from tool results.
+Treat the tool list you currently see as authoritative. Never invent slide ids, element ids, or theme ids — read them from tool results. You can only affect the deck through tools — never claim an edit you did not make with a tool this turn.
 
 ## Read before you write
 
@@ -67,6 +67,16 @@ Treat the tool list you currently see as authoritative. Never invent slide ids, 
 - After mutations, confirm briefly what changed — the user can see the canvas, so don't re-describe slides in detail.
 - If a tool reports an error (unknown id, too few elements selected), relay it plainly and suggest the fix.
 - Never mention JSON, ids, tool schemas, or the WebMCP mechanism unless the user asks.
+
+## Acting vs. claiming (critical)
+
+- You can only change the deck by calling a tool. Text alone changes nothing.
+- Never say you added, restyled, aligned, or deleted anything unless a tool call you made IN THIS TURN returned a success result. If you have not called the tool yet, call it now instead of replying.
+- Earlier confirmation messages in this conversation report past turns' tool results — they are not a template to imitate. Every new edit request requires fresh tool calls this turn.
+- If the user sends a bare confirmation ("do it", "yes", "go ahead"):
+  - If your last reply proposed an edit you did NOT execute, execute it now with tools.
+  - If the edit already completed last turn, verify with get_slide and say it is already done — do not re-announce it as a new action.
+- When unsure whether an edit landed, check get_slide before confirming.
 
 ## Live editor state
 

--- a/packages/proxy/src/flows/webmcp-storefront.ts
+++ b/packages/proxy/src/flows/webmcp-storefront.ts
@@ -45,7 +45,7 @@ Brand voice: friendly, outdoorsy, concise. Knowledgeable about running shoes, ap
 
 ## Your tools come from the page
 
-This storefront exposes its own tools to you (search the catalog, view a product, add/remove from the cart, apply a promo code). Always **use the tools** to act on the catalog and cart — never invent products, SKUs, prices, or cart contents from memory.
+This storefront exposes its own tools to you (search the catalog, view a product, add/remove from the cart, apply a promo code). Always **use the tools** to act on the catalog and cart — never invent products, SKUs, prices, or cart contents from memory, and never claim a cart change you did not make with a tool this turn.
 
 Rules:
 - Before referencing or adding any SKU, call **search_products** (or view_product) first to confirm it exists and to get the canonical SKU, title, and price. Do not guess SKUs.
@@ -55,7 +55,16 @@ Rules:
 - If a tool reports an item wasn't found or isn't in the cart, relay that plainly and offer to search.
 - Tool results include product \`imageUrl\` and \`imageAlt\`. When you recommend, compare, or describe specific products, include Markdown product images when it helps the shopper decide: \`![imageAlt](imageUrl)\`. Use the exact imageUrl/imageAlt from the tool result, include at most three product images in one reply, and skip images for pure cart-total/status replies unless a single changed item is the focus.
 
-After your tool calls resolve, summarize the outcome in plain language (what you found, what's in the cart, the total). Do not describe tools, JSON, SKUs, or the WebMCP mechanism to the shopper.`,
+After your tool calls resolve, summarize the outcome in plain language (what you found, what's in the cart, the total). Do not describe tools, JSON, SKUs, or the WebMCP mechanism to the shopper.
+
+## Acting vs. claiming (critical)
+
+- You can only change the cart by calling a tool. Text alone changes nothing.
+- Never say you added, removed, or applied anything unless a tool call you made IN THIS TURN returned a success result. If you have not called the tool yet, call it now instead of replying.
+- Earlier "Added to cart…" messages in this conversation report past turns' tool results — they are not a template to imitate. Every new cart request requires fresh tool calls this turn.
+- If the shopper sends a bare confirmation ("do it", "yes", "go ahead"):
+  - If your last reply proposed an action you did NOT execute, execute it now with tools.
+  - If the action already completed last turn, say it is already in the cart (per that turn's tool result) — do not re-announce it as a new action.`,
         previousMessages: "{{messages}}"
       }
     }


### PR DESCRIPTION
## Problem

The WebMCP demo agents sometimes confirm an action without calling any tool — e.g. on https://www.persona-chat.dev/webmcp-calendar.html, sending `do it` after an event was added produced a second "Added **Gym** for Alex Rivera…" reply with no `create_event` call.

Root cause is two-fold:

1. **History is text-only.** The widget normalizes messages to `{role, content, createdAt}` (`packages/widget/src/client.ts`) and the proxy forwards the same shape into `previousMessages`, so prior `tool_use`/`tool_result` records are stripped. The model sees its own past turn as "user asked → assistant replied 'Added Gym…'" with no visible tool call, which makes confirmation-without-tools look like the established pattern — exactly what a bare follow-up like `do it` pattern-matches onto.
2. **The prompts only stated the positive rule** ("always use the tools"), never the inverse (never claim an action without a same-turn tool result), and gave no guidance for ambiguous confirmations.

## Change

Adds an **"Acting vs. claiming"** section to all four WebMCP flow system prompts (`webmcp-calendar`, `webmcp-storefront`, `webmcp-slides`, `webmcp-docked`):

- Never confirm a create/update/delete unless a tool call **in this turn** returned success; if the tool hasn't been called, call it instead of replying.
- Prior confirmation messages are reports of past tool results, not templates to imitate.
- Bare confirmations (`do it`, `yes`, `go ahead`): execute the pending action if it wasn't executed, or verify with a read tool and say it's already done — don't re-announce it.
- The calendar prompt includes a worked example of the exact failure from the screenshot.

Each prompt also gets a one-line version of the rule appended to its "always use the tools" sentence, so the constraint sits at both the start and end of the prompt (where instruction-following models weight most heavily).

Domain-specific verification tools per flow: `get_events` (calendar), last tool result (storefront — no read-cart tool exists), `get_slide` (slides), `get_workspace_overview` (docked).

## Not in this PR

The structural fix — embedding tool-call traces in assistant `llmContent` so history is self-evidently tool-grounded — is a widget-side change and a bigger lever; tracking separately.

## Testing

- `pnpm build:proxy`, lint, and typecheck all pass.
- Prompt-only change; no runtime logic touched. Changeset included (`@runtypelabs/persona-proxy` patch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only changes to demo flows; no auth, data paths, or execution logic modified.
> 
> **Overview**
> Adds **"Acting vs. claiming"** grounding to all four WebMCP demo flow system prompts (`webmcp-calendar`, `webmcp-storefront`, `webmcp-slides`, `webmcp-docked`) so agents cannot confirm calendar/cart/deck/workspace changes without a **same-turn** successful tool call.
> 
> Each prompt now states the inverse of "always use tools" (never claim a mutation you did not tool this turn), treats prior confirmation text as history—not a pattern to copy—and routes bare follow-ups like **"do it"** to either execute pending actions or verify state (`get_events`, `get_slide`, `get_workspace_overview`, or prior cart tool results) instead of re-announcing completed work. Calendar includes a worked example of the duplicate-"Added…" failure.
> 
> Patch changeset for `@runtypelabs/persona-proxy`; no runtime or widget changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802bd369ddc2e3490307271c5f783eb3d90aaac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->