### PR TITLE
Fix Paint Pal 404 in prod: mount dispatch-paint in the deployed proxy entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,6 +151,21 @@ Hono-based server that proxies requests to the Runtype API:
 
 **CORS / `NODE_ENV`:** The proxy only enables permissive CORS when `NODE_ENV` is **exactly** `"development"`. An unset `NODE_ENV` is treated as production (origins must match the `allowedOrigins` list). The root `pnpm dev` script sets `NODE_ENV=development` automatically. If you start the proxy directly (e.g. `pnpm dev:vercel`), set it yourself or configure it in your `.env` file.
 
+### Adding a proxy route for a new demo
+
+The proxy has **two entry points that must be kept in sync** — this has caused production 404s more than once, because a demo works locally but its route was never added to the deployed entry:
+
+- `examples/vercel-edge/src/server.ts` — the **local dev** server (`pnpm dev`)
+- `examples/vercel-edge/api/index.ts` — the **deployed** proxy (Vercel serverless entry behind `https://proxy.persona-chat.dev`)
+
+Checklist for a new demo flow:
+
+1. Define the flow in `packages/proxy/src/flows/<name>.ts` and export it from `packages/proxy/src/flows/index.ts` (this is a `packages/proxy` change — **changeset required**).
+2. Mount it in **BOTH** `src/server.ts` and `api/index.ts`: import the flow, add a `createChatProxyApp({ path: "/api/chat/dispatch-<name>", … })` block (follow the existing `FLOW_ID_*` env-override pattern), and add the `app.route("/", …)` line. If you only touched `src/server.ts`, the demo will 404 in production.
+3. Run `pnpm build:proxy` before testing locally — both entries import the **built** `@runtypelabs/persona-proxy`, so a new flow isn't visible to the dev server until the package is rebuilt.
+4. Point the demo page's `apiUrl` at the new route (see any `src/webmcp-*/main.*` in `examples/embedded-app` for the proxy-port pattern).
+5. After merging, verify the route on the deployed proxy: `curl -X OPTIONS https://proxy.persona-chat.dev/api/chat/dispatch-<name>` should not 404.
+
 ## Testing
 
 Tests use Vitest. Configuration is at `packages/widget/vitest.config.ts` (Node environment).

--- a/examples/vercel-edge/api/index.ts
+++ b/examples/vercel-edge/api/index.ts
@@ -9,6 +9,7 @@ import {
   WEBMCP_STOREFRONT_FLOW,
   WEBMCP_CALENDAR_FLOW,
   WEBMCP_SLIDES_FLOW,
+  WEBMCP_PAINT_FLOW,
   WEBMCP_DOCKED_FLOW,
   PAGE_CONTEXT_FLOW,
   THEME_ASSISTANT_FLOW,
@@ -99,6 +100,17 @@ const webmcpSlidesApp = createChatProxyApp({
   upstreamUrl,
 });
 
+// WebMCP paint proxy - for the Paint Pal jspaint demo. The flow's model must
+// accept image tool results (get_canvas_snapshot returns the canvas through
+// /resume as an MCP image content block).
+const webmcpPaintApp = createChatProxyApp({
+  path: "/api/chat/dispatch-paint",
+  allowedOrigins,
+  flowId: process.env.FLOW_ID_PAINT || undefined,
+  flowConfig: process.env.FLOW_ID_PAINT ? undefined : WEBMCP_PAINT_FLOW,
+  upstreamUrl,
+});
+
 // WebMCP docked-dashboard proxy - for the docked panel demo's Copilot.
 const webmcpDockedApp = createChatProxyApp({
   path: "/api/chat/dispatch-docked",
@@ -134,6 +146,7 @@ app.route("/", storefrontApp);
 app.route("/", webmcpApp);
 app.route("/", webmcpCalendarApp);
 app.route("/", webmcpSlidesApp);
+app.route("/", webmcpPaintApp);
 app.route("/", webmcpDockedApp);
 app.route("/", pageContextApp);
 app.route("/", themeAssistantApp);


### PR DESCRIPTION
## What

`/api/chat/dispatch-paint` (from #283) was only mounted in `examples/vercel-edge/src/server.ts` — the **local dev** server — and never in `examples/vercel-edge/api/index.ts`, the **deployed** Vercel entry behind `proxy.persona-chat.dev`. So Paint Pal worked locally and 404'd in production.

This adds the missing `webmcpPaintApp` mount to `api/index.ts` (same `FLOW_ID_PAINT` override pattern as the other demos).

## Why also CLAUDE.md / AGENTS.md

This dual-entry miss has happened before. CLAUDE.md now documents the two proxy entry points and a checklist for adding new demo routes: define + export the flow (changeset), **mount in both entries**, rebuild the proxy before local testing, point the page at the route, and curl the deployed route after merge.

No changeset: examples + docs only.

## Test plan

- [x] `tsc --noEmit` on examples/vercel-edge passes
- [ ] After merge/deploy: `curl -X OPTIONS https://proxy.persona-chat.dev/api/chat/dispatch-paint` returns non-404

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples and documentation only; mirrors an existing dev-server route with no auth or package changes.
> 
> **Overview**
> Fixes **Paint Pal** 404s in production by mounting `/api/chat/dispatch-paint` on the deployed Vercel proxy (`examples/vercel-edge/api/index.ts`), matching what was already wired in the local dev server. The new `webmcpPaintApp` uses the same `FLOW_ID_PAINT` / `WEBMCP_PAINT_FLOW` pattern as the other WebMCP demos.
> 
> **CLAUDE.md** adds an **“Adding a proxy route for a new demo”** section: keep `src/server.ts` and `api/index.ts` in sync, rebuild the proxy package for local tests, and verify the route on `proxy.persona-chat.dev` after deploy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9f5ebf9633ffae7a7c45301e681142db91026f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->