### PR TITLE
feat(widget): built-in ask_user_question client tool behind expose flag

### DIFF
--- a/.changeset/ask-user-question-client-tool.md
+++ b/.changeset/ask-user-question-client-tool.md
@@ -1,0 +1,9 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Built-in `ask_user_question` client tool, exposable via a config flag.
+
+- **`features.askUserQuestion.expose: true`** advertises a built-in `ask_user_question` tool definition (model-facing description + JSON schema matching `AskUserQuestionPayload`) to the agent on every dispatch via `clientTools[]` — the same wire surface as WebMCP page tools. No server-side `runtimeTools` declaration needed; the server registers it as a bare-named LOCAL tool and the existing answer-pill sheet / `/resume` round-trip handles the call. Defaults to `false` (flows that already declare the tool server-side would otherwise present it twice), and is ignored when `enabled: false` so the agent is never offered a question tool the widget can't render an answer UI for.
+- **Exports** `ASK_USER_QUESTION_CLIENT_TOOL`, `ASK_USER_QUESTION_PARAMETERS_SCHEMA`, and `builtInClientToolsForDispatch` so integrators who prefer the server-side `runtimeTools` declaration can reuse the same description and schema.
+- **Fix:** `ClientToolDefinition.origin` is now typed `'webmcp' | 'sdk'` (was `'webmcp' | 'local'`). `'local'` was never accepted by the server's dispatch validation and would have failed the request with a 400.

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -20,13 +20,13 @@
   {
     "name": "⛔ CRITICAL · ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "141 kB",
+    "limit": "160 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "142 kB",
+    "limit": "160 kB",
     "gzip": true
   },
   {

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "⛔ CRITICAL · CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "161 kB",
+    "limit": "162 kB",
     "gzip": true
   },
   {
@@ -20,13 +20,13 @@
   {
     "name": "⛔ CRITICAL · ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "140 kB",
+    "limit": "141 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "141 kB",
+    "limit": "142 kB",
     "gzip": true
   },
   {
@@ -38,7 +38,7 @@
   {
     "name": "Opt-in · theme-editor subpath (theme-editor.js)",
     "path": "dist/theme-editor.js",
-    "limit": "150 kB",
+    "limit": "151.5 kB",
     "gzip": true
   },
   {

--- a/packages/widget/docs/UI-COMPONENTS.md
+++ b/packages/widget/docs/UI-COMPONENTS.md
@@ -244,7 +244,21 @@ Indicators are resolved in this order:
 
 The `ask_user_question` feature turns a LOCAL agent tool into an interactive prompt with tappable option pills. When the agent calls the `ask_user_question` tool, the server pauses execution and emits a `step_await` event; the widget renders an answer-pill sheet over the composer; the user picks / types / dismisses; the widget POSTs the answer to `/v1/dispatch/resume` and the paused execution continues with a structured `tool_result`.
 
-This is the recommended pattern for human-in-the-loop clarifying questions. The agent-side setup (declare `ask_user_question` as a `runtimeTools` LOCAL tool and instruct the model to call it) lives in your `RuntypeFlowConfig` in the proxy — pair it with a `POST` handler that forwards to the upstream `/resume` endpoint (see `@runtypelabs/persona-proxy` and your deployment’s `resume` route).
+This is the recommended pattern for human-in-the-loop clarifying questions.
+
+### Exposing the tool to the agent
+
+The simplest setup is `expose: true` — the widget advertises a built-in `ask_user_question` tool definition (model-facing description + JSON schema) on every dispatch via `clientTools[]`, the same wire surface WebMCP page tools use. No server-side declaration needed; the server registers it as a LOCAL tool under its bare name and any flow's agent can call it.
+
+```ts
+features: {
+  askUserQuestion: { expose: true }
+}
+```
+
+`expose` defaults to `false` — flows that already declare the tool would otherwise present it to the model twice. It is also ignored when `enabled: false`, so the agent is never offered a question tool the widget can't render an answer UI for.
+
+The alternative is declaring the tool server-side in your `RuntypeFlowConfig` (a `runtimeTools` LOCAL tool entry); the exported `ASK_USER_QUESTION_CLIENT_TOOL` / `ASK_USER_QUESTION_PARAMETERS_SCHEMA` constants give you the same description and schema to reuse there. Either way, pair your proxy with a `POST` handler that forwards to the upstream `/resume` endpoint (see `@runtypelabs/persona-proxy` and your deployment’s `resume` route).
 
 ### Configuration
 
@@ -252,6 +266,7 @@ This is the recommended pattern for human-in-the-loop clarifying questions. The 
 features: {
   askUserQuestion: {
     enabled: true,             // default: true. When false, the tool falls through to the normal tool-bubble path.
+    expose: false,             // default: false. When true, advertises the built-in tool to the agent via clientTools[].
     dismissible: true,         // default: true. Shows a × close button on the sheet.
     slideInMs: 180,            // slide-in animation duration.
     freeTextLabel: 'Other…',

--- a/packages/widget/src/ask-user-question-tool.test.ts
+++ b/packages/widget/src/ask-user-question-tool.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  ASK_USER_QUESTION_CLIENT_TOOL,
+  ASK_USER_QUESTION_PARAMETERS_SCHEMA,
+  builtInClientToolsForDispatch,
+} from "./ask-user-question-tool";
+import {
+  ASK_USER_QUESTION_MAX,
+  ASK_USER_QUESTION_TOOL_NAME,
+} from "./components/ask-user-question-bubble";
+import { AgentWidgetClient } from "./client";
+import { computeClientToolsFingerprint } from "./webmcp-bridge";
+import type { AgentWidgetConfig } from "./types";
+
+describe("ASK_USER_QUESTION_CLIENT_TOOL definition", () => {
+  it("matches the renderer's tool name and origin/annotation contract", () => {
+    expect(ASK_USER_QUESTION_CLIENT_TOOL.name).toBe(ASK_USER_QUESTION_TOOL_NAME);
+    // `'sdk'` keeps the bare name on the wire (the server only prefixes
+    // `origin: 'webmcp'` tools) so the step_await routes to the answer sheet,
+    // not the WebMCP bridge. `'local'` is NOT a valid server-side origin.
+    expect(ASK_USER_QUESTION_CLIENT_TOOL.origin).toBe("sdk");
+    expect(ASK_USER_QUESTION_CLIENT_TOOL.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("bounds questions to the renderer cap and options to 2-4", () => {
+    const questions = ASK_USER_QUESTION_PARAMETERS_SCHEMA.properties.questions;
+    expect(questions.minItems).toBe(1);
+    expect(questions.maxItems).toBe(ASK_USER_QUESTION_MAX);
+    const options = questions.items.properties.options;
+    expect(options.minItems).toBe(2);
+    expect(options.maxItems).toBe(4);
+    expect(questions.items.required).toEqual(["question", "options"]);
+  });
+});
+
+describe("builtInClientToolsForDispatch", () => {
+  it("returns nothing by default (expose is opt-in)", () => {
+    expect(builtInClientToolsForDispatch(undefined)).toEqual([]);
+    expect(builtInClientToolsForDispatch({} as AgentWidgetConfig)).toEqual([]);
+    expect(
+      builtInClientToolsForDispatch({
+        features: { askUserQuestion: {} },
+      } as AgentWidgetConfig)
+    ).toEqual([]);
+  });
+
+  it("returns the tool when expose is true", () => {
+    expect(
+      builtInClientToolsForDispatch({
+        features: { askUserQuestion: { expose: true } },
+      } as AgentWidgetConfig)
+    ).toEqual([ASK_USER_QUESTION_CLIENT_TOOL]);
+  });
+
+  it("ignores expose when the answer sheet is disabled", () => {
+    // Offering the agent a question tool the widget can't render an answer
+    // UI for would park the execution on a generic tool bubble forever.
+    expect(
+      builtInClientToolsForDispatch({
+        features: { askUserQuestion: { expose: true, enabled: false } },
+      } as AgentWidgetConfig)
+    ).toEqual([]);
+  });
+});
+
+describe("AgentWidgetClient - built-in ask_user_question exposure", () => {
+  const captureDispatchBody = () => {
+    const captured: { body: string | null } = { body: null };
+    global.fetch = vi
+      .fn()
+      .mockImplementation(async (_url: string, options: { body: string }) => {
+        captured.body = options.body;
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('data: {"type":"done"}\n\n'));
+            controller.close();
+          },
+        });
+        return new Response(stream, {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      });
+    return captured;
+  };
+
+  const userMessage = () => ({
+    id: "u1",
+    role: "user" as const,
+    content: "hi",
+    createdAt: new Date().toISOString(),
+  });
+
+  it("ships ask_user_question on clientTools when expose is on (no WebMCP)", async () => {
+    const captured = captureDispatchBody();
+    const client = new AgentWidgetClient({
+      apiUrl: "http://localhost:8000",
+      features: { askUserQuestion: { expose: true } },
+    });
+    await client.dispatch({ messages: [userMessage()] }, () => undefined);
+    const parsed = JSON.parse(captured.body!);
+    expect(parsed.clientTools).toEqual([ASK_USER_QUESTION_CLIENT_TOOL]);
+  });
+
+  it("omits clientTools entirely when expose is off and no WebMCP tools exist", async () => {
+    const captured = captureDispatchBody();
+    const client = new AgentWidgetClient({
+      apiUrl: "http://localhost:8000",
+    });
+    await client.dispatch({ messages: [userMessage()] }, () => undefined);
+    const parsed = JSON.parse(captured.body!);
+    expect(parsed.clientTools).toBeUndefined();
+  });
+
+  it("leads the WebMCP snapshot when both are present", async () => {
+    const captured = captureDispatchBody();
+    const client = new AgentWidgetClient({
+      apiUrl: "http://localhost:8000",
+      features: { askUserQuestion: { expose: true } },
+    });
+    (
+      client as unknown as {
+        webMcpBridge: { snapshotForDispatch: () => unknown[] } | null;
+      }
+    ).webMcpBridge = {
+      snapshotForDispatch: () => [
+        { name: "search", description: "s", origin: "webmcp" },
+      ],
+    };
+    await client.dispatch({ messages: [userMessage()] }, () => undefined);
+    const parsed = JSON.parse(captured.body!);
+    expect(parsed.clientTools).toEqual([
+      ASK_USER_QUESTION_CLIENT_TOOL,
+      { name: "search", description: "s", origin: "webmcp" },
+    ]);
+  });
+
+  it("changes the clientTools fingerprint when toggled (diff-only resend)", () => {
+    // In client-token mode the widget only resends the full clientTools[]
+    // when the fingerprint changes — toggling expose must change it so the
+    // server actually learns about (or forgets) the built-in tool.
+    const webMcpOnly = [{ name: "search", description: "s" }];
+    const withBuiltIn = [ASK_USER_QUESTION_CLIENT_TOOL, ...webMcpOnly];
+    expect(computeClientToolsFingerprint(withBuiltIn)).not.toBe(
+      computeClientToolsFingerprint(webMcpOnly)
+    );
+  });
+});

--- a/packages/widget/src/ask-user-question-tool.ts
+++ b/packages/widget/src/ask-user-question-tool.ts
@@ -1,0 +1,141 @@
+/**
+ * Built-in `ask_user_question` client tool.
+ *
+ * The widget can advertise this tool to the agent on every dispatch via
+ * `clientTools[]` (set `features.askUserQuestion.expose: true`) — the same
+ * wire surface WebMCP page tools ride. The server registers it as a LOCAL
+ * tool under its bare name (`origin: 'sdk'` tools are not `webmcp:`-prefixed),
+ * so when the model calls it the execution pauses with a `step_await`
+ * (`awaitReason: "local_tool_required"`), the widget's answer-pill sheet
+ * renders, and `session.resolveAskUserQuestion()` resumes the execution with
+ * the structured answers.
+ *
+ * This replaces the previous integrator burden of hand-declaring the tool in
+ * a flow's `runtimeTools` and keeping that schema in sync with the renderer.
+ * Flows that already declare `ask_user_question` server-side should leave
+ * `expose` off — the model would otherwise see the tool twice.
+ */
+
+import {
+  ASK_USER_QUESTION_MAX,
+  ASK_USER_QUESTION_TOOL_NAME,
+} from "./components/ask-user-question-bubble";
+import type { AgentWidgetConfig, ClientToolDefinition } from "./types";
+
+/**
+ * JSON Schema for the tool's parameters. Mirrors {@link AskUserQuestionPayload}
+ * — the shape `parseAskUserQuestionPayload` hydrates the answer sheet from —
+ * so the schema the model is held to and the schema the renderer expects can
+ * never drift.
+ */
+export const ASK_USER_QUESTION_PARAMETERS_SCHEMA = {
+  type: "object",
+  properties: {
+    questions: {
+      type: "array",
+      minItems: 1,
+      maxItems: ASK_USER_QUESTION_MAX,
+      description:
+        "Questions to ask the user. Prefer a single question; group up to " +
+        `${ASK_USER_QUESTION_MAX} only when the answers are genuinely related.`,
+      items: {
+        type: "object",
+        properties: {
+          question: {
+            type: "string",
+            description:
+              "The complete question to ask the user. Clear, specific, and " +
+              "ending with a question mark.",
+          },
+          header: {
+            type: "string",
+            maxLength: 12,
+            description:
+              'Very short topic label for the question (max 12 chars), e.g. "Auth method".',
+          },
+          options: {
+            type: "array",
+            minItems: 2,
+            maxItems: 4,
+            description:
+              "2-4 distinct, mutually exclusive choices (unless multiSelect " +
+              'is true). Do NOT add an "Other" option — a free-text input is ' +
+              "provided automatically.",
+            items: {
+              type: "object",
+              properties: {
+                label: {
+                  type: "string",
+                  description: "Concise display text for the choice (1-5 words).",
+                },
+                description: {
+                  type: "string",
+                  description:
+                    "What this option means or implies — trade-offs, context.",
+                },
+              },
+              required: ["label"],
+              additionalProperties: false,
+            },
+          },
+          multiSelect: {
+            type: "boolean",
+            description:
+              "Allow selecting multiple options. Use when choices are not " +
+              "mutually exclusive. Default false.",
+          },
+          allowFreeText: {
+            type: "boolean",
+            description:
+              "Show a free-text input alongside the options. Default true.",
+          },
+        },
+        required: ["question", "options"],
+        additionalProperties: false,
+      },
+    },
+  },
+  required: ["questions"],
+  additionalProperties: false,
+} as const;
+
+/**
+ * The `ClientToolDefinition` shipped on `dispatch.clientTools[]` when
+ * `features.askUserQuestion.expose` is on. Exported so integrators who prefer
+ * declaring the tool server-side (a flow's `runtimeTools`) can reuse the same
+ * description and schema instead of hand-writing them.
+ */
+export const ASK_USER_QUESTION_CLIENT_TOOL: ClientToolDefinition = {
+  name: ASK_USER_QUESTION_TOOL_NAME,
+  description:
+    "Ask the user one or more multiple-choice questions and wait for their " +
+    "answers. Use this when you are blocked on a decision that is genuinely " +
+    "the user's to make — a preference, a choice between valid approaches, or " +
+    "missing information you cannot infer from the conversation. Each question " +
+    "offers 2-4 options plus an automatic free-text input. The result maps " +
+    "each question to the user's answer (an array when multiSelect is true); " +
+    "a question absent from the result was skipped by the user. Do not use " +
+    "this for questions you can answer yourself or for confirmations the user " +
+    "has already given.",
+  parametersSchema: ASK_USER_QUESTION_PARAMETERS_SCHEMA,
+  origin: "sdk",
+  annotations: { readOnlyHint: true },
+};
+
+/**
+ * Built-in client tools to append to a dispatch's `clientTools[]` for the
+ * given widget config. Today this is only `ask_user_question`; future built-in
+ * local tools join here.
+ *
+ * Gated on BOTH flags: `expose` opts the tool into the agent's catalog, and
+ * `enabled !== false` guarantees the widget can actually render an answer UI
+ * for it — exposing a question tool with the sheet disabled would park the
+ * execution on a generic tool bubble with no way to answer.
+ */
+export const builtInClientToolsForDispatch = (
+  config: AgentWidgetConfig | undefined,
+): ClientToolDefinition[] => {
+  const feature = config?.features?.askUserQuestion;
+  if (feature?.expose !== true || feature.enabled === false) return [];
+  return [ASK_USER_QUESTION_CLIENT_TOOL];
+};

--- a/packages/widget/src/ask-user-question-tool.ts
+++ b/packages/widget/src/ask-user-question-tool.ts
@@ -35,43 +35,35 @@ export const ASK_USER_QUESTION_PARAMETERS_SCHEMA = {
       type: "array",
       minItems: 1,
       maxItems: ASK_USER_QUESTION_MAX,
-      description:
-        "Questions to ask the user. Prefer a single question; group up to " +
-        `${ASK_USER_QUESTION_MAX} only when the answers are genuinely related.`,
+      description: "Questions to ask the user. Prefer a single question.",
       items: {
         type: "object",
         properties: {
           question: {
             type: "string",
-            description:
-              "The complete question to ask the user. Clear, specific, and " +
-              "ending with a question mark.",
+            description: "The complete question, ending with a question mark.",
           },
           header: {
             type: "string",
             maxLength: 12,
-            description:
-              'Very short topic label for the question (max 12 chars), e.g. "Auth method".',
+            description: 'Short topic label, e.g. "Auth method".',
           },
           options: {
             type: "array",
             minItems: 2,
             maxItems: 4,
             description:
-              "2-4 distinct, mutually exclusive choices (unless multiSelect " +
-              'is true). Do NOT add an "Other" option — a free-text input is ' +
-              "provided automatically.",
+              '2-4 distinct choices. Do NOT add an "Other" option — free text is automatic.',
             items: {
               type: "object",
               properties: {
                 label: {
                   type: "string",
-                  description: "Concise display text for the choice (1-5 words).",
+                  description: "Concise choice text (1-5 words).",
                 },
                 description: {
                   type: "string",
-                  description:
-                    "What this option means or implies — trade-offs, context.",
+                  description: "What the option means or implies.",
                 },
               },
               required: ["label"],
@@ -80,14 +72,11 @@ export const ASK_USER_QUESTION_PARAMETERS_SCHEMA = {
           },
           multiSelect: {
             type: "boolean",
-            description:
-              "Allow selecting multiple options. Use when choices are not " +
-              "mutually exclusive. Default false.",
+            description: "Allow selecting multiple options. Default false.",
           },
           allowFreeText: {
             type: "boolean",
-            description:
-              "Show a free-text input alongside the options. Default true.",
+            description: "Show a free-text input. Default true.",
           },
         },
         required: ["question", "options"],
@@ -108,15 +97,12 @@ export const ASK_USER_QUESTION_PARAMETERS_SCHEMA = {
 export const ASK_USER_QUESTION_CLIENT_TOOL: ClientToolDefinition = {
   name: ASK_USER_QUESTION_TOOL_NAME,
   description:
-    "Ask the user one or more multiple-choice questions and wait for their " +
-    "answers. Use this when you are blocked on a decision that is genuinely " +
-    "the user's to make — a preference, a choice between valid approaches, or " +
-    "missing information you cannot infer from the conversation. Each question " +
-    "offers 2-4 options plus an automatic free-text input. The result maps " +
-    "each question to the user's answer (an array when multiSelect is true); " +
-    "a question absent from the result was skipped by the user. Do not use " +
-    "this for questions you can answer yourself or for confirmations the user " +
-    "has already given.",
+    "Ask the user multiple-choice questions and wait for their answers. Use " +
+    "only when blocked on a decision that is the user's to make — a " +
+    "preference, a choice between valid approaches, or information you " +
+    "cannot infer. Each question offers 2-4 options plus an automatic " +
+    "free-text input. The result maps each question to its answer (an array " +
+    "when multiSelect); a question absent from the result was skipped.",
   parametersSchema: ASK_USER_QUESTION_PARAMETERS_SCHEMA,
   origin: "sdk",
   annotations: { readOnlyHint: true },

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -24,6 +24,7 @@ import {
   WebMcpConfirmHandler
 } from "./types";
 import { WebMcpBridge, computeClientToolsFingerprint, isWebMcpToolName } from "./webmcp-bridge";
+import { builtInClientToolsForDispatch } from "./ask-user-question-tool";
 import {
   extractTextFromJson,
   createPlainTextParser,
@@ -1057,11 +1058,18 @@ export class AgentWidgetClient {
       }
     };
 
-    // WebMCP: snapshot the page tool registry per turn and ship as
-    // `clientTools[]`. The server merges these under the `webmcp:` namespace.
-    const webMcpSnapshot = await this.webMcpBridge?.snapshotForDispatch();
-    if (webMcpSnapshot && webMcpSnapshot.length > 0) {
-      payload.clientTools = webMcpSnapshot;
+    // Client tools: built-in widget tools (ask_user_question, when exposed)
+    // plus the per-turn WebMCP page-registry snapshot. Name collisions are
+    // impossible — WebMCP entries are `webmcp:`-prefixed server-side while
+    // `sdk`-origin built-ins keep bare names. Both kinds ride the same
+    // diff-only fingerprint path in client-token mode. Kept to a single await
+    // so dispatch microtask timing is unchanged.
+    const clientTools = [
+      ...builtInClientToolsForDispatch(this.config),
+      ...((await this.webMcpBridge?.snapshotForDispatch()) ?? []),
+    ];
+    if (clientTools.length > 0) {
+      payload.clientTools = clientTools;
     }
 
     // Add context from providers
@@ -1118,10 +1126,14 @@ export class AgentWidgetClient {
       ...(this.config.flowId && { flowId: this.config.flowId })
     };
 
-    // WebMCP: same per-turn snapshot as buildAgentPayload (flow-dispatch path).
-    const webMcpSnapshot = await this.webMcpBridge?.snapshotForDispatch();
-    if (webMcpSnapshot && webMcpSnapshot.length > 0) {
-      payload.clientTools = webMcpSnapshot;
+    // Client tools: same built-in + WebMCP merge as buildAgentPayload
+    // (flow-dispatch path).
+    const clientTools = [
+      ...builtInClientToolsForDispatch(this.config),
+      ...((await this.webMcpBridge?.snapshotForDispatch()) ?? []),
+    ];
+    if (clientTools.length > 0) {
+      payload.clientTools = clientTools;
     }
 
     if (this.contextProviders.length) {

--- a/packages/widget/src/index-core.ts
+++ b/packages/widget/src/index-core.ts
@@ -134,6 +134,12 @@ export {
   parseAskUserQuestionPayload
 } from "./components/ask-user-question-bubble";
 
+export {
+  ASK_USER_QUESTION_CLIENT_TOOL,
+  ASK_USER_QUESTION_PARAMETERS_SCHEMA,
+  builtInClientToolsForDispatch
+} from "./ask-user-question-tool";
+
 export { initAgentWidgetFn as initAgentWidget };
 export {
   createWidgetHostLayout,

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -231,8 +231,13 @@ export type ClientToolDefinition = {
   description: string;
   /** JSON Schema (per WebMCP spec) — passed through as-is. */
   parametersSchema?: object;
-  /** Set to `'webmcp'` for tools discovered via the polyfill. */
-  origin?: 'webmcp' | 'local';
+  /**
+   * `'webmcp'` for tools discovered via the polyfill (server prepends the
+   * `webmcp:` wire prefix); `'sdk'` for widget/SDK-provided tools (name stays
+   * bare on the wire). Matches the server's accepted enum — any other value
+   * fails dispatch validation.
+   */
+  origin?: 'webmcp' | 'sdk';
   /** Origin of the page that registered the tool — for server-side audit. */
   pageOrigin?: string;
   /**
@@ -1157,6 +1162,19 @@ export type AgentWidgetAskUserQuestionStyles = {
 export type AgentWidgetAskUserQuestionFeature = {
   /** Enable the feature. Defaults to true. When false, `ask_user_question` renders as a regular tool bubble. */
   enabled?: boolean;
+  /**
+   * Advertise the built-in `ask_user_question` tool to the agent on every
+   * dispatch via `clientTools[]` — no server-side `runtimeTools` declaration
+   * needed. The tool ships with a model-facing description and JSON schema
+   * matching {@link AskUserQuestionPayload}; when the model calls it, the
+   * existing answer-pill sheet renders and the answer resumes the execution.
+   *
+   * Defaults to `false`: flows that already declare `ask_user_question` via
+   * `runtimeTools` would otherwise present the tool to the model twice.
+   * Ignored when `enabled` is `false` — never offer the agent a question
+   * tool the widget can't render an answer UI for.
+   */
+  expose?: boolean;
   /** Slide-in animation duration in ms. Defaults to 180. */
   slideInMs?: number;
   /** Label for the free-text pill. Defaults to "Other…". */


### PR DESCRIPTION
## Summary

Makes `ask_user_question` a **built-in client tool** the widget can advertise to agents with a single config flag — reusing the hardened WebMCP/clientTools dispatch plumbing instead of requiring a hand-written server-side `runtimeTools` declaration:

```ts
features: { askUserQuestion: { expose: true } }
```

### How it works

When `expose` is on, both payload builders append `ASK_USER_QUESTION_CLIENT_TOOL` — a `ClientToolDefinition` with a model-facing description and a JSON schema derived from the same constants the answer-sheet renderer uses (no drift possible) — to `dispatch.clientTools[]`, ahead of the WebMCP page snapshot. Because the tool ships `origin: 'sdk'`, the server keeps its **bare name** (only `webmcp:`-origin tools get prefixed), registers it as `toolType: 'local'`, and the resulting `step_await` lands on the existing answer-pill sheet and `/resume` round-trip completely untouched. The diff-only fingerprint path (client-token mode) and proxy forwarding cover it for free.

### Safety decisions

- **`expose` defaults to `false`** — flows that already declare `ask_user_question` via `runtimeTools` would otherwise present the tool to the model twice. The exported `ASK_USER_QUESTION_CLIENT_TOOL` / `ASK_USER_QUESTION_PARAMETERS_SCHEMA` constants let those flows reuse the same description/schema.
- **Ignored when `enabled: false`** — never offer the agent a question tool the widget can't render an answer UI for (the execution would park on a generic tool bubble with no way to answer).

### Bug fix

`ClientToolDefinition.origin` was typed `'webmcp' | 'local'`, but dispatch validation accepts `z.enum(['webmcp', 'sdk'])` — verified against the live production OpenAPI spec (`enum: ["webmcp", "sdk"]`). `'local'` would 400 any dispatch that used it. Now typed `'webmcp' | 'sdk'`.

## Test plan

- 9 new tests in `ask-user-question-tool.test.ts`: flag gating (default off, expose on, expose+disabled), definition contract (name/origin/readOnlyHint, schema bounds), dispatch shipping in both modes, merge ordering with WebMCP snapshot, fingerprint change on toggle.
- Full suite: 1151 tests pass; lint, typecheck, and build clean.
- Implementation note: the clientTools merge is kept to a single `await` in the payload builders — an earlier async-helper version added a microtask tick to dispatch timing and was caught by the `cancel()` test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes dispatch `clientTools[]` and agent tool catalog wiring; misconfiguration could duplicate tools or offer a question tool without UI, though defaults and `enabled` gating mitigate that.
> 
> **Overview**
> Adds an opt-in **`features.askUserQuestion.expose: true`** flag so the widget can advertise a built-in **`ask_user_question`** tool on every dispatch via **`clientTools[]`** (same path as WebMCP), with description and JSON schema aligned to the answer-sheet renderer—no server **`runtimeTools`** entry required. **`builtInClientToolsForDispatch`** gates on **`expose`** and **`enabled !== false`**; **`AgentWidgetClient`** merges built-ins before the WebMCP snapshot in both agent and flow payload builders.
> 
> Exports **`ASK_USER_QUESTION_CLIENT_TOOL`**, **`ASK_USER_QUESTION_PARAMETERS_SCHEMA`**, and **`builtInClientToolsForDispatch`** for integrators who still declare the tool server-side. **`ClientToolDefinition.origin`** is corrected from **`'webmcp' | 'local'`** to **`'webmcp' | 'sdk'`** so dispatch validation matches the API.
> 
> Docs and changeset describe the flag; bundle **size-limit** budgets are bumped slightly; new tests cover gating, dispatch wiring, merge order, and fingerprint changes when **`expose`** toggles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb46027fcde24ed141bfb24ab365b2806738db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->