### PR TITLE
fix(theme-editor): pin Theme Copilot sidebar to viewport height

### DIFF
--- a/examples/embedded-app/src/theme-configurator.css
+++ b/examples/embedded-app/src/theme-configurator.css
@@ -4,6 +4,15 @@
   box-sizing: border-box;
 }
 
+/* The docked Theme Copilot shell sizes itself with `height: 100%`, so html and
+   body need a definite height. Without it the dock slot's height resolves to
+   auto and the copilot sidebar grows with the conversation instead of pinning
+   to the viewport with internal scroll. */
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
   padding: 0;
@@ -13,6 +22,7 @@ body {
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background: #f3f4f6;
+  overflow: hidden;
 }
 
 /* Theme Copilot dock target — the docked widget shell wraps this element and


### PR DESCRIPTION
## Summary
The Theme Copilot sidebar on the theme editor page grew with the conversation and scrolled off the page once the chat got long enough.

**Root cause:** the docked widget shell (`createDockedLayout` in `packages/widget/src/runtime/host-layout.ts`) sizes itself with `height: 100%`, which resolves to auto when `html`/`body` have no definite height. The dock slot then grows with its content instead of being clamped to the viewport. The canonical docked demo (`docked-panel-demo.html`) already guards against this with `html, body { height: 100% }`; `theme.html` was missing it.

**Fix:** give `html`/`body` a definite height in `theme-configurator.css` (plus `overflow: hidden` on body — the page is already a fixed 100vh layout that should never scroll).

## Verification
Headless Chromium against the dev server, injecting 6000px of filler into the copilot's messages body to simulate a long conversation:
- **Before:** dock panel grew to 6672px, page scrolled (the reported bug)
- **After:** panel = 900px (exact viewport height), page does not scroll, messages body scrolls internally (scrollHeight 6280 in a 508px client area)

Mobile breakpoints checked: the slide-over form drawer and mobile-fullscreen copilot are both `position: fixed`, so nothing relies on body scroll.

No changeset: examples-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples-only stylesheet change with no production package or auth/data impact.
> 
> **Overview**
> Fixes the embedded **theme editor** example so the docked Theme Copilot stays viewport-height instead of stretching with a long chat.
> 
> Adds `html, body { height: 100% }` in `theme-configurator.css` so the dock shell’s `height: 100%` chain resolves (same guard as `docked-panel-demo.html`). Also sets **`body { overflow: hidden }`** so the fixed 100vh layout doesn’t page-scroll; chat scroll stays inside the copilot.
> 
> Examples-only CSS; no widget/runtime changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41bd3f2355cc6656f17bf12a37456f1d0995d683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->