### PR TITLE
feat: Skylark Air WebMCP flight-booking demo

### DIFF
--- a/.changeset/webmcp-flights-flow.md
+++ b/.changeset/webmcp-flights-flow.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": minor
+---
+
+Add `WEBMCP_FLIGHTS_FLOW`, an in-code example flow for the new "Skylark Air" WebMCP flight-booking demo. The flow drives page-provided booking tools (flight search, an array-of-arrays seat map, passenger management, seat assignment, and an approval-gated confirm) and teaches the model the booking workflow and how to read the seat-map grid.

--- a/apps/web/src/webmcp-flights/app.ts
+++ b/apps/web/src/webmcp-flights/app.ts
@@ -1,0 +1,262 @@
+// Renders the Skylark Air booking page from the BookingStore and re-renders on
+// every change — so whether the human uses the on-page controls or the Copilot
+// calls a tool, the same store drives the same UI. Returns a `flash` helper the
+// tools call to pulse whatever the agent just touched.
+
+import type { BookingStore } from "./store";
+import { buildSeatMap, findSeat, searchFlights } from "./catalog";
+import type { Cabin, Flight, Leg } from "./types";
+import { AIRPORTS, CABINS } from "./types";
+
+const FLASH_MS = 1200;
+
+const fmtDuration = (mins: number): string =>
+  `${Math.floor(mins / 60)}h ${String(mins % 60).padStart(2, "0")}m`;
+
+const fmtMoney = (n: number): string => `$${n.toLocaleString("en-US")}`;
+
+const el = <K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  props: Partial<HTMLElementTagNameMap[K]> & { dataset?: Record<string, string> } = {},
+  children: (Node | string)[] = [],
+): HTMLElementTagNameMap[K] => {
+  const node = document.createElement(tag);
+  const { dataset, ...rest } = props;
+  Object.assign(node, rest);
+  if (dataset) for (const [k, v] of Object.entries(dataset)) node.dataset[k] = v;
+  for (const child of children) {
+    node.append(typeof child === "string" ? document.createTextNode(child) : child);
+  }
+  return node;
+};
+
+const defaultDepartDate = (): string => {
+  const d = new Date();
+  d.setDate(d.getDate() + 14);
+  return d.toISOString().slice(0, 10);
+};
+
+export const createApp = (
+  store: BookingStore,
+  root: HTMLElement,
+): { flash: (keys: string[]) => void } => {
+  // --- search bar (functional on-page controls, same store as the tools) ----
+  const originInput = el("input", { className: "sk-field", value: "SFO", placeholder: "From" });
+  const destInput = el("input", { className: "sk-field", value: "JFK", placeholder: "To" });
+  const dateInput = el("input", { className: "sk-field", type: "date", value: defaultDepartDate() });
+  const paxInput = el("input", { className: "sk-field sk-field-num", type: "number", min: "1", max: "6", value: "1" });
+  const cabinSelect = el("select", { className: "sk-field" },
+    CABINS.map((c) => el("option", { value: c, textContent: c[0].toUpperCase() + c.slice(1) })),
+  );
+  const searchButton = el("button", { className: "sk-btn sk-btn-primary", type: "button", textContent: "Search" });
+
+  const datalist = el("datalist", { id: "sk-airports" }, AIRPORTS.map((a) => el("option", { value: a })));
+  originInput.setAttribute("list", "sk-airports");
+  destInput.setAttribute("list", "sk-airports");
+
+  searchButton.addEventListener("click", () => {
+    const origin = originInput.value.trim().toUpperCase();
+    const destination = destInput.value.trim().toUpperCase();
+    const departDate = dateInput.value;
+    if (!origin || !destination || origin === destination || !departDate) return;
+    const cabin = cabinSelect.value as Cabin;
+    const passengerCount = Math.max(1, Number(paxInput.value) || 1);
+    const results = searchFlights(origin, destination, departDate, cabin);
+    store.commit((booking) => {
+      booking.search = { origin, destination, departDate, passengerCount, cabin };
+      booking.results = results;
+    });
+  });
+
+  const searchBar = el("div", { className: "sk-search" }, [
+    el("div", { className: "sk-search-fields" }, [
+      originInput, el("span", { className: "sk-arrow", textContent: "→" }), destInput,
+      dateInput, paxInput, cabinSelect, searchButton,
+    ]),
+    datalist,
+  ]);
+
+  const resultsCol = el("section", { className: "sk-results", ariaLabel: "Flight results" });
+  const tripCol = el("section", { className: "sk-trip", ariaLabel: "Your trip" });
+
+  root.classList.add("sk-app");
+  root.append(searchBar, el("div", { className: "sk-columns" }, [resultsCol, tripCol]));
+
+  // --- renderers ------------------------------------------------------------
+
+  const flightCard = (f: Flight, selectedLeg: Leg | undefined): HTMLElement => {
+    const select = (leg: Leg) =>
+      el("button", {
+        className: "sk-btn sk-btn-ghost",
+        type: "button",
+        textContent: selectedLeg === leg ? `✓ ${leg}` : `Select ${leg}`,
+        onclick: () => {
+          store.commit((booking) => {
+            const prior = booking.selectedFlights[leg];
+            if (prior && prior.id !== f.id) {
+              booking.seatAssignments = booking.seatAssignments.filter((a) => a.flightId !== prior.id);
+            }
+            booking.selectedFlights[leg] = structuredClone(f);
+          });
+        },
+      });
+    return el("article", {
+      className: `sk-flight${selectedLeg ? " is-selected" : ""}`,
+      dataset: { flashKey: `flight:${f.id}` },
+    }, [
+      el("div", { className: "sk-flight-main" }, [
+        el("div", { className: "sk-flight-time" }, [`${f.departTime} → ${f.arriveTime}`]),
+        el("div", { className: "sk-flight-meta" }, [
+          `${f.carrier} ${f.flightNumber} · ${fmtDuration(f.durationMinutes)} · ${f.stops === 0 ? "nonstop" : `${f.stops} stop`}`,
+        ]),
+      ]),
+      el("div", { className: "sk-flight-side" }, [
+        el("div", { className: "sk-flight-price" }, [fmtMoney(f.price)]),
+        el("div", { className: "sk-flight-actions" }, [select("outbound"), select("return")]),
+      ]),
+    ]);
+  };
+
+  const renderResults = (): void => {
+    resultsCol.replaceChildren();
+    const { search, results } = store.booking;
+    resultsCol.append(
+      el("h2", { className: "sk-h", textContent: search
+        ? `${search.origin} → ${search.destination} · ${search.departDate} · ${search.cabin}`
+        : "Search to see flights" }),
+    );
+    if (!results.length) {
+      resultsCol.append(el("p", { className: "sk-empty", textContent: "No flights yet. Try a search above, or ask the Copilot." }));
+      return;
+    }
+    for (const f of results) resultsCol.append(flightCard(f, store.legOfFlight(f.id)));
+  };
+
+  const seatGrid = (flight: Flight): HTMLElement => {
+    const map = buildSeatMap(flight.id, flight.cabin);
+    const assignedSeats = new Set(
+      store.booking.seatAssignments.filter((a) => a.flightId === flight.id).map((a) => a.seat),
+    );
+    const header = el("div", { className: "sk-seat-row sk-seat-head" }, [
+      el("span", { className: "sk-seat-rownum" }, [""]),
+      ...map.columns.map((c, i) =>
+        el("span", { className: "sk-seat-col", title: map.columnTypes[i] }, [c]),
+      ),
+    ]);
+    const rows = map.rows.map((row) =>
+      el("div", { className: `sk-seat-row${row.exitRow ? " is-exit" : ""}` }, [
+        el("span", { className: "sk-seat-rownum" }, [String(row.row)]),
+        ...row.seats.map((seat) => {
+          const assigned = assignedSeats.has(seat.seat);
+          const cls = assigned
+            ? "is-assigned"
+            : seat.status === "taken"
+              ? "is-taken"
+              : "is-open";
+          return el("button", {
+            className: `sk-seat ${cls}`,
+            type: "button",
+            title: `${seat.seat} · ${seat.type}${seat.extraLegroom ? " · extra legroom" : ""}${seat.price ? ` · +$${seat.price}` : ""}`,
+            disabled: seat.status === "taken" && !assigned,
+            dataset: { flashKey: `seat:${flight.id}:${seat.seat}` },
+            textContent: seat.seat.replace(/^\d+/, ""),
+          });
+        }),
+      ]),
+    );
+    return el("div", { className: "sk-seatmap" }, [
+      el("div", { className: "sk-seatmap-title" }, [`${flight.flightNumber} · ${flight.cabin}`]),
+      header,
+      ...rows,
+    ]);
+  };
+
+  const renderTrip = (): void => {
+    tripCol.replaceChildren();
+    const { booking } = store;
+    const selected = store.selectedFlightList();
+
+    // Selected flights
+    const flightsBlock = el("div", { className: "sk-block" }, [el("h3", { className: "sk-h", textContent: "Trip" })]);
+    if (!selected.length) {
+      flightsBlock.append(el("p", { className: "sk-empty", textContent: "No flights selected yet." }));
+    } else {
+      for (const leg of ["outbound", "return"] as Leg[]) {
+        const f = booking.selectedFlights[leg];
+        if (!f) continue;
+        flightsBlock.append(
+          el("div", { className: "sk-trip-leg", dataset: { flashKey: `flight:${f.id}` } }, [
+            el("span", { className: "sk-tag", textContent: leg }),
+            `${f.flightNumber} ${f.origin}→${f.destination} ${f.departTime} · ${fmtMoney(f.price)}`,
+          ]),
+        );
+      }
+    }
+    tripCol.append(flightsBlock);
+
+    // Passengers
+    const paxBlock = el("div", { className: "sk-block" }, [el("h3", { className: "sk-h", textContent: `Passengers (${booking.passengers.length})` })]);
+    if (!booking.passengers.length) {
+      paxBlock.append(el("p", { className: "sk-empty", textContent: "Tell the Copilot who's flying." }));
+    } else {
+      for (const p of booking.passengers) {
+        const name = `${p.firstName} ${p.lastName}`.trim() || "(unnamed)";
+        const missing = !p.firstName || !p.lastName || !p.dateOfBirth;
+        paxBlock.append(
+          el("div", { className: `sk-pax${missing ? " is-incomplete" : ""}`, dataset: { flashKey: `passenger:${p.id}` } }, [
+            el("span", { className: "sk-pax-name", textContent: name }),
+            el("span", { className: "sk-pax-dob", textContent: p.dateOfBirth || "DOB needed" }),
+          ]),
+        );
+      }
+    }
+    tripCol.append(paxBlock);
+
+    // Seat maps for each selected flight
+    if (selected.length && booking.passengers.length) {
+      const seatsBlock = el("div", { className: "sk-block" }, [el("h3", { className: "sk-h", textContent: "Seats" })]);
+      for (const f of selected) seatsBlock.append(seatGrid(f));
+      tripCol.append(seatsBlock);
+    }
+
+    // Review / confirm
+    const total = store.totalPrice((a) => {
+      const f = store.findFlight(a.flightId);
+      return f ? findSeat(buildSeatMap(f.id, f.cabin), a.seat)?.price ?? 0 : 0;
+    });
+    const reviewBlock = el("div", { className: "sk-block sk-review", dataset: { flashKey: "confirmation" } }, [
+      el("div", { className: "sk-total" }, [el("span", { textContent: "Total" }), el("strong", { textContent: fmtMoney(total) })]),
+    ]);
+    if (booking.confirmation) {
+      reviewBlock.append(
+        el("div", { className: "sk-confirmed" }, [
+          `✓ Booked — ${booking.confirmation.recordLocator}`,
+        ]),
+      );
+    } else {
+      reviewBlock.append(el("p", { className: "sk-hint", textContent: "Ask the Copilot to book when you're ready." }));
+    }
+    tripCol.append(reviewBlock);
+  };
+
+  const render = (): void => {
+    renderResults();
+    renderTrip();
+  };
+
+  store.subscribe(render);
+  render();
+
+  // --- agent-touch flash ----------------------------------------------------
+  const flash = (keys: string[]): void => {
+    // Re-render already ran synchronously inside commit(), so nodes exist.
+    for (const key of keys) {
+      document.querySelectorAll(`[data-flash-key="${CSS.escape(key)}"]`).forEach((node) => {
+        node.classList.add("sk-agent-flash");
+        window.setTimeout(() => node.classList.remove("sk-agent-flash"), FLASH_MS);
+      });
+    }
+  };
+
+  return { flash };
+};

