### PR TITLE
fix(widget): send client token on feedback requests

### DIFF
--- a/.changeset/feedback-client-token.md
+++ b/.changeset/feedback-client-token.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Include the client token in feedback requests (thumbs up/down, copy, CSAT, NPS) so the API can scope feedback to the originating session.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -4121,3 +4121,58 @@ describe('AgentWidgetClient - non-client-token paths always send full clientTool
     }
   });
 });
+
+describe('AgentWidgetClient - Feedback request builder', () => {
+  const INIT_RESPONSE = {
+    sessionId: 'sess_123',
+    expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    flow: {},
+    config: { welcomeMessage: 'hi', placeholder: 'type…', theme: {} },
+  };
+
+  function mockInitAndFeedback() {
+    const feedbackBodies: Array<Record<string, unknown>> = [];
+    global.fetch = vi.fn().mockImplementation(async (url: string, options: { body: string }) => {
+      if (typeof url === 'string' && url.endsWith('/v1/client/feedback')) {
+        feedbackBodies.push(JSON.parse(options.body));
+        return { ok: true, status: 200, json: async () => ({}) };
+      }
+      // init request
+      return { ok: true, status: 200, json: async () => INIT_RESPONSE };
+    });
+    return feedbackBodies;
+  }
+
+  it('includes the client token in the feedback request body', async () => {
+    const feedbackBodies = mockInitAndFeedback();
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      clientToken: 'ct_live_abc123',
+    });
+    await client.initSession();
+
+    await client.sendFeedback({ sessionId: 'sess_123', messageId: 'm1', type: 'upvote' });
+
+    expect(feedbackBodies).toHaveLength(1);
+    expect(feedbackBodies[0]).toEqual({
+      sessionId: 'sess_123',
+      messageId: 'm1',
+      type: 'upvote',
+      token: 'ct_live_abc123',
+    });
+  });
+
+  it('sends the token on csat/nps submissions too', async () => {
+    const feedbackBodies = mockInitAndFeedback();
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      clientToken: 'ct_live_xyz789',
+    });
+    await client.initSession();
+
+    await client.sendFeedback({ sessionId: 'sess_123', type: 'csat', rating: 5 });
+
+    expect(feedbackBodies[0].token).toBe('ct_live_xyz789');
+    expect(feedbackBodies[0].rating).toBe(5);
+  });
+});

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -482,12 +482,21 @@ export class AgentWidgetClient {
       console.debug("[AgentWidgetClient] sending feedback", feedback);
     }
 
+    // Scope the feedback request to the caller's client token, sourced the same
+    // way as the chat/init requests. sendFeedback is client-token-mode only
+    // (guarded above), so clientToken is always present here and an API key can
+    // never leak into the body. Left undefined only when the embed has none.
+    const requestBody = {
+      ...feedback,
+      ...(this.config.clientToken && { token: this.config.clientToken }),
+    };
+
     const response = await fetch(this.getFeedbackApiUrl(), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify(feedback),
+      body: JSON.stringify(requestBody),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
## What

Feedback requests (thumbs up/down, copy, CSAT, NPS) didn't carry the embed's client token. This adds `token` to the `POST /v1/client/feedback` body, sourced from `config.clientToken` the same way the chat/init requests are built.

## Details

- `sendFeedback()` now includes `token: config.clientToken` in the request body. It's only added when a client token is present, so nothing leaks when the embed has none.
- `sendFeedback()` already runs in client-token mode only, so this is always populated in practice.

## Tests

- Added request-builder unit tests asserting the token is included on message feedback and on CSAT/NPS submissions.
- `pnpm lint`, `pnpm typecheck`, and the widget test suite (110 tests) all pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, client-token-only request-body change with tests; no auth or server logic in this diff.
> 
> **Overview**
> **Widget feedback** now includes the embed’s **client token** on `POST /v1/client/feedback`, matching how init/chat requests are scoped.
> 
> `sendFeedback()` builds a request body that spreads the existing feedback fields and adds **`token`** from `config.clientToken` only when it is set, so nothing extra is sent when the embed has no token.
> 
> Unit tests assert the token is present for message feedback (e.g. upvote) and for CSAT/NPS submissions. A patch changeset notes the behavior for `@runtypelabs/persona`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c80d6e19cb6b952f9b17a7a206c1cb619ca3bdeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->