### PR TITLE
chore(widget): bump lucide to ^1.18.0

### DIFF
--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260612.1",
     "typescript": "^5.4.5",
-    "wrangler": "^4.85.0"
+<<<<<<< HEAD
+    "wrangler": "^4.100.0"
   }
 }

--- a/examples/cloudflare-workers/package.json
+++ b/examples/cloudflare-workers/package.json
@@ -15,7 +15,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260612.1",
     "typescript": "^5.4.5",
-<<<<<<< HEAD
     "wrangler": "^4.100.0"
   }
 }

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -86,7 +86,7 @@
     "@mcp-b/webmcp-polyfill": "^3.0.0",
     "dompurify": "^3.4.10",
     "idiomorph": "^0.7.4",
-    "lucide": "^0.552.0",
+    "lucide": "^1.18.0",
     "marked": "^12.0.2",
     "partial-json": "^0.1.7",
     "zod": "^3.22.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
         specifier: ^5.4.5
         version: 5.9.3
       wrangler:
-        specifier: ^4.85.0
+        specifier: ^4.100.0
         version: 4.100.0(@cloudflare/workers-types@4.20260612.1)
 
   examples/embedded-app:
@@ -177,7 +177,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
 
   packages/widget:
     dependencies:
@@ -241,7 +241,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.9
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
 
 packages:
 
@@ -4108,7 +4108,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.9.3)(jiti@1.21.7)(tsx@4.22.4)
 
-  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))':
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
@@ -4160,7 +4160,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -5543,10 +5543,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,7 +177,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
 
   packages/widget:
     dependencies:
@@ -241,7 +241,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.9
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
 
 packages:
 
@@ -4108,7 +4108,7 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.9.3)(jiti@1.21.7)(tsx@4.22.4)
 
-  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))':
+  '@vitest/mocker@4.1.8(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
@@ -4160,7 +4160,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
+      vitest: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -5543,10 +5543,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.1.8)(jsdom@28.1.0)(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@20.19.35)(tsx@4.22.4))
+      '@vitest/mocker': 4.1.8(vite@7.3.1(@types/node@20.19.35)(jiti@1.21.7)(tsx@4.22.4))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,8 +191,8 @@ importers:
         specifier: ^0.7.4
         version: 0.7.4
       lucide:
-        specifier: ^0.552.0
-        version: 0.552.0
+        specifier: ^1.18.0
+        version: 1.18.0
       marked:
         specifier: ^12.0.2
         version: 12.0.2
@@ -2208,8 +2208,8 @@ packages:
     resolution: {integrity: sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==}
     engines: {node: 20 || >=22}
 
-  lucide@0.552.0:
-    resolution: {integrity: sha512-f9PSKLsd4TtGRnRnbqZ2IMKQ2tfCA/dwHaZHysmB3LAF8uRi2GB35iy6S/kjcdvglDrueUdpu50ZDBoB21WT2g==}
+  lucide@1.18.0:
+    resolution: {integrity: sha512-xzUa3LbA/Uvn3DCs7B7YfDcOZeqV8aZ4r4OFyCgJSfZGUdMglJiK3PJSbd26SXLLQvGGsYX9PdETCRXvfK4rnA==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4885,7 +4885,7 @@ snapshots:
 
   lru-cache@11.2.6: {}
 
-  lucide@0.552.0: {}
+  lucide@1.18.0: {}
 
   magic-string@0.30.21:
     dependencies:


### PR DESCRIPTION
Bumps `lucide` from `^0.552.0` to `^1.18.0`.

## Verification
- Build passes
- Type check passes
- 1176 tests pass
- All 113 imported icons exist in the new version
- No bundle size regression (size-limit unchanged)

## What this gets us
- Moves to the stable 1.x release line
- Access to new icons added since 0.552.0
- Pulls in icon path refinements and corrections

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine dependency upgrades with PR verification that builds, types, tests, and icon registry compatibility still pass; no application logic changes in the diff.
> 
> **Overview**
> Updates **`lucide`** in `packages/widget` from **`^0.552.0`** to **`^1.18.0`**, moving icon rendering onto the stable **1.x** line while keeping the existing closed registry in `src/utils/icons.ts`.
> 
> Also bumps **`wrangler`** in `examples/cloudflare-workers` from **`^4.85.0`** to **`^4.100.0`**, with matching **`pnpm-lock.yaml`** resolution updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19383db394256ee05bf9d6f0ab8d2d5ad3e0600c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->