--- a/apps/web/src/webmcp-flights/catalog.ts
+++ b/apps/web/src/webmcp-flights/catalog.ts
@@ -1,0 +1,173 @@
+// Static, deterministic flight catalog + seat-map generator for the Skylark Air
+// demo. Nothing here calls a network or a clock with real fares — given the
+// same search (or the same flightId) it always returns the same flights and the
+// same taken seats, so demo prompts are reproducible.
+
+import type { Cabin, Flight, Seat, SeatMap, SeatRow, SeatType } from "./types";
+
+const CARRIERS: Array<{ name: string; code: string }> = [
+  { name: "Skylark Air", code: "SK" },
+  { name: "Meridian", code: "MR" },
+  { name: "Northwind", code: "NW" },
+];
+
+/** Cheap deterministic 32-bit hash so results are stable per input string. */
+const hash = (input: string): number => {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return h >>> 0;
+};
+
+/** Deterministic pseudo-random in [0, 1) seeded by a string. */
+const rand = (seed: string): number => (hash(seed) % 100000) / 100000;
+
+const CABIN_MULTIPLIER: Record<Cabin, number> = {
+  economy: 1,
+  premium: 1.8,
+  business: 3.2,
+};
+
+const pad = (n: number): string => String(n).padStart(2, "0");
+
+const minutesToTime = (mins: number): string => {
+  const m = ((mins % 1440) + 1440) % 1440;
+  return `${pad(Math.floor(m / 60))}:${pad(m % 60)}`;
+};
+
+/**
+ * Generate the flight options for one leg of a search. Deterministic in
+ * (origin, destination, date, cabin); returns 3–5 options sorted by departure.
+ */
+export const searchFlights = (
+  origin: string,
+  destination: string,
+  date: string,
+  cabin: Cabin,
+): Flight[] => {
+  const o = origin.toUpperCase();
+  const d = destination.toUpperCase();
+  const base = `${o}-${d}-${date}-${cabin}`;
+  const count = 3 + (hash(base) % 3); // 3..5
+  // A stable "distance" gives plausible, route-consistent durations & fares.
+  const distance = 60 + (hash(`${o}-${d}`) % 360); // 60..419 (×10 min)
+  const baseFare = 90 + (hash(`${o}-${d}-fare`) % 260); // 90..349
+
+  const flights: Flight[] = [];
+  for (let i = 0; i < count; i++) {
+    const seed = `${base}-${i}`;
+    const carrier = CARRIERS[hash(seed) % CARRIERS.length];
+    const departMins = 6 * 60 + Math.floor(rand(`${seed}-dep`) * 15 * 60); // 06:00..21:00
+    const durationMinutes = distance * 10 + Math.floor(rand(`${seed}-dur`) * 90);
+    const stops = rand(`${seed}-stops`) < 0.65 ? 0 : 1;
+    const fare = Math.round(
+      (baseFare + Math.floor(rand(`${seed}-price`) * 120) + (stops ? -40 : 30)) *
+        CABIN_MULTIPLIER[cabin],
+    );
+    flights.push({
+      id: `${carrier.code}${100 + (hash(seed) % 899)}-${date}`,
+      carrier: carrier.name,
+      flightNumber: `${carrier.code}${100 + (hash(seed) % 899)}`,
+      origin: o,
+      destination: d,
+      date,
+      departTime: minutesToTime(departMins),
+      arriveTime: minutesToTime(departMins + durationMinutes),
+      durationMinutes,
+      stops,
+      cabin,
+      price: fare,
+    });
+  }
+  return flights.sort((a, b) => a.departTime.localeCompare(b.departTime));
+};
+
+// ---------------------------------------------------------------------------
+// Seat maps
+
+type CabinLayout = {
+  columns: string[];
+  columnTypes: SeatType[];
+  firstRow: number;
+  lastRow: number;
+  /** 1-based row offsets (from firstRow) that are exit rows / extra legroom. */
+  exitRowOffsets: number[];
+  basePrice: number;
+};
+
+const LAYOUTS: Record<Cabin, CabinLayout> = {
+  business: {
+    columns: ["A", "C", "D", "F"],
+    columnTypes: ["window", "aisle", "aisle", "window"],
+    firstRow: 1,
+    lastRow: 5,
+    exitRowOffsets: [],
+    basePrice: 0,
+  },
+  premium: {
+    columns: ["A", "B", "C", "D", "E", "F"],
+    columnTypes: ["window", "middle", "aisle", "aisle", "middle", "window"],
+    firstRow: 6,
+    lastRow: 12,
+    exitRowOffsets: [0],
+    basePrice: 18,
+  },
+  economy: {
+    columns: ["A", "B", "C", "D", "E", "F"],
+    columnTypes: ["window", "middle", "aisle", "aisle", "middle", "window"],
+    firstRow: 14,
+    lastRow: 32,
+    // Rows 14 & 15 sit at the over-wing exits with extra legroom.
+    exitRowOffsets: [0, 1],
+    basePrice: 0,
+  },
+};
+
+/**
+ * Build the seat map for a flight. Taken seats are deterministic in the
+ * flightId so re-reading the map is stable across turns. Business rows and the
+ * exit rows carry extra legroom; window/aisle/middle come from column position.
+ */
+export const buildSeatMap = (flightId: string, cabin: Cabin): SeatMap => {
+  const layout = LAYOUTS[cabin];
+  const rows: SeatRow[] = [];
+  for (let r = layout.firstRow; r <= layout.lastRow; r++) {
+    const offset = r - layout.firstRow;
+    const isExit = layout.exitRowOffsets.includes(offset);
+    const extraLegroom = isExit || cabin === "business";
+    const seats: Seat[] = layout.columns.map((col, i) => {
+      const type = layout.columnTypes[i];
+      const taken = rand(`${flightId}-${r}${col}`) < 0.4;
+      const legroomSurcharge = extraLegroom ? 15 : 0;
+      const windowAisleSurcharge = type === "middle" ? 0 : 6;
+      return {
+        seat: `${r}${col}`,
+        status: taken ? "taken" : "available",
+        type,
+        exitRow: isExit,
+        extraLegroom,
+        price: layout.basePrice + legroomSurcharge + windowAisleSurcharge,
+      };
+    });
+    rows.push({ row: r, exitRow: isExit, extraLegroom, seats });
+  }
+  return {
+    flightId,
+    cabin,
+    columns: layout.columns,
+    columnTypes: layout.columnTypes,
+    rows,
+  };
+};
+
+/** Look up a single seat in a flight's map (or undefined if it doesn't exist). */
+export const findSeat = (map: SeatMap, seat: string): Seat | undefined => {
+  const target = seat.toUpperCase();
+  for (const row of map.rows) {
+    const found = row.seats.find((s) => s.seat === target);
+    if (found) return found;
+  }
+  return undefined;
+};

