### PR TITLE
fix(widget): push-dock uses margin offset, not transform (unbreaks position:fixed host chrome)

### DIFF
--- a/.changeset/push-dock-fixed-position.md
+++ b/.changeset/push-dock-fixed-position.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix push-dock reveal breaking `position: fixed` host chrome. The push track was offset with a CSS `transform`, which made it the containing block for any `position: fixed` descendant — so viewport-fixed elements rendered inside the pushed content (e.g. a host app's `fixed top-0 right-0` toolbar) resolved against the track and landed the panel width off-screen. The track now uses a `margin-left` offset, which produces the identical visual push without establishing a containing block, so fixed (and sticky) descendants resolve against the viewport again.

--- a/packages/widget/src/runtime/host-layout.test.ts
+++ b/packages/widget/src/runtime/host-layout.test.ts
@@ -108,7 +108,7 @@ describe("createWidgetHostLayout docked", () => {
     layout.destroy();
   });
 
-  it("push reveal translates a track; main column width stays fixed in px", () => {
+  it("push reveal offsets a track with margin (no transform); main column width stays fixed in px", () => {
     const parent = document.createElement("div");
     parent.style.width = "800px";
     document.body.appendChild(parent);
@@ -132,15 +132,20 @@ describe("createWidgetHostLayout docked", () => {
     expect(shell.dataset.personaDockReveal).toBe("push");
     expect(contentSlot?.style.width).toBe("800px");
     expect(pushTrack?.style.width).toBe("1120px");
-    expect(pushTrack?.style.transform).toBe("translateX(0)");
+    expect(pushTrack?.style.marginLeft).toBe("0px");
+    // The track must NOT carry a transform: a transformed ancestor becomes the
+    // containing block for `position: fixed` host chrome and pushes it
+    // off-screen (regression guard, see host-layout.ts push branch).
+    expect(pushTrack?.style.transform).toBe("");
 
     layout.syncWidgetState({ open: true, launcherEnabled: true });
-    expect(pushTrack?.style.transform).toBe("translateX(-320px)");
+    expect(pushTrack?.style.marginLeft).toBe("-320px");
+    expect(pushTrack?.style.transform).toBe("");
 
     layout.destroy();
   });
 
-  it("push reveal on the left uses negative translate when closed", () => {
+  it("push reveal on the left uses negative margin when closed", () => {
     const parent = document.createElement("div");
     parent.style.width = "600px";
     document.body.appendChild(parent);
@@ -159,10 +164,12 @@ describe("createWidgetHostLayout docked", () => {
     layout.updateConfig({ launcher: dockConfig });
 
     const pushTrack = shell.querySelector<HTMLElement>('[data-persona-dock-role="push-track"]');
-    expect(pushTrack?.style.transform).toBe("translateX(-200px)");
+    expect(pushTrack?.style.marginLeft).toBe("-200px");
+    expect(pushTrack?.style.transform).toBe("");
 
     layout.syncWidgetState({ open: true, launcherEnabled: true });
-    expect(pushTrack?.style.transform).toBe("translateX(0)");
+    expect(pushTrack?.style.marginLeft).toBe("0px");
+    expect(pushTrack?.style.transform).toBe("");
 
     layout.destroy();
   });
@@ -219,9 +226,9 @@ describe("createWidgetHostLayout docked", () => {
     }
   });
 
-  it("clamps push and overlay dock slots without sticky (transform/absolute contexts)", () => {
-    // push: the slot lives inside the translated track, where a transformed
-    // ancestor defeats sticky — cap only. overlay: keeps absolute positioning.
+  it("clamps push and overlay dock slots without sticky (in-flow/absolute contexts)", () => {
+    // push: the slot is an in-flow `position: relative` column — max-height cap
+    // only, no sticky. overlay: keeps absolute positioning.
     const cases = [
       { reveal: "push" as const, position: "relative" },
       { reveal: "overlay" as const, position: "absolute" },

--- a/packages/widget/src/runtime/host-layout.ts
+++ b/packages/widget/src/runtime/host-layout.ts
@@ -53,9 +53,10 @@ const applyDockSlotMaxHeight = (
  * when the surrounding page is taller than the screen (e.g. a missing height
  * chain or a deliberately scrolling page). With a properly sized shell it
  * behaves exactly like the previous `position: relative`. Not used for push:
- * there the slot lives inside the translated push track, and that transformed
- * ancestor defeats sticky (verified in Chromium) — push gets the max-height
- * cap only, like overlay.
+ * push gets the max-height cap only, like overlay, since the dock slot is an
+ * in-flow `position: relative` column there rather than a viewport-pinned one.
+ * (The push track itself is offset with `margin-left`, not a transform, so it
+ * no longer establishes a containing block for fixed/sticky descendants.)
  */
 const applyInFlowDockSlotPosition = (
   dockSlot: HTMLElement,
@@ -151,6 +152,7 @@ const clearPushTrackStyles = (pushTrack: HTMLElement): void => {
   pushTrack.style.alignItems = "";
   pushTrack.style.transition = "";
   pushTrack.style.transform = "";
+  pushTrack.style.marginLeft = "";
 };
 
 const resetContentSlotFlexSizing = (contentSlot: HTMLElement): void => {
@@ -359,15 +361,24 @@ const applyDockStyles = (
 
     const panelPx = parseDockWidthToPx(dock.width, shell.clientWidth);
     const contentPx = Math.max(0, shell.clientWidth);
-    const dockTransition = dock.animate ? "transform 180ms ease" : "none";
-    const translate =
+    const dockTransition = dock.animate ? "margin-left 180ms ease" : "none";
+    // Slide the wide track with a negative left margin rather than a CSS
+    // transform. A `transform` (even `translateX(0)`) turns the push track into
+    // the containing block for any `position: fixed` descendant, so host pages
+    // that render viewport-fixed chrome inside the pushed content (e.g. the
+    // dashboard editor's `fixed top-0 right-0` toolbar) resolve `right: 0`
+    // against the track's right edge — `panelPx` past the viewport, off-screen.
+    // `margin-left` produces the identical visual offset (the track is clipped
+    // by the overflow:hidden shell) without establishing a containing block for
+    // fixed OR absolutely-positioned descendants.
+    const marginOffsetPx =
       dock.side === "right"
         ? expanded
-          ? `translateX(-${panelPx}px)`
-          : "translateX(0)"
+          ? -panelPx
+          : 0
         : expanded
-          ? "translateX(0)"
-          : `translateX(-${panelPx}px)`;
+          ? 0
+          : -panelPx;
 
     pushTrack.style.display = "flex";
     pushTrack.style.flexDirection = "row";
@@ -378,7 +389,10 @@ const applyDockStyles = (
     pushTrack.style.height = "100%";
     pushTrack.style.width = `${contentPx + panelPx}px`;
     pushTrack.style.transition = dockTransition;
-    pushTrack.style.transform = translate;
+    pushTrack.style.marginLeft = `${marginOffsetPx}px`;
+    // Defensively clear any transform a previous reveal mode may have set —
+    // leaving one would re-establish the fixed-position containing block.
+    pushTrack.style.transform = "";
 
     contentSlot.style.flex = "0 0 auto";
     contentSlot.style.flexGrow = "0";

--- a/packages/widget/src/runtime/init.test.ts
+++ b/packages/widget/src/runtime/init.test.ts
@@ -424,11 +424,11 @@ describe("initAgentWidget docked mode", () => {
     const panelSlot = shell.querySelector<HTMLElement>('[data-persona-dock-role="panel"]')!;
     expect(pushTrack).not.toBeNull();
     expect(panelSlot.style.width).toBe("400px");
-    expect(pushTrack?.style.transform).toBe("translateX(-400px)");
+    expect(pushTrack?.style.marginLeft).toBe("-400px");
 
     handle.close();
     expect(panelSlot.style.width).toBe("400px");
-    expect(pushTrack?.style.transform).toBe("translateX(0)");
+    expect(pushTrack?.style.marginLeft).toBe("0px");
 
     handle.destroy();
     wrapper.remove();

--- a/packages/widget/src/ui.docked.test.ts
+++ b/packages/widget/src/ui.docked.test.ts
@@ -286,11 +286,11 @@ describe("createAgentExperience docked mode", () => {
     const closeButton = mount.querySelector<HTMLButtonElement>('[aria-label="Close chat"]');
 
     expect(pushTrack).not.toBeNull();
-    expect(pushTrack?.style.transform).toBe("translateX(-420px)");
+    expect(pushTrack?.style.marginLeft).toBe("-420px");
 
     closeButton!.click();
 
-    expect(pushTrack?.style.transform).toBe("translateX(0)");
+    expect(pushTrack?.style.marginLeft).toBe("0px");
 
     openUnsub();
     closeUnsub();


### PR DESCRIPTION
## Problem

The push-dock reveal (`reveal: "push"`) offsets the push track with a CSS `transform: translateX(...)` — even `translateX(0)` when closed. Any non-`none` transform turns the push track into the **containing block for `position: fixed` descendants**. Host pages that render viewport-fixed chrome inside the pushed content resolve `right: 0` against the track's right edge — `panelPx` (the panel width) past the viewport — so those elements land off-screen.

Concretely, this breaks the Runtype dashboard editor's `fixed top-0 right-0` toolbar (Run/Publish/Save buttons) whenever the docked Assistant is enabled in `push` mode: the buttons render ~420px off the right edge. It's currently latent only because the dashboard-assistant flag is off; it ships with the assistant rollout unless fixed.

## Fix

Offset the push track with `margin-left` instead of `transform`. A negative left margin slides the (already-wider-than-viewport) track exactly the same amount, and the `overflow: hidden` shell clips it identically — but `margin` does **not** establish a containing block, so `position: fixed` (and `sticky`) descendants resolve against the viewport again. The transition switches from `transform` to `margin-left`; `clearPushTrackStyles` now also clears `marginLeft`, and the push branch defensively clears any stale `transform`.

The stale comment claiming push can't use sticky "because the slot lives inside the translated push track" is updated — the track is no longer transformed.

## Verification

- Unit: `host-layout.test.ts`, `ui.docked.test.ts`, `runtime/init.test.ts` updated to assert `marginLeft` and that `transform` stays `""` (a regression guard against reintroducing the containing block). All widget tests + lint + typecheck pass.
- Browser (Chromium, via the `docked-panel-demo` harness): a `position: fixed; top:0; right:0` probe inside the pushed content sits at the viewport's right edge (`right === innerWidth`) with the dock open in push mode. Reintroducing `transform: translateX(-360px)` as a control pushes the probe's right edge to exactly `innerWidth - 360` (off-screen), confirming the probe detects the bug and that `margin-left` resolves it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Layout behavior for push-dock is changed at the CSS level (margin vs transform); risk is localized to docked push reveal but affects how embedded host pages position fixed/sticky UI.
> 
> **Overview**
> **Push-dock reveal** no longer slides the push track with `transform: translateX(...)`. It uses **`margin-left`** with the same open/closed offsets, **`margin-left` animation** when `dock.animate` is on, and an explicit **clear of `transform`** on the track so a prior reveal mode cannot reintroduce a fixed-position containing block.
> 
> That fixes host UI inside the pushed content (e.g. `position: fixed; top: 0; right: 0` toolbars) that was anchoring to the transformed track and sitting **panel width off the viewport**.
> 
> Comments and tests now describe push as an in-flow track (not a transformed ancestor) and assert **`marginLeft`** plus **empty `transform`** as a regression guard. A **patch changeset** documents the `@runtypelabs/persona` fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e51146378b5834dfacb89f34230c05c8092824f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->