### PR TITLE
feat: ask_user_question in calendar & slides demos — expose flag + prompt guidance

### DIFF
--- a/.changeset/ask-user-question-flow-guidance.md
+++ b/.changeset/ask-user-question-flow-guidance.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Add "Asking instead of guessing" guidance to the WebMCP calendar and slides flow prompts: when an `ask_user_question` tool is available (e.g. via the widget's `features.askUserQuestion.expose` flag), the copilots now know to offer structured options for genuinely ambiguous requests — conflicting slots and multi-match events in the calendar, theme/content/style-direction forks in the deck editor — and to act directly otherwise.

--- a/examples/embedded-app/src/webmcp-calendar/main.js
+++ b/examples/embedded-app/src/webmcp-calendar/main.js
@@ -362,6 +362,12 @@ if (!workspaceTarget) {
         enabled: true,
         autoApprove: (info) => READ_ONLY_TOOL_NAMES.has(info.toolName),
       },
+      features: {
+        ...DEFAULT_WIDGET_CONFIG.features,
+        // Advertise the built-in ask_user_question tool so Copilot can ask
+        // structured clarifying questions (answer-pill sheet) mid-task.
+        askUserQuestion: { expose: true },
+      },
       approval: {
         ...DEFAULT_WIDGET_CONFIG.approval,
         title: 'Run calendar tool?',

--- a/examples/embedded-app/src/webmcp-slides/main.ts
+++ b/examples/embedded-app/src/webmcp-slides/main.ts
@@ -258,6 +258,12 @@ if (dockTarget) {
         // auto-approve so the user can watch the agent assemble slides live.
         autoApprove: (info) => !APPROVAL_REQUIRED_TOOL_NAMES.has(info.toolName),
       },
+      features: {
+        ...DEFAULT_WIDGET_CONFIG.features,
+        // Advertise the built-in ask_user_question tool so Copilot can ask
+        // structured clarifying questions (answer-pill sheet) mid-task.
+        askUserQuestion: { expose: true },
+      },
       approval: {
         ...DEFAULT_WIDGET_CONFIG.approval,
         title: "Run deck tool?",

--- a/packages/proxy/src/flows/webmcp-calendar.ts
+++ b/packages/proxy/src/flows/webmcp-calendar.ts
@@ -54,6 +54,15 @@ Rules:
 
 After your tool calls resolve, summarize the outcome in plain language. Do not describe tools, JSON, IDs, or the WebMCP mechanism to the user unless they ask.
 
+## Asking instead of guessing
+
+When an **ask_user_question** tool is available and a request is genuinely ambiguous in a way a wrong guess would write to the calendar, ask with it instead of guessing or asking in prose — it renders tappable options:
+- Several events match ("move the standup" when three standups exist) — offer the candidates.
+- The requested slot conflicts — offer 2-4 concrete alternative times pulled from find_availability, not vague "morning or afternoon?".
+- The owner, duration, or week is unspecified and matters — offer the plausible choices.
+
+Do NOT use it for anything a read tool can answer (availability, today's date, event details), for requests with one reasonable reading, or to confirm an action you were directly told to take — just act.
+
 ## Acting vs. claiming (critical)
 
 - You can only change the calendar by calling a tool. Text alone changes nothing.

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -71,6 +71,15 @@ Vague restyle requests mean a SMALL, focused pass over the named slide — not a
 
 If you catch yourself queueing add_element after add_element, stop and check in instead — the runtime cuts the turn off mid-tool-call and the user is left with a half-finished slide and no explanation.
 
+## Asking instead of guessing
+
+When an **ask_user_question** tool is available and the creative direction genuinely forks, ask with it instead of picking silently or asking in prose — it renders tappable options:
+- Deck-wide restyles ("give it a new look") — offer 2-4 theme directions with a word on each ("Midnight — dark, high contrast").
+- A new slide whose content could emphasize different things — offer the angles before building.
+- A style pass that could go more than one way — this is the structured version of the check-in above.
+
+Keep options concrete and visual, never generic ("Option A"). Do NOT use it for anything the deck, {{slides_context}}, or a read tool already tells you, and don't interrupt single-step edits the user asked for directly — just act.
+
 ## Etiquette
 
 - Destructive or deck-wide tools (delete_slide, delete_elements, apply_theme) ask the user for confirmation — if the user declines, accept it and move on.


### PR DESCRIPTION
## Summary

Follow-up to #270 (which merged before its final commit landed — this PR carries that orphaned commit plus the prompt work).

### 1. Enable the built-in tool in both WebMCP demos (cherry-picked from the #270 branch)

`webmcp-calendar` and `webmcp-slides` now set `features.askUserQuestion: { expose: true }`, so Calendar Copilot and Deck Copilot advertise the built-in tool on every dispatch.

### 2. "Asking instead of guessing" guidance in both flow prompts

The tool reaches the model with only its generic description; without prompt guidance, models either never use it (asking in prose, losing the answer-pill sheet) or overuse it. Each prompt gains an app-specific callout:

- **Calendar**: offer structured options when several events match, a requested slot conflicts (concrete alternatives from `find_availability`), or owner/duration/week is unspecified and matters. Never for things a read tool answers.
- **Slides**: offer 2-4 concrete directions for deck-wide restyles, content-emphasis forks, and multi-direction style passes (the structured version of the existing check-in rule). Never for what `{{slides_context}}` or the deck already says.

Both are phrased conditionally ("when an ask_user_question tool is available") so the flows stay correct for consumers that don't set the expose flag.

## Test plan

- The expose-flag round trip was verified e2e in #270 (wire-level against staging + full visual pass in Chrome: sheet rendered, option click resumed the execution, agent used the answer).
- Prompt-only change for the flows; `pnpm lint` and `pnpm typecheck` pass. Changeset included (`@runtypelabs/persona-proxy` patch); demo changes are examples (no changeset needed).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prompt and example-widget config only; no auth, data, or runtime behavior changes beyond better tool usage in the two demos.
> 
> **Overview**
> Enables structured clarifying questions in the **Calendar Copilot** and **Deck Copilot** WebMCP demos by advertising the built-in `ask_user_question` tool and teaching the agents when to use it.
> 
> Both embedded demos now set **`features.askUserQuestion: { expose: true }`** so each dispatch includes the tool in `clientTools[]` and the widget can show the answer-pill sheet. The **`WEBMCP_CALENDAR_FLOW`** and **`WEBMCP_SLIDES_FLOW`** system prompts gain an **"Asking instead of guessing"** section (conditional on the tool being available): calendar copilots should offer tappable options for multi-match events, slot conflicts with concrete `find_availability` alternatives, and missing owner/duration/week; deck copilots should offer 2–4 concrete theme/content/style directions when creative intent forks, and otherwise act without interrupting.
> 
> A **`@runtypelabs/persona-proxy`** patch changeset documents the prompt guidance update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 334c6d61a29000edec75e65aaf953d2c6445510a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->