### PR TITLE
feat(widget): built-in suggest_replies client tool behind expose flag

### DIFF
--- a/.changeset/suggest-replies-client-tool.md
+++ b/.changeset/suggest-replies-client-tool.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Built-in `suggest_replies` client tool behind `features.suggestReplies.expose`. When exposed, the widget advertises the tool on every dispatch via `clientTools[]`; when the agent calls it, the widget renders the suggestions as tappable quick-reply chips above the composer (reusing the suggestion-chips surface and `suggestionChipsConfig` styling) and immediately auto-resumes the execution — fire-and-forget, no user input awaited. Tapping a chip sends its text verbatim as the user's next message; chips clear once any user message follows them. Exports `SUGGEST_REPLIES_CLIENT_TOOL`, `SUGGEST_REPLIES_PARAMETERS_SCHEMA`, `SUGGEST_REPLIES_TOOL_NAME`, `parseSuggestRepliesPayload`, and `latestAgentSuggestions` for integrators who declare the tool server-side. New DOM events: `persona:suggestReplies:shown` / `persona:suggestReplies:selected`.

--- a/examples/embedded-app/ask-user-question-demo.html
+++ b/examples/embedded-app/ask-user-question-demo.html
@@ -5,15 +5,15 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="stylesheet" href="/src/demo-shared.css">
     <link rel="icon" href="/favicon.ico" />
-    <title>Ask User Question - Persona</title>
+    <title>Ask User Question &amp; Suggested Replies - Persona</title>
   </head>
   <body>
     <main class="shell-main">
       <div class="stage">
         <aside class="stage-controls">
           <header class="demo-meta">
-            <h1>Ask User Question</h1>
-            <p>The <code>ask_user_question</code> local-tool sheet — built-in stacked layout vs. horizontal-pill plugin. Pick a preset to inject a simulated tool call.</p>
+            <h1>Ask User Question &amp; Suggested Replies</h1>
+            <p>The two built-in client tools: the <code>ask_user_question</code> answer sheet (blocking) and <code>suggest_replies</code> quick-reply chips (fire-and-forget). Pick a preset to inject a simulated tool call, or just send a message — every mocked reply ends with fresh chips.</p>
             <div class="mount-toolbar" data-mount-toolbar></div>
           </header>
 
@@ -72,6 +72,25 @@
               </div>
 
               <div class="section">
+                <label>Suggested-reply presets</label>
+                <div class="btn-group" id="suggest-preset-group">
+                  <button data-suggest-preset="three">Replies (3)</button>
+                  <button data-suggest-preset="four">Replies (4 — cap)</button>
+                  <button data-suggest-preset="longChips">Long labels</button>
+                </div>
+                <p class="hint">Injects a simulated <code>suggest_replies</code> call. The widget renders the chips and immediately auto-POSTs <code>/resume</code> (watch the event log) — tapping a chip sends it as your message.</p>
+              </div>
+
+              <div class="section">
+                <label>Chips after each reply</label>
+                <div class="mode-group" id="chips-loop-selector">
+                  <button class="mode-btn active" data-chipsloop="on">On</button>
+                  <button class="mode-btn" data-chipsloop="off">Off</button>
+                </div>
+                <p class="hint">When on, the mocked chat reply ends with a real <code>step_await</code> for <code>suggest_replies</code> — the full loop: send → reply → fresh chips → tap → repeat.</p>
+              </div>
+
+              <div class="section">
                 <label>Actions</label>
                 <div class="btn-row">
                   <button id="btn-reset">Reset transcript</button>
@@ -102,6 +121,16 @@
         <div class="notes-section">
           <h3 class="notes-section-title">Persistence</h3>
           <p>Off (default) passes <code>persistState: false</code> — nothing is written to <code>localStorage</code>, so reloading wipes any injected tool calls. On wires up a <code>storageAdapter</code> with a demo-scoped key, so the active question survives a reload. "Reset transcript" still clears either way.</p>
+        </div>
+
+        <div class="notes-section">
+          <h3 class="notes-section-title">Suggested replies — the fire-and-forget loop</h3>
+          <p>Where <code>ask_user_question</code> blocks the execution until you answer, <code>suggest_replies</code> resolves instantly: the chips render above the composer and the widget auto-POSTs <code>/resume</code> with a canned "shown" result so the agent's turn completes. Three ways to see it here:</p>
+          <ul>
+            <li><strong>Presets</strong> — inject a simulated call; the event log shows the immediate auto-resume.</li>
+            <li><strong>Chips loop</strong> — type anything (or tap a chip). The mocked reply ends with a real <code>step_await</code>, so fresh chips appear after every turn — the full send → reply → chips cycle.</li>
+            <li><strong>Soft dismiss</strong> — ignore the chips and type your own message: they clear the moment any user message lands. Latest call wins if several arrive in one turn.</li>
+          </ul>
         </div>
 
         <div class="notes-section">
@@ -171,9 +200,18 @@
       let resumeMockMode = "fast"; // "off" | "fast" | "slow" | "hang"
       const RESUME_MOCK_DELAYS = { off: 0, fast: 300, slow: 2000, hang: Infinity };
 
+      // When on, every mocked chat reply ends with a real `step_await` for
+      // `suggest_replies` — the widget renders chips and auto-resumes, so a
+      // chip tap (or any typed message) loops: send → reply → fresh chips.
+      let chipsLoop = true;
+      let simTurn = 0;
+
       // Wrap fetch once. We intercept any POST whose URL ends with `/resume`
       // (matches both the demo's noop apiUrl and any real proxy) when the mock
-      // is on; otherwise we pass straight through to the original implementation.
+      // is on, plus chat dispatches to the demo's noop apiUrl so typed
+      // messages and chip taps get a simulated reply instead of a network
+      // error; otherwise we pass straight through to the original
+      // implementation.
       const originalFetch = window.fetch.bind(window);
       window.fetch = (input, init) => {
         try {
@@ -182,11 +220,83 @@
           if (resumeMockMode !== "off" && method === "POST" && /\/resume(?:\?|$)/.test(url)) {
             return mockResumeResponse(init?.body);
           }
+          if (resumeMockMode !== "off" && method === "POST" && /noop\.test\/chat(?:\?|$)/.test(url)) {
+            return mockDispatchResponse(init?.body);
+          }
         } catch {
           // Any detection error → fall through to real fetch.
         }
         return originalFetch(input, init);
       };
+
+      // Simulated chat reply: echo the user's message, then (when the chips
+      // loop is on) pause the "execution" with a real suggest_replies
+      // step_await — exactly the wire shape a flow emits — so the widget's
+      // fire-and-forget auto-resume runs against the /resume mock above.
+      function mockDispatchResponse(body) {
+        let lastUserText = "";
+        try {
+          const parsed = typeof body === "string" ? JSON.parse(body) : null;
+          const userMsgs = (parsed?.messages ?? []).filter((m) => m.role === "user");
+          const last = userMsgs[userMsgs.length - 1];
+          lastUserText = typeof last?.content === "string" ? last.content : "";
+        } catch {}
+
+        const n = ++simTurn;
+        const replyText = `You said "${lastUserText}" — here's a simulated reply (turn ${n}).`;
+        const chips = [
+          "Tell me more",
+          `Show example #${n}`,
+          "What else can you do?",
+        ];
+        const events = [
+          `data: {"type":"step_chunk","id":"sim-step-${n}","name":"sim","executionType":"prompt","index":0,"text":${JSON.stringify(replyText)}}`,
+          ``,
+          `data: {"type":"step_complete","id":"sim-step-${n}","name":"sim","executionType":"prompt","index":0,"success":true,"result":{"promptId":"sim","promptName":"sim","response":${JSON.stringify(replyText)},"tokens":{"input":0,"output":0,"total":0},"cost":0,"executionTime":120,"order":0},"executionTime":120}`,
+          ``,
+        ];
+        if (chipsLoop) {
+          // Server pauses at step_await and closes the SSE — no flow_complete.
+          // The widget's auto-resume posts /resume (mocked above) to finish.
+          events.push(
+            `event: step_await`,
+            `data: ${JSON.stringify({
+              type: "step_await",
+              awaitReason: "local_tool_required",
+              id: `sim-await-${n}`,
+              name: "sim",
+              stepType: "prompt",
+              index: 1,
+              toolCallId: `sr-call-${n}`,
+              toolName: "suggest_replies",
+              executionId: `sim-exec-${n}`,
+              parameters: { suggestions: chips },
+            })}`,
+            ``,
+          );
+          log(`mock /chat → reply + suggest_replies step_await (turn ${n})`, "info");
+        } else {
+          events.push(
+            `data: {"type":"flow_complete","flowId":"sim-flow","success":true,"duration":120,"completedAt":${JSON.stringify(new Date().toISOString())},"totalTokensUsed":0}`,
+            ``,
+          );
+          log(`mock /chat → reply (turn ${n}, chips loop off)`, "info");
+        }
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream({
+          start(c) {
+            // The trailing "\n" matters: each SSE event must be terminated by
+            // a blank line, and the final step_await would otherwise be
+            // dropped as an unterminated partial when the stream closes.
+            c.enqueue(encoder.encode(events.join("\n") + "\n"));
+            c.close();
+          },
+        });
+        return Promise.resolve(new Response(stream, {
+          status: 200,
+          headers: { "Content-Type": "text/event-stream" },
+        }));
+      }
 
       function mockResumeResponse(body) {
         const delay = RESUME_MOCK_DELAYS[resumeMockMode] ?? 0;
@@ -195,6 +305,33 @@
           parsedBody = typeof body === "string" ? JSON.parse(body) : null;
         } catch {}
         const toolOutputs = parsedBody?.toolOutputs ?? {};
+
+        // suggest_replies auto-resume (fire-and-forget): keyed by the wire
+        // tool name for injected presets, or by the per-call `sr-call-*` id
+        // for chips-loop step_awaits. The agent "ends its turn" after
+        // suggesting, so reply with flow_complete only — no extra text.
+        const isSuggestResume = Object.keys(toolOutputs).some(
+          (k) => k === "suggest_replies" || k.startsWith("sr-call-"),
+        );
+        if (isSuggestResume) {
+          log(`mock /resume ← suggest_replies auto-resolve → flow_complete`, "answered");
+          const encoder = new TextEncoder();
+          const sse = [
+            `data: {"type":"flow_complete","flowId":"sim-flow","success":true,"duration":0,"completedAt":${JSON.stringify(new Date().toISOString())},"totalTokensUsed":0}`,
+            ``,
+          ].join("\n");
+          const stream = new ReadableStream({
+            start(c) {
+              c.enqueue(encoder.encode(sse));
+              c.close();
+            },
+          });
+          return Promise.resolve(new Response(stream, {
+            status: 200,
+            headers: { "Content-Type": "text/event-stream" },
+          }));
+        }
+
         const answer = toolOutputs.ask_user_question;
         const answerText = typeof answer === "object" && answer !== null
           ? Object.entries(answer).map(([q, v]) => `${q}: ${Array.isArray(v) ? v.join(", ") : v}`).join(" • ")
