### PR TITLE
docs: document generated API types workflow in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,27 @@ pnpm typecheck      # type check
 cd packages/widget
 pnpm test:run       # run once
 pnpm test           # watch mode
+pnpm test:ui        # browser UI (http://localhost:51204)
 ```
+
+## Generated API types
+
+The widget's request/response types are generated from Runtype's public OpenAPI
+spec into `packages/widget/src/generated/runtype-openapi-contract.ts`, which is
+committed to the repo.
+
+`pnpm typecheck` re-fetches the live spec and **fails if the committed contract
+is out of date** — so if typecheck reports a contract mismatch (and you didn't
+touch the generated file), regenerate it:
+
+```bash
+pnpm generate:runtype-types   # fetch spec + rewrite the contract, then commit it
+pnpm check:runtype-types      # verify-only (what CI runs)
+```
+
+This requires network access to `api.runtype.com`. The fetched spec is cached at
+`packages/widget/openapi/*.local.json` (gitignored); only the generated `.ts`
+contract is committed.
 
 ## Submitting changes
 


### PR DESCRIPTION
## What

Adds a **Generated API types** section to CONTRIBUTING.md and a `test:ui` line to the dev workflow.

## Why

The widget generates `src/generated/runtype-openapi-contract.ts` from Runtype's public OpenAPI spec, and `pnpm typecheck` re-fetches the live spec and fails if the committed contract is stale. That check runs in CI, but CONTRIBUTING.md never mentioned the generation workflow — so a contributor whose branch predates an upstream API change could hit a typecheck failure unrelated to their own code with no guidance on `pnpm generate:runtype-types`.

## Notes

Docs-only change — no changeset required (per CONTRIBUTING / CLAUDE.md, docs don't need one).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only; no runtime, CI logic, or package behavior changes.
> 
> **Overview**
> **CONTRIBUTING.md** now documents how widget API types are kept in sync with Runtype’s OpenAPI spec and how to fix CI/typecheck failures when the committed contract is stale.
> 
> The dev workflow block adds **`pnpm test:ui`** (Vitest browser UI). A new **Generated API types** section explains that types live in `packages/widget/src/generated/runtype-openapi-contract.ts`, that **`pnpm typecheck`** re-fetches the live spec and fails on mismatch, and points contributors to **`pnpm generate:runtype-types`** vs **`pnpm check:runtype-types`**, plus network/cache notes for `api.runtype.com` and gitignored `openapi/*.local.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b36f004ce05cb7532c916c8956000076d8dbdfe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->