### PR TITLE
fix(proxy): ground WebMCP slides flow style passes against tool-call sprees

### DIFF
--- a/.changeset/webmcp-slides-style-pass.md
+++ b/.changeset/webmcp-slides-style-pass.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Ground the WebMCP slides flow for vague restyle requests ("make the title slide pop"): treat them as a small focused style pass (4-5 mutations, prefer update_element, at most one new decorative element, theme tokens only) ending in a summary, instead of an open-ended add_element spree that hits the runtime's per-turn tool-call cap and strands the user with "Stopped after calling a tool."

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -60,6 +60,17 @@ Treat the tool list you currently see as authoritative. Never invent slide ids, 
 - Prefer theme tokens over literal colors and fonts: 'theme.text', 'theme.accent', 'theme.background', 'theme.surface', 'theme.accentText' for colors, 'theme.heading' / 'theme.body' for fonts. Token-styled elements restyle automatically when apply_theme runs — hex values do not.
 - Build slides with add_slide layouts first, then refine with update_element patches (one patch can move, resize, and restyle at once). Use align_elements / distribute_elements for clean composition instead of eyeballing coordinates.
 
+## Style passes ("make it pop", "more modern", "punch it up")
+
+Vague restyle requests mean a SMALL, focused pass over the named slide — not a rebuild and not a decoration spree:
+
+- Read the slide with get_slide, then budget yourself: at most 4-5 mutations total for the whole request.
+- Prefer update_element on what's already there — scale the headline up, strengthen the accent, rebalance spacing, sharpen hierarchy. Add at most ONE new decorative element (a single accent bar or shape), and only if it earns its place.
+- Stay on theme tokens. A literal hex color is how a title ends up invisible the next time the theme changes.
+- Then STOP and summarize the changes in a sentence, offering one direction to push further (e.g. "Want it louder? I can add a full-bleed accent background.").
+
+If you catch yourself queueing add_element after add_element, stop and check in instead — the runtime cuts the turn off mid-tool-call and the user is left with a half-finished slide and no explanation.
+
 ## Etiquette
 
 - Destructive or deck-wide tools (delete_slide, delete_elements, apply_theme) ask the user for confirmation — if the user declines, accept it and move on.


### PR DESCRIPTION
## Problem

The "Make the title slide pop" starter pill on https://www.persona-chat.dev/webmcp-slides.html ends badly. Reproduced on the live demo (fresh deck, cleared chat):

1. The model starts well — `get_slide`, then three sensible `update_element` patches (title → 72px accent, subtitle → 28px `theme.text`, accent bar repositioned).
2. Then it queues **ten consecutive `add_element` decoration calls** until the Runtype runtime's per-turn tool-call cap aborts the turn.
3. The user is left with hanging "Using tool…" bubbles, no summary, and *"Stopped after calling a tool. Send a follow-up to continue."*

The deck I loaded also carried scars from an earlier run: a title slide whose heading had been restyled into invisibility against the Midnight theme — the same vague-restyle path, different failure.

The prompt had geometry/style conventions but nothing telling the model what a vague aesthetic request *means* operationally, so it free-runs until the cap kills it.

## Change

Adds a **"Style passes"** section to `WEBMCP_SLIDES_FLOW`'s system prompt: vague restyle asks are a small focused pass —

- read the slide, then at most 4-5 mutations total, preferring `update_element` on existing elements
- at most ONE new decorative element
- theme tokens only (literal hex is how titles go invisible on theme switch)
- then stop, summarize in a sentence, and offer one direction to push further
- explicit warning that long `add_element` runs get cut off mid-turn

Changeset included (`@runtypelabs/persona-proxy` patch). Build/lint/typecheck pass.

## Verification plan

Once the Vercel preview deployment for this branch is up, I'll re-run the pill against the preview site and confirm the turn completes within budget with a proper summary. If the behavior is still unacceptable after grounding, fallback is dropping the pill from `examples/embedded-app/src/webmcp-slides/main.ts` (no changeset needed for examples).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt-only change in the slides flow system message; no runtime or API logic, with low blast radius beyond Deck Copilot behavior.
> 
> **Overview**
> **Grounds vague WebMCP slide restyle requests** so the Deck Copilot stops chaining many `add_element` calls and hitting the per-turn tool cap (users saw "Stopped after calling a tool" with no summary).
> 
> Adds a **"Style passes"** section to `WEBMCP_SLIDES_FLOW` in `webmcp-slides.ts`: treat asks like "make it pop" as a tight pass—`get_slide` first, **4–5 mutations max**, favor **`update_element`**, at most **one** new decorative element, **theme tokens only**, then **stop with a one-sentence summary** and an optional next step. Includes an explicit warning about `add_element` sprees getting cut off mid-turn.
> 
> Ships a **`@runtypelabs/persona-proxy` patch** changeset documenting the behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b356799902c631456a7b7b8842f5ef3c7a1afdba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->