@@ -398,6 +535,9 @@
           plugins,
           features: {
             askUserQuestion: { groupedAutoAdvance: autoAdvance },
+            // expose only matters for real dispatch advertising (the mock
+            // ignores clientTools); set for config-inspector fidelity.
+            suggestReplies: { expose: true },
           },
           copy: {
             welcomeTitle: "Ask User Question Demo",
@@ -459,6 +599,62 @@
             agentMetadata: { awaitingLocalTool: true },
           },
           `injectTestMessage · preset: ${key}`,
+        );
+      }
+
+      const SUGGEST_PRESETS = {
+        three: ["Tell me more", "Show pricing", "Talk to a human"],
+        four: [
+          "Compare the plans",
+          "What's included?",
+          "Start a free trial",
+          "Book a demo",
+        ],
+        longChips: [
+          "Walk me through migrating an existing store step by step",
+          "What does the enterprise onboarding timeline look like?",
+          "Send me the full feature comparison for mid-market retailers",
+        ],
+      };
+
+      let suggestCounter = 0;
+      function triggerSuggestReplies(key) {
+        const suggestions = SUGGEST_PRESETS[key];
+        if (!suggestions || !controller) return;
+        const id = `demo-sr-${++suggestCounter}`;
+        controller.injectTestMessage({
+          type: "message",
+          message: {
+            id,
+            role: "assistant",
+            content: "",
+            createdAt: new Date().toISOString(),
+            streaming: false,
+            variant: "tool",
+            toolCall: {
+              id,
+              name: "suggest_replies",
+              status: "complete",
+              args: { suggestions },
+              chunks: [],
+            },
+            agentMetadata: {
+              executionId: `demo-sr-exec-${suggestCounter}`,
+              awaitingLocalTool: true,
+            },
+          },
+        });
+        // A real flow closes its SSE at step_await; the widget flushes the
+        // auto-resume batch on stream end. Simulate that end so the injected
+        // call actually fires its /resume (intercepted by the mock above).
+        controller.injectTestMessage({ type: "status", status: "idle" });
+        log(`Injected suggest_replies preset: ${key} (toolCallId=${id})`, "info");
+        configInspector.setScenario(
+          {
+            toolCall: { name: "suggest_replies", args: { suggestions } },
+            agentMetadata: { awaitingLocalTool: true },
+          },
+          `injectTestMessage · suggest preset: ${key}`,
         );
       }
 
@@ -538,6 +734,25 @@
         triggerQuestion(btn.dataset.preset);
       });
 
