### PR TITLE
refactor(demos): slim WebMCP demo tool surfaces — fewer, better-shaped tools

### DIFF
--- a/.changeset/webmcp-flow-prompt-tool-slimming.md
+++ b/.changeset/webmcp-flow-prompt-tool-slimming.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Update the WebMCP calendar and slides flow prompts for the slimmed demo tool surfaces: the calendar demo dropped its lookup-only tools (`get_users`, `get_event_colors`, `get_page_title` — users now ride along on `get_calendar_state` and colors are schema enums), and the slides demo folded `distribute_elements` into `align_elements`.

--- a/examples/embedded-app/src/docked-panel-demo.ts
+++ b/examples/embedded-app/src/docked-panel-demo.ts
@@ -363,15 +363,17 @@ if (modelContext) {
       },
       required: ["section"],
     },
-    annotations: { readOnlyHint: true },
+    // Mutates UI state (active nav item), so no readOnlyHint — but it stays in
+    // READ_ONLY_TOOLS above: pure navigation auto-approves at the gate.
+    annotations: { readOnlyHint: false },
     execute(args) {
       const requested = String(args.section ?? "").trim().toLowerCase();
       const items = navItems();
       const target = items.find((el) => sectionName(el).toLowerCase() === requested);
       if (!target) {
-        return {
-          error: `Unknown section "${args.section}". Available: ${items.map(sectionName).join(", ")}.`,
-        };
+        throw new Error(
+          `Unknown section "${args.section}". Available: ${items.map(sectionName).join(", ")}.`,
+        );
       }
       items.forEach((el) => {
         el.classList.toggle("is-active", el === target);
@@ -401,7 +403,7 @@ if (modelContext) {
     execute(args) {
       if (args.side !== undefined) {
         if (args.side !== "left" && args.side !== "right") {
-          return { error: `Invalid side "${args.side}" — use "left" or "right".` };
+          throw new Error(`Invalid side "${args.side}" — use "left" or "right".`);
         }
         sideSelect.value = args.side;
       }
@@ -409,14 +411,14 @@ if (modelContext) {
         const raw = String(args.width).trim();
         const width = /^\d+(\.\d+)?$/.test(raw) ? `${raw}px` : raw;
         if (!/^\d+(\.\d+)?(px|rem|em|vw|%)$/.test(width)) {
-          return { error: `Invalid width "${args.width}" — use a CSS length like "360px".` };
+          throw new Error(`Invalid width "${args.width}" — use a CSS length like "360px".`);
         }
         widthInput.value = width;
       }
       if (args.reveal !== undefined) {
         const reveal = String(args.reveal);
         if (!["resize", "emerge", "overlay", "push"].includes(reveal)) {
-          return { error: `Invalid reveal "${args.reveal}" — use resize, emerge, overlay, or push.` };
+          throw new Error(`Invalid reveal "${args.reveal}" — use resize, emerge, overlay, or push.`);
         }
         revealSelect.value = reveal;
       }
@@ -444,7 +446,7 @@ if (modelContext) {
     },
     execute(args) {
       const feed = document.querySelector(".workspace-feed");
-      if (!feed) return { error: "Activity feed not found on the page." };
+      if (!feed) throw new Error("Activity feed not found on the page.");
 
       // Built with textContent — agent-supplied strings never touch innerHTML.
       const item = document.createElement("div");

--- a/examples/embedded-app/src/webmcp-calendar/calendar.js
+++ b/examples/embedded-app/src/webmcp-calendar/calendar.js
@@ -32,11 +32,8 @@ const EVENT_COLORS = {
 };
 
 const READ_ONLY_TOOL_NAMES = new Set([
-  'get_page_title',
   'get_calendar_state',
   'get_events',
-  'get_users',
-  'get_event_colors',
   'find_availability',
 ]);
 
@@ -134,7 +131,7 @@ const requireUser = (id) => {
   const user = USERS.find((candidate) => candidate.id === id);
   if (!user) {
     throw new Error(
-      `Unknown userId "${id}". Valid user IDs: ${USERS.map((candidate) => candidate.id).join(', ')} — call get_users.`,
+      `Unknown userId "${id}". Valid user IDs: ${USERS.map((candidate) => candidate.id).join(', ')} — call get_calendar_state.`,
     );
   }
   return user;
@@ -263,6 +260,9 @@ const getCalendarState = () => {
     timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
     eventCount: state.events.length,
     visibleEvents: weekEvents,
+    // The full (static) user roster rides along so the agent never needs a
+    // separate lookup tool to learn valid userIds for create/update.
+    users: USERS.map(({ id, name, role }) => ({ id, name, role })),
   };
 };
 
@@ -408,24 +408,10 @@ const registerCalendarTools = () => {
   registerTool(
     modelContext,
     {
-      name: 'get_page_title',
-      title: 'Get page title',
-      description: 'Get the current page title for this calendar example.',
-      inputSchema: { type: 'object', properties: {} },
-      async execute() {
-        return toolResult({ title: document.title }, document.title);
-      },
-    },
-    controller.signal,
-  );
-
-  registerTool(
-    modelContext,
-    {
       name: 'get_calendar_state',
       title: 'Read calendar state',
       description:
-        'Read the current calendar state: current local date-time, selected date, visible week, timezone, total event count, and visible events. Call this before creating or editing events. All event times are local wall-clock times in the calendar timezone.',
+        'Read the current calendar state: current local date-time, selected date, visible week, timezone, total event count, visible events, and the valid users (with the userIds create_event accepts). Call this before creating or editing events. All event times are local wall-clock times in the calendar timezone.',
       inputSchema: { type: 'object', properties: {} },
       annotations: { readOnlyHint: true },
       async execute() {
@@ -454,41 +440,6 @@ const registerCalendarTools = () => {
       async execute(args) {
         const events = filterEvents(args).map(publicEvent);
         return toolResult({ count: events.length, events }, `Found ${events.length} event${events.length === 1 ? '' : 's'}.`);
-      },
-    },
-    controller.signal,
-  );
-
-  registerTool(
-    modelContext,
-    {
-      name: 'get_users',
-      title: 'List calendar users',
-      description:
-        'Return valid calendar users/owners. Use one of these user IDs when creating an event.',
-      inputSchema: { type: 'object', properties: {} },
-      annotations: { readOnlyHint: true },
-      async execute() {
-        const text = USERS.map((user) => `${user.name} (${user.role}) — ID: ${user.id}`).join('\n');
-        return toolResult({ users: USERS }, text);
-      },
-    },
-    controller.signal,
-  );
-
-  registerTool(
-    modelContext,
-    {
-      name: 'get_event_colors',
-      title: 'List event colors',
-      description: 'Return the allowed event color names and their hex values.',
-      inputSchema: { type: 'object', properties: {} },
-      annotations: { readOnlyHint: true },
-      async execute() {
-        return toolResult(
-          { colors: Object.entries(EVENT_COLORS).map(([name, hex]) => ({ name, hex })) },
-          `Allowed colors: ${Object.keys(EVENT_COLORS).join(', ')}.`,
-        );
       },
     },
     controller.signal,
@@ -550,7 +501,7 @@ const registerCalendarTools = () => {
       name: 'create_event',
       title: 'Create event',
       description:
-        'Create a calendar event and render it on the page. startDate/endDate are LOCAL wall-clock times in the calendar timezone, formatted YYYY-MM-DDTHH:mm — never append "Z" or a UTC offset (any offset is ignored and the stated clock time is used as-is). Use a userId from get_users and a color from get_event_colors.',
+        'Create a calendar event and render it on the page. startDate/endDate are LOCAL wall-clock times in the calendar timezone, formatted YYYY-MM-DDTHH:mm — never append "Z" or a UTC offset (any offset is ignored and the stated clock time is used as-is). Use a userId from get_calendar_state.',
       inputSchema: {
         type: 'object',
         properties: {
@@ -558,8 +509,8 @@ const registerCalendarTools = () => {
           description: { type: 'string', description: 'Optional event notes.' },
           startDate: { type: 'string', description: 'Event start as local wall-clock time, e.g. 2026-06-11T08:00. No "Z" or UTC offset.' },
           endDate: { type: 'string', description: 'Event end as local wall-clock time, e.g. 2026-06-11T09:00. No "Z" or UTC offset.' },
-          userId: { type: 'string', description: 'Owner/attendee user ID from get_users.' },
-          color: { type: 'string', description: 'Color name from get_event_colors.' },
+          userId: { type: 'string', description: 'Owner/attendee user ID from get_calendar_state.' },
+          color: { type: 'string', enum: Object.keys(EVENT_COLORS), description: 'Event color.' },
           location: { type: 'string', description: 'Optional location or video link.' },
         },
         required: ['title', 'startDate', 'endDate'],
@@ -588,8 +539,8 @@ const registerCalendarTools = () => {
           description: { type: 'string' },
           startDate: { type: 'string', description: 'Local wall-clock time, e.g. 2026-06-11T08:00. No "Z" or UTC offset.' },
           endDate: { type: 'string', description: 'Local wall-clock time, e.g. 2026-06-11T09:00. No "Z" or UTC offset.' },
-          userId: { type: 'string' },
-          color: { type: 'string' },
+          userId: { type: 'string', description: 'Owner/attendee user ID from get_calendar_state.' },
+          color: { type: 'string', enum: Object.keys(EVENT_COLORS) },
           location: { type: 'string' },
         },
         required: ['eventId'],
@@ -623,7 +574,7 @@ const registerCalendarTools = () => {
     controller.signal,
   );
 
-  setToolStatus('10 WebMCP tools registered for Chrome DevTools MCP and Persona.', 'ready');
+  setToolStatus('7 WebMCP tools registered for Chrome DevTools MCP and Persona.', 'ready');
 };
 
 const setToolStatus = (message, tone = 'ready') => {

--- a/examples/embedded-app/src/webmcp-slides/tools.ts
+++ b/examples/embedded-app/src/webmcp-slides/tools.ts
@@ -6,7 +6,7 @@ import { THEMES, getTheme } from "./themes";
 // WebMCP tool surface for the slide editor. Three tool sets share two
 // AbortController owners (the calendar demo's re-registration pattern):
 //
-//   1. the static editing set (18 tools) — registered while mode === 'edit';
+//   1. the static editing set (17 tools) — registered while mode === 'edit';
 //   2. the presenter set (4 tools) — replaces the editing set wholesale while
 //      mode === 'present', so the agent only sees show controls mid-show;
 //   3. the selection-scoped set (2 tools) — registered only while 2+ elements
@@ -36,6 +36,10 @@ export const APPROVAL_REQUIRED_TOOL_NAMES = new Set([
   "apply_theme",
 ]);
 
+// "Read-only" here is the approval-gate sense: true reads plus pure navigation
+// (goto_slide, the presenter controls). Navigation changes what's on screen but
+// never deck data, so it auto-approves; the descriptors carry the matching
+// readOnlyHint annotation.
 export const READ_ONLY_TOOL_NAMES = new Set([
   "get_deck_overview",
   "get_slide",
@@ -756,15 +760,20 @@ const buildEditingTools = (store: DeckStore): ToolDescriptor[] => [
     name: "align_elements",
     title: "Align elements",
     description:
-      "Align elements to the slide or to their shared bounding box. Returns the new positions.",
+      "Align elements to the slide or to their shared bounding box, and/or space them evenly along an axis (distribute needs 3+ elements; the first/last stay put). Same shape as align_selection. Returns the new positions.",
     inputSchema: {
       type: "object",
-      required: ["elementIds", "alignment"],
+      required: ["elementIds"],
       properties: {
         elementIds: { type: "array", items: { type: "string" }, minItems: 1 },
         alignment: {
           type: "string",
           enum: ["left", "center-x", "right", "top", "center-y", "bottom"],
+        },
+        distribute: {
+          type: "string",
+          enum: ["horizontal", "vertical"],
+          description: "Space the elements evenly along this axis; needs 3+ elements.",
         },
         relativeTo: {
           type: "string",
@@ -777,52 +786,28 @@ const buildEditingTools = (store: DeckStore): ToolDescriptor[] => [
     execute(args) {
       const ids = Array.isArray(args.elementIds) ? args.elementIds.map(String) : [];
       if (!ids.length) throw new Error("elementIds is required.");
+      if (!args.alignment && !args.distribute) {
+        throw new Error("Provide alignment and/or distribute.");
+      }
       const first = store.findElement(ids[0]);
       if (!first) throw new Error(`No element with id "${ids[0]}".`);
       store.commit((deck) => {
         const slide = deck.slides.find((s) => s.id === first.slide.id);
         if (!slide) return;
         const targets = slide.elements.filter((el) => ids.includes(el.id));
-        alignElements(
-          targets,
-          String(args.alignment) as Alignment,
-          args.relativeTo === "selection-bounds" ? "selection-bounds" : "slide",
-        );
-      });
-      flashAgentTouch(store, first.slide.id, ids);
-      const fresh = store.findSlide(first.slide.id);
-      return toolResult({
-        positions: positionsOf(
-          fresh?.elements.filter((el) => ids.includes(el.id)) ?? [],
-        ),
-      });
-    },
-  },
-  {
-    name: "distribute_elements",
-    title: "Distribute elements",
-    description:
-      "Space three or more elements evenly along an axis (their first/last stay put). Returns the new positions.",
-    inputSchema: {
-      type: "object",
-      required: ["elementIds", "axis"],
-      properties: {
-        elementIds: { type: "array", items: { type: "string" }, minItems: 3 },
-        axis: { type: "string", enum: ["horizontal", "vertical"] },
-      },
-    },
-    execute(args) {
-      const ids = Array.isArray(args.elementIds) ? args.elementIds.map(String) : [];
-      const first = store.findElement(ids[0] ?? "");
-      if (!first) throw new Error("elementIds must reference existing elements.");
-      store.commit((deck) => {
-        const slide = deck.slides.find((s) => s.id === first.slide.id);
-        if (!slide) return;
-        const targets = slide.elements.filter((el) => ids.includes(el.id));
-        distributeElements(
-          targets,
-          args.axis === "vertical" ? "vertical" : "horizontal",
-        );
+        if (args.alignment) {
+          alignElements(
+            targets,
+            String(args.alignment) as Alignment,
+            args.relativeTo === "selection-bounds" ? "selection-bounds" : "slide",
+          );
+        }
+        if (args.distribute) {
+          distributeElements(
+            targets,
+            args.distribute === "vertical" ? "vertical" : "horizontal",
+          );
+        }
       });
       flashAgentTouch(store, first.slide.id, ids);
       const fresh = store.findSlide(first.slide.id);
@@ -891,6 +876,7 @@ const buildEditingTools = (store: DeckStore): ToolDescriptor[] => [
         position: { type: "number", description: "1-based slide to start from; defaults to slide 1." },
       },
     },
+    annotations: { readOnlyHint: true },
     execute(args) {
       if (typeof args.position === "number") {
         store.setCurrentSlide(Math.round(args.position) - 1);

--- a/packages/proxy/src/flows/webmcp-calendar.ts
+++ b/packages/proxy/src/flows/webmcp-calendar.ts
@@ -5,10 +5,11 @@ import type { RuntypeFlowConfig } from "../index.js";
  * (`examples/embedded-app/webmcp-calendar.html`).
  *
  * Like WEBMCP_STOREFRONT_FLOW, this agent owns **no** tools of its own. The
- * demo page registers ten calendar tools on `document.modelContext` via WebMCP
- * (`get_calendar_state`, `get_events`, `get_users`, `get_event_colors`,
- * `find_availability`, `select_date`, `create_event`, `update_event`,
- * `delete_event`, `get_page_title`); the widget snapshots them every turn and
+ * demo page registers seven calendar tools on `document.modelContext` via
+ * WebMCP (`get_calendar_state`, `get_events`, `find_availability`,
+ * `select_date`, `create_event`, `update_event`, `delete_event`; valid users
+ * ride along on `get_calendar_state` and colors are schema enums, so there are
+ * no lookup-only tools); the widget snapshots them every turn and
  * the proxy forwards them on the dispatch payload as `clientTools[]`. The
  * model calls them by name and the widget executes them **on the page**,
  * posting results back via `/resume` — so the calendar UI updates live.
@@ -46,7 +47,7 @@ The dashboard exposes its own calendar tools to you. Always **use the tools** to
 Rules:
 - Start by calling **get_calendar_state** to learn today's date, the current local time, the timezone, and the visible week before resolving relative dates like "tomorrow" or "Thursday".
 - All date-times are LOCAL wall-clock strings in the calendar's timezone, formatted \`YYYY-MM-DDTHH:mm\`. Never append "Z" or a UTC offset — write the clock time the user said.
-- Use a real userId from **get_users** and a color from **get_event_colors** when creating events. Do not guess IDs.
+- Use a real userId from **get_calendar_state**'s users list when creating events. Do not guess IDs.
 - Before proposing a meeting time, check **find_availability** for that date; the workday is 9am–5pm local.
 - To change or remove an event, find its eventId via **get_events** or **get_calendar_state** first.
 - After a mutation, confirm briefly what changed (title, day, time) — the page renders the calendar, so don't repeat the full schedule unless asked.

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -58,7 +58,7 @@ Treat the tool list you currently see as authoritative. Never invent slide ids, 
 
 - The canvas is 960 wide x 540 tall, origin at the top-left. Keep ~40px margins; slide titles sit around y 40-60 at fontSize 36-48.
 - Prefer theme tokens over literal colors and fonts: 'theme.text', 'theme.accent', 'theme.background', 'theme.surface', 'theme.accentText' for colors, 'theme.heading' / 'theme.body' for fonts. Token-styled elements restyle automatically when apply_theme runs — hex values do not.
-- Build slides with add_slide layouts first, then refine with update_element patches (one patch can move, resize, and restyle at once). Use align_elements / distribute_elements for clean composition instead of eyeballing coordinates.
+- Build slides with add_slide layouts first, then refine with update_element patches (one patch can move, resize, and restyle at once). Use align_elements (alignment and/or distribute) for clean composition instead of eyeballing coordinates.
 
 ## Style passes ("make it pop", "more modern", "punch it up")
 


### PR DESCRIPTION
## Summary

A design pass over the WebMCP tools our demos register, following the [Arcade MCP tool patterns](https://www.arcade.dev/blog/mcp-tool-patterns/) philosophy: optimize for agent experience, keep response/error shapes consistent, and prefer fewer tools with schema-level affordances over lookup-tool detours. **Net: −55 lines, 4 tools deleted, 1 merged.**

## Calendar demo: 10 → 7 tools

- **Deleted `get_page_title`** — returned `document.title`; pure registration-proof cruft.
- **Deleted `get_event_colors`** — five static color names are now a schema `enum` on `create_event`/`update_event`, read for free at tool-selection time instead of costing a round trip.
- **Deleted `get_users`** — the static three-person roster now rides along on `get_calendar_state` (which the agent is already instructed to call first).

The happy path drops from *orient → look up users → look up colors → create* to *orient → create*.

## Slides demo: 18 → 17 edit tools

- **Merged `distribute_elements` into `align_elements`** (`alignment` and/or `distribute` params). The selection-scoped `align_selection` already had this shape — the static set was inconsistent with it.
- `enter_presenter_mode` now carries the `readOnlyHint` annotation the rest of the presenter set has, and `READ_ONLY_TOOL_NAMES` documents the "navigation counts as read-only for the gate" convention.

## Docked-panel demo: consistency fixes

- Validation failures now **throw** (like the calendar/slides demos) instead of returning `{ error }` data — one error convention across demos, recovery hints intact.
- `switch_section` is annotated `readOnlyHint: false` (it rewrites the active nav state); it stays auto-approved via the name-based gate set, with a comment explaining why.

## Proxy flows

System prompts and header comments in `webmcp-calendar.ts` / `webmcp-slides.ts` updated for the new tool lists, so the prompts never reference tools that no longer exist. Changeset included (`@runtypelabs/persona-proxy` patch).

## Testing

- `pnpm build`, `pnpm lint`, `pnpm typecheck` — all green
- `pnpm test:run` in `packages/widget` — green
- `vite build` of `examples/embedded-app` — green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only embedded examples and persona-proxy prompt text; no production auth or data paths, with behavior preserved via schema and payload changes.
> 
> **Overview**
> Slims WebMCP demo tool surfaces so agents need fewer round trips and prompts match what pages actually register.
> 
> **Calendar (10 → 7):** Drops `get_page_title`, `get_users`, and `get_event_colors`. `get_calendar_state` now includes the user roster; `create_event` / `update_event` expose colors as schema enums. Copy and `requireUser` errors point agents at `get_calendar_state` instead of removed tools.
> 
> **Slides (18 → 17 edit tools):** Removes `distribute_elements` and folds optional `distribute` into `align_elements` (aligned with `align_selection`). `enter_presenter_mode` gets `readOnlyHint: true`; comments clarify navigation tools as auto-approved at the Persona gate.
> 
> **Docked-panel demo:** Validation failures **throw** `Error` instead of returning `{ error }`, matching calendar/slides. `switch_section` is annotated `readOnlyHint: false` while staying in the name-based auto-approve set.
> 
> **Proxy:** `@runtypelabs/persona-proxy` patch updates `webmcp-calendar` and `webmcp-slides` flow prompts and header comments for the new tool lists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81cd472cace8019f4c0fbd5a14b260cf2e537af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->