--- a/apps/web/src/webmcp-flights/main.ts
+++ b/apps/web/src/webmcp-flights/main.ts
@@ -1,0 +1,241 @@
+// WebMCP flight-booking demo ("Skylark Air") — a multi-step booking form the
+// embedded Persona widget and the human fill together through the page's WebMCP
+// tools. See tools.ts for the tool surface (search, select, passengers, seat
+// map, seat assignment, and the approval-gated confirm).
+import "@runtypelabs/persona/widget.css";
+import "./style.css";
+
+import {
+  DEFAULT_WIDGET_CONFIG,
+  createLocalStorageAdapter,
+  initAgentWidget,
+  markdownPostprocessor,
+} from "@runtypelabs/persona";
+// `@mcp-b/webmcp-polyfill` polyfills the strict standard surface on
+// `document.modelContext`; it must be initialized before tools register.
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+
+import { BookingStore } from "./store";
+import { createApp } from "./app";
+import { buildSeatMap, findSeat } from "./catalog";
+import {
+  APPROVAL_REQUIRED_TOOL_NAMES,
+  setupFlightTools,
+} from "./tools";
+
+initializeWebMCPPolyfill();
+
+const store = new BookingStore();
+
+const dockTarget = document.querySelector<HTMLElement>("#booking-dock-target");
+
+if (!dockTarget) {
+  console.warn("[Flights] Missing #booking-dock-target in webmcp-flights.html");
+} else {
+  const { flash } = createApp(store, dockTarget);
+  setupFlightTools(store, flash);
+
+  // Proxy mode, like the other example demos — the agent is defined in code as
+  // WEBMCP_FLIGHTS_FLOW (packages/proxy/src/flows/webmcp-flights.ts) and the
+  // local proxy mounts it at /api/chat/dispatch-flights (see
+  // examples/runtype-hono-proxy/src/app.ts). No hosted agent or client token needed.
+  const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
+  const proxyApiUrl = import.meta.env.VITE_PROXY_URL
+    ? `${import.meta.env.VITE_PROXY_URL}/api/chat/dispatch-flights`
+    : `http://localhost:${proxyPort}/api/chat/dispatch-flights`;
+
+  // User-facing summary copy for tool approval bubbles. Returning undefined
+  // falls back to Persona's humanized default ("The assistant wants to use …").
+  const describeFlightsApproval = ({
+    toolName,
+  }: {
+    toolName?: string;
+    parameters?: unknown;
+  }): string | undefined => {
+    const name = String(toolName ?? "").replace(/^webmcp[:_]/, "");
+    switch (name) {
+      case "confirm_booking": {
+        const total = store.totalPrice((a) => {
+          const f = store.findFlight(a.flightId);
+          return f ? findSeat(buildSeatMap(f.id, f.cabin), a.seat)?.price ?? 0 : 0;
+        });
+        const pax = store.booking.passengers.length;
+        return `Book this trip for ${pax} passenger${pax === 1 ? "" : "s"} — total $${total}? This finalizes the booking.`;
+      }
+      case "reset_booking":
+        return "Clear the entire booking and start over?";
+      default:
+        return undefined;
+    }
+  };
+
+  const skylarkTheme = {
+    semantic: {
+      colors: {
+        primary: "#0f1f3a",
+        accent: "#1d4ed8",
+        surface: "#ffffff",
+        background: "#ffffff",
+        container: "#eef2f8",
+        text: "#0f1f3a",
+        textMuted: "#5b6b86",
+        textInverse: "#ffffff",
+        border: "#d9e0ec",
+        divider: "#d9e0ec",
+      },
+    },
+    components: {
+      panel: { borderRadius: "0", border: "none", shadow: "none" },
+      header: {
+        borderRadius: "0",
+        background: "#ffffff",
+        titleForeground: "#0f1f3a",
+        subtitleForeground: "#5b6b86",
+        iconBackground: "#1d4ed8",
+        iconForeground: "#ffffff",
+        borderBottom: "1px solid #d9e0ec",
+      },
+      message: {
+        user: {
+          background: "#0f1f3a",
+          text: "#ffffff",
+          borderRadius: "16px",
+          shadow: "none",
+        },
+        assistant: {
+          background: "#eef2f8",
+          text: "#0f1f3a",
+          border: "#d9e0ec",
+          borderRadius: "16px",
+          shadow: "none",
+        },
+      },
+      approval: {
+        approve: {
+          background: "#1d4ed8",
+          foreground: "#ffffff",
+          border: "#1d4ed8",
+          borderRadius: "999px",
+        },
+        deny: {
+          background: "#ffffff",
+          foreground: "#b91c1c",
+          border: "#d9e0ec",
+          borderRadius: "999px",
+        },
+      },
+      toolBubble: { shadow: "none" },
+    },
+  };
+
+  const widget = initAgentWidget({
+    target: dockTarget,
+    useShadowDom: false,
+    config: {
+      ...DEFAULT_WIDGET_CONFIG,
+      apiUrl: proxyApiUrl,
+      storageAdapter: createLocalStorageAdapter("persona-state-webmcp-flights"),
+      postprocessMessage: ({ text }) => markdownPostprocessor(text),
+      colorScheme: "light",
+      theme: skylarkTheme,
+      copy: {
+        ...DEFAULT_WIDGET_CONFIG.copy,
+        welcomeTitle: "Ask the Skylark Copilot",
+        welcomeSubtitle:
+          "I search flights, fill passenger details, and pick seats by what you want — all through the page's WebMCP tools. I only book once you say so.",
+        inputPlaceholder: "Find a flight, add passengers, pick seats…",
+      },
+      suggestionChips: [
+        "Find a flight from SFO to JFK in two weeks for 2 people",
+        "Passengers are Jane Doe (1990-04-12) and John Doe (1988-09-30)",
+        "Put us in two window seats together near the front",
+        "What's left to do before we can book?",
+      ],
+      launcher: {
+        ...DEFAULT_WIDGET_CONFIG.launcher,
+        mountMode: "docked",
+        dock: {
+          side: "right",
+          width: "420px",
+          reveal: "emerge",
+          animate: true,
+        },
+        autoExpand: true,
+        mobileBreakpoint: 1080,
+        title: "Skylark Copilot",
+        subtitle: "Flight booking assistant",
+      },
+      webmcp: {
+        enabled: true,
+        // Reads and form fills auto-approve so the user can watch the Copilot
+        // build the booking; only the irreversible commit/reset confirm.
+        autoApprove: (info) => !APPROVAL_REQUIRED_TOOL_NAMES.has(info.toolName),
+      },
+      features: {
+        ...DEFAULT_WIDGET_CONFIG.features,
+        // Advertise the built-in ask_user_question tool so the Copilot can ask
+        // structured clarifying questions (answer-pill sheet) mid-task — e.g.
+        // "aisle or window?" when the traveler hasn't said.
+        askUserQuestion: { expose: true },
+      },
+      approval: {
+        ...DEFAULT_WIDGET_CONFIG.approval,
+        title: "Confirm with Skylark?",
+        approveLabel: "Book it",
+        denyLabel: "Not yet",
+        detailsDisplay: "collapsed",
+        formatDescription: describeFlightsApproval,
+      },
+      // Fresh booking state rides along with every message, so "book us in
+      // window seats" needs no extra read round-trip. The flow prompt
+      // interpolates {{booking_context}}.
+      contextProviders: [
+        () => ({
+          booking_context: JSON.stringify({
+            search: store.booking.search,
+            selectedFlights: {
+              outbound: store.booking.selectedFlights.outbound?.id ?? null,
+              return: store.booking.selectedFlights.return?.id ?? null,
+            },
+            resultCount: store.booking.results.length,
+            passengers: store.booking.passengers.map((p) => ({
+              id: p.id,
+              name: `${p.firstName} ${p.lastName}`.trim(),
+              hasDob: Boolean(p.dateOfBirth),
+            })),
+            seatAssignments: store.booking.seatAssignments,
+            confirmed: Boolean(store.booking.confirmation),
+          }),
+        }),
+      ],
+      // The provider's output lands in `payload.context`, but the proxy only
+      // forwards `inputs`/`metadata` to the flow. Move it into `inputs` so
+      // {{booking_context}} resolves in WEBMCP_FLIGHTS_FLOW's prompt.
+      requestMiddleware: ({ payload }) => {
+        const ctx = payload.context;
+        if (!ctx) return payload;
+        return {
+          ...payload,
+          inputs: { ...payload.inputs, ...ctx },
+          context: undefined,
+        };
+      },
+      statusIndicator: {
+        ...DEFAULT_WIDGET_CONFIG.statusIndicator,
+        visible: true,
+        idleText: "Copilot can make mistakes. Review your trip before booking.",
+        connectedText: "Copilot can make mistakes. Review your trip before booking.",
+        connectingText: "Connecting Skylark Copilot…",
+        errorText: "Skylark Copilot connection error",
+      },
+    },
+  });
+
+  window.personaFlightsWidget = widget;
+}
+
+declare global {
+  interface Window {
+    personaFlightsWidget?: unknown;
+  }
+}

