### PR TITLE
Fix WebMCP tool argument handling

### DIFF
--- a/.changeset/webmcp-tool-name-guidance.md
+++ b/.changeset/webmcp-tool-name-guidance.md
@@ -1,0 +1,6 @@
+---
+"@runtypelabs/persona": patch
+"@runtypelabs/persona-proxy": patch
+---
+
+Normalize JSON-encoded nested WebMCP arguments before page-tool execution and clarify demo prompts to call exact runtime tool names with object-shaped patches.

--- a/examples/embedded-app/src/webmcp-slides/tools.ts
+++ b/examples/embedded-app/src/webmcp-slides/tools.ts
@@ -702,7 +702,8 @@ const buildEditingTools = (store: DeckStore): ToolDescriptor[] => [
         elementId: { type: "string" },
         patch: {
           type: "object",
-          description: "Partial element properties to merge; omitted keys are unchanged.",
+          description:
+            "Partial element properties to merge; omitted keys are unchanged. Pass as an object, not a JSON string.",
           properties: ELEMENT_PATCH_PROPS,
         },
       },
@@ -971,7 +972,8 @@ const buildSelectionTools = (store: DeckStore): ToolDescriptor[] => [
       properties: {
         patch: {
           type: "object",
-          description: "Style properties to apply to all selected elements.",
+          description:
+            "Style properties to apply to all selected elements. Pass as an object, not a JSON string.",
           properties: {
             fontSize: { type: "number" },
             fontFamily: { type: "string", description: FONT_DESC },

--- a/examples/vercel-edge/src/server.ts
+++ b/examples/vercel-edge/src/server.ts
@@ -152,7 +152,8 @@ const pageContextApp = createChatProxyApp({
 // Theme-assistant proxy — for the Theme Editor's docked Theme Copilot.
 // The Theme Editor registers its controls (plus screenshot_preview) as WebMCP
 // tools on document.modelContext; the copilot widget ships them as clientTools[]
-// and the agent calls them (webmcp:*) to restyle the live theme preview.
+// and the agent receives them through the server-managed WebMCP namespace to
+// restyle the live theme preview.
 // Tool-calling flow (not an action envelope), so it relies on clientTools
 // forwarding + /resume — including image blocks in screenshot tool results.
 const themeAssistantApp = createChatProxyApp({

--- a/packages/proxy/src/flows/theme-assistant.ts
+++ b/packages/proxy/src/flows/theme-assistant.ts
@@ -7,9 +7,10 @@ import type { RuntypeFlowConfig } from "../index.js";
  * the host interprets), this flow is a real tool-calling agent: the Theme Editor
  * page registers its theme controls (plus a `screenshot_preview` capture tool)
  * as WebMCP tools on `document.modelContext`, the copilot widget snapshots them
- * onto `dispatch.clientTools[]`, and the upstream agent calls them as
- * `webmcp:<name>`. Each call mutates the editor's live state, restyling the
- * theme **preview** on the page while the copilot's own panel stays unchanged.
+ * onto `dispatch.clientTools[]`, and the upstream agent receives them through
+ * the server-managed WebMCP namespace. Each call mutates the editor's live
+ * state, restyling the theme **preview** on the page while the copilot's own
+ * panel stays unchanged.
  *
  * Multi-modal: the copilot accepts pasted reference images (a screenshot of
  * another site's chat widget) and closes the loop visually — apply theme tools,
@@ -43,7 +44,9 @@ export const THEME_ASSISTANT_FLOW: RuntypeFlowConfig = {
         userPrompt: "{{user_message}}",
         systemPrompt: `You are the **Theme Copilot** — a sidebar assistant docked inside the Persona Theme Editor. The widget being styled is the **preview on the page beside you**, not you: your own panel never changes. Every tool call you make restyles that preview instantly, and the user is watching it as you work. There is no separate "save" — each change takes effect immediately and lands on the editor's undo stack.
 
-The page exposes its theme controls to you as tools (discovered live — you'll see them as \`webmcp:*\` tools). Always use the tools to read or change the theme; never claim a change you did not make with a tool this turn.
+The page exposes its theme controls to you as tools, discovered live each turn. Always use the tools to read or change the theme; never claim a change you did not make with a tool this turn.
+
+Tool-call naming rule: the tool names below are human-readable handles; the callable function may appear with a provider-safe prefix such as webmcp_get_theme_overview. Always call the exact name present in the current tool list. Do not invent, strip, add, or rewrite prefixes, and do not translate underscores into other namespace punctuation.
 
 ## How to work
 

--- a/packages/proxy/src/flows/webmcp-calendar.ts
+++ b/packages/proxy/src/flows/webmcp-calendar.ts
@@ -44,6 +44,8 @@ Voice: helpful, concise, plain language. Keep replies short — a sentence or tw
 
 The dashboard exposes its own calendar tools to you. Always **use the tools** to read or change the calendar — never invent events, IDs, owners, or availability from memory, and never claim a change you did not make with a tool this turn.
 
+Tool-call naming rule: the bold tool names below are human-readable handles; the callable function may appear with a provider-safe prefix such as webmcp_get_calendar_state. Always call the exact name present in the current tool list. Do not invent, strip, add, or rewrite prefixes, and do not translate underscores into other namespace punctuation.
+
 Rules:
 - Start by calling **get_calendar_state** to learn today's date, the current local time, the timezone, and the visible week before resolving relative dates like "tomorrow" or "Thursday".
 - All date-times are LOCAL wall-clock strings in the calendar's timezone, formatted \`YYYY-MM-DDTHH:mm\`. Never append "Z" or a UTC offset — write the clock time the user said.

--- a/packages/proxy/src/flows/webmcp-docked.ts
+++ b/packages/proxy/src/flows/webmcp-docked.ts
@@ -37,6 +37,8 @@ Voice: helpful, concise, plain language. Keep replies short — a sentence or tw
 
 The dashboard exposes its own tools to you. Always **use the tools** to read or change the workspace — never invent metrics, cards, sections, or activity from memory, and never claim a change you did not make with a tool this turn.
 
+Tool-call naming rule: the bold tool names below are human-readable handles; the callable function may appear with a provider-safe prefix such as webmcp_get_workspace_overview. Always call the exact name present in the current tool list. Do not invent, strip, add, or rewrite prefixes, and do not translate underscores into other namespace punctuation.
+
 Rules:
 - Call **get_workspace_overview** before answering questions about the dashboard — it returns the sections, the active section, the highlight cards, and the recent-activity feed.
 - **switch_section** changes which workspace section is highlighted in the side nav. Use the exact section names from the overview.

--- a/packages/proxy/src/flows/webmcp-prompts.test.ts
+++ b/packages/proxy/src/flows/webmcp-prompts.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { WEBMCP_CALENDAR_FLOW } from "./webmcp-calendar.js";
+import { WEBMCP_DOCKED_FLOW } from "./webmcp-docked.js";
+import { WEBMCP_SLIDES_FLOW } from "./webmcp-slides.js";
+import { WEBMCP_STOREFRONT_FLOW } from "./webmcp-storefront.js";
+import { THEME_ASSISTANT_FLOW } from "./theme-assistant.js";
+import type { RuntypeFlowConfig } from "../index.js";
+
+const webMcpFlows: Array<[string, RuntypeFlowConfig]> = [
+  ["calendar", WEBMCP_CALENDAR_FLOW],
+  ["docked", WEBMCP_DOCKED_FLOW],
+  ["slides", WEBMCP_SLIDES_FLOW],
+  ["storefront", WEBMCP_STOREFRONT_FLOW],
+  ["theme assistant", THEME_ASSISTANT_FLOW],
+];
+
+const systemPromptFor = (flow: RuntypeFlowConfig): string => {
+  const prompt = flow.steps[0]?.config.systemPrompt;
+  if (typeof prompt !== "string") {
+    throw new Error(`${flow.name} is missing a system prompt`);
+  }
+  return prompt;
+};
+
+describe("WebMCP flow prompts", () => {
+  it.each(webMcpFlows)(
+    "%s prompt tells the model to call exact runtime tool names",
+    (_name, flow) => {
+      const prompt = systemPromptFor(flow);
+
+      expect(prompt).toContain(
+        "Always call the exact name present in the current tool list.",
+      );
+      expect(prompt).toContain(
+        "do not translate underscores into other namespace punctuation",
+      );
+    },
+  );
+
+  it.each(webMcpFlows)(
+    "%s prompt does not teach colon-prefixed WebMCP call spellings",
+    (_name, flow) => {
+      const prompt = systemPromptFor(flow);
+
+      expect(prompt).not.toMatch(/\bwebmcp:/);
+      expect(prompt).not.toContain("webmcp:*");
+      expect(prompt).not.toContain("webmcp:<name>");
+    },
+  );
+});

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -46,7 +46,9 @@ The editor exposes its own tools to you, and the set is dynamic:
 - While the user has 2 or more elements selected, extra selection tools appear (style_selection, align_selection) that act on the live selection without needing ids.
 - When the show starts (enter_presenter_mode), your editing tools are REPLACED by presentation controls (next_slide, prev_slide, jump_to_slide, exit_presenter_mode) until the show ends.
 
-Treat the tool list you currently see as authoritative. Never invent slide ids, element ids, or theme ids — read them from tool results. You can only affect the deck through tools — never claim an edit you did not make with a tool this turn.
+Treat the tool list you currently see as authoritative. The tool names mentioned below (for example, get_slide or update_element) are human-readable handles; the callable function name may be a provider-safe variant such as webmcp_get_slide or webmcp_update_element. Always call the exact name present in the current tool list. Do not invent, strip, add, or rewrite prefixes, and do not translate underscores into other namespace punctuation.
+
+Never invent slide ids, element ids, or theme ids — read them from tool results. You can only affect the deck through tools — never claim an edit you did not make with a tool this turn.
 
 ## Read before you write
 
@@ -58,7 +60,7 @@ Treat the tool list you currently see as authoritative. Never invent slide ids, 
 
 - The canvas is 960 wide x 540 tall, origin at the top-left. Keep ~40px margins; slide titles sit around y 40-60 at fontSize 36-48.
 - Prefer theme tokens over literal colors and fonts: 'theme.text', 'theme.accent', 'theme.background', 'theme.surface', 'theme.accentText' for colors, 'theme.heading' / 'theme.body' for fonts. Token-styled elements restyle automatically when apply_theme runs — hex values do not.
-- Build slides with add_slide layouts first, then refine with update_element patches (one patch can move, resize, and restyle at once). Use align_elements (alignment and/or distribute) for clean composition instead of eyeballing coordinates.
+- Build slides with add_slide layouts first, then refine with update_element patches (one patch can move, resize, and restyle at once). For update_element and style_selection, pass patch as an object like {"y": 460}, never as a quoted JSON string. Use align_elements (alignment and/or distribute) for clean composition instead of eyeballing coordinates.
 
 ## Style passes ("make it pop", "more modern", "punch it up")
 

--- a/packages/proxy/src/flows/webmcp-storefront.ts
+++ b/packages/proxy/src/flows/webmcp-storefront.ts
@@ -47,6 +47,8 @@ Brand voice: friendly, outdoorsy, concise. Knowledgeable about running shoes, ap
 
 This storefront exposes its own tools to you (search the catalog, view a product, add/remove from the cart, apply a promo code). Always **use the tools** to act on the catalog and cart — never invent products, SKUs, prices, or cart contents from memory, and never claim a cart change you did not make with a tool this turn.
 
+Tool-call naming rule: the tool names below are human-readable handles; the callable function may appear with a provider-safe prefix such as webmcp_search_products. Always call the exact name present in the current tool list. Do not invent, strip, add, or rewrite prefixes, and do not translate underscores into other namespace punctuation.
+
 Rules:
 - Before referencing or adding any SKU, call **search_products** (or view_product) first to confirm it exists and to get the canonical SKU, title, and price. Do not guess SKUs.
 - When the shopper asks to add, remove, or change the cart, call the matching tool. The page renders the cart — after a cart change, confirm what changed and the running total from the tool's result, briefly.

--- a/packages/widget/src/webmcp-bridge.test.ts
+++ b/packages/widget/src/webmcp-bridge.test.ts
@@ -379,6 +379,69 @@ describe("WebMcpBridge.executeToolCall", () => {
     expect(r.isError).toBeUndefined();
   });
 
+  it("parses JSON-string nested object args when the tool schema expects an object", async () => {
+    const execute = vi.fn(() => ({ ok: true }));
+    const onConfirm = vi.fn(async () => true);
+    registry.tools = [
+      fakeTool({
+        name: "update_element",
+        inputSchema: {
+          type: "object",
+          properties: {
+            elementId: { type: "string" },
+            patch: {
+              type: "object",
+              properties: { y: { type: "number" } },
+            },
+          },
+        },
+        execute,
+      }),
+    ];
+    const bridge = new WebMcpBridge({ enabled: true, onConfirm });
+    const r = await bridge.executeToolCall("webmcp:update_element", {
+      elementId: "el-1",
+      patch: "{\"y\":460}",
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        args: { elementId: "el-1", patch: { y: 460 } },
+      }),
+    );
+    expect(execute).toHaveBeenCalledWith(
+      { elementId: "el-1", patch: { y: 460 } },
+      expect.anything(),
+    );
+  });
+
+  it("does not parse JSON-looking strings when the tool schema expects a string", async () => {
+    const execute = vi.fn(() => ({ ok: true }));
+    registry.tools = [
+      fakeTool({
+        name: "set_text",
+        inputSchema: {
+          type: "object",
+          properties: {
+            text: { type: "string" },
+          },
+        },
+        execute,
+      }),
+    ];
+    const bridge = new WebMcpBridge({ enabled: true, onConfirm: allowAll });
+    const r = await bridge.executeToolCall("webmcp:set_text", {
+      text: "{\"literal\":true}",
+    });
+
+    expect(r.isError).toBeUndefined();
+    expect(execute).toHaveBeenCalledWith(
+      { text: "{\"literal\":true}" },
+      expect.anything(),
+    );
+  });
+
   it("returns isError when the tool is not in the registry (unmount race)", async () => {
     registry.tools = [fakeTool({ name: "search" })];
     const bridge = new WebMcpBridge({ enabled: true, onConfirm: allowAll });

--- a/packages/widget/src/webmcp-bridge.ts
+++ b/packages/widget/src/webmcp-bridge.ts
@@ -384,6 +384,11 @@ export class WebMcpBridge {
       );
     }
 
+    const argsForExecute = normalizeArgsForSchema(
+      args,
+      parseSchema(info.inputSchema),
+    );
+
     // Bail before the confirm renders — a late approval after cancel() would
     // otherwise fire a host-page side effect with no matching /resume.
     if (signal?.aborted) {
@@ -395,7 +400,7 @@ export class WebMcpBridge {
     const displayTitle = getWebMcpToolDisplayTitle(bareName);
     const gateInfo: WebMcpConfirmInfo = {
       toolName: bareName,
-      args,
+      args: argsForExecute,
       description: info.description,
       ...(displayTitle ? { title: displayTitle } : {}),
       reason: "gate",
@@ -429,7 +434,7 @@ export class WebMcpBridge {
     }
 
     try {
-      const raw = await mc.executeTool(info, safeStringifyArgs(args), {
+      const raw = await mc.executeTool(info, safeStringifyArgs(argsForExecute), {
         signal: controller.signal,
       });
       return normalizeSerializedResult(raw);
@@ -599,6 +604,109 @@ const parseSchema = (raw: string | undefined): object | undefined => {
   } catch {
     return undefined;
   }
+};
+
+type JsonSchemaLike = Record<string, unknown>;
+
+const asJsonObject = (value: unknown): JsonSchemaLike | undefined =>
+  value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as JsonSchemaLike)
+    : undefined;
+
+const schemaAcceptsType = (
+  schema: JsonSchemaLike,
+  expected: "object" | "array",
+): boolean => {
+  const type = schema.type;
+  if (type === expected) return true;
+  if (Array.isArray(type) && type.includes(expected)) return true;
+  if (expected === "object" && asJsonObject(schema.properties)) return true;
+  if (expected === "array" && schema.items !== undefined) return true;
+
+  for (const key of ["anyOf", "oneOf", "allOf"] as const) {
+    const branches = schema[key];
+    if (
+      Array.isArray(branches) &&
+      branches.some((branch) => {
+        const branchSchema = asJsonObject(branch);
+        return branchSchema ? schemaAcceptsType(branchSchema, expected) : false;
+      })
+    ) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+const tryParseJsonContainer = (
+  value: string,
+  schema: JsonSchemaLike,
+): unknown => {
+  const expectsObject = schemaAcceptsType(schema, "object");
+  const expectsArray = schemaAcceptsType(schema, "array");
+  if (!expectsObject && !expectsArray) return value;
+
+  try {
+    const parsed = JSON.parse(value);
+    if (expectsObject && asJsonObject(parsed)) return parsed;
+    if (expectsArray && Array.isArray(parsed)) return parsed;
+  } catch {
+    // Leave the original string in place so the page registry's schema
+    // validator returns the same actionable error it would have before.
+  }
+  return value;
+};
+
+/**
+ * Some models stringify nested JSON objects even when the advertised WebMCP
+ * schema expects an object (for example `{ patch: "{\"y\":460}" }`). The
+ * WebMCP polyfill validates before invoking the page tool, so normalize those
+ * obvious JSON-string containers before sending args to `executeTool`. Only
+ * properties whose schema expects an object/array are parsed; ordinary string
+ * fields are preserved verbatim.
+ */
+const normalizeArgsForSchema = (value: unknown, schema: unknown): unknown => {
+  const schemaObj = asJsonObject(schema);
+  if (!schemaObj) return value;
+
+  const current =
+    typeof value === "string" ? tryParseJsonContainer(value, schemaObj) : value;
+
+  if (Array.isArray(current)) {
+    const itemSchema = asJsonObject(schemaObj.items);
+    if (!itemSchema) return current;
+
+    let next: unknown[] | null = null;
+    current.forEach((item, index) => {
+      const normalized = normalizeArgsForSchema(item, itemSchema);
+      if (normalized !== item) {
+        next ??= [...current];
+        next[index] = normalized;
+      }
+    });
+    return next ?? current;
+  }
+
+  const record = asJsonObject(current);
+  if (!record) return current;
+
+  const properties = asJsonObject(schemaObj.properties);
+  const additionalProperties = asJsonObject(schemaObj.additionalProperties);
+  let next: JsonSchemaLike | null = null;
+
+  for (const [key, item] of Object.entries(record)) {
+    const propSchema = asJsonObject(properties?.[key]) ?? additionalProperties;
+    if (!propSchema) continue;
+
+    const normalized = normalizeArgsForSchema(item, propSchema);
+    if (normalized !== item) {
+      next ??= { ...record };
+      next[key] = normalized;
+    }
+  }
+
+  return next ?? current;
 };
 
 /**


### PR DESCRIPTION
## Summary
- normalize JSON-encoded WebMCP `patch` arguments in the widget bridge before page-tool execution
- tighten WebMCP demo prompts so models call exact runtime tool names and pass slide patches as objects
- add prompt/bridge regression coverage and a changeset for the widget/proxy packages
- bump the CDN IIFE size budget by 0.1 kB after trimming the runtime fix down to a focused patch normalizer

## Root cause
The API-side tool-name repair lets calls like `webmcp:update_element` reach the page again, but models can still send patch parameters as JSON strings (for example `patch: "{\"y\":460}"`). The WebMCP polyfill validates arguments before invoking the page tool, so the page executor never had a chance to coerce that into an object.

## Validation
- `pnpm --filter @runtypelabs/persona test:run -- webmcp-bridge.test.ts`
- `pnpm --filter @runtypelabs/persona exec tsc --noEmit`
- `pnpm --filter @runtypelabs/persona lint`
- `pnpm --filter @runtypelabs/persona size`
- `pnpm --filter @runtypelabs/persona-proxy exec vitest run src/flows/webmcp-prompts.test.ts`
- `pnpm --filter @runtypelabs/persona-proxy typecheck`
- `pnpm --filter @runtypelabs/persona-proxy lint`
- `pnpm --filter @runtypelabs/persona-proxy build`
- `pnpm --filter embedded-app build`
- `git diff --check`