+      // Suggested-reply preset buttons.
+      document.getElementById("suggest-preset-group").addEventListener("click", (e) => {
+        const btn = e.target.closest("button[data-suggest-preset]");
+        if (!btn) return;
+        triggerSuggestReplies(btn.dataset.suggestPreset);
+      });
+
+      // Chips-loop toggle. No re-mount needed — the dispatch mock reads
+      // `chipsLoop` on every call.
+      const chipsLoopSelector = document.getElementById("chips-loop-selector");
+      chipsLoopSelector.addEventListener("click", (e) => {
+        const btn = e.target.closest(".mode-btn");
+        if (!btn) return;
+        chipsLoopSelector.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
+        btn.classList.add("active");
+        chipsLoop = btn.dataset.chipsloop === "on";
+        log(`Chips after each reply → ${chipsLoop ? "on" : "off"}`, "info");
+      });
+
       // Reset. Clears the persisted key first so the freshly re-created widget
       // doesn't rehydrate the just-cleared transcript when persistence is on.
       document.getElementById("btn-reset").addEventListener("click", () => {
@@ -561,6 +776,14 @@
       window.addEventListener("persona:askUserQuestion:dismissed", (e) => {
         const { toolCallId } = e.detail ?? {};
         log(`dismissed (toolCallId=${toolCallId})`, "dismissed");
+      });
+      window.addEventListener("persona:suggestReplies:shown", (e) => {
+        const { suggestions } = e.detail ?? {};
+        log(`chips shown → ${JSON.stringify(suggestions)}`, "info");
+      });
+      window.addEventListener("persona:suggestReplies:selected", (e) => {
+        const { suggestion } = e.detail ?? {};
+        log(`chip selected → "${suggestion}"`, "answered");
       });
 
       // Initial mount. Sync the persist toggle to its stored preference before

--- a/examples/embedded-app/src/examples-nav.ts
+++ b/examples/embedded-app/src/examples-nav.ts
@@ -78,8 +78,8 @@ export const ADVANCED_EXAMPLES: readonly AdvancedExample[] = [
   {
     slug: "ask-user-question-demo",
     href: "/ask-user-question-demo.html",
-    title: "Ask User Question",
-    blurb: "Stacked answers and horizontal-pill question variants.",
+    title: "Ask User Question & Suggested Replies",
+    blurb: "Blocking answer sheets and fire-and-forget quick-reply chips.",
     tier: "patterns",
     tags: ["interaction", "forms"],
     modes: ["inline"],

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -38,7 +38,7 @@
   {
     "name": "Opt-in · theme-editor subpath (theme-editor.js)",
     "path": "dist/theme-editor.js",
-    "limit": "151.5 kB",
+    "limit": "152 kB",
     "gzip": true
   },
   {

--- a/packages/widget/docs/UI-COMPONENTS.md
+++ b/packages/widget/docs/UI-COMPONENTS.md
@@ -397,6 +397,65 @@ For plugins that want to re-parse a tool message outside the hook context, the w
 2. **Built-in overlay sheet** — when the feature is enabled and no plugin handles it.
 3. **Generic tool bubble** — when `features.askUserQuestion.enabled` is `false`, the tool call renders through the normal `renderToolCall` path.
 
+## Suggested Replies
+
+The `suggest_replies` feature lets the agent offer tappable quick-reply chips for the user's next message. When the agent calls the `suggest_replies` tool, the widget renders the suggestions as chips above the composer (the same slot — and `suggestionChipsConfig` styling — as the static `suggestionChips`) and **immediately** resumes the paused execution with a canned "shown" result. Unlike `ask_user_question`, nothing blocks on the user: the agent's turn completes, and tapping a chip simply sends its text verbatim as the user's next message.
+
+This is the recommended pattern for follow-up discovery — teaching users what to ask next without forcing typing.
+
+### Exposing the tool to the agent
+
+```ts
+features: {
+  suggestReplies: { expose: true }
+}
+```
+
+`expose` defaults to `false` — flows that already declare the tool via `runtimeTools` would otherwise present it to the model twice. It is also ignored when `enabled: false`: a disabled feature neither renders chips nor auto-resumes, so exposing the tool alongside it would park the execution on a generic tool bubble forever. (The same applies to a server-declared `suggest_replies` with `enabled: false` — treat that combination as a configuration error.)
+
+For server-side declaration, the exported `SUGGEST_REPLIES_CLIENT_TOOL` / `SUGGEST_REPLIES_PARAMETERS_SCHEMA` constants provide the same description and schema to reuse in a flow's `runtimeTools`.
+
+### Tool schema
+
+```ts
+{
+  suggestions: string[]   // 1-4 items, each ≤60 chars, phrased in the user's voice
+}
+```
+
+### Lifecycle
+
+Chip visibility is derived from the transcript, not toggled imperatively: the widget shows the chips of the **last** `suggest_replies` tool message that has **no user message after it**. That one rule covers everything:
+
+- Chips soft-dismiss the moment any user message lands — typed, voice, or a chip tap (which itself sends a user message).
+- Chips survive panel close/reopen and page reload (the tool message persists in history and the rule re-evaluates on hydrate). If the page reloads before the automatic resume fired, the execution stays paused server-side; tapping a chip starts a fresh dispatch and the conversation recovers naturally.
+- When one turn carries several `suggest_replies` calls, every call is resumed but only the latest renders (latest wins).
+- Chips are disabled while a response is streaming, like all composer controls.
+
+No transcript bubble is rendered for the tool message — the chips are the entire UI. When `enabled: false`, the message falls through to the generic tool bubble instead.
+
+Note: integrators who replace the composer's suggestions slot via the composer layout API won't see agent-pushed chips — they render in the same container as `suggestionChips`.
+
+### Configuration
+
+```ts
+features: {
+  suggestReplies: {
+    enabled: true,   // default: true. When false, the tool falls through to the normal tool-bubble path and is NOT auto-resumed.
+    expose: false    // default: false. When true, advertises the built-in tool to the agent via clientTools[].
+  }
+}
+```
+
+Chip styling reuses the widget-level `suggestionChipsConfig` (font family/weight, padding).
+
+### DOM events
+
+| Event | Detail |
+|---|---|
+| `persona:suggestReplies:shown` | `{ suggestions: string[] }` — fires once per distinct chip set |
+| `persona:suggestReplies:selected` | `{ suggestion: string }` — fires before the chip text is sent |
+
 ## Dropdown Menu
 
 A reusable dropdown menu utility for building custom menus in plugins, custom components, or host-page UI that matches the widget's theme.

--- a/packages/widget/src/ask-user-question-tool.ts
+++ b/packages/widget/src/ask-user-question-tool.ts
@@ -20,6 +20,10 @@ import {
   ASK_USER_QUESTION_MAX,
   ASK_USER_QUESTION_TOOL_NAME,
 } from "./components/ask-user-question-bubble";
+import {
+  SUGGEST_REPLIES_CLIENT_TOOL,
+  shouldExposeSuggestReplies,
+} from "./suggest-replies-tool";
 import type { AgentWidgetConfig, ClientToolDefinition } from "./types";
 
 /**
@@ -110,18 +114,25 @@ export const ASK_USER_QUESTION_CLIENT_TOOL: ClientToolDefinition = {
 
 /**
  * Built-in client tools to append to a dispatch's `clientTools[]` for the
- * given widget config. Today this is only `ask_user_question`; future built-in
- * local tools join here.
+ * given widget config: `ask_user_question` and `suggest_replies`; future
+ * built-in local tools join here.
  *
- * Gated on BOTH flags: `expose` opts the tool into the agent's catalog, and
- * `enabled !== false` guarantees the widget can actually render an answer UI
- * for it — exposing a question tool with the sheet disabled would park the
- * execution on a generic tool bubble with no way to answer.
+ * Each tool is gated on BOTH of its feature flags: `expose` opts the tool
+ * into the agent's catalog, and `enabled !== false` guarantees the widget can
+ * actually render UI (and, for fire-and-forget tools, auto-resume) for it —
+ * exposing a tool with its feature disabled would park the execution on a
+ * generic tool bubble with no way to advance.
  */
 export const builtInClientToolsForDispatch = (
   config: AgentWidgetConfig | undefined,
 ): ClientToolDefinition[] => {
-  const feature = config?.features?.askUserQuestion;
-  if (feature?.expose !== true || feature.enabled === false) return [];
-  return [ASK_USER_QUESTION_CLIENT_TOOL];
+  const tools: ClientToolDefinition[] = [];
+  const ask = config?.features?.askUserQuestion;
+  if (ask?.expose === true && ask.enabled !== false) {
+    tools.push(ASK_USER_QUESTION_CLIENT_TOOL);
+  }
+  if (shouldExposeSuggestReplies(config)) {
+    tools.push(SUGGEST_REPLIES_CLIENT_TOOL);
+  }
+  return tools;
 };

--- a/packages/widget/src/components/messages.ts
+++ b/packages/widget/src/components/messages.ts
@@ -9,6 +9,7 @@ import {
   isAskUserQuestionMessage,
   removeAskUserQuestionSheet,
 } from "./ask-user-question-bubble";
+import { isSuggestRepliesMessage } from "../suggest-replies-tool";
 
 export const renderMessages = (
   container: HTMLElement,
@@ -39,6 +40,15 @@ export const renderMessages = (
         if (message.toolCall?.id) liveAskToolIds.add(message.toolCall.id);
         ensureAskUserQuestionSheet(message, config, composerOverlay ?? null);
       }
+      return;
+    } else if (
+      isSuggestRepliesMessage(message) &&
+      config?.features?.suggestReplies?.enabled !== false
+    ) {
+      // No transcript bubble — the chips above the composer are the only UI.
+      // When the feature is disabled the message falls through to the generic
+      // tool bubble below (and is never auto-resumed), making the parked
+      // execution visible instead of silently swallowed.
       return;
     } else if (message.variant === "tool" && message.toolCall) {
       if (!showToolCalls) return;

--- a/packages/widget/src/components/suggestions.ts
+++ b/packages/widget/src/components/suggestions.ts
@@ -9,29 +9,50 @@ export interface SuggestionButtons {
     session: AgentWidgetSession,
     textarea: HTMLTextAreaElement,
     messages?: AgentWidgetMessage[],
-    config?: AgentWidgetSuggestionChipsConfig
+    config?: AgentWidgetSuggestionChipsConfig,
+    opts?: SuggestionRenderOptions
   ) => void;
+}
+
+export interface SuggestionRenderOptions {
+  /**
+   * Chips pushed by the agent's `suggest_replies` tool rather than the
+   * static `suggestionChips` config. Skips the before-first-user-message
+   * gate (the caller already applied the latest-turn visibility rule) and
+   * dispatches `persona:suggestReplies:*` DOM events.
+   */
+  agentPushed?: boolean;
 }
 
 export const createSuggestions = (container: HTMLElement): SuggestionButtons => {
   const suggestionButtons: HTMLButtonElement[] = [];
+  // render() runs on every message change; only announce agent-pushed chips
+  // when the visible set actually changes, not on each re-render pass.
+  let lastAgentShownKey: string | null = null;
 
   const render = (
     chips: string[] | undefined,
     session: AgentWidgetSession,
     textarea: HTMLTextAreaElement,
     messages?: AgentWidgetMessage[],
-    chipsConfig?: AgentWidgetSuggestionChipsConfig
+    chipsConfig?: AgentWidgetSuggestionChipsConfig,
+    opts?: SuggestionRenderOptions
   ) => {
     container.innerHTML = "";
     suggestionButtons.length = 0;
+    const agentPushed = opts?.agentPushed === true;
+    if (!agentPushed) lastAgentShownKey = null;
     if (!chips || !chips.length) return;
 
-    // Hide suggestions after the first user message is sent
+    // Hide config suggestions after the first user message is sent.
+    // Agent-pushed chips skip this gate — their visibility is the caller's
+    // latest-turn rule (last suggest_replies call with no user message after).
     // Use provided messages or get from session
-    const messagesToCheck = messages ?? (session ? session.getMessages() : []);
-    const hasUserMessage = messagesToCheck.some((msg) => msg.role === "user");
-    if (hasUserMessage) return;
+    if (!agentPushed) {
+      const messagesToCheck = messages ?? (session ? session.getMessages() : []);
+      const hasUserMessage = messagesToCheck.some((msg) => msg.role === "user");
+      if (hasUserMessage) return;
+    }
 
     const fragment = document.createDocumentFragment();
     const streaming = session ? session.isStreaming() : false;
@@ -79,12 +100,34 @@ export const createSuggestions = (container: HTMLElement): SuggestionButtons => 
       btn.addEventListener("click", () => {
         if (!session || session.isStreaming()) return;
         textarea.value = "";
+        if (agentPushed) {
+          container.dispatchEvent(
+            new CustomEvent("persona:suggestReplies:selected", {
+              detail: { suggestion: chip },
+              bubbles: true,
+              composed: true,
+            })
+          );
+        }
         session.sendMessage(chip);
       });
       fragment.appendChild(btn);
       suggestionButtons.push(btn);
     });
     container.appendChild(fragment);
+    if (agentPushed) {
+      const shownKey = JSON.stringify(chips);
+      if (shownKey !== lastAgentShownKey) {
+        lastAgentShownKey = shownKey;
+        container.dispatchEvent(
+          new CustomEvent("persona:suggestReplies:shown", {
+            detail: { suggestions: [...chips] },
+            bubbles: true,
+            composed: true,
+          })
+        );
+      }
+    }
   };
 
   return {

--- a/packages/widget/src/index-core.ts
+++ b/packages/widget/src/index-core.ts
@@ -140,6 +140,15 @@ export {
   builtInClientToolsForDispatch
 } from "./ask-user-question-tool";
 
+export {
+  SUGGEST_REPLIES_TOOL_NAME,
+  SUGGEST_REPLIES_CLIENT_TOOL,
+  SUGGEST_REPLIES_PARAMETERS_SCHEMA,
+  isSuggestRepliesMessage,
+  parseSuggestRepliesPayload,
+  latestAgentSuggestions
+} from "./suggest-replies-tool";
+
 export { initAgentWidgetFn as initAgentWidget };
 export {
   createWidgetHostLayout,

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -1,6 +1,10 @@
 import { AgentWidgetClient, type SSEEventCallback } from "./client";
 import { isWebMcpToolName } from "./webmcp-bridge";
 import {
+  SUGGEST_REPLIES_TOOL_NAME,
+  suggestRepliesToolResult,
+} from "./suggest-replies-tool";
+import {
   AgentWidgetConfig,
   AgentWidgetEvent,
   AgentWidgetMessage,
@@ -133,6 +137,15 @@ const getWebMcpErrorMessage = (
   if (typeof error === "string" && error) return error;
   return fallback;
 };
+
+/**
+ * Tool names whose `step_await` the widget resolves automatically (no user
+ * pill click): `webmcp:*` page tools and the built-in fire-and-forget
+ * `suggest_replies`. These share the await-batch / dedupe / resume machinery;
+ * `ask_user_question` is NOT one of them — it blocks on the answer sheet.
+ */
+const isAutoResolvedLocalToolName = (name: string): boolean =>
+  isWebMcpToolName(name) || name === SUGGEST_REPLIES_TOOL_NAME;
 
 export class AgentWidgetSession {
   private client: AgentWidgetClient;
@@ -1593,7 +1606,8 @@ export class AgentWidgetSession {
   }
 
   /**
-   * Collect a `webmcp:*` LOCAL-tool `step_await` into a per-executionId batch
+   * Collect an auto-resolving LOCAL-tool `step_await` (`webmcp:*` page tools
+   * and the built-in `suggest_replies`) into a per-executionId batch
    * and schedule a single deferred flush. Parallel calls (core#3878) emit
    * several `step_await`s for ONE paused execution within the same stream tick;
    * buffering them and flushing once lets us post ONE `/resume` keyed by the
@@ -1724,6 +1738,9 @@ export class AgentWidgetSession {
     result: unknown,
     startedAt: number,
     completedAt = Date.now(),
+    extraMetadata?: Partial<
+      NonNullable<AgentWidgetMessage["agentMetadata"]>
+    >,
   ): void {
     // A teardown such as clearMessages()/hydrateMessages()/new send can remove
     // the bubble while an aborted WebMCP promise is settling. Never resurrect a
@@ -1735,6 +1752,7 @@ export class AgentWidgetSession {
       agentMetadata: {
         ...toolMessage.agentMetadata,
         awaitingLocalTool: false,
+        ...extraMetadata,
       },
       toolCall: toolMessage.toolCall
         ? {
@@ -1808,14 +1826,28 @@ export class AgentWidgetSession {
         // only means the server paused for a local tool; it is not completion.
         const startedAt = this.markWebMcpToolRunning(toolMessage);
 
-        const controller = new AbortController();
-        this.webMcpResolveControllers.add(controller);
-        controllers.push(controller);
-
         // Per-call id wins for resume keying; fall back to the wire tool name
         // for legacy servers that don't emit `webMcpToolCallId`.
         const resumeKey =
           toolMessage.agentMetadata?.webMcpToolCallId ?? wireToolName;
+
+        // Built-in fire-and-forget tool: no bridge, no confirm gate, no
+        // browser-side execution — the chips render from the message list and
+        // the canned output joins the batch's single /resume.
+        if (wireToolName === SUGGEST_REPLIES_TOOL_NAME) {
+          return {
+            dedupeKey,
+            resumeKey,
+            output: suggestRepliesToolResult(),
+            toolMessage,
+            startedAt,
+            completedAt: Date.now(),
+          };
+        }
+
+        const controller = new AbortController();
+        this.webMcpResolveControllers.add(controller);
+        controllers.push(controller);
 
         const execPromise = this.client.executeWebMcpToolCall(
           wireToolName,
@@ -1911,6 +1943,9 @@ export class AgentWidgetSession {
           r.output,
           r.startedAt,
           r.completedAt,
+          r.toolMessage.toolCall?.name === SUGGEST_REPLIES_TOOL_NAME
+            ? { suggestRepliesResolved: true }
+            : undefined,
         );
       }
       if (response.body) {
@@ -1950,12 +1985,16 @@ export class AgentWidgetSession {
   }
 
   /**
-   * Resolve a paused `webmcp:*` LOCAL tool call by executing it against the
-   * host page's tool registry and posting the result to `/resume`.
+   * Resolve a paused auto-resolving LOCAL tool call and post the result to
+   * `/resume`: `webmcp:*` calls execute against the host page's tool
+   * registry; the built-in `suggest_replies` skips execution entirely and
+   * resumes with a canned "shown" result (the chips render from the message
+   * list, not from this resolve).
    *
    * Triggered automatically from `handleEvent` when a `step_await`-derived
-   * message arrives with a `webmcp:` prefix — the user does not click a
-   * pill; the bridge's confirm-bubble gate is the only interactive surface.
+   * message arrives for such a tool — the user does not click a pill; the
+   * bridge's confirm-bubble gate (WebMCP only) is the only interactive
+   * surface.
    *
    * Idempotent on the message's `toolCall.id`: re-emits of the same step_await
    * (e.g. from message coalescing) won't double-fire `tool.execute`. Failure
@@ -1976,8 +2015,9 @@ export class AgentWidgetSession {
     //     via onError so an operator can react. This is a server-side
     //     wire-shape bug — Persona can't recover it from the client.
     //   - no wireToolName: defensive guard — handleEvent only calls us
-    //     when tc.name is a `webmcp:` prefix, so this path indicates a
-    //     direct caller misuse. Silent return.
+    //     for an auto-resolving local tool name (`webmcp:*` or
+    //     `suggest_replies`), so this path indicates a direct caller
+    //     misuse. Silent return.
     //   - no toolCallId: dedupe key falls apart, but the server can still
     //     advance if we post an isError for the wireToolName. Do that
     //     and bail before the dedupe path.
@@ -2057,21 +2097,27 @@ export class AgentWidgetSession {
     const { signal } = resolveController;
     this.setStreaming(true);
 
+    // Built-in fire-and-forget tool: no bridge, no confirm gate, no
+    // browser-side execution — the chips render from the message list and the
+    // canned output resumes the execution immediately. Branch BEFORE any
+    // bridge access so the missing-bridge error path can never fire for it.
+    const isSuggestReplies = wireToolName === SUGGEST_REPLIES_TOOL_NAME;
+
     const args = toolMessage.toolCall?.args;
     // Thread the signal INTO the bridge — short-circuits the confirm bubble
     // and the execute() race on cancel(), so a late confirm-approval after
     // cancel() cannot fire a host-page side effect with no matching /resume.
-    const execPromise = this.client.executeWebMcpToolCall(
-      wireToolName,
-      args,
-      signal,
-    );
+    const execPromise = isSuggestReplies
+      ? null
+      : this.client.executeWebMcpToolCall(wireToolName, args, signal);
 
     let phase: "execute" | "resume" = "execute";
     let completedAt = startedAt;
     try {
       let resumeOutput: unknown;
-      if (!execPromise) {
+      if (isSuggestReplies) {
+        resumeOutput = suggestRepliesToolResult();
+      } else if (!execPromise) {
         // Client has no bridge (config.webmcp.enabled !== true). Resume with
         // an error so the dispatch can advance instead of hanging.
         resumeOutput = {
@@ -2120,6 +2166,7 @@ export class AgentWidgetSession {
             resumeOutput,
             startedAt,
             completedAt,
+            isSuggestReplies ? { suggestRepliesResolved: true } : undefined,
           );
         },
         signal,
@@ -2438,10 +2485,13 @@ export class AgentWidgetSession {
     if (event.type === "message") {
       this.upsertMessage(event.message);
 
-      // WebMCP auto-resolve: when a step_await emits a tool-variant message
-      // for a `webmcp:*` tool, drive the bridge to execute it and post the
-      // result to /resume. Unlike ask_user_question, no user pill click is
-      // required — the bridge's confirm bubble is the only interactive surface.
+      // Local-tool auto-resolve: when a step_await emits a tool-variant
+      // message for a `webmcp:*` tool — or the built-in fire-and-forget
+      // `suggest_replies` — resolve it and post the result to /resume.
+      // Unlike ask_user_question, no user pill click is required; for WebMCP
+      // the bridge's confirm bubble is the only interactive surface, and
+      // suggest_replies resumes with a canned "shown" result while the chips
+      // render above the composer.
       //
       // Defer via `queueMicrotask` so handleEvent returns FIRST. The current
       // SSE consumer is still mid-loop; once we return, the dispatch's
@@ -2455,11 +2505,19 @@ export class AgentWidgetSession {
       // if the bridge is non-operational. Otherwise the dispatch stays paused
       // indefinitely — `resolveWebMcpToolCall` translates the missing-bridge
       // case into an isError result that resumes the flow cleanly.
+      // `suggest_replies`, by contrast, is gated on its feature flag: when
+      // `features.suggestReplies.enabled === false` the widget neither
+      // renders chips nor resumes — the same parked-execution posture as a
+      // server-declared ask_user_question with its sheet disabled.
       const tc = event.message.toolCall;
+      const autoResolvable =
+        !!tc?.name &&
+        (isWebMcpToolName(tc.name) ||
+          (tc.name === SUGGEST_REPLIES_TOOL_NAME &&
+            this.config.features?.suggestReplies?.enabled !== false));
       if (
         event.message.agentMetadata?.awaitingLocalTool === true &&
-        tc?.name &&
-        isWebMcpToolName(tc.name)
+        autoResolvable
       ) {
         // Collect the await into its executionId's batch instead of resolving
         // it on the spot. Parallel same-tool calls (core#3878) arrive as
@@ -2744,9 +2802,10 @@ export class AgentWidgetSession {
           parameters: incoming.parameters ?? prior.parameters,
         };
       }
-      // WebMCP equivalent: once a `webmcp:*` tool has started resolving
-      // (inflight) or resolved, a duplicate `step_await` re-emit must not
-      // flip `awaitingLocalTool` back to true and resurrect the "waiting on
+      // Auto-resolved local-tool equivalent (`webmcp:*` and the built-in
+      // `suggest_replies`): once such a tool has started resolving (inflight)
+      // or resolved, a duplicate `step_await` re-emit must not flip
+      // `awaitingLocalTool` back to true and resurrect the "waiting on
       // local tool" UI. It also must not overwrite an existing running or
       // completed toolCall with the fresh running skeleton emitted by client.ts
       // for every step_await. resolveWebMcpToolCall's dedupe path returns
@@ -2757,7 +2816,7 @@ export class AgentWidgetSession {
       const reTcId = withSequence.toolCall?.id;
       if (
         reTcName &&
-        isWebMcpToolName(reTcName) &&
+        isAutoResolvedLocalToolName(reTcName) &&
         reExecId &&
         reTcId &&
         withSequence.agentMetadata?.awaitingLocalTool === true
@@ -2770,7 +2829,7 @@ export class AgentWidgetSession {
           existing.agentMetadata?.executionId === reExecId &&
           existing.toolCall?.id === reTcId &&
           existingToolName !== undefined &&
-          isWebMcpToolName(existingToolName) &&
+          isAutoResolvedLocalToolName(existingToolName) &&
           existing.toolCall?.status === "complete";
         if (isInflight || isResolved || hasCompletedTool) {
           merged.agentMetadata = {

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -1708,6 +1708,26 @@ export class AgentWidgetSession {
     return Date.now();
   }
 
+  /**
+   * Persisted-resolution guard for `suggest_replies`. The in-memory dedupe
+   * sets (`webMcpInflightKeys` / `webMcpResolvedKeys`) are cleared by
+   * hydrateMessages/clearMessages/cancel, but `suggestRepliesResolved`
+   * survives on the stored message — so a stale `step_await` re-emit after a
+   * hydration must not re-POST `/resume` for an already-resolved call (the
+   * historical double-resume failure mode the batching work exists to avoid).
+   * Checks the LIVE message first; the handleEvent snapshot is a fresh wire
+   * skeleton whose metadata never carries the flag.
+   */
+  private isSuggestRepliesAlreadyResolved(
+    toolMessage: AgentWidgetMessage,
+  ): boolean {
+    if (toolMessage.toolCall?.name !== SUGGEST_REPLIES_TOOL_NAME) return false;
+    const stored = this.messages.find((m) => m.id === toolMessage.id);
+    return (
+      (stored ?? toolMessage).agentMetadata?.suggestRepliesResolved === true
+    );
+  }
+
   private markWebMcpToolRunning(
     toolMessage: AgentWidgetMessage,
   ): number {
@@ -1814,7 +1834,8 @@ export class AgentWidgetSession {
         const dedupeKey = `${executionId}:${callId}`;
         if (
           this.webMcpInflightKeys.has(dedupeKey) ||
-          this.webMcpResolvedKeys.has(dedupeKey)
+          this.webMcpResolvedKeys.has(dedupeKey) ||
+          this.isSuggestRepliesAlreadyResolved(toolMessage)
         ) {
           return null;
         }
@@ -2064,11 +2085,14 @@ export class AgentWidgetSession {
     }
 
     // Dedupe key scoped by executionId — see `webMcpInflightKeys` doc comment
-    // for the failure-recovery + cross-dispatch rationale.
+    // for the failure-recovery + cross-dispatch rationale. The persisted
+    // `suggestRepliesResolved` guard backs the in-memory sets across
+    // hydrations.
     const dedupeKey = `${executionId}:${toolCallId}`;
     if (
       this.webMcpInflightKeys.has(dedupeKey) ||
-      this.webMcpResolvedKeys.has(dedupeKey)
+      this.webMcpResolvedKeys.has(dedupeKey) ||
+      this.isSuggestRepliesAlreadyResolved(toolMessage)
     ) {
       return;
     }
@@ -2772,6 +2796,21 @@ export class AgentWidgetSession {
             : {}),
           // Keep awaiting flag false once resolved — never let a stale
           // re-emit flip us back to awaiting.
+          awaitingLocalTool: false,
+        };
+      }
+      // suggest_replies equivalent: preserve the persisted fire-and-forget
+      // resolution across re-emissions. It is the only dedupe signal that
+      // survives a hydration (the in-memory key sets are cleared), so a
+      // stale step_await re-emit must not wipe it before
+      // `isSuggestRepliesAlreadyResolved` checks it in the resolve path.
+      if (
+        existing.agentMetadata?.suggestRepliesResolved === true &&
+        withSequence.agentMetadata
+      ) {
+        merged.agentMetadata = {
+          ...(merged.agentMetadata ?? withSequence.agentMetadata),
+          suggestRepliesResolved: true,
           awaitingLocalTool: false,
         };
       }

--- a/packages/widget/src/suggest-replies-tool.test.ts
+++ b/packages/widget/src/suggest-replies-tool.test.ts
@@ -1,0 +1,417 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  SUGGEST_REPLIES_CLIENT_TOOL,
+  SUGGEST_REPLIES_MAX,
+  SUGGEST_REPLIES_PARAMETERS_SCHEMA,
+  SUGGEST_REPLIES_TOOL_NAME,
+  latestAgentSuggestions,
+  parseSuggestRepliesPayload,
+} from "./suggest-replies-tool";
+import {
+  ASK_USER_QUESTION_CLIENT_TOOL,
+  builtInClientToolsForDispatch,
+} from "./ask-user-question-tool";
+import { AgentWidgetClient } from "./client";
+import { AgentWidgetSession } from "./session";
+import { computeClientToolsFingerprint } from "./webmcp-bridge";
+import type { AgentWidgetConfig, AgentWidgetMessage } from "./types";
+
+describe("SUGGEST_REPLIES_CLIENT_TOOL definition", () => {
+  it("matches the tool name and origin/annotation contract", () => {
+    expect(SUGGEST_REPLIES_CLIENT_TOOL.name).toBe(SUGGEST_REPLIES_TOOL_NAME);
+    // `'sdk'` keeps the bare name on the wire (the server only prefixes
+    // `origin: 'webmcp'` tools) so the step_await routes to the widget's
+    // auto-resolve, not the WebMCP bridge.
+    expect(SUGGEST_REPLIES_CLIENT_TOOL.origin).toBe("sdk");
+    expect(SUGGEST_REPLIES_CLIENT_TOOL.annotations?.readOnlyHint).toBe(true);
+  });
+
+  it("bounds suggestions to 1-4 short strings", () => {
+    const suggestions =
+      SUGGEST_REPLIES_PARAMETERS_SCHEMA.properties.suggestions;
+    expect(suggestions.minItems).toBe(1);
+    expect(suggestions.maxItems).toBe(SUGGEST_REPLIES_MAX);
+    expect(suggestions.items.maxLength).toBe(60);
+    expect(SUGGEST_REPLIES_PARAMETERS_SCHEMA.required).toEqual(["suggestions"]);
+  });
+});
+
+describe("parseSuggestRepliesPayload", () => {
+  it("parses object args and JSON-string args", () => {
+    expect(parseSuggestRepliesPayload({ suggestions: ["A", "B"] })).toEqual([
+      "A",
+      "B",
+    ]);
+    expect(
+      parseSuggestRepliesPayload(JSON.stringify({ suggestions: ["A"] })),
+    ).toEqual(["A"]);
+  });
+
+  it("drops non-strings and empty strings, trims whitespace", () => {
+    expect(
+      parseSuggestRepliesPayload({
+        suggestions: ["  A  ", 42, "", null, "B", "   "],
+      }),
+    ).toEqual(["A", "B"]);
+  });
+
+  it("truncates past the cap with a console warning", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const result = parseSuggestRepliesPayload({
+      suggestions: ["1", "2", "3", "4", "5", "6"],
+    });
+    expect(result).toEqual(["1", "2", "3", "4"]);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it("returns [] for malformed payloads", () => {
+    expect(parseSuggestRepliesPayload(undefined)).toEqual([]);
+    expect(parseSuggestRepliesPayload("not json")).toEqual([]);
+    expect(parseSuggestRepliesPayload({ suggestions: "oops" })).toEqual([]);
+    expect(parseSuggestRepliesPayload({})).toEqual([]);
+  });
+});
+
+describe("latestAgentSuggestions", () => {
+  const msg = (
+    overrides: Partial<AgentWidgetMessage> & { id: string },
+  ): AgentWidgetMessage => ({
+    role: "assistant",
+    content: "",
+    createdAt: "2026-06-10T00:00:00.000Z",
+    ...overrides,
+  });
+  const suggest = (id: string, suggestions: string[]): AgentWidgetMessage =>
+    msg({
+      id,
+      variant: "tool",
+      toolCall: {
+        id: `tc-${id}`,
+        name: SUGGEST_REPLIES_TOOL_NAME,
+        status: "complete",
+        args: { suggestions },
+      },
+    });
+  const user = (id: string): AgentWidgetMessage =>
+    msg({ id, role: "user", content: "hi" });
+
+  it("returns null when no suggest_replies message exists", () => {
+    expect(latestAgentSuggestions([])).toBeNull();
+    expect(latestAgentSuggestions([user("u1"), msg({ id: "a1" })])).toBeNull();
+  });
+
+  it("returns the chips of the latest call (latest wins)", () => {
+    expect(
+      latestAgentSuggestions([
+        user("u1"),
+        suggest("s1", ["Old A"]),
+        suggest("s2", ["New A", "New B"]),
+      ]),
+    ).toEqual(["New A", "New B"]);
+  });
+
+  it("hides chips once a user message follows them", () => {
+    expect(
+      latestAgentSuggestions([user("u1"), suggest("s1", ["A"]), user("u2")]),
+    ).toBeNull();
+  });
+
+  it("keeps chips visible through trailing assistant text", () => {
+    expect(
+      latestAgentSuggestions([
+        user("u1"),
+        suggest("s1", ["A"]),
+        msg({ id: "a1", content: "anything else?" }),
+      ]),
+    ).toEqual(["A"]);
+  });
+
+  it("returns null when the latest call's payload is unparseable", () => {
+    expect(
+      latestAgentSuggestions([
+        msg({
+          id: "s1",
+          variant: "tool",
+          toolCall: {
+            id: "tc-s1",
+            name: SUGGEST_REPLIES_TOOL_NAME,
+            status: "complete",
+            args: { nope: true },
+          },
+        }),
+      ]),
+    ).toBeNull();
+  });
+});
+
+describe("builtInClientToolsForDispatch - suggest_replies gating", () => {
+  it("returns nothing by default (expose is opt-in)", () => {
+    expect(builtInClientToolsForDispatch(undefined)).toEqual([]);
+    expect(
+      builtInClientToolsForDispatch({
+        features: { suggestReplies: {} },
+      } as AgentWidgetConfig),
+    ).toEqual([]);
+  });
+
+  it("returns the tool when expose is true", () => {
+    expect(
+      builtInClientToolsForDispatch({
+        features: { suggestReplies: { expose: true } },
+      } as AgentWidgetConfig),
+    ).toEqual([SUGGEST_REPLIES_CLIENT_TOOL]);
+  });
+
+  it("ignores expose when the feature is disabled", () => {
+    // Exposing the tool with the feature off would park the execution on a
+    // generic tool bubble awaiting a fire-and-forget resume that never comes.
+    expect(
+      builtInClientToolsForDispatch({
+        features: { suggestReplies: { expose: true, enabled: false } },
+      } as AgentWidgetConfig),
+    ).toEqual([]);
+  });
+
+  it("composes with ask_user_question, ask first", () => {
+    expect(
+      builtInClientToolsForDispatch({
+        features: {
+          askUserQuestion: { expose: true },
+          suggestReplies: { expose: true },
+        },
+      } as AgentWidgetConfig),
+    ).toEqual([ASK_USER_QUESTION_CLIENT_TOOL, SUGGEST_REPLIES_CLIENT_TOOL]);
+  });
+});
+
+describe("AgentWidgetClient - built-in suggest_replies exposure", () => {
+  const captureDispatchBody = () => {
+    const captured: { body: string | null } = { body: null };
+    global.fetch = vi
+      .fn()
+      .mockImplementation(async (_url: string, options: { body: string }) => {
+        captured.body = options.body;
+        const encoder = new TextEncoder();
+        const stream = new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode('data: {"type":"done"}\n\n'));
+            controller.close();
+          },
+        });
+        return new Response(stream, {
+          headers: { "Content-Type": "text/event-stream" },
+        });
+      });
+    return captured;
+  };
+
+  const userMessage = () => ({
+    id: "u1",
+    role: "user" as const,
+    content: "hi",
+    createdAt: new Date().toISOString(),
+  });
+
+  it("ships suggest_replies on clientTools when expose is on", async () => {
+    const captured = captureDispatchBody();
+    const client = new AgentWidgetClient({
+      apiUrl: "http://localhost:8000",
+      features: { suggestReplies: { expose: true } },
+    });
+    await client.dispatch({ messages: [userMessage()] }, () => undefined);
+    const parsed = JSON.parse(captured.body!);
+    expect(parsed.clientTools).toEqual([SUGGEST_REPLIES_CLIENT_TOOL]);
+  });
+
+  it("omits clientTools entirely when expose is off and no WebMCP tools exist", async () => {
+    const captured = captureDispatchBody();
+    const client = new AgentWidgetClient({
+      apiUrl: "http://localhost:8000",
+    });
+    await client.dispatch({ messages: [userMessage()] }, () => undefined);
+    const parsed = JSON.parse(captured.body!);
+    expect(parsed.clientTools).toBeUndefined();
+  });
+
+  it("changes the clientTools fingerprint when toggled (diff-only resend)", () => {
+    const webMcpOnly = [{ name: "search", description: "s" }];
+    const withBuiltIn = [SUGGEST_REPLIES_CLIENT_TOOL, ...webMcpOnly];
+    expect(computeClientToolsFingerprint(withBuiltIn)).not.toBe(
+      computeClientToolsFingerprint(webMcpOnly),
+    );
+  });
+});
+
+describe("AgentWidgetSession - suggest_replies fire-and-forget auto-resolve", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Mirrors session.webmcp.test.ts's harness: spy the client's resume/execute
+  // seams and stub connectStream so no real network or SSE parsing happens.
+  const makeSession = (config?: Partial<AgentWidgetConfig>) => {
+    const session = new AgentWidgetSession(
+      { apiUrl: "http://test", ...config },
+      {
+        onMessagesChanged: () => undefined,
+        onStatusChanged: () => undefined,
+        onStreamingChanged: () => undefined,
+      },
+    );
+    const client = (session as unknown as { client: Record<string, unknown> })
+      .client;
+    const executeSpy = vi.fn();
+    client.executeWebMcpToolCall = executeSpy;
+    const resumeSpy = vi.fn(
+      async () => new Response(new Blob([""]), { status: 200 }),
+    );
+    client.resumeFlow = resumeSpy;
+    (
+      session as unknown as { connectStream: () => Promise<void> }
+    ).connectStream = vi.fn(async () => undefined);
+    return { session, executeSpy, resumeSpy };
+  };
+
+  const suggestAwait = (
+    toolCallId: string,
+    executionId = "exec-sr",
+  ): AgentWidgetMessage => ({
+    id: `tool-${toolCallId}`,
+    role: "assistant",
+    content: "",
+    createdAt: new Date().toISOString(),
+    agentMetadata: {
+      executionId,
+      awaitingLocalTool: true,
+      webMcpToolCallId: toolCallId,
+    },
+    toolCall: {
+      id: toolCallId,
+      name: SUGGEST_REPLIES_TOOL_NAME,
+      status: "complete",
+      args: { suggestions: ["Tell me more", "Show pricing"] },
+    },
+  });
+
+  const webMcpAwait = (
+    toolCallId: string,
+    executionId = "exec-sr",
+  ): AgentWidgetMessage => ({
+    id: `tool-${toolCallId}`,
+    role: "assistant",
+    content: "",
+    createdAt: new Date().toISOString(),
+    agentMetadata: {
+      executionId,
+      awaitingLocalTool: true,
+      webMcpToolCallId: toolCallId,
+    },
+    toolCall: {
+      id: toolCallId,
+      name: "webmcp:search",
+      status: "complete",
+      args: { q: "shoes" },
+    },
+  });
+
+  const feed = (session: AgentWidgetSession, msg: AgentWidgetMessage) =>
+    (session as unknown as { handleEvent: (e: unknown) => void }).handleEvent({
+      type: "message",
+      message: msg,
+    });
+
+  const endStream = (session: AgentWidgetSession) =>
+    (session as unknown as { handleEvent: (e: unknown) => void }).handleEvent({
+      type: "status",
+      status: "idle",
+    });
+
+  const flushMicrotasks = async () => {
+    for (let i = 0; i < 6; i++) await Promise.resolve();
+  };
+
+  it("auto-POSTs ONE /resume with the canned output after stream idle — no bridge, no WebMCP config", async () => {
+    const { session, executeSpy, resumeSpy } = makeSession();
+
+    feed(session, suggestAwait("toolu_S"));
+    // Not resolved at step_await receipt — only after the stream ends.
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    endStream(session);
+    await flushMicrotasks();
+
+    expect(executeSpy).not.toHaveBeenCalled();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    const [execId, toolOutputs] = resumeSpy.mock.calls[0]! as unknown as [
+      string,
+      Record<string, { content: { type: string; text: string }[] }>,
+    ];
+    expect(execId).toBe("exec-sr");
+    expect(toolOutputs["toolu_S"]).toEqual({
+      content: [{ type: "text", text: "Suggestions shown to the user." }],
+    });
+  });
+
+  it("marks suggestRepliesResolved and clears awaitingLocalTool on resume OK", async () => {
+    const { session } = makeSession();
+    feed(session, suggestAwait("toolu_S"));
+    endStream(session);
+    await flushMicrotasks();
+
+    const stored = (
+      session as unknown as { messages: AgentWidgetMessage[] }
+    ).messages.find((m) => m.toolCall?.id === "toolu_S");
+    expect(stored?.agentMetadata?.suggestRepliesResolved).toBe(true);
+    expect(stored?.agentMetadata?.awaitingLocalTool).toBe(false);
+    expect(stored?.toolCall?.status).toBe("complete");
+  });
+
+  it("dedupes a duplicate step_await re-emit (no double resume)", async () => {
+    const { session, resumeSpy } = makeSession();
+    feed(session, suggestAwait("toolu_S"));
+    feed(session, suggestAwait("toolu_S")); // same-batch duplicate
+    endStream(session);
+    await flushMicrotasks();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+
+    // A stale re-emit after resolution must not trigger a second resume.
+    feed(session, suggestAwait("toolu_S"));
+    endStream(session);
+    await flushMicrotasks();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("joins a parallel webmcp await in ONE batched /resume", async () => {
+    const { session, executeSpy, resumeSpy } = makeSession({
+      webmcp: { enabled: true },
+    });
+    executeSpy.mockImplementation(() =>
+      Promise.resolve({ content: [{ type: "text", text: "found" }] }),
+    );
+
+    feed(session, webMcpAwait("toolu_W"));
+    feed(session, suggestAwait("toolu_S"));
+    endStream(session);
+    await flushMicrotasks();
+
+    // The page tool executed; suggest_replies did not touch the bridge.
+    expect(executeSpy).toHaveBeenCalledTimes(1);
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    const [, toolOutputs] = resumeSpy.mock.calls[0]! as unknown as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(Object.keys(toolOutputs).sort()).toEqual(["toolu_S", "toolu_W"]);
+  });
+
+  it("does NOT auto-resume when the feature is disabled", async () => {
+    const { session, resumeSpy } = makeSession({
+      features: { suggestReplies: { enabled: false } },
+    });
+    feed(session, suggestAwait("toolu_S"));
+    endStream(session);
+    await flushMicrotasks();
+    expect(resumeSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/widget/src/suggest-replies-tool.test.ts
+++ b/packages/widget/src/suggest-replies-tool.test.ts
@@ -414,4 +414,32 @@ describe("AgentWidgetSession - suggest_replies fire-and-forget auto-resolve", ()
     await flushMicrotasks();
     expect(resumeSpy).not.toHaveBeenCalled();
   });
+
+  it("never re-resumes after hydration clears the in-memory dedupe keys (persisted flag wins)", async () => {
+    const { session, resumeSpy } = makeSession();
+    feed(session, suggestAwait("toolu_S"));
+    endStream(session);
+    await flushMicrotasks();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+
+    // Hydration (e.g. storage restore) wipes webMcpInflightKeys /
+    // webMcpResolvedKeys — only the suggestRepliesResolved metadata persisted
+    // on the message survives to block a replayed step_await.
+    const resolved = (
+      session as unknown as { messages: AgentWidgetMessage[] }
+    ).messages;
+    session.hydrateMessages(resolved);
+    // Force-clear both dedupe sets so only the persisted flag can block.
+    const internals = session as unknown as {
+      webMcpInflightKeys: Set<string>;
+      webMcpResolvedKeys: Set<string>;
+    };
+    internals.webMcpInflightKeys.clear();
+    internals.webMcpResolvedKeys.clear();
+
+    feed(session, suggestAwait("toolu_S"));
+    endStream(session);
+    await flushMicrotasks();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/widget/src/suggest-replies-tool.ts
+++ b/packages/widget/src/suggest-replies-tool.ts
@@ -1,0 +1,152 @@
+/**
+ * Built-in `suggest_replies` client tool.
+ *
+ * The widget can advertise this tool to the agent on every dispatch via
+ * `clientTools[]` (set `features.suggestReplies.expose: true`) — the same
+ * wire surface as `ask_user_question` and WebMCP page tools. When the model
+ * calls it, the execution pauses with a `step_await`
+ * (`awaitReason: "local_tool_required"`); unlike `ask_user_question`, the
+ * widget resolves it FIRE-AND-FORGET — it renders the suggestions as tappable
+ * chips above the composer and immediately resumes the execution with a
+ * canned "shown" result, so the agent's turn completes without waiting on the
+ * user. Tapping a chip sends its text verbatim as the user's next message.
+ *
+ * Chip visibility is DERIVED state, not imperative show/hide: the chips of
+ * the last `suggest_replies` tool message with no user message after it are
+ * shown (see {@link latestAgentSuggestions}). That single rule covers
+ * soft-dismiss on any user message (typed, voice, or chip click), restore on
+ * reload/hydration, and latest-wins when a turn carries multiple calls.
+ */
+
+import type {
+  AgentWidgetConfig,
+  AgentWidgetMessage,
+  ClientToolDefinition,
+} from "./types";
+
+export const SUGGEST_REPLIES_TOOL_NAME = "suggest_replies";
+
+/** Renderer cap — payloads beyond this are truncated with a console warning. */
+export const SUGGEST_REPLIES_MAX = 4;
+
+/**
+ * JSON Schema for the tool's parameters. Mirrors what
+ * {@link parseSuggestRepliesPayload} hydrates the chips from, so the schema
+ * the model is held to and the shape the renderer expects can never drift.
+ */
+export const SUGGEST_REPLIES_PARAMETERS_SCHEMA = {
+  type: "object",
+  properties: {
+    suggestions: {
+      type: "array",
+      minItems: 1,
+      maxItems: SUGGEST_REPLIES_MAX,
+      description:
+        "1-4 short, distinct follow-up replies, phrased in the user's voice.",
+      items: { type: "string", minLength: 1, maxLength: 60 },
+    },
+  },
+  required: ["suggestions"],
+  additionalProperties: false,
+} as const;
+
+/**
+ * The `ClientToolDefinition` shipped on `dispatch.clientTools[]` when
+ * `features.suggestReplies.expose` is on. Exported so integrators who prefer
+ * declaring the tool server-side (a flow's `runtimeTools`) can reuse the same
+ * description and schema instead of hand-writing them.
+ */
+export const SUGGEST_REPLIES_CLIENT_TOOL: ClientToolDefinition = {
+  name: SUGGEST_REPLIES_TOOL_NAME,
+  description:
+    "Offer the user tappable quick-reply suggestions for their next message. " +
+    "Call at most once per turn, as the LAST action after your reply text is " +
+    "complete. Each suggestion is sent verbatim as the user's next message, " +
+    'so phrase suggestions in the user\'s voice (e.g. "Tell me more about ' +
+    'pricing"). Keep them short and distinct. The result only confirms the ' +
+    "suggestions were shown — do not add further commentary after calling " +
+    "this tool; end your turn.",
+  parametersSchema: SUGGEST_REPLIES_PARAMETERS_SCHEMA,
+  origin: "sdk",
+  annotations: { readOnlyHint: true },
+};
+
+/**
+ * The canned tool output posted to `/resume` the moment the chips render.
+ * MCP content shape, matching what the WebMCP resume path posts for page
+ * tools. Built fresh per call so a caller can't mutate a shared object.
+ */
+export const suggestRepliesToolResult = (): {
+  content: { type: "text"; text: string }[];
+} => ({
+  content: [{ type: "text", text: "Suggestions shown to the user." }],
+});
+
+/** A tool-variant message produced by a `suggest_replies` call. */
+export const isSuggestRepliesMessage = (
+  message: AgentWidgetMessage,
+): boolean =>
+  message.variant === "tool" &&
+  message.toolCall?.name === SUGGEST_REPLIES_TOOL_NAME;
+
+/**
+ * Tolerant parse of a `suggest_replies` tool call's args into chip labels:
+ * accepts a JSON string or object, coerces items to trimmed strings, drops
+ * empties, and truncates past the renderer cap with a console warning.
+ */
+export const parseSuggestRepliesPayload = (args: unknown): string[] => {
+  let parsed: unknown = args;
+  if (typeof parsed === "string") {
+    try {
+      parsed = JSON.parse(parsed);
+    } catch {
+      return [];
+    }
+  }
+  const raw = (parsed as { suggestions?: unknown } | null | undefined)
+    ?.suggestions;
+  if (!Array.isArray(raw)) return [];
+  const chips = raw
+    .filter((item): item is string => typeof item === "string")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+  if (chips.length > SUGGEST_REPLIES_MAX) {
+    console.warn(
+      `[persona] suggest_replies: ${chips.length} suggestions exceeds the cap of ${SUGGEST_REPLIES_MAX}; extra suggestions dropped.`,
+    );
+    return chips.slice(0, SUGGEST_REPLIES_MAX);
+  }
+  return chips;
+};
+
+/**
+ * The chips to show right now: those of the LAST `suggest_replies` tool
+ * message with NO user message after it, or `null` when none apply. All
+ * calls in a turn still get resumed (the server awaits each); only the
+ * latest renders.
+ */
+export const latestAgentSuggestions = (
+  messages: AgentWidgetMessage[],
+): string[] | null => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.role === "user") return null;
+    if (!isSuggestRepliesMessage(message)) continue;
+    const chips = parseSuggestRepliesPayload(message.toolCall?.args);
+    return chips.length > 0 ? chips : null;
+  }
+  return null;
+};
+
+/**
+ * Gate for advertising the tool: `expose` opts it into the agent's catalog,
+ * and `enabled !== false` guarantees the widget will actually auto-resolve
+ * and render chips for it — exposing the tool with the feature disabled
+ * would park the execution on a generic tool bubble with no resume coming.
+ */
+export const shouldExposeSuggestReplies = (
+  config: AgentWidgetConfig | undefined,
+): boolean => {
+  const feature = config?.features?.suggestReplies;
+  return feature?.expose === true && feature.enabled !== false;
+};

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -402,6 +402,13 @@ export type AgentMessageMetadata = {
    * paginated stepper. Persists alongside `askUserQuestionAnswers`.
    */
   askUserQuestionIndex?: number;
+  /**
+   * Set to `true` once a `suggest_replies` tool call's fire-and-forget
+   * `/resume` has been accepted by the server. Persisted belt-and-suspenders
+   * mirror of the in-memory resolved-key dedupe, so hydration/re-emit paths
+   * never re-resume the call.
+   */
+  suggestRepliesResolved?: boolean;
 };
 
 export type AgentWidgetRequestMiddlewareContext = {
@@ -1097,6 +1104,38 @@ export type AgentWidgetFeatureFlags = {
    * pills + optional free-text input.
    */
   askUserQuestion?: AgentWidgetAskUserQuestionFeature;
+  /**
+   * Built-in `suggest_replies` quick-reply chips. When the assistant invokes
+   * the tool, the widget shows the suggestions as tappable chips above the
+   * composer (reusing the suggestion-chips surface) and immediately resumes
+   * the execution — fire-and-forget, no user input awaited.
+   */
+  suggestReplies?: AgentWidgetSuggestRepliesFeature;
+};
+
+/**
+ * Feature config for the built-in `suggest_replies` quick-reply chips.
+ * Chips render in the existing suggestions slot above the composer and are
+ * styled by the widget-level `suggestionChipsConfig`. A tapped chip is sent
+ * verbatim as the user's next message; chips clear once any user message
+ * follows them.
+ */
+export type AgentWidgetSuggestRepliesFeature = {
+  /**
+   * Enable the feature. Defaults to true. When false, `suggest_replies`
+   * renders as a regular tool bubble and is NOT auto-resumed — only set this
+   * with no server-side `suggest_replies` declaration, or the execution
+   * parks awaiting a resume that never comes.
+   */
+  enabled?: boolean;
+  /**
+   * Advertise the built-in `suggest_replies` tool to the agent on every
+   * dispatch via `clientTools[]` — no server-side `runtimeTools` declaration
+   * needed. Defaults to `false`: flows that already declare the tool via
+   * `runtimeTools` would otherwise present it to the model twice. Ignored
+   * when `enabled` is `false`.
+   */
+  expose?: boolean;
 };
 
 /**

--- a/packages/widget/src/ui.suggest-replies.test.ts
+++ b/packages/widget/src/ui.suggest-replies.test.ts
@@ -160,6 +160,27 @@ describe("suggest_replies chips UI", () => {
     controller.destroy();
   });
 
+  it("keeps live agent chips through a config update", () => {
+    const { mount, controller } = makeController();
+    injectUserMessage(controller);
+    injectSuggestReplies(controller);
+    expect(chipButtons(mount, "Tell me more")).toHaveLength(1);
+
+    // A display-only config update (e.g. theme tweak) re-renders the
+    // suggestions row — it must re-apply the agent-chips rule, not fall back
+    // to the static config chips (which are hidden mid-conversation).
+    controller.update({
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      suggestionChips: [],
+      copy: { title: "Updated title" },
+    } as unknown as Parameters<typeof controller.update>[0]);
+
+    expect(chipButtons(mount, "Tell me more")).toHaveLength(1);
+
+    controller.destroy();
+  });
+
   it("renders no chips and falls back to the tool bubble when disabled", () => {
     const { mount, controller } = makeController({
       features: { suggestReplies: { enabled: false } },

--- a/packages/widget/src/ui.suggest-replies.test.ts
+++ b/packages/widget/src/ui.suggest-replies.test.ts
@@ -1,0 +1,216 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentExperience } from "./ui";
+import { SUGGEST_REPLIES_TOOL_NAME } from "./suggest-replies-tool";
+
+const createMount = () => {
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  return mount;
+};
+
+const makeController = (config?: Record<string, unknown>) => {
+  const mount = createMount();
+  const controller = createAgentExperience(mount, {
+    apiUrl: "https://api.example.com/chat",
+    launcher: { enabled: false },
+    suggestionChips: [],
+    ...config,
+  } as unknown as Parameters<typeof createAgentExperience>[1]);
+  return { mount, controller };
+};
+
+const injectUserMessage = (
+  controller: ReturnType<typeof createAgentExperience>,
+  id = "u1",
+  createdAt = "2026-06-10T00:00:00.000Z",
+) => {
+  controller.injectTestMessage({
+    type: "message",
+    message: {
+      id,
+      role: "user",
+      content: "hello",
+      createdAt,
+      streaming: false,
+    },
+  });
+};
+
+const injectSuggestReplies = (
+  controller: ReturnType<typeof createAgentExperience>,
+  {
+    id = "sr-1",
+    suggestions = ["Tell me more", "Show pricing"],
+  }: { id?: string; suggestions?: string[] } = {},
+) => {
+  controller.injectTestMessage({
+    type: "message",
+    message: {
+      id,
+      role: "assistant",
+      content: "",
+      createdAt: "2026-06-10T00:00:01.000Z",
+      streaming: false,
+      variant: "tool",
+      toolCall: {
+        id,
+        name: SUGGEST_REPLIES_TOOL_NAME,
+        status: "complete",
+        args: { suggestions },
+        chunks: [],
+      },
+      // No executionId/awaitingLocalTool — rendering is driven purely by the
+      // message list; the auto-resume path is covered in
+      // suggest-replies-tool.test.ts.
+    },
+  });
+};
+
+const chipButtons = (mount: HTMLElement, label: string): HTMLButtonElement[] =>
+  Array.from(mount.querySelectorAll("button")).filter(
+    (btn) => btn.textContent === label,
+  );
+
+describe("suggest_replies chips UI", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    if (typeof localStorage !== "undefined") localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("renders agent-pushed chips mid-conversation (after a user message exists)", () => {
+    const { mount, controller } = makeController();
+    injectUserMessage(controller);
+    injectSuggestReplies(controller);
+
+    expect(chipButtons(mount, "Tell me more")).toHaveLength(1);
+    expect(chipButtons(mount, "Show pricing")).toHaveLength(1);
+
+    controller.destroy();
+  });
+
+  it("suppresses the transcript tool bubble for the suggest_replies message", () => {
+    const { mount, controller } = makeController();
+    injectUserMessage(controller);
+    injectSuggestReplies(controller);
+
+    // No tool bubble rendered for the suggest_replies tool message.
+    expect(mount.querySelector('[data-bubble-type="tool"]')).toBeNull();
+    expect(mount.textContent).not.toContain("suggest_replies");
+
+    controller.destroy();
+  });
+
+  it("clears the chips once a user message follows them", () => {
+    const { mount, controller } = makeController();
+    injectUserMessage(controller, "u1");
+    injectSuggestReplies(controller);
+    expect(chipButtons(mount, "Tell me more")).toHaveLength(1);
+
+    injectUserMessage(controller, "u2", "2026-06-10T00:00:02.000Z");
+    expect(chipButtons(mount, "Tell me more")).toHaveLength(0);
+
+    controller.destroy();
+  });
+
+  it("shows only the latest call's chips when a turn carries several", () => {
+    const { mount, controller } = makeController();
+    injectUserMessage(controller);
+    injectSuggestReplies(controller, { id: "sr-1", suggestions: ["Old"] });
+    injectSuggestReplies(controller, { id: "sr-2", suggestions: ["New"] });
+
+    expect(chipButtons(mount, "Old")).toHaveLength(0);
+    expect(chipButtons(mount, "New")).toHaveLength(1);
+
+    controller.destroy();
+  });
+
+  it("sends the chip text verbatim as a user message on click", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(encoder.encode('data: {"type":"done"}\n\n'));
+          c.close();
+        },
+      });
+      return new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    });
+
+    const { mount, controller } = makeController();
+    injectUserMessage(controller);
+    injectSuggestReplies(controller);
+
+    chipButtons(mount, "Tell me more")[0]!.click();
+    await Promise.resolve();
+
+    const sent = controller
+      .getMessages()
+      .filter((m) => m.role === "user")
+      .map((m) => m.content);
+    expect(sent).toContain("Tell me more");
+    // The chip click appended a user message, so the chips cleared.
+    expect(chipButtons(mount, "Tell me more")).toHaveLength(0);
+
+    controller.destroy();
+  });
+
+  it("renders no chips and falls back to the tool bubble when disabled", () => {
+    const { mount, controller } = makeController({
+      features: { suggestReplies: { enabled: false } },
+    });
+    injectUserMessage(controller);
+    injectSuggestReplies(controller);
+
+    expect(chipButtons(mount, "Tell me more")).toHaveLength(0);
+    // The generic tool bubble renders instead, keeping the parked call visible.
+    expect(mount.textContent).toContain("suggest_replies");
+
+    controller.destroy();
+  });
+
+  it("dispatches persona:suggestReplies:shown and :selected DOM events", async () => {
+    global.fetch = vi.fn().mockImplementation(async () => {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(encoder.encode('data: {"type":"done"}\n\n'));
+          c.close();
+        },
+      });
+      return new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    });
+
+    const shown: string[][] = [];
+    const selected: string[] = [];
+    document.addEventListener("persona:suggestReplies:shown", (e) => {
+      shown.push((e as CustomEvent).detail.suggestions);
+    });
+    document.addEventListener("persona:suggestReplies:selected", (e) => {
+      selected.push((e as CustomEvent).detail.suggestion);
+    });
+
+    const { mount, controller } = makeController();
+    injectUserMessage(controller);
+    injectSuggestReplies(controller);
+
+    expect(shown).toEqual([["Tell me more", "Show pricing"]]);
+
+    // Re-rendering the same chip set must not re-fire `shown`.
+    injectSuggestReplies(controller, { id: "sr-1" });
+    expect(shown).toHaveLength(1);
+
+    chipButtons(mount, "Show pricing")[0]!.click();
+    await Promise.resolve();
+    expect(selected).toEqual(["Show pricing"]);
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2629,6 +2629,43 @@ export const createAgentExperience = (
   const suggestionsManager = createSuggestions(suggestions);
   let closeHandler: (() => void) | null = null;
   let session: AgentWidgetSession;
+
+  // Single render rule for the suggestions row, shared by the message-change,
+  // initial-paint, and config-update paths: agent-pushed `suggest_replies`
+  // chips win when the latest-turn rule yields any (last suggest_replies tool
+  // message with no user message after it); otherwise static config chips
+  // keep their before-first-user-message behavior. Config updates MUST route
+  // through here too — re-rendering with only `config.suggestionChips` would
+  // drop a live agent chip row until the next message change.
+  const renderSuggestions = (messages?: AgentWidgetMessage[]) => {
+    if (!session) return;
+    const current = messages ?? session.getMessages();
+    const agentChips =
+      config.features?.suggestReplies?.enabled !== false
+        ? latestAgentSuggestions(current)
+        : null;
+    if (agentChips) {
+      suggestionsManager.render(
+        agentChips,
+        session,
+        textarea,
+        current,
+        config.suggestionChipsConfig,
+        { agentPushed: true }
+      );
+    } else if (current.some((msg) => msg.role === "user")) {
+      // Hide suggestions once a user message exists.
+      suggestionsManager.render([], session, textarea, current);
+    } else {
+      suggestionsManager.render(
+        config.suggestionChips,
+        session,
+        textarea,
+        current,
+        config.suggestionChipsConfig
+      );
+    }
+  };
   let isStreaming = false;
   const messageCache = createMessageCache();
   // Tracks the last fingerprint we rendered a plugin-rendered ask_user_question
@@ -4774,27 +4811,9 @@ export const createAgentExperience = (
       renderMessagesWithPlugins(messagesWrapper, messages, postprocess);
       // Start elapsed timer if any active tool has a live duration span
       ensureToolElapsedTimer();
-      // Re-render suggestions. Agent-pushed `suggest_replies` chips win when
-      // the latest-turn rule yields any (last suggest_replies tool message
-      // with no user message after it); otherwise the static config chips
-      // keep their before-first-user-message behavior.
+      // Re-render suggestions — agent chips vs config chips, one shared rule.
       // Pass messages directly to avoid calling session.getMessages() during construction
-      if (session) {
-        const agentChips =
-          config.features?.suggestReplies?.enabled !== false
-            ? latestAgentSuggestions(messages)
-            : null;
-        const hasUserMessage = messages.some((msg) => msg.role === "user");
-        if (agentChips) {
-          suggestionsManager.render(agentChips, session, textarea, messages, config.suggestionChipsConfig, { agentPushed: true });
-        } else if (hasUserMessage) {
-          // Hide suggestions if user message exists
-          suggestionsManager.render([], session, textarea, messages);
-        } else {
-          // Show suggestions if no user message yet
-          suggestionsManager.render(config.suggestionChips, session, textarea, messages, config.suggestionChipsConfig);
-        }
-      }
+      renderSuggestions(messages);
       scheduleAutoScroll(!isStreaming);
       trackMessages(messages);
 
@@ -5723,7 +5742,7 @@ export const createAgentExperience = (
     mount.appendChild(customLauncherElement);
   }
   updateOpenState();
-  suggestionsManager.render(config.suggestionChips, session, textarea, undefined, config.suggestionChipsConfig);
+  renderSuggestions();
   updateCopy();
   setComposerDisabled(session.isStreaming());
   if (getScrollMode() === "follow") {
@@ -7007,7 +7026,7 @@ export const createAgentExperience = (
         session.getMessages(),
         postprocess
       );
-      suggestionsManager.render(config.suggestionChips, session, textarea, undefined, config.suggestionChipsConfig);
+      renderSuggestions();
       updateCopy();
       setComposerDisabled(session.isStreaming());
       

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -88,6 +88,10 @@ import {
   removeAskUserQuestionSheet,
   setCurrentAnswer,
 } from "./components/ask-user-question-bubble";
+import {
+  isSuggestRepliesMessage,
+  latestAgentSuggestions,
+} from "./suggest-replies-tool";
 import { formatElapsedMs } from "./utils/formatting";
 import { approvalDetailsExpansionState, createApprovalBubble, updateApprovalDetailsUI } from "./components/approval-bubble";
 import { createSuggestions } from "./components/suggestions";
@@ -3359,6 +3363,18 @@ export const createAgentExperience = (
         return;
       }
 
+      // suggest_replies renders no transcript bubble — the chips above the
+      // composer are the only UI, and the session auto-resumes the call.
+      // When the feature is disabled the message falls through to the generic
+      // tool bubble (and is never auto-resumed), keeping the parked execution
+      // visible instead of silently swallowed.
+      if (
+        isSuggestRepliesMessage(message) &&
+        config.features?.suggestReplies?.enabled !== false
+      ) {
+        return;
+      }
+
       if (
         isAskUserQuestionMessage(message) &&
         config.features?.askUserQuestion?.enabled !== false
@@ -4758,11 +4774,20 @@ export const createAgentExperience = (
       renderMessagesWithPlugins(messagesWrapper, messages, postprocess);
       // Start elapsed timer if any active tool has a live duration span
       ensureToolElapsedTimer();
-      // Re-render suggestions to hide them after first user message
+      // Re-render suggestions. Agent-pushed `suggest_replies` chips win when
+      // the latest-turn rule yields any (last suggest_replies tool message
+      // with no user message after it); otherwise the static config chips
+      // keep their before-first-user-message behavior.
       // Pass messages directly to avoid calling session.getMessages() during construction
       if (session) {
+        const agentChips =
+          config.features?.suggestReplies?.enabled !== false
+            ? latestAgentSuggestions(messages)
+            : null;
         const hasUserMessage = messages.some((msg) => msg.role === "user");
-        if (hasUserMessage) {
+        if (agentChips) {
+          suggestionsManager.render(agentChips, session, textarea, messages, config.suggestionChipsConfig, { agentPushed: true });
+        } else if (hasUserMessage) {
           // Hide suggestions if user message exists
           suggestionsManager.render([], session, textarea, messages);
         } else {


### PR DESCRIPTION
## Summary

Adds `suggest_replies` as the second **built-in client tool** following the pattern established by `ask_user_question` (#270):

```ts
features: { suggestReplies: { expose: true } }
```

When exposed, the widget advertises the tool on every dispatch via `clientTools[]` (`origin: 'sdk'`, bare name on the wire). When the agent calls it, the widget renders the 1–4 suggestions as tappable quick-reply chips above the composer — reusing the existing suggestion-chips surface and `suggestionChipsConfig` styling — and **immediately auto-resumes** the paused execution with a canned "shown" result. Fire-and-forget: unlike `ask_user_question`, nothing blocks on the user. Tapping a chip sends its text verbatim as the user's next message.

### How the auto-resume works

The `step_await` rides the existing WebMCP await-batch machinery in `session.ts` (`enqueueWebMcpAwait` → post-stream-idle `scheduleWebMcpBatchFlush`) rather than a separate `/resume` path — so a turn that calls `suggest_replies` in parallel with `webmcp:*` tools still produces exactly ONE batched `/resume` per execution (two racing resumes on one execution historically 404'd and hung the turn). The suggest branch sits before any bridge access, so no WebMCP config is required and the missing-bridge error path can never fire. Idempotency reuses the existing `executionId:toolCallId` dedupe keys, plus a persisted `suggestRepliesResolved` metadata flag.

### Chip lifecycle (derived state, not imperative show/hide)

Show the chips of the **last** `suggest_replies` tool message with **no user message after it**. This single rule covers soft-dismiss on any user message (typed, voice, or chip click), reload/hydration restore, and latest-wins when a turn carries several calls (all are still resumed — the server awaits each — only the last renders). Static `suggestionChips` keep their existing before-first-user-message behavior.

### Safety decisions (mirrors #270)

- `expose` defaults to **false** — flows already declaring the tool via `runtimeTools` would otherwise present it twice. Exported `SUGGEST_REPLIES_CLIENT_TOOL` / `SUGGEST_REPLIES_PARAMETERS_SCHEMA` constants let those flows reuse the same description/schema.
- Ignored when `enabled: false` — a disabled feature neither renders chips nor auto-resumes, so the tool is never offered when the execution would park. When disabled, the tool message falls through to the generic tool bubble (visible, not silently swallowed).

### Schema

Plain `suggestions: string[]` (1–4 items, ≤60 chars) — no label/value split, since a chip click sends the text verbatim; a hidden divergent value would make the transcript show something the user never said.

New DOM events: `persona:suggestReplies:shown` (deduped per distinct chip set) and `persona:suggestReplies:selected`.

## Test plan

- 30 new tests across `suggest-replies-tool.test.ts` (definition contract, schema bounds, tolerant parse, latest-turn rule, dispatch gating/ordering with ask_user_question, fingerprint toggle, session auto-resolve: single batch after stream idle, dedupe, mixed webmcp+suggest batch, disabled gating) and `ui.suggest-replies.test.ts` (chips render mid-conversation, transcript bubble suppressed, clear-on-user-message, latest wins, verbatim send, disabled fall-through, DOM events).
- Full suite: 1181 tests pass; lint, typecheck, build, and size-limit clean (theme-editor budget +0.5 kB, tripped by 143 B).

Research and roadmap context: runtypelabs/core#4118.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session `/resume` batching and message merge/dedupe alongside WebMCP; misconfiguration (`expose` with `enabled: false`) can park executions, but gating and tests mitigate that.
> 
> **Overview**
> Adds a built-in **`suggest_replies`** client tool (second after `ask_user_question`), gated by `features.suggestReplies.expose` / `enabled`. When the agent calls it, the widget shows 1–4 quick-reply chips above the composer (same slot and styling as static `suggestionChips`), **auto-resumes** the paused execution with a canned “shown” result via the existing WebMCP await-batch path, and hides the tool from the transcript when enabled.
> 
> **Chip visibility** is derived from the transcript (`latestAgentSuggestions`: last `suggest_replies` with no user message after). Tapping a chip sends that text as the user message; `persona:suggestReplies:shown` / `:selected` DOM events fire from the suggestions row. Session changes extend auto-resolve to `suggest_replies` (no WebMCP bridge), with `suggestRepliesResolved` on message metadata to prevent double `/resume` after hydration.
> 
> Exports tool constants and helpers for server-side `runtimeTools` reuse; docs, changeset, embedded demo mocks (chips loop + presets), and ~30 unit/UI tests cover the flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12be7bf7247195d7bf08381fd6c31cd784cfe838. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->