### PR TITLE
Update Persona documentation for current features

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to AI coding agents (Claude Code, Codex, Cursor, etc
 
 ## Project Overview
 
-Persona is a pnpm monorepo containing a themeable, pluggable streaming chat widget for websites. It consists of two publishable packages and three example applications.
+Persona is a pnpm monorepo containing a themeable, pluggable streaming chat widget for websites. It consists of two publishable packages and four example applications.
 
 **Packages:**
 - `packages/widget` (`@runtypelabs/persona`) - The main chat widget library
@@ -12,6 +12,7 @@ Persona is a pnpm monorepo containing a themeable, pluggable streaming chat widg
 
 **Examples:**
 - `examples/embedded-app` - Vite demo with vanilla JS (35+ demo pages)
+- `examples/ai-sdk-webmcp` - Next.js / Vercel AI SDK WebMCP demo without Runtype
 - `examples/vercel-edge` - Node.js proxy for Vercel/Railway/Fly.io
 - `examples/cloudflare-workers` - Edge proxy for Cloudflare Workers
 
@@ -85,7 +86,7 @@ The widget uses a layered architecture:
 2. **Core Layer**
    - `client.ts` - HTTP client handling SSE streaming, message dispatch, and API communication
    - `session.ts` - Message state management, injection methods, client session handling
-   - `types.ts` - All TypeScript type definitions (~2900 lines; covers multi-modal content, agent loop config, tool config, theme types, request/response payloads)
+   - `types.ts` - All TypeScript type definitions (covers multi-modal content, agent loop config, tool/client-tool config, WebMCP, theme types, request/response payloads)
 
 3. **UI Layer** (`ui.ts` + `components/`)
    - `ui.ts` - Main UI controller, DOM rendering, event handling
@@ -101,6 +102,7 @@ The widget uses a layered architecture:
    - `tokens.ts` / `theme.ts` - Design tokens and theme utilities
    - `virtual-scroller.ts` - Performance optimization for long message lists
    - `event-stream-*.ts` - SSE event buffering, capture, control, and storage
+   - `ask-user-question-tool.ts` / `suggest-replies-tool.ts` - Built-in LOCAL client tool definitions advertised via `features.*.expose`
 
 5. **Voice** (`voice/`)
    - `browser-voice-provider.ts` - Web Audio API voice input
@@ -124,23 +126,28 @@ The widget uses a layered architecture:
 
 **DOM Updates:** Uses `idiomorph` for efficient DOM morphing/diffing.
 
-**Shadow DOM:** Widgets render inside a Shadow DOM by default, providing style isolation from the host page.
+**Shadow DOM:** Widgets can render inside a Shadow DOM for style isolation when `useShadowDom: true` is set. The default is `false` for CSS compatibility.
 
 **Theme System:** CSS custom properties (variables) + Tailwind with the `tvw-` prefix. The `tokens.ts` and `theme.ts` utilities manage runtime theme application. See `packages/widget/THEME-CONFIG.md` for the full theming reference.
 
 **HTML Sanitization:** All rendered markdown is sanitized via DOMPurify by default (`utils/sanitize.ts`). Configurable per-widget via the `sanitize` option: `true` (default), `false`, or a custom `(html: string) => string` function. When writing sanitization hooks, always compare URI schemes case-insensitively (e.g. `val.toLowerCase().startsWith("data:")`) per RFC 3986.
+
+**Built-in LOCAL client tools:** `features.askUserQuestion.expose` and `features.suggestReplies.expose` append SDK-origin `ClientToolDefinition`s to `dispatch.clientTools[]`. `ask_user_question` pauses for a user answer sheet; `suggest_replies` renders quick-reply chips and auto-resumes. Leave `expose` false when the flow already declares the tool server-side.
+
+**WebMCP page tools:** `webmcp.enabled` snapshots tools from `document.modelContext`, sends them as `clientTools[]`, executes returned `webmcp:<name>` calls in the browser with approval gating, and resumes via `${apiUrl}/resume`. `contextProviders` run on both agent and flow/proxy paths.
 
 **Deferred Launcher Loading:** For the common floating-launcher case, `install.ts` paints the real launcher from the tiny `launcher.global.js` (~13 KB brotli) at page load and defers the full `index.global.js` (~134 KB) until the user's first click. `shouldDeferPanel()` gates this — floating launcher, not auto-expanded, no restored/`onStateLoaded` open state, derivable launcher URL — and everything else eager-loads unchanged. The critical launcher is mount-then-destroyed at handoff and renders pixel-identically to the full widget's, so the swap is invisible. Installer lifecycle hooks (`onScriptLoad` / `onLauncherShown` / `onChatReady` / `onError`) and matching `persona:*` DOM events expose each stage; `onChatReady` (formerly `onReady`, now a deprecated alias) fires after first open in a deferred install. See the header comment in `launcher-global.ts` and the gate/handoff comments in `install.ts` for the invariants.
 
 ### Proxy Package (`packages/proxy/src/`)
 
 Hono-based server that proxies requests to the Runtype API:
-- `index.ts` - Main app factory (`createChatProxyApp()`) and route handlers
+- `index.ts` - Main app factory (`createChatProxyApp()`) and route handlers, including `${path}/resume` and feedback endpoints
 - `flows/` - Pre-configured flow definitions:
   - `conversational.ts` - Basic chat flow
   - `shopping-assistant.ts` - E-commerce flow
   - `scheduling.ts` - Calendar/scheduling flow
   - `bakery-assistant.ts` - Example specialized flow
+  - `webmcp-*.ts` / `theme-assistant.ts` / `page-context.ts` - WebMCP demo, theme copilot, and page-context flows
 
 **CORS / `NODE_ENV`:** The proxy only enables permissive CORS when `NODE_ENV` is **exactly** `"development"`. An unset `NODE_ENV` is treated as production (origins must match the `allowedOrigins` list). The root `pnpm dev` script sets `NODE_ENV=development` automatically. If you start the proxy directly (e.g. `pnpm dev:vercel`), set it yourself or configure it in your `.env` file.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 
 A themeable, pluggable AI chat widget for websites — built in Typescript with zero framework dependencies. It renders using Vanilla JS.
 
-Persona gives you a drop-in UI for your AI assistant that works on basically any site or product on the web. It ships with support for streaming responses, voice I/O, multi-modal content, tool call visualization, artifact rendering, and a plugin system so you can customize every layer of the UI.
+Persona gives you a drop-in UI for your AI assistant that works on basically any site or product on the web. It ships with support for streaming responses, direct client-token installs, WebMCP/page tools, built-in local client tools, voice I/O, multi-modal content, tool call visualization, approval gates, artifact rendering, safe markdown/HTML rendering, and a plugin system so you can customize every layer of the UI.
 
-Persona works with any SSE-capable backend. It's pre-integrated with [Runtype](https://runtype.com) out of the box, so you can go from install to live assistant with zero configuration.
+Persona works with any SSE-capable backend. It's pre-integrated with [Runtype](https://runtype.com) out of the box, so you can go from install to a live assistant with a `clientToken`, or route through `@runtypelabs/persona-proxy` when you need server-side API-key control.
 
 ## Live demo
 
@@ -54,49 +54,49 @@ npm install @runtypelabs/persona-proxy   # proxy (optional)
 Everything below is opt-in and configurable via the widget config, feature flags, or the plugin system.
 
 ### Streaming Chat
-SSE-based message streaming with pluggable parsers (plain text, JSON, XML, regex). Bring your own stream parser or use the built-ins. Supports partial JSON parsing for incomplete chunks.
+SSE-based message streaming with pluggable parsers (plain text, JSON, XML, regex). Bring your own stream parser or use the built-ins. Supports partial JSON parsing for incomplete chunks, configurable dispatch-failure copy via `errorMessage`, and optional stream reveal animations (`typewriter`, `letter-rise`, `word-fade`, `wipe`, `glyph-cycle`, `pop-bubble`, or custom plugins).
 
 ### Multi-Modal Content
 Text, images (PNG, JPEG, GIF, WebP, SVG), and documents (PDF, DOCX, TXT, CSV, JSON, Excel). Configure allowed file types, size limits, and previews through the attachments config.
 
 ### Voice Input & Output
-Optional speech-to-text via the Web Speech API or Runtype's WebSocket voice service with barge-in interruption and voice activity detection. Text-to-speech playback for assistant responses. Enable via the voice config.
+Optional speech-to-text via the Web Speech API or Runtype's WebSocket voice service with barge-in interruption and voice activity detection. Text-to-speech playback for assistant responses. Enable via `voiceRecognition` and `textToSpeech`.
 
 ### Reasoning & Extended Thinking
 Collapsible reasoning bubbles that display model chain-of-thought with duration tracking and streaming. Controlled by `features.showReasoning` — on by default, or override the renderer with a plugin hook.
 
-### Tool Calls & Approvals
-Expandable tool call bubbles showing name, status, arguments, and results. Optional human-in-the-loop approval system with configurable timeout. Controlled by `features.showToolCalls` with a plugin hook for custom rendering.
+### Tool Calls, Approvals & Local Client Tools
+Expandable tool call bubbles showing name, status, arguments, and results, with compact display modes, active previews, grouping, and loading animations. Optional human-in-the-loop approval bubbles include friendly summaries, hidden/collapsed technical details, agent-stated reasons, and custom approve/deny handlers. Built-in LOCAL client tools (`ask_user_question` and `suggest_replies`) can be advertised from the widget with `features.askUserQuestion.expose` and `features.suggestReplies.expose`.
 
 ### Artifacts
 Optional side-panel for rendering markdown and component content. Desktop split layout (resizable) or mobile drawer. Enable via `features.artifacts`, configure toolbar presets, copy behavior, and appearance.
 
 ### Event Stream Inspector
-Optional real-time event capture with search/filter, badge coloring, timestamps, and expandable payloads. Enable via `features.showEventStreamToggle`. Customize rows, toolbar, and payload rendering through plugin hooks.
+Optional real-time event capture with search/filter, badge coloring, timestamps, expandable payloads, and output-throughput diagnostics. Enable via `features.showEventStreamToggle`. Customize rows, toolbar, and payload rendering through plugin hooks.
 
-### Composer Keyboard Shortcuts
-`Enter` sends a message (`Shift+Enter` for a newline) and is inert while a response is streaming — it never interrupts generation. Press `Esc` within the widget to stop an in-flight response (the visible Stop button does the same). `Up`/`Down` navigate previously sent messages for quick re-entry or editing — entered only when the caret is at the start of the input, so multi-line editing is preserved, and your in-progress draft is restored when you page back to the present. History navigation is on by default; disable via `features.composerHistory: false`.
+### Composer, Scrolling & Keyboard Shortcuts
+`Enter` sends a message (`Shift+Enter` for a newline) and is inert while a response is streaming — it never interrupts generation. Press `Esc` within the widget to stop an in-flight response (the visible Stop button does the same). `Up`/`Down` navigate previously sent messages for quick re-entry or editing — entered only when the caret is at the start of the input, so multi-line editing is preserved, and your in-progress draft is restored when you page back to the present. History navigation is on by default; disable via `features.composerHistory: false`. Streaming scroll behavior is configurable with `features.scrollBehavior` (`follow`, `anchor-top`, or `none`), and the shared scroll-to-bottom affordance shows a new-message count while you're scrolled away.
 
 ### Themes & Styling
 Light and dark themes included. Full design token system (palette, semantic, component-level) with CSS variable support. Extend with built-in plugins for accessibility, reduced motion, high contrast, and branding — or create your own.
 
-### Layout & Presets
-Start from a built-in preset (shop, minimal, fullscreen) or configure from scratch. Header layouts, message layouts, avatars, timestamps, and slot-based rendering are all customizable. Dock as a floating widget or embed inline.
+### Layout, Docking & Fast Script Installs
+Start from a built-in preset (shop, minimal, fullscreen) or configure from scratch. Header layouts, message layouts, avatars, timestamps, and slot-based rendering are all customizable. Dock as a floating widget, wrap a page region with a side panel (`resize`, `emerge`, `overlay`, or `push` reveals with a `dock.maxHeight` viewport guard), or embed inline. Script-tag installs paint a tiny real launcher first and defer the full panel bundle until first open when the config allows it.
 
 ### Plugin System
-14 render hooks covering the launcher, header, composer, messages, reasoning, tool calls, approvals, loading/idle indicators, and the event stream. Priority-based ordering with automatic fallback to defaults. Replace any piece of the UI without forking.
+14 render hooks covering the launcher, header, composer, messages, reasoning, tool calls, ask-user-question sheets, approvals, loading/idle indicators, and the event stream. Priority-based ordering with automatic fallback to defaults. Replace any piece of the UI without forking; use the optional `@runtypelabs/persona/plugin-kit` helpers for Shadow-DOM-safe styles and popovers.
 
 ### Feedback & Analytics
-Optional message-level upvote/downvote/copy with automatic backend submission. CSAT and NPS survey components. Wire up custom callbacks for your own analytics.
+Optional message-level upvote/downvote/copy with automatic backend submission in client-token mode. CSAT and NPS survey components. Script-tag lifecycle callbacks/events (`onScriptLoad`, `onLauncherShown`, `onChatReady`, `onError`) and controller events make it easy to wire custom analytics.
 
 ### Agent Execution
 Renders multi-turn agent loops as they stream from the backend — displaying iteration progress, reflections, and stop reasons. Agent metadata is attached to every message. Customize how execution events appear through plugin hooks.
 
 ### Component System
-Register custom components and render them inline via directives. Stream-aware parser and middleware for dynamic UI insertion during streaming.
+Register custom components and render them inline via directives. Stream-aware parser and middleware support dynamic UI insertion during streaming, with live DOM element hydration so event listeners survive transcript re-renders.
 
-### Message Injection
-Programmatically insert messages (`injectMessage`, `injectAssistantMessage`, `injectUserMessage`, `injectSystemMessage`) with dual-content support — display one thing to the user while sending different content to the LLM.
+### Message Injection, Context & Page Tools
+Programmatically insert messages (`injectMessage`, `injectAssistantMessage`, `injectUserMessage`, `injectSystemMessage`) with dual-content support — display one thing to the user while sending different content to the LLM. Inject page/editor context with `contextProviders` and `requestMiddleware`; use `webmcp: { enabled: true }` to expose page actions through `document.modelContext`. For richer page context, import the optional `@runtypelabs/persona/smart-dom-reader` provider.
 
 ## Proxy Deployment
 

--- a/examples/embedded-app/README.md
+++ b/examples/embedded-app/README.md
@@ -121,9 +121,9 @@ The action middleware example demonstrates:
 ### WebMCP Demo
 - **WebMCP page**: `http://localhost:5173/webmcp-demo.html`
   - Demonstrates the widget consuming **page-provided tools** via WebMCP (`document.modelContext`)
-  - The page registers `search_products` and `add_to_cart` on the polyfilled `document.modelContext` (`@mcp-b/webmcp-polyfill`); the widget snapshots them per turn and sends them to the agent as `clientTools[]`
-  - When the agent calls one, the widget executes it on the page (behind an `onConfirm` gate) and resumes the turn with the result
-  - The catalog (`webmcp-catalog.ts`) and the on-page **Cart** panel are the visible side effects: `search_products` filters the static catalog; `add_to_cart` updates the cart
+  - The page registers five storefront tools (`search_products`, `view_product`, `add_to_cart`, `remove_from_cart`, `apply_promo`) on the polyfilled `document.modelContext` (`@mcp-b/webmcp-polyfill`); the widget snapshots them per turn and sends them to the agent as `clientTools[]`
+  - When the agent calls one, the widget executes it on the page (behind an `onConfirm` gate for writes) and resumes the turn with the result
+  - The catalog (`webmcp-catalog.ts`), selected-product state, and on-page **Cart** panel are the visible side effects: `search_products` filters the static catalog, `view_product` focuses details, and cart/promo tools update the cart
 
 #### What the starter pills show
 
@@ -139,7 +139,7 @@ The action middleware example demonstrates:
 ### WebMCP Calendar Copilot
 - **Calendar page**: `http://localhost:5173/webmcp-calendar.html` (proxy mode — agent defined in code as `WEBMCP_CALENDAR_FLOW`, mounted at `/api/chat/dispatch-calendar`)
   - A hybrid "AI-native dashboard": a calendar with a manual **Quick Add** form *and* a conversational prompt bar; both drive the same state the WebMCP tools expose
-  - `src/webmcp-calendar/calendar.js` registers **ten tools** on `document.modelContext` via `@mcp-b/global` (create/update/delete events, availability search, state reads) — callable by the embedded Persona widget *and* by [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp/) against the same page
+  - `src/webmcp-calendar/calendar.js` registers **seven tools** on `document.modelContext` via `@mcp-b/global` (calendar/event reads, availability search, date selection, create/update/delete events) — callable by the embedded Persona widget *and* by [Chrome DevTools MCP](https://github.com/ChromeDevTools/chrome-devtools-mcp/) against the same page. Static lookup data such as users and event colors is intentionally baked into schemas/context instead of exposed as lookup-only tools.
   - Submitting the prompt bar slides Persona out as a **full-height docked copilot** and collapses the manual input surfaces; closing restores them. Append `?mode=pill` to mount the native composer-bar pill instead
   - Read-only tools auto-approve (`webmcp.autoApprove`); mutating tools show approval bubbles with friendly copy via tool `title`s + `approval.formatDescription`
   - Tool inputs/outputs use **local wall-clock times** (no UTC offsets) so "8am" lands at 8am on the visible calendar
@@ -147,19 +147,19 @@ The action middleware example demonstrates:
 
 #### Wiring — same pattern as the other demos
 
-Like the bakery and storefront demos, this demo runs entirely through the **local proxy** — there is no client token and no hosted Runtype agent. The agent that drives the storefront is defined **in code** as `WEBMCP_STOREFRONT_FLOW` (`packages/proxy/src/flows/webmcp-storefront.ts`) and mounted at `/api/chat/dispatch-webmcp` by the proxy server (`examples/vercel-edge/src/server.ts`). `webmcp-demo.ts` simply points its `apiUrl` at that path.
+Like the bakery and storefront demos, the WebMCP demos run entirely through the **local proxy** — there is no client token and no hosted Runtype agent. Each agent is defined **in code** (`WEBMCP_STOREFRONT_FLOW`, `WEBMCP_CALENDAR_FLOW`, `WEBMCP_SLIDES_FLOW`) and mounted by the proxy server (`examples/vercel-edge/src/server.ts`) at its matching route (`/api/chat/dispatch-webmcp`, `/api/chat/dispatch-calendar`, `/api/chat/dispatch-slides`). The page code simply points `apiUrl` at that route.
 
 How the page tools reach the agent: the page registers its tools on `document.modelContext`; the widget snapshots them every turn and sends them on the dispatch payload as `clientTools[]`; the proxy forwards `clientTools[]` upstream, where the Runtype runtime threads them into the flow's prompt step. When the model calls one, the widget executes it on the page and posts the result back via `/resume`. The agent definition, system prompt, and model (`claude-sonnet-4-6`, chosen because WebMCP needs reliable **native** tool calls) all live in the repo.
 
-`pnpm dev` starts this proxy automatically (port 43111). The page log at the top of the demo prints the resolved backend, e.g. `mode: proxy → http://localhost:43111/api/chat/dispatch-webmcp`.
+`pnpm dev` starts this proxy automatically (port 43111). The page log at the top of each WebMCP demo prints the resolved backend, e.g. `mode: proxy → http://localhost:43111/api/chat/dispatch-webmcp`.
 
-To run against your own Runtype flow instead of the in-code definition, set `FLOW_ID_WEBMCP` on the proxy (`examples/vercel-edge/src/server.ts`) — same override the other demos support.
+To run against your own Runtype flow instead of the in-code definitions, set the matching `FLOW_ID_*` override on the proxy (`FLOW_ID_WEBMCP`, `FLOW_ID_CALENDAR`, or `FLOW_ID_SLIDES` in `examples/vercel-edge/src/server.ts`).
 
 > **Note on parallel local tool calls.** "Add SHOE-001 and SHOE-007 at the same time" makes the model emit *parallel* local tool calls in one turn, which depends on **runtypelabs/core#3878** / **#3870** being deployed upstream; single-tool turns work regardless.
 
 ### WebMCP Slide-Deck Editor (Deck Copilot)
 - **Slides page**: `http://localhost:5173/webmcp-slides.html` (proxy mode — agent defined in code as `WEBMCP_SLIDES_FLOW`, mounted at `/api/chat/dispatch-slides`)
-  - A Keynote-lite editor (960×540 canvas, slide sorter, themes, presenter mode) where the human and the Persona agent **co-edit the same live canvas** — the richest WebMCP surface in the repo (~20 tools vs. the calendar's ten)
+  - A Keynote-lite editor (960×540 canvas, slide sorter, themes, presenter mode) where the human and the Persona agent **co-edit the same live canvas** — the richest WebMCP surface in the repo (roughly twenty tools vs. the calendar's seven)
   - `src/webmcp-slides/tools.ts` registers the tools on `document.modelContext`, and the tool set is **dynamic** — the demo's headline trick:
     - `style_selection` / `align_selection` exist only while the user has **2+ elements selected** (AbortController re-registration, debounced)
     - `enter_presenter_mode` **replaces the entire editing set** with show controls (`next_slide`, `prev_slide`, `jump_to_slide`, `exit_presenter_mode`) until the show ends

--- a/examples/embedded-app/llms.txt
+++ b/examples/embedded-app/llms.txt
@@ -7,9 +7,9 @@
 > Full reference (config + theming): https://persona-chat.dev/llms-full.txt
 > Agent skills: https://github.com/runtypelabs/skills
 
-Persona is a drop-in streaming chat UI for AI assistants that works on any website. It's built in TypeScript with vanilla JS — no React, Vue, or framework dependency. It renders inside a Shadow DOM for style isolation and ships as ESM, CJS, and IIFE (script tag).
+Persona is a drop-in streaming chat UI for AI assistants that works on any website. It's built in TypeScript with vanilla JS — no React, Vue, or framework dependency. It can render inside an opt-in Shadow DOM (`useShadowDom: true`) for style isolation and ships as ESM, CJS, IIFE script-tag bundles, and focused subpath exports for codegen, plugin helpers, animations, theme tools, testing, and smart DOM page-context reading.
 
-The fastest way to deploy an AI chat experience is with [Runtype](https://runtype.com) — Persona is pre-integrated, so you get streaming chat with tools, voice, theming, and analytics out of the box with zero backend code. Just set a `clientToken` and go. It also works with any SSE-capable backend if you want to bring your own.
+The fastest way to deploy an AI chat experience is with [Runtype](https://runtype.com) — Persona is pre-integrated, so you get streaming chat with client tokens, WebMCP/page tools, built-in local client tools, voice, theming, analytics, approvals, and artifacts out of the box. Just set a `clientToken` and go. It also works with any SSE-capable backend if you want to bring your own.
 
 ## Agent Skills
 
@@ -84,6 +84,15 @@ initAgentWidget({
 });
 ```
 
+## Recommended Modern Defaults
+
+- Prefer `clientToken` for direct browser-to-Runtype installs when the surface is already configured in Runtype; use `apiUrl` + `@runtypelabs/persona-proxy` when you need server-side API-key control or custom flow definitions.
+- Use `features.askUserQuestion.expose: true` to let an agent ask blocking clarifying questions through the built-in `ask_user_question` answer sheet. Leave it `false` when the flow already declares the tool server-side.
+- Use `features.suggestReplies.expose: true` to let the agent push fire-and-forget quick-reply chips via `suggest_replies`; chips auto-resume the paused execution and clear after the next user message.
+- Use `webmcp: { enabled: true }` to snapshot tools registered on `document.modelContext`, send them as `clientTools[]`, execute returned `webmcp:<name>` calls on the page, and resume the agent with the result. Gate writes with native approval bubbles or `webmcp.onConfirm`; auto-approve safe reads with `webmcp.autoApprove`.
+- Keep `sanitize` enabled (default) for DOMPurify sanitization of markdown/custom HTML. If you intentionally return custom HTML from `postprocessMessage`, either fit the built-in allowlist or provide a custom sanitizer; only set `sanitize: false` for fully trusted content.
+- Script-tag installs automatically use the small `launcher.global.js` fast path for ordinary floating launchers and defer the full widget until first open. Use `onScriptLoad`, `onLauncherShown`, `onChatReady`, and `onError` (or matching `persona:*` DOM events) for lifecycle analytics.
+
 ## Initialization
 
 Two entry points:
@@ -136,19 +145,21 @@ The full config is passed as `config` to `initAgentWidget()`. Key sections:
 - **`layout`** — Header, messages, and slot configuration
 - **`voiceRecognition`** — Speech-to-text (browser Web Speech API or Runtype WebSocket)
 - **`textToSpeech`** — TTS for assistant responses
-- **`features`** — Feature flags (showReasoning, showToolCalls, artifacts, showEventStreamToggle)
+- **`features`** — Feature flags for reasoning/tool-call visibility, event stream, artifacts, scroll behavior, stream animations, composer history, `ask_user_question`, and `suggest_replies`
+- **`webmcp`** — Page tool discovery/execution via WebMCP (`document.modelContext`) and `clientTools[]`
+- **`contextProviders` / `requestMiddleware`** — Inject page/editor context into each request (for example, current slide selection)
 - **`plugins`** — Array of plugin objects with render hooks
 - **`parserType`** — `'plain'`, `'json'`, `'regex-json'`, or `'xml'` for structured streaming
 - **`attachments`** — File upload config (types, size limits)
 - **`messageActions`** — Copy/upvote/downvote buttons
 - **`suggestionChips`** — Quick-reply buttons above the composer
 - **`persistState`** — Save widget state across page navigations
-- **`postprocessMessage`** — Transform message text before rendering (return HTML)
+- **`postprocessMessage` / `markdown` / `sanitize`** — Transform and render message HTML; DOMPurify sanitization is on by default
 
 ## Launcher Modes
 
-- **Floating** (default): `launcher.mountMode: 'floating'` — corner-anchored button + popup panel
-- **Docked**: `launcher.mountMode: 'docked'` — side panel that wraps a content container. `dock.reveal` controls the animation: `'resize'` (default), `'emerge'`, `'overlay'`, `'push'`
+- **Floating** (default): `launcher.mountMode: 'floating'` — corner-anchored button + popup panel. Script-tag installs defer the heavy panel bundle until first open when possible.
+- **Docked**: `launcher.mountMode: 'docked'` — side panel that wraps a content container. `dock.reveal` controls the animation: `'resize'` (default), `'emerge'`, `'overlay'`, `'push'`. `dock.maxHeight` defaults to `100dvh` as a viewport guard when the page has no definite height chain.
 
 ## Message Injection
 
@@ -161,7 +172,7 @@ chat.injectAssistantMessage({
 });
 ```
 
-Content priority: `contentParts > llmContent > content`.
+Content priority: `contentParts > llmContent > rawContent > content`.
 
 ## Plugin System
 
@@ -213,7 +224,12 @@ Works with any framework. In React/Next.js/Remix/etc., initialize in a `useEffec
 | `createAgentExperience` | Mount inline widget, returns controller |
 | `DEFAULT_WIDGET_CONFIG` | Sensible default config to spread over |
 | `mergeWithDefaults` | Deep-merge your overrides with defaults |
-| `markdownPostprocessor` | Render markdown in messages |
+| `markdownPostprocessor` / `createMarkdownProcessor` | Render markdown in messages |
+| `createDefaultSanitizer` / `resolveSanitizer` | DOMPurify-backed sanitization helpers |
+| `ASK_USER_QUESTION_CLIENT_TOOL` / `SUGGEST_REPLIES_CLIENT_TOOL` | Built-in local client tool definitions for server-side reuse |
+| `parseAskUserQuestionPayload` / `parseSuggestRepliesPayload` | Parse built-in client-tool payloads |
+| `WebMcpBridge` / `WEBMCP_TOOL_PREFIX` | WebMCP bridge utilities |
+| `generateCodeSnippet` (subpath `@runtypelabs/persona/codegen`) | Server/CLI-safe embed snippet generation |
 | `createJsonStreamParser` | JSON stream parser factory |
 | `createXmlParser` | XML stream parser factory |
 | `createPlainTextParser` | Plain text parser (default) |
@@ -223,6 +239,9 @@ Works with any framework. In React/Next.js/Remix/etc., initialize in a `useEffec
 | `createDropdownMenu` | Dropdown menu utility |
 | `createIconButton` / `createLabelButton` / `createToggleGroup` | Button utilities |
 | `collectEnrichedPageContext` / `formatEnrichedContext` | DOM context collection for tool use |
+| `@runtypelabs/persona/smart-dom-reader` | Optional Shadow-DOM/iframe-aware page context provider |
+| `@runtypelabs/persona/plugin-kit` | Shadow-DOM-safe plugin utilities (`injectStyles`, `createPopover`, `isEditableEventTarget`) |
+| `@runtypelabs/persona/animations/*` | Optional stream animation plugins such as `wipe` and `glyph-cycle` |
 
 ## License
 

--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -233,9 +233,11 @@ function serveWidgetDist(): Plugin {
 
 function llmsTxt(): Plugin {
   const llmsTxtPath = path.resolve(__dirname, "llms.txt");
-  const widgetDir = path.resolve(__dirname, "../../packages/widget");
+  const repoDir = path.resolve(__dirname, "../..");
+  const widgetDir = path.resolve(repoDir, "packages/widget");
   // Order matters: README first (overview), then the split reference docs,
-  // then the theme/token reference. Keep in sync with packages/widget/docs/.
+  // then examples/integration guides, then the theme/token reference.
+  // Keep in sync with packages/widget/docs/ and docs/.
   const widgetDocPaths = [
     "README.md",
     "docs/PROGRAMMATIC-CONTROL.md",
@@ -243,8 +245,17 @@ function llmsTxt(): Plugin {
     "docs/INSTALLATION-FRAMEWORKS.md",
     "docs/CONFIGURATION-REFERENCE.md",
     "docs/STREAM-PARSERS.md",
+    "docs/MESSAGE-INJECTION.md",
+    "docs/DYNAMIC-FORMS.md",
+    "docs/CODE-GENERATOR.md",
     "THEME-CONFIG.md",
   ].map((p) => path.resolve(widgetDir, p));
+  const integrationDocPaths = [
+    "docs/webmcp-without-runtype.md",
+  ].map((p) => path.resolve(repoDir, p));
+  const proxyDocPaths = [
+    "packages/proxy/README.md",
+  ].map((p) => path.resolve(repoDir, p));
 
   function buildLlmsTxt(): string {
     return fs.readFileSync(llmsTxtPath, "utf-8");
@@ -253,6 +264,8 @@ function llmsTxt(): Plugin {
   function buildLlmsFullTxt(): string {
     const overview = fs.readFileSync(llmsTxtPath, "utf-8");
     const widgetDocs = widgetDocPaths.map((p) => fs.readFileSync(p, "utf-8"));
+    const integrationDocs = integrationDocPaths.map((p) => fs.readFileSync(p, "utf-8"));
+    const proxyDocs = proxyDocPaths.map((p) => fs.readFileSync(p, "utf-8"));
     return [
       overview.replace(
         /^(> Full reference .*)$/m,
@@ -263,9 +276,21 @@ function llmsTxt(): Plugin {
       "",
       "# Widget Configuration Reference",
       "",
-      "The sections below are the complete widget documentation (initialization, programmatic control, UI components, config tables, parsers, proxy setup, framework guides) and the theme/token reference.",
+      "The sections below are the complete widget documentation (initialization, programmatic control, UI components, config tables, parsers, message injection, dynamic forms, code generation, proxy setup, framework guides), integration guides, and the theme/token reference.",
       "",
       widgetDocs.join("\n\n---\n\n"),
+      "",
+      "---",
+      "",
+      "# Integration Guides",
+      "",
+      integrationDocs.join("\n\n---\n\n"),
+      "",
+      "---",
+      "",
+      "# Proxy Documentation",
+      "",
+      proxyDocs.join("\n\n---\n\n"),
     ].join("\n");
   }
 

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -1,6 +1,6 @@
 ## Vanilla Agent Proxy
 
-Proxy server library for `@runtypelabs/persona` widget. Handles flow configuration and forwards requests to Runtype or other AI backends.
+Proxy server library for `@runtypelabs/persona` widget. Handles flow configuration, CORS, feedback collection, WebMCP/client-tool forwarding, `/resume` continuations, and secure forwarding to Runtype.
 
 ### Installation
 
@@ -10,7 +10,7 @@ npm install @runtypelabs/persona-proxy
 
 ### Usage
 
-The proxy server handles flow configuration and forwards requests to Runtype. You can configure it in three ways:
+The proxy server handles flow configuration and forwards requests to Runtype. It mounts both the dispatch endpoint (default `/api/chat/dispatch`) and a matching child resume endpoint (`/api/chat/dispatch/resume`) so browser-executed LOCAL tools such as WebMCP page tools, `ask_user_question`, and `suggest_replies` can resume a paused execution. You can configure dispatch in three ways:
 
 **Option 1: Use default flow (recommended for getting started)**
 
@@ -88,10 +88,28 @@ export default createVercelHandler({
 | `allowedOrigins` | `string[]` | CORS allowed origins |
 | `flowId` | `string` | Runtype flow ID to use |
 | `flowConfig` | `RuntypeFlowConfig` | Custom flow configuration |
+| `feedbackPath` | `string` | Message-feedback endpoint path. Default: `/api/feedback`. |
+| `onFeedback` | `(feedback) => Promise<void> \| void` | Optional handler for upvote/downvote payloads. |
+| `previewOriginPattern` | `RegExp \| false` | Additional dynamic preview-origin allowlist (defaults to `https://*.vercel.app`; disable with `false`). |
+
+### WebMCP and built-in client tools
+
+For flow-dispatch requests, the proxy preserves `clientTools[]` from the widget payload and forwards them upstream so Runtype can register browser-local tools for that turn. Tool results are sent by the widget to `${path}/resume`, and the proxy forwards that body to the upstream `/resume` endpoint using the same API key. Agent-mode payloads are forwarded as-is and also retain `clientTools[]`.
+
+### CORS behavior
+
+- If `allowedOrigins` is omitted or empty, the proxy reflects the request origin (or `*`).
+- If `allowedOrigins` is set, exact matches are allowed.
+- `NODE_ENV=development` reflects local dev origins even when they are not in `allowedOrigins`; an unset `NODE_ENV` is treated as production.
+- Vercel preview deployments (`VERCEL_ENV=preview`) and origins matching `previewOriginPattern` are reflected so per-branch preview URLs work without enumerating them.
+
+### Feedback endpoint
+
+`messageActions` feedback can POST to `feedbackPath` (default `/api/feedback`). The built-in handler validates `type` (`upvote`/`downvote`) and `messageId`, adds a timestamp, logs in development, and then calls `onFeedback` if provided.
 
 ### Environment Setup
 
-Add `RUNTYPE_API_KEY` to your environment. The proxy constructs the Runtype payload (including flow configuration) and streams the response back to the client.
+Add `RUNTYPE_API_KEY` to your environment. The proxy constructs the Runtype payload (including flow configuration/client tools) and streams the response back to the client.
 
 ### Building
 

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -17,6 +17,8 @@ pnpm build
 - `dist/index.js` (ESM), `dist/index.cjs` (CJS), and `dist/index.global.js` (IIFE) provide different module formats.
 - `dist/widget.css` is the prefixed Tailwind bundle.
 - `dist/install.global.js` is the automatic installer script for easy script tag installation.
+- `dist/launcher.global.js` is the tiny critical launcher used by deferred script-tag installs before the full panel bundle loads.
+- `dist/webmcp-polyfill.js` is the lazy WebMCP polyfill chunk used by the IIFE bundle only when `config.webmcp.enabled` is true and the page has no `document.modelContext`.
 
 ### Using with modules
 
@@ -92,7 +94,7 @@ const docked = initAgentWidget({
 | --- | --- | --- |
 | `target` | `string \| HTMLElement` | CSS selector or element where widget mounts. |
 | `config` | `AgentWidgetConfig` | Widget configuration object (see the [Configuration Reference](./docs/CONFIGURATION-REFERENCE.md)). |
-| `useShadowDom` | `boolean` | Use Shadow DOM for style isolation (default: `true`). |
+| `useShadowDom` | `boolean` | Use Shadow DOM for style isolation (default: `false`). |
 | `onChatReady` | `() => void` | Callback fired when the widget is initialized and its API is callable. |
 | `onReady` | `() => void` | **Deprecated** alias of `onChatReady`; still works, removed in the next major. |
 | `windowKey` | `string` | If provided, stores the controller on `window[windowKey]` for global access. Automatically cleaned up on `destroy()`. |
@@ -107,20 +109,21 @@ With **`dock.reveal: 'resize'`** (default), a **closed** dock uses a **`0px`** c
 
 **Inner push/overlay:** With `reveal: 'push'` or `'overlay'`, only the wrapped node moves. Use a **narrow `target`** (e.g. a main canvas div). For **`dock.side: 'left'`**, place a persistent rail **in flow** next to the stage (e.g. flex `[nav | stage]`) so the dock doesn’t open **under** the sidebar. For a **right** dock, you can instead use a **full-width** stage with an **absolute** left rail if you want the canvas to translate **behind** that rail.
 
-> **Security note:** When you return HTML from `postprocessMessage`, make sure you sanitise it before injecting into the page. The provided postprocessors (`markdownPostprocessor`, `directivePostprocessor`) do not perform sanitisation.
+> **Security note:** Persona sanitizes rendered message HTML with DOMPurify by default (`sanitize: true`), including output returned from `postprocessMessage`, `markdownPostprocessor`, and `directivePostprocessor`. If your custom postprocessor intentionally returns tags or attributes outside the built-in allowlist, provide `sanitize: (html) => ...`; only set `sanitize: false` for fully trusted content.
 
 ### Documentation
 
 The full reference lives in [`docs/`](./docs/) and the theming guide:
 
 - [Programmatic Control & Events](./docs/PROGRAMMATIC-CONTROL.md) — controller API, message hooks and injection, enriched DOM context, WebMCP page tools, DOM and controller events, state loading
-- [UI Features & Components](./docs/UI-COMPONENTS.md) — message actions and feedback, loading indicators, ask-user-question, dropdown menus, button utilities, dynamic forms
-- [Script Tag Installation & Framework Integration](./docs/INSTALLATION-FRAMEWORKS.md) — automatic installer, manual script tag setup, React, Next.js, Remix, Gatsby, and Astro guides
-- [Configuration Reference](./docs/CONFIGURATION-REFERENCE.md) — every config option: core, client token mode, agent mode, UI & theme, launcher, layout, voice, tool calls, suggestion chips, state & storage
+- [UI Features & Components](./docs/UI-COMPONENTS.md) — message actions and feedback, loading/idle indicators, approvals, built-in `ask_user_question` and `suggest_replies` tools, dropdown menus, button utilities, dynamic forms
+- [Script Tag Installation & Framework Integration](./docs/INSTALLATION-FRAMEWORKS.md) — automatic installer, deferred launcher lifecycle hooks, manual script tag setup, React, Next.js, Remix, Gatsby, and Astro guides
+- [Configuration Reference](./docs/CONFIGURATION-REFERENCE.md) — every config option: core, client token mode, agent mode, UI & theme, launcher/docking, layout, voice, WebMCP, tool calls, features, suggestion chips, state & storage
 - [Stream Parser Configuration](./docs/STREAM-PARSERS.md) — JSON, XML, and plain-text stream parsers and custom parser factories
-- [THEME-CONFIG.md](./THEME-CONFIG.md) — the complete theme and design-token reference
 - [Message Injection](./docs/MESSAGE-INJECTION.md) — full injection and component-directive reference
 - [Dynamic Forms](./docs/DYNAMIC-FORMS.md) — field schema, form styles, and recipes
+- [Code Generator](./docs/CODE-GENERATOR.md) — `@runtypelabs/persona/codegen` options for CLI/server-side snippet generation
+- [THEME-CONFIG.md](./THEME-CONFIG.md) — the complete theme and design-token reference
 
 ### Optional proxy server
 
@@ -198,7 +201,9 @@ Add `RUNTYPE_API_KEY` to your environment. The proxy constructs the Runtype payl
 
 ### Development notes
 
-- The widget streams results using SSE and mirrors the backend `flow_complete`/`step_chunk` events.
-- Tailwind-esc classes are prefixed with `tvw-` and scoped to `[data-persona-root]`, so they won't collide with the host page.
-- Run `pnpm dev` from the repository root to boot the example proxy (`examples/proxy`) and the vanilla demo (`examples/embedded-app`).
+- The widget streams results using SSE and mirrors Runtype flow/agent events, including `step_await` local-tool pauses and `/resume` continuations.
+- Tailwind classes are prefixed with `tvw-` and scoped to `[data-persona-root]`, so they won't collide with the host page.
+- Run `pnpm dev` from the repository root to boot the example proxy (`examples/vercel-edge`) and the vanilla demo (`examples/embedded-app`).
 - The proxy prefers port `43111` but automatically selects the next free port if needed.
+- `features.askUserQuestion.expose` and `features.suggestReplies.expose` advertise built-in LOCAL client tools through `clientTools[]`; leave `expose` off if the flow already declares those tools server-side.
+- `webmcp: { enabled: true }` snapshots page-registered tools on `document.modelContext`, sends them as `clientTools[]`, executes returned `webmcp:*` calls in the browser, and resumes the paused execution.

--- a/packages/widget/docs/CODE-GENERATOR.md
+++ b/packages/widget/docs/CODE-GENERATOR.md
@@ -1,12 +1,12 @@
 # Code Snippet Generation API
 
-The `generateCodeSnippet` function programmatically generates ready-to-use code snippets for embedding the widget. This is useful for building configuration tools, documentation generators, or automated setup workflows.
+The `generateCodeSnippet` function programmatically generates ready-to-use code snippets for embedding the widget. This is useful for building configuration tools, documentation generators, CLIs, or automated setup workflows. Prefer the server/Worker-safe `@runtypelabs/persona/codegen` subpath when you only need snippet generation; the package root also re-exports it for browser/bundler consumers already using the widget runtime.
 
 ## Basic Usage
 
 ```typescript
-import { generateCodeSnippet } from '@runtypelabs/persona';
-import type { CodeFormat, CodeGeneratorOptions } from '@runtypelabs/persona';
+import { generateCodeSnippet } from '@runtypelabs/persona/codegen';
+import type { CodeFormat, CodeGeneratorOptions } from '@runtypelabs/persona/codegen';
 
 const config = {
   apiUrl: '/api/chat/dispatch',
@@ -98,8 +98,9 @@ const code = generateCodeSnippet(config, 'esm', {
       }
     ],
 
-    // Custom message postprocessor
-    postprocessMessage: ({ text }) => DOMPurify.sanitize(text),
+    // Custom message postprocessor. Persona still sanitizes this HTML by default
+    // via config.sanitize (DOMPurify); provide config.sanitize for a custom allowlist.
+    postprocessMessage: ({ text }) => marked.parse(text),
 
     // Custom stream parser factory
     streamParser: () => createCustomParser()
@@ -152,7 +153,7 @@ import type {
   CodeFormat,
   CodeGeneratorHooks,
   CodeGeneratorOptions
-} from '@runtypelabs/persona';
+} from '@runtypelabs/persona/codegen';
 
 // CodeFormat options
 type CodeFormat =
@@ -181,13 +182,14 @@ type CodeGeneratorOptions = {
   hooks?: CodeGeneratorHooks;
   includeHookComments?: boolean;
   windowKey?: string; // Emit windowKey in generated initAgentWidget call (script formats only)
+  target?: string;    // CSS selector mount target; defaults to 'body'
 };
 ```
 
 ## Example: Building a Configuration UI
 
 ```typescript
-import { generateCodeSnippet, type CodeFormat } from '@runtypelabs/persona';
+import { generateCodeSnippet, type CodeFormat } from '@runtypelabs/persona/codegen';
 
 // User configures widget in a UI (palette swatches → semantic roles)
 const userConfig = {
@@ -222,7 +224,7 @@ const hooks = {
 };
 
 // Generate code snippet
-const code = generateCodeSnippet(userConfig, format, { hooks });
+const code = generateCodeSnippet(userConfig, format, { hooks, target: '#chat-root' });
 
 // Display in code editor
 codeEditor.setValue(code);

--- a/packages/widget/docs/CONFIGURATION-REFERENCE.md
+++ b/packages/widget/docs/CONFIGURATION-REFERENCE.md
@@ -50,6 +50,8 @@ For detailed theme styling properties, see [THEME-CONFIG.md](../THEME-CONFIG.md)
 | `getHeaders` | `() => Record<string, string> \| Promise<...>` | Dynamic headers function called before each request. Use for auth tokens that may change. |
 | `customFetch` | `(url, init, payload) => Promise<Response>` | Replace the default `fetch` entirely. Receives URL, RequestInit, and the payload. |
 | `parseSSEEvent` | `(eventData) => { text?, done?, error? } \| null` | Transform non-standard SSE events into the expected format. Return `null` to ignore an event. |
+| `onSSEEvent` | `(eventType, payload) => void` | Observe every parsed SSE frame before Persona handles it. Useful for lightweight telemetry; does not replace native streaming. |
+| `errorMessage` | `string \| (error: Error) => string` | Override the fallback assistant bubble shown when a dispatch fails before streaming. Return an empty string to suppress the bubble while still firing `onError`. |
 
 ### Client Token Mode
 
@@ -91,6 +93,8 @@ Use agent loop execution instead of flow dispatch. Mutually exclusive with `flow
 | `model` | `string` | Model identifier (e.g. `'openai:gpt-4o-mini'`). |
 | `systemPrompt` | `string` | System prompt for the agent. |
 | `temperature` | `number?` | Temperature for model responses. |
+| `tools` | `AgentToolsConfig?` | Tool configuration for the agent (see below). |
+| `artifacts` | `ArtifactConfigPayload?` | Artifact-generation config for virtual-agent/API parity. |
 | `loopConfig` | `AgentLoopConfig?` | Loop behavior configuration (see below). |
 
 **`AgentLoopConfig`**
@@ -226,8 +230,9 @@ In docked mode, `position`, `fullHeight`, and `sidebarMode` are ignored because 
 
 | Option | Type | Description |
 | --- | --- | --- |
-| `postprocessMessage` | `(ctx: { text, message, streaming, raw? }) => string` | Transform message text before rendering (return HTML). |
+| `postprocessMessage` | `(ctx: { text, message, streaming, raw? }) => string` | Transform message text before rendering (return HTML). Output is still sanitized by `sanitize` unless disabled/replaced. |
 | `markdown` | `AgentWidgetMarkdownConfig` | Markdown rendering configuration (see sub-table). |
+| `sanitize` | `boolean \| (html: string) => string` | HTML sanitization for rendered message content. `true`/omitted uses the built-in DOMPurify sanitizer; `false` disables sanitization for fully trusted content only; a function supplies a custom sanitizer. |
 | `messageActions` | `AgentWidgetMessageActionsConfig` | Action buttons on assistant messages (see sub-table). |
 | `loadingIndicator` | `AgentWidgetLoadingIndicatorConfig` | Customize the loading indicator (see sub-table). |
 
@@ -390,12 +395,13 @@ config: {
 | `denyLabel` | `string?` | Label for the deny button. |
 | `detailsDisplay` | `'collapsed' \| 'expanded' \| 'hidden'?` | How the technical details (agent-facing tool description + raw parameters JSON) are presented. Default: `'collapsed'` (behind a "Show details" toggle). `'expanded'` shows them open; `'hidden'` never renders them. |
 | `showDetailsLabel`, `hideDetailsLabel` | `string?` | Labels for the details toggle. Defaults: `"Show details"` / `"Hide details"`. |
-| `formatDescription` | `(approval) => string \| undefined` | Build the user-facing summary line. Receives `{ toolName, toolType, description, parameters, displayTitle }`. Return a falsy value to fall back to the default copy for that approval. |
-| `backgroundColor`, `borderColor`, `titleColor`, `descriptionColor` | `string?` | Bubble styling. |
+| `formatDescription` | `(approval) => string \| undefined` | Build the user-facing summary line. Receives `{ toolName, toolType, description, parameters, displayTitle, reason }`. Return a falsy value to fall back to the default copy for that approval. If you include `reason`, keep it attributed to the agent. |
+| `backgroundColor`, `borderColor`, `shadow`, `titleColor`, `descriptionColor` | `string?` | Bubble styling; pass `shadow: "none"` to remove the default shadow. |
+| `reasonColor`, `reasonLabel` | `string?` | Styling/copy for the agent-authored reason line when an approval event includes `reason`. |
 | `approveButtonColor`, `approveButtonTextColor` | `string?` | Approve button styling. |
 | `denyButtonColor`, `denyButtonTextColor` | `string?` | Deny button styling. |
 | `parameterBackgroundColor`, `parameterTextColor` | `string?` | Parameters block styling. |
-| `onDecision` | `(data, decision) => Promise<Response \| ReadableStream \| void>?` | Custom approval handler. Return `void` for SDK auto-resolve. |
+| `onDecision` | `(data, decision, options?) => Promise<Response \| ReadableStream \| void>?` | Custom approval handler. Return `void` for SDK auto-resolve. `options.remember` is forwarded from custom "always allow" affordances. |
 
 **How the summary line is chosen.** A tool's wire `description` is written for the
 agent (usage rules, prompt prose), not for end users, so the bubble doesn't lead
@@ -425,6 +431,40 @@ initAgentWidget({
   },
 });
 ```
+
+### WebMCP Page Tools
+
+WebMCP lets the page register browser-local tools on `document.modelContext`. With `webmcp.enabled`, Persona snapshots those tools for each dispatch, sends them to the agent as `clientTools[]`, executes returned `webmcp:<name>` calls in the browser, and resumes the paused execution with the tool result.
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `webmcp` | `AgentWidgetWebMcpConfig` | Page-tool discovery/execution config. Default: disabled. |
+
+**`webmcp`** — `AgentWidgetWebMcpConfig`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `enabled` | `boolean?` | Install/use the WebMCP polyfill and include page-registered tools in dispatch payloads. Default: `false`. |
+| `allowlist` | `string[]?` | Glob-ish bare tool-name patterns to include client-side; `*` matches any chars except `:`. If omitted, all registered tools are included (subject to server-side policy). |
+| `autoApprove` | `(info: WebMcpConfirmInfo) => boolean` | Return `true` to skip the native approval bubble for safe tools (for example read-only searches). |
+| `onConfirm` | `(info: WebMcpConfirmInfo) => Promise<boolean>` | Override the native in-panel approval bubble with a custom confirmer. Receives bare `toolName`, `args`, optional `title`, annotations, and `reason: 'gate'`. |
+
+```ts
+initAgentWidget({
+  target: '#app',
+  config: {
+    apiUrl: '/api/chat/dispatch',
+    webmcp: {
+      enabled: true,
+      allowlist: ['search_*', 'add_to_cart'],
+      autoApprove: ({ annotations, toolName }) =>
+        annotations?.readOnlyHint === true || toolName.startsWith('search_'),
+    },
+  },
+});
+```
+
+For a direct AI SDK backend that translates WebMCP calls into Persona-compatible `step_await` / `/resume` traffic, see the repo-level [WebMCP without Runtype guide](../../../docs/webmcp-without-runtype.md).
 
 ### Suggestion Chips
 
@@ -473,8 +513,79 @@ initAgentWidget({
 | `showToolCalls` | `boolean?` | Show tool usage bubbles. Default: `true`. |
 | `showEventStreamToggle` | `boolean?` | Show the event stream inspector toggle in the header. Default: `false`. |
 | `composerHistory` | `boolean?` | `Up`/`Down` arrows in the composer navigate previously sent user messages for re-entry/editing (shell / Slack style). Entered only when the caret is at the start of the input, so multi-line cursor movement is preserved. Default: `true`. |
+| `scrollToBottom` | `AgentWidgetScrollToBottomFeature?` | Shared transcript/event-stream scroll-to-bottom affordance. Defaults: `enabled: true`, `iconName: "arrow-down"`, icon-only label. Shows a new-message count while scrolled away. |
+| `scrollBehavior` | `AgentWidgetScrollBehaviorFeature?` | Streaming transcript scroll mode. Defaults: `{ mode: "follow", anchorTopOffset: 16 }`. |
+| `toolCallDisplay` | `AgentWidgetToolCallDisplayFeature?` | Collapsed tool-call row behavior: summary mode, active preview, grouping, expandability, and loading animation. |
+| `reasoningDisplay` | `AgentWidgetReasoningDisplayFeature?` | Collapsed reasoning row behavior: active preview, expandability, and loading animation. |
+| `streamAnimation` | `AgentWidgetStreamAnimationFeature?` | Assistant text reveal animation while streaming (`none`, `typewriter`, `letter-rise`, `word-fade`, `wipe`, `glyph-cycle`, `pop-bubble`, or custom plugin). |
 | `eventStream` | `EventStreamConfig?` | Event stream inspector configuration: `badgeColors`, `timestampFormat`, `showSequenceNumbers`, `maxEvents`, `descriptionFields`, `classNames`. |
 | `artifacts` | `AgentWidgetArtifactsFeature?` | Artifact sidebar: `enabled`, `allowedTypes`, optional `layout` (see below). |
+| `askUserQuestion` | `AgentWidgetAskUserQuestionFeature?` | Built-in `ask_user_question` answer sheet. `enabled` defaults to `true`; set `expose: true` to advertise the LOCAL tool via `clientTools[]`. |
+| `suggestReplies` | `AgentWidgetSuggestRepliesFeature?` | Built-in `suggest_replies` chips. `enabled` defaults to `true`; set `expose: true` to advertise the LOCAL tool via `clientTools[]` and auto-resume when called. |
+
+**`features.scrollBehavior`** — `AgentWidgetScrollBehaviorFeature`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `mode` | `'follow' \| 'anchor-top' \| 'none'?` | `follow` keeps the latest content in view; `anchor-top` pins the sent user message near the top while the response streams; `none` disables streaming auto-scroll. Default: `'follow'`. |
+| `anchorTopOffset` | `number?` | Top gap in pixels for `anchor-top`. Default: `16`. |
+
+**`features.scrollToBottom`** — `AgentWidgetScrollToBottomFeature`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `enabled` | `boolean?` | Show the affordance when the user is away from the latest transcript/event-stream content. Default: `true`. |
+| `iconName` | `string?` | Lucide icon name. Default: `'arrow-down'`. |
+| `label` | `string?` | Optional text label; empty string renders icon-only. Default: `''`. |
+
+**`features.toolCallDisplay`** — `AgentWidgetToolCallDisplayFeature`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `collapsedMode` | `'tool-call' \| 'tool-name' \| 'tool-preview'?` | Summary shown while collapsed. Default: `'tool-call'`. |
+| `activePreview` | `boolean?` | Show a lightweight preview while a collapsed tool is running. Default: `false`. |
+| `activeMinHeight` | `string?` | Optional CSS min-height for active collapsed rows. |
+| `previewMaxLines` | `number?` | Max preview lines. Default: `3`. |
+| `grouped` | `boolean?` | Visually group consecutive tool-call rows. Default: `false`. |
+| `expandable` | `boolean?` | Allow users to expand details. Default: `true`. |
+| `loadingAnimation` | `'none' \| 'pulse' \| 'shimmer' \| 'shimmer-color' \| 'rainbow'?` | Header animation while active. Default: `'none'`. |
+
+**`features.reasoningDisplay`** — `AgentWidgetReasoningDisplayFeature`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `activePreview` | `boolean?` | Show a lightweight preview while reasoning is active. Default: `false`. |
+| `activeMinHeight` | `string?` | Optional CSS min-height for active collapsed rows. |
+| `previewMaxLines` | `number?` | Max preview lines. Default: `3`. |
+| `expandable` | `boolean?` | Allow users to expand details. Default: `true`. |
+| `loadingAnimation` | `'none' \| 'pulse' \| 'shimmer' \| 'shimmer-color' \| 'rainbow'?` | Header animation while active. Default: `'none'`. |
+
+**`features.streamAnimation`** — `AgentWidgetStreamAnimationFeature`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `type` | `string?` | Built-ins: `'none'`, `'typewriter'`, `'word-fade'`, `'letter-rise'`, `'glyph-cycle'`, `'wipe'`, `'pop-bubble'`; custom names are allowed after registering a plugin. Default: `'none'`. |
+| `placeholder` | `'none' \| 'skeleton'?` | Pre-first-token placeholder. Default: `'none'`. |
+| `speed` | `number?` | Per-unit animation duration for character/word plugins. Default: `120`. |
+| `duration` | `number?` | Container animation duration for `pop-bubble`/custom container plugins. Default: `1800`. |
+| `buffer` | `'none' \| 'word' \| 'line'?` | Trim incomplete streaming units before rendering. Default: `'none'`. |
+| `plugins` | `Record<string, StreamAnimationPlugin>?` | Instance-scoped animation plugins. |
+
+**`features.askUserQuestion`** — `AgentWidgetAskUserQuestionFeature`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `enabled` | `boolean?` | Render `ask_user_question` with the built-in answer sheet. Default: `true`. When `false`, it falls through to a generic tool bubble. |
+| `expose` | `boolean?` | Advertise the built-in LOCAL tool definition on `clientTools[]`. Default: `false`; leave off when the flow already declares the tool server-side. |
+| `layout` | `'rows' \| 'pills'?` | Option layout. `rows` is the default full-width layout; `pills` is the legacy compact wrap layout. |
+| `slideInMs`, `freeTextLabel`, `freeTextPlaceholder`, `submitLabel`, `nextLabel`, `backLabel`, `submitAllLabel`, `skipLabel`, `groupedAutoAdvance`, `styles` | various | Sheet animation, copy, multi-question navigation, and CSS variable overrides. See [UI Features & Components](./UI-COMPONENTS.md#ask-user-question). |
+
+**`features.suggestReplies`** — `AgentWidgetSuggestRepliesFeature`
+
+| Property | Type | Description |
+| --- | --- | --- |
+| `enabled` | `boolean?` | Render chips and auto-resume `suggest_replies`. Default: `true`. When `false`, it falls through to a generic tool bubble and does not auto-resume. |
+| `expose` | `boolean?` | Advertise the built-in LOCAL tool definition on `clientTools[]`. Default: `false`; leave off when the flow already declares the tool server-side. |
 
 **`features.artifacts`** — `AgentWidgetArtifactsFeature`
 

--- a/packages/widget/docs/INSTALLATION-FRAMEWORKS.md
+++ b/packages/widget/docs/INSTALLATION-FRAMEWORKS.md
@@ -83,8 +83,8 @@ The installer is fully asynchronous (it waits for framework hydration, then load
     clientToken: 'YOUR_TOKEN',
     windowKey: 'myChat',
     onChatReady(handle) {
-      handle.on('message:sent', (e) => console.log('sent:', e));
-      handle.on('message:received', (e) => console.log('received:', e));
+      handle.on('user:message', (message) => console.log('sent:', message));
+      handle.on('assistant:complete', (message) => console.log('received:', message));
     }
   };
 </script>
@@ -97,7 +97,7 @@ The installer is fully asynchronous (it waits for framework hydration, then load
 <script>
   window.addEventListener('persona:chat-ready', (e) => {
     const handle = e.detail;
-    handle.on('message:sent', (e) => console.log('sent:', e));
+    handle.on('user:message', (message) => console.log('sent:', message));
   });
 </script>
 

--- a/packages/widget/docs/PROGRAMMATIC-CONTROL.md
+++ b/packages/widget/docs/PROGRAMMATIC-CONTROL.md
@@ -386,9 +386,7 @@ initAgentWidget({
 });
 ```
 
-`contextProviders` are honored on the **agent** send path (`buildAgentPayload` merges each
-provider's result into `payload.context` on every request). If you drive the legacy
-flow/`buildPayload` path, call `collectSmartDomContext()` yourself and inject the result.
+`contextProviders` are honored on both send paths: agent mode and flow/proxy dispatch mode merge each provider's result into `payload.context` on every request. `requestMiddleware` then receives that payload, so you can transform or template the collected context before it leaves the browser.
 
 You can also use the pieces directly:
 
@@ -545,7 +543,7 @@ Dispatched on `window` by the automatic installer script (`install.global.js`) w
 ```ts
 window.addEventListener('persona:chat-ready', (e) => {
   const handle = e.detail;
-  handle.on('message:sent', (msg) => console.log(msg));
+  handle.on('user:message', (msg) => console.log(msg));
   handle.open();
 });
 ```
@@ -576,6 +574,7 @@ The widget controller exposes an event system for reacting to chat events. Use `
 | `assistant:complete` | `AgentWidgetMessage` | Emitted when an assistant message finishes streaming |
 | `voice:state` | `AgentWidgetVoiceStateEvent` | Emitted when voice recognition state changes |
 | `action:detected` | `AgentWidgetActionEventPayload` | Emitted when an action is parsed from an assistant message |
+| `action:resubmit` | `AgentWidgetActionEventPayload` | Emitted when an action handler requests a follow-up/resubmit after injection |
 | `widget:opened` | `AgentWidgetStateEvent` | Emitted when the widget panel opens |
 | `widget:closed` | `AgentWidgetStateEvent` | Emitted when the widget panel closes |
 | `widget:state` | `AgentWidgetStateSnapshot` | Emitted on any widget state change |
@@ -583,6 +582,8 @@ The widget controller exposes an event system for reacting to chat events. Use `
 | `message:copy` | `AgentWidgetMessage` | Emitted when user copies a message |
 | `eventStream:opened` | `{ timestamp: number }` | Emitted when the event stream panel opens |
 | `eventStream:closed` | `{ timestamp: number }` | Emitted when the event stream panel closes |
+| `approval:requested` | `{ approval, message }` | Emitted when an approval bubble is created |
+| `approval:resolved` | `{ approval, decision }` | Emitted when an approval is approved/denied |
 
 ### Event Payload Types
 

--- a/packages/widget/docs/UI-COMPONENTS.md
+++ b/packages/widget/docs/UI-COMPONENTS.md
@@ -267,11 +267,16 @@ features: {
   askUserQuestion: {
     enabled: true,             // default: true. When false, the tool falls through to the normal tool-bubble path.
     expose: false,             // default: false. When true, advertises the built-in tool to the agent via clientTools[].
-    dismissible: true,         // default: true. Shows a × close button on the sheet.
+    layout: 'rows',            // default: 'rows'. Use 'pills' for the legacy compact wrap layout.
     slideInMs: 180,            // slide-in animation duration.
     freeTextLabel: 'Other…',
     freeTextPlaceholder: 'Type your answer…',
-    submitLabel: 'Send',
+    submitLabel: 'Send',       // submit label for free-text / multi-select.
+    nextLabel: 'Next',         // grouped (multi-question) payloads.
+    backLabel: 'Back',
+    submitAllLabel: 'Submit all',
+    skipLabel: 'Skip',
+    groupedAutoAdvance: true,  // single-select intermediate pages auto-advance.
     styles: {
       sheetBackground: '#ffffff',
       sheetBorder: '#e5e7eb',
@@ -287,7 +292,11 @@ features: {
 }
 ```
 
-The composer-overlay sheet is the only question UI — no transcript stub is rendered. After the user picks, the picked answer appears as a normal user bubble so the transcript reads naturally.
+The default `rows` layout renders full-width choices with descriptions always visible and an inline free-text row when `allowFreeText !== false`. `pills` preserves the older compact wrapped pills where descriptions surface as tooltips and the "Other…" pill expands into an input.
+
+A tool call may include 1–8 questions. Single-question payloads render as one sheet. Multi-question payloads render as a paginated "Question N of M" stepper with Back / Next / Skip / Submit-all controls; progress and partial answers persist on the tool message so a refresh can restore the user's place. On the final page, users always confirm with Submit-all — auto-advance never auto-submits the entire group.
+
+The composer-overlay sheet is the question UI. After the user answers, the picked answer (or grouped summary) appears as a normal user bubble so the transcript reads naturally; the answered tool message stores structured answers for review/re-rendering.
 
 ### DOM events
 
@@ -295,7 +304,7 @@ The widget dispatches two events on the mount element so the host page can react
 
 | Event | Detail |
 |---|---|
-| `persona:askUserQuestion:answered` | `{ toolUseId, answer, values, isFreeText, source }` where `source` is `'pick' \| 'multi' \| 'free-text'` |
+| `persona:askUserQuestion:answered` | `{ toolUseId, answer, answers?, values, isFreeText, source }` where `answers` is the structured question→answer map and `source` is `'pick' \| 'multi' \| 'free-text' \| 'submit-all'` |
 | `persona:askUserQuestion:dismissed` | `{ toolUseId }` |
 
 ```ts
@@ -364,18 +373,19 @@ initAgentWidget({
 type AskUserQuestionOption = {
   label: string;
   description?: string;
+  preview?: string; // reserved for future richer rendering
 };
 
 type AskUserQuestionPrompt = {
   question: string;
-  header?: string;           // short chip label, ≤12 chars
-  options: AskUserQuestionOption[];
-  multiSelect?: boolean;     // allow multiple picks with a Submit button
-  allowFreeText?: boolean;   // show an "Other…" free-text pill
+  header?: string;           // short group label, ≤12 chars
+  options: AskUserQuestionOption[]; // 2–4 options
+  multiSelect?: boolean;     // allow multiple picks with a Submit/Next action
+  allowFreeText?: boolean;   // show an "Other…" free-text input (default true)
 };
 
 type AskUserQuestionPayload = {
-  questions: AskUserQuestionPrompt[];
+  questions: AskUserQuestionPrompt[]; // 1–8 questions; extras are dropped with a warning
 };
 
 // Plugin hook signature


### PR DESCRIPTION
## Summary
- refresh `llms.txt` and the generated full-reference source list so LLM-facing docs cover the current widget, integration, and proxy documentation
- document current Persona defaults and features: client-token installs, WebMCP page tools, built-in local client tools, deferred launcher loading, default sanitization, and opt-in Shadow DOM
- align widget/proxy/demo docs with current controller events, config options, WebMCP demo behavior, and codegen guidance

## Validation
- `pnpm --filter embedded-app build`
- `git diff --check`
- LLM full-reference source-doc readability check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown and doc-assembly changes only; no widget or proxy runtime code in the diff.
> 
> **Overview**
> Documentation-only refresh across the repo so public and LLM-facing references match current Persona behavior.
> 
> **LLM reference:** `examples/embedded-app/llms.txt` adds modern defaults (client tokens, WebMCP, built-in local tools, sanitization, deferred launcher) and expanded exports/config sections. `vite.config.ts` widens `llms-full.txt` to concatenate more widget docs plus `docs/webmcp-without-runtype.md` and `packages/proxy/README.md`.
> 
> **Top-level & agent guides:** Root `README.md` and `CLAUDE.md` document WebMCP/page tools, `ask_user_question` / `suggest_replies`, opt-in Shadow DOM (`useShadowDom: true`, default `false`), DOMPurify-by-default `sanitize`, deferred `launcher.global.js` installs, and the `examples/ai-sdk-webmcp` example.
> 
> **Widget & proxy docs:** Configuration reference gains `webmcp`, `sanitize`, `errorMessage`, `onSSEEvent`, scroll/stream-animation feature flags, and richer approval/tool-call docs. Widget README corrects `useShadowDom` default and security/sanitization guidance. Proxy README documents `${path}/resume`, `clientTools[]` forwarding, feedback/CORS options. Codegen docs steer imports to `@runtypelabs/persona/codegen` and note default sanitization.
> 
> **Demos:** Embedded-app WebMCP README updates storefront tool list, calendar tool count, and multi-route proxy wiring. Install/framework docs use `user:message` / `assistant:complete` instead of deprecated `message:sent` / `message:received`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8044959470e252dd2d9a3576b4f387898c1acaf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->