--- a/apps/web/src/webmcp-flights/store.ts
+++ b/apps/web/src/webmcp-flights/store.ts
@@ -1,0 +1,149 @@
+import type {
+  Booking,
+  Flight,
+  Leg,
+  Passenger,
+  SeatAssignment,
+  SearchCriteria,
+} from "./types";
+
+const STORAGE_KEY = "persona-webmcp-flights-v1";
+const PERSIST_DEBOUNCE_MS = 400;
+
+const emptyBooking = (): Booking => ({
+  search: null,
+  results: [],
+  selectedFlights: {},
+  passengers: [],
+  seatAssignments: [],
+  confirmation: null,
+});
+
+/**
+ * Single source of truth for the booking, shared by human gestures and agent
+ * tools. Every mutation goes through `commit()`, so the page re-renders and
+ * persists identically whether the user or the Copilot made the change.
+ */
+export class BookingStore {
+  booking: Booking;
+
+  private listeners = new Set<(store: BookingStore) => void>();
+  private persistTimer: number | undefined;
+
+  constructor() {
+    this.booking = loadBooking() ?? emptyBooking();
+  }
+
+  subscribe(listener: (store: BookingStore) => void): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /** All mutations — human or agent — enter here. */
+  commit(mutate: (booking: Booking) => void): void {
+    const next = structuredClone(this.booking);
+    mutate(next);
+    this.booking = next;
+    this.afterChange();
+  }
+
+  reset(): void {
+    this.booking = emptyBooking();
+    this.afterChange();
+  }
+
+  // ---- lookups -------------------------------------------------------------
+
+  /** A flight by id from either the current results or the selected legs. */
+  findFlight(flightId: string): Flight | undefined {
+    if (this.booking.results.some((f) => f.id === flightId)) {
+      return this.booking.results.find((f) => f.id === flightId);
+    }
+    return Object.values(this.booking.selectedFlights).find(
+      (f) => f?.id === flightId,
+    );
+  }
+
+  /** Every flight that is part of the trip (selected outbound/return). */
+  selectedFlightList(): Flight[] {
+    const { outbound, return: ret } = this.booking.selectedFlights;
+    return [outbound, ret].filter((f): f is Flight => Boolean(f));
+  }
+
+  legOfFlight(flightId: string): Leg | undefined {
+    const { outbound, return: ret } = this.booking.selectedFlights;
+    if (outbound?.id === flightId) return "outbound";
+    if (ret?.id === flightId) return "return";
+    return undefined;
+  }
+
+  findPassenger(passengerId: string): Passenger | undefined {
+    return this.booking.passengers.find((p) => p.id === passengerId);
+  }
+
+  seatFor(flightId: string, passengerId: string): SeatAssignment | undefined {
+    return this.booking.seatAssignments.find(
+      (a) => a.flightId === flightId && a.passengerId === passengerId,
+    );
+  }
+
+  /** Total fare across selected flights × passengers, plus seat surcharges. */
+  totalPrice(seatSurcharge: (a: SeatAssignment) => number): number {
+    const paxCount = Math.max(this.booking.passengers.length, 1);
+    const fares = this.selectedFlightList().reduce(
+      (sum, f) => sum + f.price * paxCount,
+      0,
+    );
+    const seats = this.booking.seatAssignments.reduce(
+      (sum, a) => sum + seatSurcharge(a),
+      0,
+    );
+    return fares + seats;
+  }
+
+  // ---- internals -----------------------------------------------------------
+
+  private afterChange(): void {
+    this.schedulePersist();
+    this.notify();
+  }
+
+  private notify(): void {
+    this.listeners.forEach((listener) => listener(this));
+  }
+
+  private schedulePersist(): void {
+    window.clearTimeout(this.persistTimer);
+    this.persistTimer = window.setTimeout(() => {
+      try {
+        window.localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify(this.booking),
+        );
+      } catch {
+        // Storage may be unavailable (private mode, quota) — demo keeps working.
+      }
+    }, PERSIST_DEBOUNCE_MS);
+  }
+}
+
+const loadBooking = (): Booking | null => {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<Booking>;
+    if (!parsed || typeof parsed !== "object") return null;
+    return {
+      ...emptyBooking(),
+      ...parsed,
+      selectedFlights: parsed.selectedFlights ?? {},
+      results: parsed.results ?? [],
+      passengers: parsed.passengers ?? [],
+      seatAssignments: parsed.seatAssignments ?? [],
+    };
+  } catch {
+    return null;
+  }
+};
+
+export type { SearchCriteria };

