### PR TITLE
Stop Paint Pal page loads from fetching jspaint news images off GitHub

### DIFF
--- a/examples/embedded-app/package.json
+++ b/examples/embedded-app/package.json
@@ -13,7 +13,7 @@
     "@runtypelabs/persona": "workspace:^",
     "handlebars": "^4.7.8",
     "idiomorph": "^0.7.4",
-    "jspaint": "github:runtypelabs/jspaint#53be67ab8c47cc0d2168899e7481bc04839c4c81",
+    "jspaint": "github:runtypelabs/jspaint#61814a33efbd2021859caf37381f1005dfc25666",
     "modern-screenshot": "^4.7.0",
     "partial-json": "^0.1.7",
     "zod": "^3.25.76",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,8 +89,8 @@ importers:
         specifier: ^0.7.4
         version: 0.7.4
       jspaint:
-        specifier: github:runtypelabs/jspaint#53be67ab8c47cc0d2168899e7481bc04839c4c81
-        version: https://codeload.github.com/runtypelabs/jspaint/tar.gz/53be67ab8c47cc0d2168899e7481bc04839c4c81
+        specifier: github:runtypelabs/jspaint#61814a33efbd2021859caf37381f1005dfc25666
+        version: https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666
       modern-screenshot:
         specifier: ^4.7.0
         version: 4.7.0
@@ -2173,8 +2173,8 @@ packages:
   jsonfile@4.0.0:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
-  jspaint@https://codeload.github.com/runtypelabs/jspaint/tar.gz/53be67ab8c47cc0d2168899e7481bc04839c4c81:
-    resolution: {tarball: https://codeload.github.com/runtypelabs/jspaint/tar.gz/53be67ab8c47cc0d2168899e7481bc04839c4c81}
+  jspaint@https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666:
+    resolution: {tarball: https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666}
     version: 1.1.0
     hasBin: true
 
@@ -4898,7 +4898,7 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
-  jspaint@https://codeload.github.com/runtypelabs/jspaint/tar.gz/53be67ab8c47cc0d2168899e7481bc04839c4c81:
+  jspaint@https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666:
     dependencies:
       argparse: 2.0.1
       electron-squirrel-startup: 1.0.1


### PR DESCRIPTION
## What

The prod Paint Pal page fired ~70 requests to `github.com` / `raw.githubusercontent.com` on every load (visible in DevTools). These are **jspaint's own changelog images**: the news entries baked into its `index.html` embed before/after tool-icon screenshots as eager `<img>` tags with absolute GitHub URLs, and eager images load even inside hidden markup — each one redirect-chains through `blob?raw=true` → `/raw/` → `raw.githubusercontent.com`.

## Fix

This is what the `runtypelabs/jspaint` fork is for: it now carries a one-commit patch ([`runtype/lazy-news-images`](https://github.com/runtypelabs/jspaint/tree/runtype/lazy-news-images)) adding `loading="lazy"` to the 9 GitHub-hosted news images — hidden lazy images never fetch, and the News window still works if opened. This PR bumps the pinned SHA to that commit.

Upstream-friendly: the patch is a candidate to PR back to 1j01/jspaint.

## Test plan

- [x] `pnpm install` resolves the new pin; `/jspaint/index.html` serves with 9 `loading="lazy"` tags
- [x] Browser-verified: page load makes **zero** requests to GitHub domains (was ~70), all 173 asset requests same-origin

No changeset: examples only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples-only dependency SHA bump with no runtime code changes in this repo; behavior change is limited to fewer network requests on jspaint load.
> 
> **Overview**
> Updates the **Paint Pal** embedded app’s pinned `runtypelabs/jspaint` git dependency (and `pnpm-lock.yaml`) to commit `61814a33…`, which carries a fork patch that adds `loading="lazy"` to changelog/news `<img>` tags that previously used eager GitHub URLs.
> 
> **Effect:** initial `/jspaint/` loads no longer trigger dozens of off-origin GitHub/raw requests from hidden news markup; images still load if the News UI is opened. No application source changes in this repo—examples dependency pin only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ea226d26b97e8f238c1534a00edc9d0f20710c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->