### PR TITLE
feat: broadcast widget version as X-Persona-Version header

### DIFF
--- a/.changeset/persona-version-header.md
+++ b/.changeset/persona-version-header.md
@@ -1,0 +1,6 @@
+---
+"@runtypelabs/persona": minor
+"@runtypelabs/persona-proxy": minor
+---
+
+Broadcast the widget version as an `X-Persona-Version` request header. The widget now sends its package version on every outgoing request (chat dispatch, session init, feedback, approve, and resume), and the proxy allows the header through CORS and forwards it upstream to the Runtype API.

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -204,7 +204,8 @@ const withCors =
 
       const headers: Record<string, string> = {
         "Access-Control-Allow-Origin": corsOrigin,
-        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        "Access-Control-Allow-Headers":
+          "Content-Type, Authorization, X-Persona-Version",
         "Access-Control-Allow-Methods": "POST, OPTIONS",
         Vary: "Origin"
       };
@@ -381,11 +382,15 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
       console.log("Request Payload:", JSON.stringify(runtypePayload, null, 2));
     }
 
+    // Forward the widget's self-reported version to the API, when present.
+    const personaVersion = c.req.header("x-persona-version");
+
     const response = await fetch(upstream, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        ...(personaVersion && { "X-Persona-Version": personaVersion })
       },
       body: JSON.stringify(runtypePayload)
     });
@@ -459,11 +464,15 @@ export const createChatProxyApp = (options: ChatProxyOptions = {}) => {
       console.log("=== End Runtype Proxy Resume ===\n");
     }
 
+    // Forward the widget's self-reported version to the API, when present.
+    const personaVersion = c.req.header("x-persona-version");
+
     const response = await fetch(upstreamResumeUrl, {
       method: "POST",
       headers: {
         Authorization: `Bearer ${apiKey}`,
-        "Content-Type": "application/json"
+        "Content-Type": "application/json",
+        ...(personaVersion && { "X-Persona-Version": personaVersion })
       },
       body: JSON.stringify(body)
     });

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { AgentWidgetClient, preferFinalStructuredContent } from './client';
 import { AgentWidgetEvent, AgentWidgetMessage } from './types';
 import { createJsonStreamParser } from './utils/formatting';
+import { VERSION } from './version';
 
 describe('AgentWidgetClient - Empty Message Filtering', () => {
   let client: AgentWidgetClient;
@@ -4174,5 +4175,48 @@ describe('AgentWidgetClient - Feedback request builder', () => {
 
     expect(feedbackBodies[0].token).toBe('ct_live_xyz789');
     expect(feedbackBodies[0].rating).toBe(5);
+  });
+});
+
+describe('AgentWidgetClient - version header', () => {
+  function captureHeaders() {
+    const headers: Array<Record<string, string>> = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, options: { headers: Record<string, string> }) => {
+      headers.push(options.headers);
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(c) {
+          c.enqueue(encoder.encode('data: {"type":"flow_complete","success":true}\n\n'));
+          c.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+    return headers;
+  }
+
+  const msg = () => ({
+    messages: [{ id: 'u1', role: 'user' as const, content: 'hi', createdAt: '2025-01-01T00:00:00.000Z' }],
+  });
+
+  it('broadcasts X-Persona-Version on the dispatch request', async () => {
+    const headers = captureHeaders();
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+
+    await client.dispatch(msg(), () => undefined);
+
+    expect(headers[0]['X-Persona-Version']).toBe(VERSION);
+  });
+
+  it('lets an explicit config header override the version', async () => {
+    const headers = captureHeaders();
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      headers: { 'X-Persona-Version': 'override' },
+    });
+
+    await client.dispatch(msg(), () => undefined);
+
+    expect(headers[0]['X-Persona-Version']).toBe('override');
   });
 });

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -33,6 +33,7 @@ import {
   createXmlParser
 } from "./utils/formatting";
 import { SequenceReorderBuffer } from "./utils/sequence-buffer";
+import { VERSION } from "./version";
 // artifactsSidebarEnabled is used in ui.ts to gate the sidebar pane rendering;
 // artifact events are always processed here regardless of config.
 
@@ -188,6 +189,7 @@ export class AgentWidgetClient {
     this.apiUrl = config.apiUrl ?? DEFAULT_ENDPOINT;
     this.headers = {
       "Content-Type": "application/json",
+      "X-Persona-Version": VERSION,
       ...config.headers
     };
     this.debug = Boolean(config.debug);
@@ -355,6 +357,7 @@ export class AgentWidgetClient {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'X-Persona-Version': VERSION,
       },
       body: JSON.stringify(requestBody),
     });
@@ -495,6 +498,7 @@ export class AgentWidgetClient {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        'X-Persona-Version': VERSION,
       },
       body: JSON.stringify(requestBody),
     });
@@ -682,6 +686,7 @@ export class AgentWidgetClient {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
+            'X-Persona-Version': VERSION,
           },
           body: JSON.stringify(chatRequest),
           signal: controller.signal,


### PR DESCRIPTION
## What

The Persona widget now broadcasts its own version (`X-Persona-Version`, sourced from `version.ts` → `package.json`, currently `3.35.0`) on every outgoing request, and the proxy forwards it through to the Runtype API.

## Why

Lets the backend (and the proxy) see which widget version a request came from — useful for debugging, deprecation tracking, and version-gated behavior.

## Changes

**Widget — `packages/widget/src/client.ts`**
- Import `VERSION`.
- Add `X-Persona-Version: VERSION` to `this.headers` (covers chat dispatch + the approve/resume paths that spread it).
- Add it to the three standalone fetch paths that don't spread `this.headers`: session **init**, **feedback**, and **client-token chat**.
- `...config.headers` still spreads last, so consumers can override the value.

**Proxy — `packages/proxy/src/index.ts`**
- CORS: add `X-Persona-Version` to `Access-Control-Allow-Headers` so the browser→proxy preflight passes.
- Forward the header on **both** upstream fetches (dispatch + resume) when present; absent header → nothing added.

**Tests** — `client.test.ts`: asserts the header is present on dispatch and that a config header overrides it.

**Changeset** — `minor` for both packages.


## Verification

`pnpm build`, `pnpm typecheck`, `pnpm lint` all pass; widget test suite green (1281 tests).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive request metadata and proxy passthrough; no auth or payload semantics change. Direct (non-proxy) embeds may need API CORS to allow the new header.
> 
> **Overview**
> Adds **`X-Persona-Version`** (from `VERSION` / `package.json`) on widget HTTP calls so backends can attribute traffic to a specific embed release.
> 
> The widget sets the header on default **`this.headers`** (dispatch, approve, resume) and on standalone fetches for **session init**, **feedback**, and **client-token chat**. **`config.headers`** still wins when embedders override the value.
> 
> The proxy **allows the header in CORS** preflight and **forwards** `x-persona-version` to Runtype on **dispatch** and **resume** upstream POSTs when the browser sends it. A changeset marks **minor** bumps for `@runtypelabs/persona` and `@runtypelabs/persona-proxy`. Tests assert dispatch sends the package version and that a config override is respected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca0cafd261147549c40da06c67c30316808e268. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->