--- a/apps/web/src/webmcp-flights/style.css
+++ b/apps/web/src/webmcp-flights/style.css
@@ -1,0 +1,410 @@
+/* Skylark Air — WebMCP flight-booking demo page chrome.
+   The Copilot and the on-page controls drive the same BookingStore, so the UI
+   renders identically whoever made the change. */
+
+:root {
+  --sk-chrome-bg: #eef2f8;
+  --sk-surface: #ffffff;
+  --sk-border: #d9e0ec;
+  --sk-text: #0f1f3a;
+  --sk-text-muted: #5b6b86;
+  --sk-accent: #1d4ed8;
+  --sk-accent-soft: #e8efff;
+  --sk-agent: #1d4ed8;
+  --sk-ok: #047857;
+  --sk-warn: #b45309;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body.sk-body {
+  margin: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: var(--sk-chrome-bg);
+  color: var(--sk-text);
+  font-family: Inter, "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+/* ---- toolbar ---- */
+
+.sk-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  background: var(--sk-surface);
+  border-bottom: 1px solid var(--sk-border);
+  flex: 0 0 auto;
+}
+
+.sk-logo {
+  font-weight: 800;
+  font-size: 18px;
+  letter-spacing: -0.02em;
+}
+
+.sk-logo span {
+  color: var(--sk-accent);
+}
+
+.sk-badge {
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--sk-accent);
+  background: var(--sk-accent-soft);
+  padding: 3px 8px;
+  border-radius: 999px;
+}
+
+/* ---- main / dock layout ---- */
+
+.sk-main {
+  flex: 1;
+  display: flex;
+  min-height: 0;
+}
+
+/* Persona's docked mount wraps #booking-dock-target in a generated
+   [data-persona-host-layout="docked"] flex row and docks the panel beside it —
+   the page shrinks to make room (same pattern as webmcp-slides). */
+.sk-app {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 16px;
+  gap: 14px;
+}
+
+[data-persona-host-layout="docked"] {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  border: none;
+}
+
+/* ---- search bar ---- */
+
+.sk-search-fields {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+  background: var(--sk-surface);
+  border: 1px solid var(--sk-border);
+  border-radius: 14px;
+  padding: 10px 12px;
+}
+
+.sk-field {
+  height: 36px;
+  padding: 0 10px;
+  border: 1px solid var(--sk-border);
+  border-radius: 8px;
+  font: inherit;
+  font-size: 14px;
+  color: var(--sk-text);
+  background: #fff;
+  min-width: 88px;
+}
+
+.sk-field-num {
+  width: 64px;
+  min-width: 0;
+}
+
+.sk-arrow {
+  color: var(--sk-text-muted);
+  font-size: 16px;
+}
+
+/* ---- columns ---- */
+
+.sk-columns {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+@media (max-width: 720px) {
+  .sk-columns {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sk-results,
+.sk-trip {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sk-h {
+  margin: 4px 0;
+  font-size: 13px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--sk-text-muted);
+}
+
+.sk-empty,
+.sk-hint {
+  margin: 0;
+  font-size: 13px;
+  color: var(--sk-text-muted);
+}
+
+/* ---- flight cards ---- */
+
+.sk-flight {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  background: var(--sk-surface);
+  border: 1px solid var(--sk-border);
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+.sk-flight.is-selected {
+  border-color: var(--sk-accent);
+  box-shadow: 0 0 0 1px var(--sk-accent) inset;
+}
+
+.sk-flight-time {
+  font-weight: 700;
+  font-size: 15px;
+}
+
+.sk-flight-meta {
+  font-size: 12px;
+  color: var(--sk-text-muted);
+  margin-top: 2px;
+}
+
+.sk-flight-side {
+  text-align: right;
+}
+
+.sk-flight-price {
+  font-weight: 800;
+  font-size: 16px;
+}
+
+.sk-flight-actions {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+/* ---- buttons ---- */
+
+.sk-btn {
+  font: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  border-radius: 8px;
+  padding: 6px 12px;
+  cursor: pointer;
+  border: 1px solid var(--sk-border);
+  background: #fff;
+  color: var(--sk-text);
+}
+
+.sk-btn-primary {
+  background: var(--sk-accent);
+  border-color: var(--sk-accent);
+  color: #fff;
+}
+
+.sk-btn-ghost {
+  padding: 5px 9px;
+  font-size: 12px;
+}
+
+.sk-btn-ghost:hover {
+  border-color: var(--sk-accent);
+  color: var(--sk-accent);
+}
+
+/* ---- trip blocks ---- */
+
+.sk-block {
+  background: var(--sk-surface);
+  border: 1px solid var(--sk-border);
+  border-radius: 12px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sk-trip-leg {
+  font-size: 13px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sk-tag {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--sk-accent);
+  background: var(--sk-accent-soft);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.sk-pax {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 13px;
+  padding: 6px 8px;
+  border-radius: 8px;
+  background: var(--sk-chrome-bg);
+}
+
+.sk-pax.is-incomplete {
+  background: #fff7ed;
+  color: var(--sk-warn);
+}
+
+.sk-pax-dob {
+  color: var(--sk-text-muted);
+  font-size: 12px;
+}
+
+/* ---- seat map ---- */
+
+.sk-seatmap {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sk-seatmap-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--sk-text-muted);
+  margin-bottom: 2px;
+}
+
+.sk-seat-row {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+
+.sk-seat-row.is-exit {
+  padding-bottom: 4px;
+  border-bottom: 1px dashed var(--sk-warn);
+}
+
+.sk-seat-head .sk-seat-col {
+  width: 26px;
+  text-align: center;
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--sk-text-muted);
+}
+
+.sk-seat-rownum {
+  width: 22px;
+  text-align: right;
+  font-size: 11px;
+  color: var(--sk-text-muted);
+  padding-right: 2px;
+}
+
+.sk-seat {
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  border: 1px solid var(--sk-border);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: default;
+  padding: 0;
+}
+
+.sk-seat.is-open {
+  background: #fff;
+  border-color: #b9c6dd;
+  color: var(--sk-text-muted);
+}
+
+.sk-seat.is-taken {
+  background: #e2e8f0;
+  color: #aab6c8;
+  border-color: #e2e8f0;
+}
+
+.sk-seat.is-assigned {
+  background: var(--sk-accent);
+  border-color: var(--sk-accent);
+  color: #fff;
+}
+
+/* ---- review ---- */
+
+.sk-total {
+  display: flex;
+  justify-content: space-between;
+  font-size: 15px;
+}
+
+.sk-total strong {
+  font-size: 18px;
+}
+
+.sk-confirmed {
+  font-weight: 700;
+  color: var(--sk-ok);
+}
+
+/* ---- agent-touch flash ---- */
+
+@keyframes sk-agent-pulse {
+  0% {
+    outline-color: rgba(29, 78, 216, 0.9);
+    outline-offset: 1px;
+  }
+  100% {
+    outline-color: rgba(29, 78, 216, 0);
+    outline-offset: 6px;
+  }
+}
+
+.sk-agent-flash {
+  outline: 3px solid rgba(29, 78, 216, 0.9);
+  animation: sk-agent-pulse 1.2s ease-out forwards;
+  border-radius: 8px;
+}
+
+/* ---- footer ---- */
+
+.sk-footer {
+  flex: 0 0 auto;
+  padding: 8px 18px;
+  font-size: 12px;
+  color: var(--sk-text-muted);
+  background: var(--sk-surface);
+  border-top: 1px solid var(--sk-border);
+}

--- a/apps/web/src/webmcp-flights/tools.ts
+++ b/apps/web/src/webmcp-flights/tools.ts
@@ -1,0 +1,534 @@
+import type { BookingStore } from "./store";
+import type {
+  Cabin,
+  Flight,
+  Leg,
+  Passenger,
+  SeatAssignment,
+} from "./types";
+import { CABINS, makeId } from "./types";
+import { buildSeatMap, findSeat, searchFlights } from "./catalog";
+
+// WebMCP tool surface for the Skylark Air booking demo. The page registers
+// these on document.modelContext; the Persona widget snapshots them every turn
+// and forwards them as clientTools[], so the in-code WEBMCP_FLIGHTS_FLOW drives
+// them and the widget executes them here, on the page.
+//
+// Every tool returns structured JSON (the ids/seats it touched) so the model
+// can chain calls without re-reading state. Reads + ordinary form fills
+// auto-approve; only the irreversible commit (confirm_booking) and reset raise
+// Persona's approval bubble — see the sets below + main.ts's autoApprove.
+
+const OWNER = "__webmcpFlightsAbort";
+
+declare global {
+  interface Window {
+    [OWNER]?: AbortController;
+  }
+}
+
+// Only the irreversible / destructive tools confirm; everything else
+// auto-approves so the user can watch the Copilot fill the form live.
+export const APPROVAL_REQUIRED_TOOL_NAMES = new Set([
+  "confirm_booking",
+  "reset_booking",
+]);
+
+export const READ_ONLY_TOOL_NAMES = new Set([
+  "get_booking_state",
+  "search_flights",
+  "get_seat_map",
+]);
+
+type ToolDescriptor = {
+  name: string;
+  title?: string;
+  description: string;
+  inputSchema: object;
+  annotations?: Record<string, unknown>;
+  execute: (args: Record<string, unknown>) => unknown | Promise<unknown>;
+};
+
+type RegisterableModelContext = {
+  registerTool: (
+    tool: ToolDescriptor & { annotations?: Record<string, unknown> },
+    options?: { signal?: AbortSignal },
+  ) => void;
+};
+
+const getModelContext = (): RegisterableModelContext | undefined =>
+  (document as unknown as { modelContext?: RegisterableModelContext })
+    .modelContext ??
+  (navigator as unknown as { modelContext?: RegisterableModelContext })
+    .modelContext;
+
+const toolResult = (data: unknown, summary?: string): unknown => ({
+  content: [
+    {
+      type: "text",
+      text: `${summary ? `${summary}\n\n` : ""}${JSON.stringify(data, null, 2)}`,
+    },
+  ],
+  structuredContent: data,
+});
+
+const registerTool = (
+  modelContext: RegisterableModelContext,
+  tool: ToolDescriptor,
+  signal: AbortSignal,
+): void => {
+  try {
+    // The WebMCP spec carries the display title on the descriptor, but the
+    // current @mcp-b SDK only surfaces annotations.title to consumers (Persona
+    // approval bubbles, Chrome DevTools MCP) — mirror it there.
+    const descriptor = tool.title
+      ? { ...tool, annotations: { title: tool.title, ...tool.annotations } }
+      : tool;
+    modelContext.registerTool(descriptor, { signal });
+  } catch (error) {
+    console.warn(`[Flights] Failed to register ${tool.name}`, error);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// Serialization + pricing helpers
+
+const seatSurcharge = (store: BookingStore) => (a: SeatAssignment): number => {
+  const flight = store.findFlight(a.flightId);
+  if (!flight) return 0;
+  const seat = findSeat(buildSeatMap(flight.id, flight.cabin), a.seat);
+  return seat?.price ?? 0;
+};
+
+const passengerIsComplete = (p: Passenger): boolean =>
+  Boolean(p.firstName?.trim() && p.lastName?.trim() && p.dateOfBirth?.trim());
+
+const publicFlight = (f: Flight): Record<string, unknown> => ({
+  id: f.id,
+  carrier: f.carrier,
+  flightNumber: f.flightNumber,
+  route: `${f.origin}→${f.destination}`,
+  date: f.date,
+  depart: f.departTime,
+  arrive: f.arriveTime,
+  durationMinutes: f.durationMinutes,
+  stops: f.stops,
+  cabin: f.cabin,
+  price: f.price,
+});
+
+const bookingSnapshot = (store: BookingStore): Record<string, unknown> => {
+  const { booking } = store;
+  return {
+    search: booking.search,
+    selectedFlights: {
+      outbound: booking.selectedFlights.outbound
+        ? publicFlight(booking.selectedFlights.outbound)
+        : null,
+      return: booking.selectedFlights.return
+        ? publicFlight(booking.selectedFlights.return)
+        : null,
+    },
+    passengers: booking.passengers.map((p) => ({
+      id: p.id,
+      firstName: p.firstName,
+      lastName: p.lastName,
+      dateOfBirth: p.dateOfBirth,
+      complete: passengerIsComplete(p),
+    })),
+    seatAssignments: booking.seatAssignments,
+    totalPrice: store.totalPrice(seatSurcharge(store)),
+    confirmation: booking.confirmation,
+  };
+};
+
+const normalizeCabin = (value: unknown, fallback: Cabin): Cabin =>
+  CABINS.includes(value as Cabin) ? (value as Cabin) : fallback;
+
+// ---------------------------------------------------------------------------
+// Tool definitions
+
+const buildTools = (
+  store: BookingStore,
+  flash: (keys: string[]) => void,
+): ToolDescriptor[] => [
+  {
+    name: "get_booking_state",
+    title: "Read the booking",
+    description:
+      "Read the whole trip: search criteria, selected outbound/return flights, passengers (with whether each has all required details), seat assignments, the running price total, and any confirmation. The same state rides along every turn as booking_context, so call this only when you need a fresh read after several changes.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute() {
+      return toolResult(bookingSnapshot(store));
+    },
+  },
+  {
+    name: "search_flights",
+    title: "Search flights",
+    description:
+      "Search the catalog for one leg and store the results (also sets the trip's search criteria). Returns flight options with id, times, duration, stops, cabin, and per-passenger price. Always search before selecting a flight — never invent flight ids, times, or fares.",
+    inputSchema: {
+      type: "object",
+      required: ["origin", "destination", "departDate"],
+      properties: {
+        origin: { type: "string", description: "Origin airport code, e.g. 'SFO'." },
+        destination: { type: "string", description: "Destination airport code, e.g. 'JFK'." },
+        departDate: { type: "string", description: "Outbound date, ISO 'YYYY-MM-DD'." },
+        returnDate: {
+          type: "string",
+          description: "Optional return date, ISO 'YYYY-MM-DD'. Must be on or after departDate.",
+        },
+        passengers: { type: "number", description: "Number of passengers (default 1)." },
+        cabin: { type: "string", enum: ["economy", "premium", "business"] },
+      },
+    },
+    execute(args) {
+      const origin = String(args.origin ?? "").trim().toUpperCase();
+      const destination = String(args.destination ?? "").trim().toUpperCase();
+      const departDate = String(args.departDate ?? "").trim();
+      const returnDate =
+        typeof args.returnDate === "string" && args.returnDate.trim()
+          ? args.returnDate.trim()
+          : undefined;
+      if (!origin || !destination) throw new Error("origin and destination are required.");
+      if (origin === destination) throw new Error("origin and destination must differ.");
+      if (!departDate) throw new Error("departDate is required (ISO YYYY-MM-DD).");
+      if (returnDate && returnDate < departDate) {
+        throw new Error(
+          `returnDate (${returnDate}) is before departDate (${departDate}). The return must be on or after the outbound date.`,
+        );
+      }
+      const passengerCount =
+        typeof args.passengers === "number" && args.passengers > 0
+          ? Math.floor(args.passengers)
+          : store.booking.search?.passengerCount ?? 1;
+      const cabin = normalizeCabin(args.cabin, store.booking.search?.cabin ?? "economy");
+
+      const results = searchFlights(origin, destination, departDate, cabin);
+      store.commit((booking) => {
+        booking.search = { origin, destination, departDate, returnDate, passengerCount, cabin };
+        booking.results = results;
+      });
+      return toolResult(
+        { count: results.length, cabin, flights: results.map(publicFlight) },
+        `Found ${results.length} ${cabin} flights ${origin}→${destination} on ${departDate}.`,
+      );
+    },
+  },
+  {
+    name: "get_seat_map",
+    title: "Read a seat map",
+    description:
+      "Read a flight's seat map as a grid. `columns` + `columnTypes` are the spatial legend (window seats are the first & last columns; aisle seats border the middle gap). Each row object has its absolute `row` number (lower = nearer the front) and a `seats` array in left-to-right column order, so seats next to each other in the array are physically adjacent. Each seat carries its own type, exitRow, extraLegroom, status, and surcharge. Use this to pick seats by human description (e.g. 'two windows together near the front with extra legroom').",
+    inputSchema: {
+      type: "object",
+      required: ["flightId"],
+      properties: {
+        flightId: { type: "string", description: "A selected flight's id." },
+      },
+    },
+    annotations: { readOnlyHint: true },
+    execute(args) {
+      const flightId = String(args.flightId ?? "");
+      const flight = store.findFlight(flightId);
+      if (!flight) {
+        throw new Error(
+          `No flight "${flightId}". Search and select a flight first, then read its seat map.`,
+        );
+      }
+      const map = buildSeatMap(flight.id, flight.cabin);
+      const available = map.rows.reduce(
+        (n, r) => n + r.seats.filter((s) => s.status === "available").length,
+        0,
+      );
+      return toolResult(
+        map,
+        `Seat map for ${flight.flightNumber} (${flight.cabin}): ${available} seats available.`,
+      );
+    },
+  },
+  {
+    name: "select_flight",
+    title: "Select a flight",
+    description:
+      "Add a flight to the trip as the outbound or return leg. The flight id must come from a search_flights result. Selecting a leg replaces any prior choice for that leg (and clears seats assigned on the replaced flight).",
+    inputSchema: {
+      type: "object",
+      required: ["flightId", "leg"],
+      properties: {
+        flightId: { type: "string", description: "A flight id from search_flights." },
+        leg: { type: "string", enum: ["outbound", "return"] },
+      },
+    },
+    execute(args) {
+      const flightId = String(args.flightId ?? "");
+      const leg = String(args.leg ?? "") as Leg;
+      if (leg !== "outbound" && leg !== "return") {
+        throw new Error("leg must be 'outbound' or 'return'.");
+      }
+      const flight = store.booking.results.find((f) => f.id === flightId);
+      if (!flight) {
+        throw new Error(
+          `No flight "${flightId}" in the latest search results. Call search_flights first.`,
+        );
+      }
+      store.commit((booking) => {
+        const prior = booking.selectedFlights[leg];
+        if (prior && prior.id !== flight.id) {
+          booking.seatAssignments = booking.seatAssignments.filter(
+            (a) => a.flightId !== prior.id,
+          );
+        }
+        booking.selectedFlights[leg] = structuredClone(flight);
+      });
+      flash([`flight:${flight.id}`]);
+      return toolResult(
+        { leg, flight: publicFlight(flight) },
+        `Selected ${flight.flightNumber} as the ${leg} flight.`,
+      );
+    },
+  },
+  {
+    name: "set_passengers",
+    title: "Set the passenger list",
+    description:
+      "Replace the whole passenger list. Each passenger needs firstName, lastName, and dateOfBirth (ISO YYYY-MM-DD). Returns the passengers with their assigned ids — use those ids for assign_seat and update_passenger.",
+    inputSchema: {
+      type: "object",
+      required: ["passengers"],
+      properties: {
+        passengers: {
+          type: "array",
+          minItems: 1,
+          items: {
+            type: "object",
+            required: ["firstName", "lastName"],
+            properties: {
+              firstName: { type: "string" },
+              lastName: { type: "string" },
+              dateOfBirth: { type: "string", description: "ISO YYYY-MM-DD." },
+            },
+          },
+        },
+      },
+    },
+    execute(args) {
+      const list = Array.isArray(args.passengers) ? args.passengers : [];
+      if (!list.length) throw new Error("Provide at least one passenger.");
+      const passengers: Passenger[] = list.map((raw) => {
+        const p = (raw ?? {}) as Record<string, unknown>;
+        return {
+          id: makeId("pax"),
+          firstName: String(p.firstName ?? "").trim(),
+          lastName: String(p.lastName ?? "").trim(),
+          dateOfBirth: String(p.dateOfBirth ?? "").trim(),
+        };
+      });
+      store.commit((booking) => {
+        booking.passengers = passengers;
+        // Passenger ids changed, so prior seat assignments no longer resolve.
+        booking.seatAssignments = [];
+      });
+      flash(passengers.map((p) => `passenger:${p.id}`));
+      return toolResult(
+        {
+          passengers: passengers.map((p) => ({
+            id: p.id,
+            firstName: p.firstName,
+            lastName: p.lastName,
+            dateOfBirth: p.dateOfBirth || null,
+            complete: passengerIsComplete(p),
+          })),
+        },
+        `Set ${passengers.length} passenger(s).`,
+      );
+    },
+  },
+  {
+    name: "update_passenger",
+    title: "Update a passenger",
+    description:
+      "Patch one passenger's details (e.g. fill in a missing date of birth or fix a name). Identify the passenger by passengerId or 1-based index. Omitted fields are unchanged.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        passengerId: { type: "string" },
+        index: { type: "number", description: "1-based passenger index (alternative to passengerId)." },
+        firstName: { type: "string" },
+        lastName: { type: "string" },
+        dateOfBirth: { type: "string", description: "ISO YYYY-MM-DD." },
+      },
+    },
+    execute(args) {
+      const { passengers } = store.booking;
+      let passenger: Passenger | undefined;
+      if (typeof args.passengerId === "string" && args.passengerId) {
+        passenger = passengers.find((p) => p.id === args.passengerId);
+      } else if (typeof args.index === "number") {
+        passenger = passengers[Math.floor(args.index) - 1];
+      }
+      if (!passenger) {
+        throw new Error(
+          "No matching passenger. Pass a valid passengerId or 1-based index, or call set_passengers first.",
+        );
+      }
+      const targetId = passenger.id;
+      store.commit((booking) => {
+        const p = booking.passengers.find((x) => x.id === targetId);
+        if (!p) return;
+        if (typeof args.firstName === "string") p.firstName = args.firstName.trim();
+        if (typeof args.lastName === "string") p.lastName = args.lastName.trim();
+        if (typeof args.dateOfBirth === "string") p.dateOfBirth = args.dateOfBirth.trim();
+      });
+      flash([`passenger:${targetId}`]);
+      const fresh = store.findPassenger(targetId);
+      return toolResult({
+        passenger: fresh && {
+          id: fresh.id,
+          firstName: fresh.firstName,
+          lastName: fresh.lastName,
+          dateOfBirth: fresh.dateOfBirth || null,
+          complete: passengerIsComplete(fresh),
+        },
+      });
+    },
+  },
+  {
+    name: "assign_seat",
+    title: "Assign a seat",
+    description:
+      "Assign one seat to one passenger on a selected flight. The seat must exist in that flight's seat map and be available; a passenger can hold only one seat per flight, and a seat can't be given to two passengers. Read get_seat_map first to choose a real, available seat.",
+    inputSchema: {
+      type: "object",
+      required: ["flightId", "passengerId", "seat"],
+      properties: {
+        flightId: { type: "string", description: "A selected flight's id." },
+        passengerId: { type: "string", description: "A passenger id from set_passengers." },
+        seat: { type: "string", description: "Seat number, e.g. '14A'." },
+      },
+    },
+    execute(args) {
+      const flightId = String(args.flightId ?? "");
+      const passengerId = String(args.passengerId ?? "");
+      const seat = String(args.seat ?? "").trim().toUpperCase();
+      const flight = store.findFlight(flightId);
+      if (!flight || !store.legOfFlight(flightId)) {
+        throw new Error(`Flight "${flightId}" isn't selected for this trip. Select it first.`);
+      }
+      const passenger = store.findPassenger(passengerId);
+      if (!passenger) {
+        throw new Error(`No passenger "${passengerId}". Call set_passengers first.`);
+      }
+      const map = buildSeatMap(flight.id, flight.cabin);
+      const seatInfo = findSeat(map, seat);
+      if (!seatInfo) {
+        throw new Error(`Seat "${seat}" doesn't exist on ${flight.flightNumber}. Read get_seat_map.`);
+      }
+      if (seatInfo.status === "taken") {
+        throw new Error(`Seat ${seat} on ${flight.flightNumber} is already taken. Pick an available seat.`);
+      }
+      const clash = store.booking.seatAssignments.find(
+        (a) => a.flightId === flightId && a.seat === seat && a.passengerId !== passengerId,
+      );
+      if (clash) {
+        throw new Error(`Seat ${seat} is already assigned to another passenger on this flight.`);
+      }
+      store.commit((booking) => {
+        booking.seatAssignments = booking.seatAssignments.filter(
+          (a) => !(a.flightId === flightId && a.passengerId === passengerId),
+        );
+        booking.seatAssignments.push({ flightId, passengerId, seat });
+      });
+      flash([`seat:${flightId}:${seat}`, `passenger:${passengerId}`]);
+      return toolResult(
+        {
+          flightId,
+          passengerId,
+          seat,
+          type: seatInfo.type,
+          extraLegroom: seatInfo.extraLegroom,
+          surcharge: seatInfo.price,
+        },
+        `Assigned seat ${seat} (${seatInfo.type}${seatInfo.extraLegroom ? ", extra legroom" : ""}) to ${passenger.firstName || "passenger"}.`,
+      );
+    },
+  },
+  {
+    name: "confirm_booking",
+    title: "Confirm and book the trip",
+    description:
+      "Finalize the booking. This is the irreversible commit — only call it when the traveler has explicitly said to book. It validates that an outbound flight is selected, every passenger has all required details, and every passenger has a seat on every selected flight; it relays any problem instead of booking. Returns a record locator on success.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { destructiveHint: true },
+    execute() {
+      const { booking } = store;
+      const problems: string[] = [];
+      if (!booking.selectedFlights.outbound) problems.push("no outbound flight is selected");
+      if (!booking.passengers.length) problems.push("there are no passengers");
+      const incomplete = booking.passengers.filter((p) => !passengerIsComplete(p));
+      if (incomplete.length) {
+        problems.push(
+          `${incomplete.length} passenger(s) are missing a name or date of birth`,
+        );
+      }
+      for (const flight of store.selectedFlightList()) {
+        const seated = booking.seatAssignments.filter((a) => a.flightId === flight.id).length;
+        if (seated < booking.passengers.length) {
+          problems.push(
+            `${booking.passengers.length - seated} passenger(s) still need a seat on ${flight.flightNumber}`,
+          );
+        }
+      }
+      if (problems.length) {
+        throw new Error(`Can't confirm yet: ${problems.join("; ")}.`);
+      }
+      const total = store.totalPrice(seatSurcharge(store));
+      const recordLocator = makeId("SKY").slice(-6).toUpperCase();
+      store.commit((b) => {
+        b.confirmation = {
+          recordLocator,
+          bookedAt: new Date().toISOString(),
+          totalPrice: total,
+        };
+      });
+      flash(["confirmation"]);
+      return toolResult(
+        { recordLocator, totalPrice: total, passengers: booking.passengers.length },
+        `Booked! Record locator ${recordLocator}, total $${total}.`,
+      );
+    },
+  },
+  {
+    name: "reset_booking",
+    title: "Start over",
+    description: "Clear the entire booking — search, flights, passengers, seats, and any confirmation.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { destructiveHint: true },
+    execute() {
+      store.reset();
+      return toolResult({ ok: true }, "Cleared the booking.");
+    },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Registration
+
+export const setupFlightTools = (
+  store: BookingStore,
+  flash: (keys: string[]) => void,
+): boolean => {
+  const modelContext = getModelContext();
+  if (!modelContext?.registerTool) {
+    console.warn("[Flights] WebMCP unavailable — no modelContext found on this page.");
+    return false;
+  }
+  window[OWNER]?.abort?.();
+  const controller = new AbortController();
+  window[OWNER] = controller;
+  for (const tool of buildTools(store, flash)) {
+    registerTool(modelContext, tool, controller.signal);
+  }
+  return true;
+};

--- a/apps/web/src/webmcp-flights/types.ts
+++ b/apps/web/src/webmcp-flights/types.ts
@@ -1,0 +1,116 @@
+// Data model for the WebMCP flight-booking demo ("Skylark Air"). The booking
+// is a multi-step form: search criteria → selected flights → passengers →
+// seat assignments → confirmation. Every field is filled by either a human
+// gesture or an agent tool, through the same BookingStore.
+
+export type Cabin = "economy" | "premium" | "business";
+
+export type Flight = {
+  id: string;
+  carrier: string;
+  flightNumber: string;
+  origin: string;
+  destination: string;
+  /** ISO date, e.g. "2026-06-19". */
+  date: string;
+  /** Local 24h time, e.g. "08:15". */
+  departTime: string;
+  arriveTime: string;
+  /** Whole minutes. */
+  durationMinutes: number;
+  stops: number;
+  cabin: Cabin;
+  /** Base fare per passenger, USD. */
+  price: number;
+};
+
+export type Leg = "outbound" | "return";
+
+export type Passenger = {
+  id: string;
+  firstName: string;
+  lastName: string;
+  /** ISO date of birth, e.g. "1990-04-12". */
+  dateOfBirth: string;
+};
+
+export type SeatType = "window" | "middle" | "aisle";
+export type SeatStatus = "available" | "taken";
+
+export type Seat = {
+  /** e.g. "14A". */
+  seat: string;
+  status: SeatStatus;
+  type: SeatType;
+  exitRow: boolean;
+  extraLegroom: boolean;
+  /** Seat surcharge on top of the fare, USD. */
+  price: number;
+};
+
+export type SeatRow = {
+  row: number;
+  exitRow: boolean;
+  extraLegroom: boolean;
+  seats: Seat[];
+};
+
+/**
+ * Seat map shaped as a grid (rows × columns) so the agent can reason about
+ * human seat concepts directly from the data layout: `columnTypes` is the
+ * spatial legend (window seats are the first/last columns), each cell repeats
+ * its own type/legroom/status so it is self-describing, adjacency is the row
+ * array order, and "near the front" is ascending `row`.
+ */
+export type SeatMap = {
+  flightId: string;
+  cabin: Cabin;
+  columns: string[];
+  columnTypes: SeatType[];
+  rows: SeatRow[];
+};
+
+/** A finalized seat choice for one passenger on one flight. */
+export type SeatAssignment = {
+  flightId: string;
+  passengerId: string;
+  seat: string;
+};
+
+export type SearchCriteria = {
+  origin: string;
+  destination: string;
+  departDate: string;
+  returnDate?: string;
+  passengerCount: number;
+  cabin: Cabin;
+};
+
+export type Confirmation = {
+  recordLocator: string;
+  bookedAt: string;
+  totalPrice: number;
+};
+
+export type Booking = {
+  search: SearchCriteria | null;
+  /** Last search's results, kept so the UI can render the options list. */
+  results: Flight[];
+  selectedFlights: Partial<Record<Leg, Flight>>;
+  passengers: Passenger[];
+  seatAssignments: SeatAssignment[];
+  confirmation: Confirmation | null;
+};
+
+let idCounter = 0;
+
+/** Short unique id, readable in tool output (e.g. "pax-kf3a9x-7"). */
+export const makeId = (prefix: string): string =>
+  `${prefix}-${Date.now().toString(36)}-${(idCounter++).toString(36)}`;
+
+export const clamp = (value: number, min: number, max: number): number =>
+  Math.min(max, Math.max(min, value));
+
+export const AIRPORTS = ["SFO", "JFK", "LAX", "ORD", "SEA", "BOS", "DEN", "AUS"];
+
+export const CABINS: Cabin[] = ["economy", "premium", "business"];

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -647,6 +647,8 @@ export default defineConfig({
         'litert-shop': path.resolve(__dirname, 'litert-shop.html'),
         // WebMCP: voice/paste intake form copilot, driven by Gemma 4 on-device
         'litert-intake': path.resolve(__dirname, 'litert-intake.html'),
+        // WebMCP — Skylark Air (multi-step booking form; array-of-arrays seat map)
+        'webmcp-flights': path.resolve(__dirname, 'webmcp-flights.html'),
         // Bakery demo pages
         'bakery': path.resolve(__dirname, 'bakery.html'),
         'bakery-story': path.resolve(__dirname, 'bakery-story.html'),

--- a/apps/web/webmcp-flights.html
+++ b/apps/web/webmcp-flights.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" href="/favicon.ico" />
+    <title>WebMCP Flights — Skylark Air</title>
+  </head>
+  <body class="sk-body">
+    <header class="sk-toolbar">
+      <span class="sk-logo">Skylark<span>Air</span></span>
+      <span class="sk-badge">WebMCP demo</span>
+    </header>
+
+    <main class="sk-main">
+      <!-- The docked Persona panel wraps this target and docks beside it,
+           shrinking the booking page — same pattern as webmcp-slides. -->
+      <div id="booking-dock-target"></div>
+    </main>
+
+    <footer class="sk-footer">
+      <p>
+        A multi-step booking form driven by WebMCP page tools. The Copilot and
+        the on-page controls share one store, so seat picks, passenger details,
+        and flight selections render the same either way. Only
+        <strong>Confirm&nbsp;booking</strong> asks for approval.
+      </p>
+    </footer>
+
+    <script type="module" src="/src/webmcp-flights/main.ts"></script>
+  </body>
+</html>

--- a/examples/runtype-hono-proxy/src/app.ts
+++ b/examples/runtype-hono-proxy/src/app.ts
@@ -11,6 +11,7 @@ import {
   WEBMCP_SLIDES_FLOW,
   WEBMCP_PAINT_FLOW,
   WEBMCP_DOCKED_FLOW,
+  WEBMCP_FLIGHTS_FLOW,
   PAGE_CONTEXT_AGENT,
   THEME_ASSISTANT_AGENT,
   TRAVEL_PLANNER_AGENT,
@@ -190,6 +191,21 @@ export function createRuntypeProxyApp(env: ProxyEnv): Hono {
     upstreamUrl,
   });
 
+  // WebMCP flights proxy - for the Skylark Air flight-booking demo. Same pattern
+  // as the storefront/calendar: the page registers booking tools (search, seat
+  // map, passengers, seat assignment, the approval-gated confirm) on
+  // document.modelContext, the widget forwards them as clientTools[], and the
+  // in-code WEBMCP_FLIGHTS_FLOW drives them. Live booking state rides along as
+  // {{booking_context}}.
+  const webmcpFlightsApp = createChatProxyApp({
+    path: "/api/chat/dispatch-flights",
+    apiKey,
+    allowedOrigins,
+    flowId: env.FLOW_ID_FLIGHTS || undefined,
+    flowConfig: env.FLOW_ID_FLIGHTS ? undefined : WEBMCP_FLIGHTS_FLOW,
+    upstreamUrl,
+  });
+
   const pageContextApp = createChatProxyApp({
     ...proxyProtection,
     path: "/api/chat/dispatch-page-context",
@@ -271,6 +287,7 @@ export function createRuntypeProxyApp(env: ProxyEnv): Hono {
   app.route("/", webmcpSlidesApp);
   app.route("/", webmcpPaintApp);
   app.route("/", webmcpDockedApp);
+  app.route("/", webmcpFlightsApp);
   app.route("/", pageContextApp);
   app.route("/", themeAssistantApp);
   app.route("/", agentLoopApp);

--- a/packages/proxy/src/flows/index.ts
+++ b/packages/proxy/src/flows/index.ts
@@ -16,5 +16,6 @@ export { WEBMCP_CALENDAR_FLOW } from "./webmcp-calendar.js";
 export { WEBMCP_SLIDES_FLOW } from "./webmcp-slides.js";
 export { WEBMCP_PAINT_FLOW } from "./webmcp-paint.js";
 export { WEBMCP_DOCKED_FLOW } from "./webmcp-docked.js";
+export { WEBMCP_FLIGHTS_FLOW } from "./webmcp-flights.js";
 export { PAGE_CONTEXT_FLOW } from "./page-context.js";
 export { THEME_ASSISTANT_FLOW } from "./theme-assistant.js";

--- a/packages/proxy/src/flows/webmcp-flights.ts
+++ b/packages/proxy/src/flows/webmcp-flights.ts
@@ -1,0 +1,93 @@
+import type { RuntypeFlowConfig } from "../index.js";
+
+/**
+ * WebMCP flight-booking flow for the "Skylark Air" demo
+ * (`apps/web/webmcp-flights.html`).
+ *
+ * Like the other WebMCP example flows, this agent owns **no** tools of its own.
+ * The demo page registers its tools on `document.modelContext` via WebMCP
+ * (`search_flights`, `get_seat_map`, `select_flight`, `set_passengers`,
+ * `update_passenger`, `assign_seat`, `confirm_booking`, …); the widget snapshots
+ * them every turn and the proxy forwards them on the dispatch payload as
+ * `clientTools[]`. The Runtype runtime threads those into this prompt step's
+ * tool set, so the model calls them by name and the widget executes them **on
+ * the page**, posting results back via `/resume`.
+ *
+ * The agent definition that drives the demo lives entirely in this repo — no
+ * hosted Runtype agent / client token required. The flow just needs a
+ * tool-capable model and a system prompt that knows the booking workflow and
+ * how to read the seat-map grid.
+ *
+ * Model: `nemotron-3-ultra-550b-a55b`. WebMCP depends on the model emitting
+ * **native** tool calls (each surfaces as a `step_await` the widget resumes), so
+ * a tool-reliable model is required here. No image content is involved (the
+ * seat map is structured JSON, by design), so a text model is the right fit.
+ * `responseFormat` is markdown so the model can interleave tool calls with a
+ * natural-language summary instead of being constrained to a JSON envelope.
+ *
+ * Live booking state rides along every turn as `{{booking_context}}` (the demo
+ * page ships it via contextProviders → inputs), so the agent rarely needs a
+ * read round-trip before acting.
+ */
+export const WEBMCP_FLIGHTS_FLOW: RuntypeFlowConfig = {
+  name: "WebMCP Flights Flow",
+  description:
+    "Skylark Air booking assistant — drives page-provided WebMCP tools (clientTools[]) to fill a multi-step booking form",
+  steps: [
+    {
+      id: "webmcp_flights_prompt",
+      name: "WebMCP Flights Prompt",
+      type: "prompt",
+      enabled: true,
+      config: {
+        model: "nemotron-3-ultra-550b-a55b",
+        reasoning: false,
+        responseFormat: "markdown",
+        outputVariable: "prompt_result",
+        userPrompt: "{{user_message}}",
+        systemPrompt: `You are the booking Copilot for **Skylark Air**. You help a traveler book a trip by filling a multi-step form: search flights → select flights → add passengers → choose seats → review → confirm.
+
+Brand voice: warm, efficient, concrete. No hype, no emoji. Keep replies short — a sentence or two around the actions you take.
+
+## Your tools come from the page
+
+This booking page exposes its own tools to you (search flights, read a seat map, select a flight, set/update passengers, assign seats, confirm the booking). Always **use the tools** to act — never invent flight ids, flight numbers, times, fares, seat numbers, or confirmation codes from memory, and never claim a change you did not make with a tool this turn.
+
+Live booking state is provided each turn as booking_context (selected flight ids, passenger ids and whether each has a date of birth, seat assignments, and whether it's already confirmed). Use it to avoid redundant reads; call get_booking_state only when you need a fresh, full snapshot after several changes.
+
+## The booking workflow
+
+1. **Search** with search_flights before selecting anything. It needs origin, destination, and an outbound date (ISO YYYY-MM-DD); pass returnDate, passengers, and cabin when the traveler gives them. A returnDate before the departDate is rejected — relay that and ask for a valid date.
+2. **Select** a flight per leg with select_flight using an id from the latest search results. For a round trip, search and select each leg.
+3. **Passengers**: capture everyone with set_passengers (firstName, lastName, dateOfBirth as ISO YYYY-MM-DD). Use the returned passenger ids for seats. Fill a missing detail later with update_passenger. If the traveler hasn't given a date of birth, ask for it — it's required to book.
+4. **Seats**: call get_seat_map for a selected flight, then assign_seat for each passenger.
+5. **Confirm** only when the traveler explicitly says to book.
+
+## Reading the seat map (important)
+
+get_seat_map returns a grid, not a flat list. Read human seat concepts from its shape:
+- **window vs aisle vs middle**: \`columns\` + \`columnTypes\` are the legend (window = the first and last columns; aisle seats border the center gap). Each seat also carries its own \`type\`, so trust that.
+- **adjacency** ("two seats together"): seats next to each other in a row's \`seats\` array are physically adjacent. For a pair together, pick two open seats from the same row that are neighbors in the array.
+- **front vs back** ("near the front"): lower \`row\` number is nearer the front.
+- **legroom / exit row**: each seat carries \`exitRow\` and \`extraLegroom\`; business rows and the exit rows have extra legroom (and may add a surcharge in \`price\`).
+- Only assign seats whose \`status\` is "available". If a request can't be met exactly (e.g. no two windows free in one row), get as close as you can and say what you did.
+
+When the traveler's seat preference is ambiguous and it matters (e.g. they say "good seats" but you must choose aisle vs window), it's fine to ask a brief clarifying question before assigning.
+
+## Validation is enforced by the tools
+
+The tools reject invalid actions (return before departure, a taken or non-existent seat, a seat on an unselected flight, confirming with missing passenger details or unseated passengers). When a tool returns an error, relay it plainly and do the missing step — don't pretend it succeeded. Before booking, if something's missing, say exactly what's left.
+
+## Acting vs. claiming (critical)
+
+- You can only change the booking by calling a tool. Text alone changes nothing.
+- Never say you searched, selected, seated, or booked anything unless a tool call you made IN THIS TURN returned a success result. If you haven't called the tool yet, call it now instead of replying.
+- Earlier messages reporting past actions are not a template to imitate — every new request needs fresh tool calls this turn.
+- confirm_booking is the irreversible commit. Only call it when the traveler clearly asks to book ("book it", "confirm", "yes, book"). Do not confirm preemptively; the page also asks the traveler to approve it.
+
+After your tool calls resolve, summarize what changed in plain language (flights, passengers, seats, the running total, and what's left before booking). Do not describe tools, JSON, ids, or the WebMCP mechanism to the traveler.`,
+        previousMessages: "{{messages}}"
+      }
+    }
+  ]
+};


### PR DESCRIPTION
## What

A new WebMCP demo — **Skylark Air**, a flight-booking Copilot — that fills the gap the existing demos miss: a **multi-step form** with repeater fields, cross-field validation, and an approval-gated commit. The Copilot and the on-page controls drive the same `BookingStore`, so flight selection, passenger details, and seat picks render identically whoever made the change.

## The centerpiece: seat-map tool design

`get_seat_map` returns a **rows × columns grid (array of arrays)** so the agent reads human seat concepts straight from the data shape:

- **window vs aisle vs middle** — `columnTypes` legend (window = first/last column) + each cell's own `type`
- **adjacency** ("two together") — neighbors in a row's `seats` array
- **near the front** — ascending `row`
- **legroom / exit row** — per-cell `exitRow` / `extraLegroom`

Structured JSON only, no image round-trip — it runs on a **text model**. Verified output, row 14: `14A:w 14B:mx 14C:a 14D:a 14E:m 14F:wx`.

## Tool surface

| Group | Tools | Approval |
|---|---|---|
| Reads | `get_booking_state`, `search_flights`, `get_seat_map` | auto |
| Form fills | `select_flight`, `set_passengers`, `update_passenger`, `assign_seat` | auto |
| Commit | `confirm_booking`, `reset_booking` | **gated** |

Validation (return ≥ depart, taken/nonexistent seats, missing passenger details, unseated passengers before confirm) lives in the tool handlers and surfaces as relayed errors.

## Changes

- **`packages/proxy`** — `WEBMCP_FLIGHTS_FLOW` (nemotron, markdown) teaching the booking workflow + how to read the seat grid; exported from `flows/index.ts`; mounted at `/api/chat/dispatch-flights` in **both** `vercel-edge/src/server.ts` and `api/index.ts`. Changeset included (`minor`).
- **`examples/embedded-app`** — `webmcp-flights` demo: `store.ts`, `catalog.ts` (deterministic flights + seat-map generator), `tools.ts`, `app.ts` (page UI with agent-touch flash), `main.ts` (docked widget, Skylark theme, live `{{booking_context}}` via contextProviders → requestMiddleware). Registered in `vite.config.ts`, the index carousel/pattern-links, and the demo list.

## Verification

- `pnpm build:proxy` ✅ · proxy `typecheck` ✅ · proxy `lint` ✅
- All demo TS modules compile + serve through Vite (200); no errors in `src/webmcp-flights`
- Core logic unit-checked: determinism, seat-map shape, window=first/last column, exit-row legroom, self-describing cells, business 4-abreast — all PASS
- Driven **live end-to-end against staging**: proxy authenticates upstream → `WebMCP Flights Flow` streams `flow_start`/`step_delta`s, Copilot engages the tools
