### PR TITLE
feat(widget): add support for unified event vocabulary

### DIFF
--- a/.changeset/unified-event-consumer.md
+++ b/.changeset/unified-event-consumer.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add opt-in `events: 'unified'` support. When set, the widget requests the API's neutral unified SSE vocabulary (`?events=unified` on dispatch and `/resume`) and bridges each frame back onto the existing event handlers, so rendering is unchanged. Defaults to `'legacy'`; the wire mode is auto-detected from the first stream frame, so an upstream that doesn't support the param falls back to legacy automatically. Also exposed as a top-level `events` option on the script-tag installer.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -4220,3 +4220,101 @@ describe('AgentWidgetClient - version header', () => {
     expect(headers[0]['X-Persona-Version']).toBe('override');
   });
 });
+
+describe('AgentWidgetClient - Unified event vocabulary (events: "unified")', () => {
+  const unifiedTextStream = (execId: string) => [
+    sseEvent('execution_start', { kind: 'agent', executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+    sseEvent('turn_start', { executionId: execId, id: 'turn_1', iteration: 1, role: 'assistant', seq: 2 }),
+    sseEvent('text_start', { executionId: execId, id: 'text_1', role: 'assistant', seq: 3 }),
+    sseEvent('text_delta', { executionId: execId, id: 'text_1', delta: 'Hello', seq: 4 }),
+    sseEvent('text_delta', { executionId: execId, id: 'text_1', delta: ' World', seq: 5 }),
+    sseEvent('text_complete', { executionId: execId, id: 'text_1', seq: 6 }),
+    sseEvent('turn_complete', { executionId: execId, id: 'turn_1', iteration: 1, role: 'assistant', completedAt: new Date().toISOString(), seq: 7 }),
+    sseEvent('execution_complete', { kind: 'agent', executionId: execId, success: true, completedAt: new Date().toISOString(), seq: 8 }),
+  ];
+
+  it('appends ?events=unified to the dispatch URL when opted in', async () => {
+    let capturedUrl = '';
+    global.fetch = vi.fn().mockImplementation(async (url: string) => {
+      capturedUrl = url;
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream({
+        start(c) {
+          for (const e of unifiedTextStream('exec_u')) c.enqueue(encoder.encode(e));
+          c.close();
+        },
+      });
+      return { ok: true, body: stream };
+    });
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      events: 'unified',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      () => {}
+    );
+    expect(capturedUrl).toContain('events=unified');
+  });
+
+  it('renders a unified stream by bridging it back to the legacy handlers', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_u1';
+    global.fetch = createAgentStreamFetch(unifiedTextStream(execId));
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      events: 'unified',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const messageEvents = events.filter((e) => e.type === 'message');
+    expect(messageEvents.length).toBeGreaterThan(0);
+    const last = messageEvents[messageEvents.length - 1];
+    expect(last.type).toBe('message');
+    if (last.type === 'message') {
+      expect(last.message.content).toBe('Hello World');
+      expect(last.message.streaming).toBe(false);
+      expect(last.message.role).toBe('assistant');
+      expect(last.message.agentMetadata?.executionId).toBe(execId);
+    }
+  });
+
+  it('auto-falls-back to legacy when "unified" was requested but the API streamed legacy frames', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_legacy_fallback';
+    // Same content, LEGACY vocabulary — the API ignored ?events=unified.
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', { executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+      sseEvent('agent_turn_start', { executionId: execId, iteration: 1, turnId: 'turn_1', role: 'assistant', seq: 2 }),
+      sseEvent('agent_turn_delta', { executionId: execId, iteration: 1, delta: 'Hello', contentType: 'text', turnId: 'turn_1', seq: 3 }),
+      sseEvent('agent_turn_delta', { executionId: execId, iteration: 1, delta: ' World', contentType: 'text', turnId: 'turn_1', seq: 4 }),
+      sseEvent('agent_turn_complete', { executionId: execId, iteration: 1, turnId: 'turn_1', completedAt: new Date().toISOString(), seq: 5 }),
+      sseEvent('agent_complete', { executionId: execId, success: true, stopReason: 'max_iterations', completedAt: new Date().toISOString(), seq: 6 }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      events: 'unified',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+
+    const messageEvents = events.filter((e) => e.type === 'message');
+    const last = messageEvents[messageEvents.length - 1];
+    expect(last.type).toBe('message');
+    if (last.type === 'message') {
+      expect(last.message.content).toBe('Hello World');
+      expect(last.message.streaming).toBe(false);
+    }
+  });
+});

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -33,6 +33,7 @@ import {
   createXmlParser
 } from "./utils/formatting";
 import { SequenceReorderBuffer } from "./utils/sequence-buffer";
+import { UnifiedToLegacyBridge, isUnifiedLifecycleStart } from "./utils/unified-event-bridge";
 import { VERSION } from "./version";
 // artifactsSidebarEnabled is used in ui.ts to gate the sidebar pane rendering;
 // artifact events are always processed here regardless of config.
@@ -290,6 +291,17 @@ export class AgentWidgetClient {
    */
   public isAgentMode(): boolean {
     return !!this.config.agent;
+  }
+
+  /**
+   * Append `?events=unified` when the widget opted into the unified vocabulary,
+   * preserving any existing query string. No-op for the default legacy mode.
+   * The server only switches vocabularies when it sees the param; the widget
+   * still auto-detects the actual wire mode from the first stream frame.
+   */
+  private withEventsParam(url: string): string {
+    if (this.config.events !== "unified") return url;
+    return url + (url.includes("?") ? "&" : "?") + "events=unified";
   }
 
   /**
@@ -682,7 +694,7 @@ export class AgentWidgetClient {
           console.debug("[AgentWidgetClient] client token dispatch", chatRequest);
         }
 
-        response = await fetch(this.getClientApiUrl('chat'), {
+        response = await fetch(this.withEventsParam(this.getClientApiUrl('chat')), {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
@@ -802,7 +814,7 @@ export class AgentWidgetClient {
     if (this.customFetch) {
       try {
         response = await this.customFetch(
-          this.apiUrl,
+          this.withEventsParam(this.apiUrl),
           {
             method: "POST",
             headers,
@@ -817,7 +829,7 @@ export class AgentWidgetClient {
         throw err;
       }
     } else {
-      response = await fetch(this.apiUrl, {
+      response = await fetch(this.withEventsParam(this.apiUrl), {
         method: "POST",
         headers,
         body: JSON.stringify(payload),
@@ -878,7 +890,7 @@ export class AgentWidgetClient {
     if (this.customFetch) {
       try {
         response = await this.customFetch(
-          this.apiUrl,
+          this.withEventsParam(this.apiUrl),
           {
             method: "POST",
             headers,
@@ -893,7 +905,7 @@ export class AgentWidgetClient {
         throw err;
       }
     } else {
-      response = await fetch(this.apiUrl, {
+      response = await fetch(this.withEventsParam(this.apiUrl), {
         method: "POST",
         headers,
         body: JSON.stringify(payload),
@@ -996,9 +1008,11 @@ export class AgentWidgetClient {
     options?: { streamResponse?: boolean; signal?: AbortSignal }
   ): Promise<Response> {
     const isClientToken = this.isClientTokenMode();
-    const url = isClientToken
-      ? this.getClientApiUrl('resume')
-      : `${this.config.apiUrl?.replace(/\/+$/, '') || DEFAULT_CLIENT_API_BASE}/resume`;
+    const url = this.withEventsParam(
+      isClientToken
+        ? this.getClientApiUrl('resume')
+        : `${this.config.apiUrl?.replace(/\/+$/, '') || DEFAULT_CLIENT_API_BASE}/resume`
+    );
 
     // The client-token resume route authenticates the session, not a Bearer
     // key. A WebMCP approval can sit awaiting user input for a long time, so by
@@ -1833,6 +1847,17 @@ export class AgentWidgetClient {
       seqReadyQueue.push({ payloadType, payload });
       scheduleReadyQueueDrain();
     });
+    // Unified-event consumer (opt-in; see utils/unified-event-bridge.ts). When the
+    // API streams the neutral unified vocabulary, each frame is transduced back to
+    // the legacy events the dispatch chain below already renders. Seed the mode from
+    // the requested vocabulary so /resume (whose stream continues mid-run with no
+    // `execution_start`) bridges correctly; a leading lifecycle frame is then
+    // authoritative and can flip it (e.g. an upstream that ignored `?events=unified`
+    // streams `agent_start`). The unified stream is single-connection and in order,
+    // so bridged events bypass the reorder buffer.
+    const unifiedBridge = new UnifiedToLegacyBridge();
+    let unifiedMode = this.config.events === "unified";
+    let wireModeResolved = false;
     // Agent execution state tracking
     let agentExecution: AgentExecutionState | null = null;
     // Track assistant messages per agent iteration for 'separate' mode
@@ -3371,6 +3396,31 @@ export class AgentWidgetClient {
             assistantMessage = assistantMessageRef.current;
           }
           if (handled) continue; // Skip default handling if custom handler processed it
+        }
+
+        // Unified vocabulary (opt-in): resolve the wire mode from the first
+        // lifecycle frame (the flag only requests the param; the frame is
+        // authoritative), then transduce unified → legacy, bypassing the reorder
+        // buffer (the unified stream is single-connection and already in order).
+        if (!wireModeResolved) {
+          if (isUnifiedLifecycleStart(payloadType)) {
+            unifiedMode = true;
+            wireModeResolved = true;
+          } else if (
+            payloadType === "agent_start" ||
+            payloadType === "flow_start" ||
+            payloadType === "step_start"
+          ) {
+            unifiedMode = false;
+            wireModeResolved = true;
+          }
+        }
+        if (unifiedMode) {
+          for (const legacyEvent of unifiedBridge.push(payloadType, payload)) {
+            seqReadyQueue.push(legacyEvent);
+          }
+          drainReadyQueue();
+          continue;
         }
 
         // Push through the sequence reorder buffer

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -1190,6 +1190,7 @@ export type RuntypeClientChatRequest = {
   type: "object";
   [key: string]: unknown;
 };
+  untrustedContentHint?: boolean;
 }>;
   clientToolsFingerprint?: string;
   inputs?: Record<string, unknown>;

--- a/packages/widget/src/install.ts
+++ b/packages/widget/src/install.ts
@@ -18,6 +18,9 @@ interface SiteAgentInstallConfig {
   clientToken?: string;
   flowId?: string;
   apiUrl?: string;
+  /** Wire vocabulary requested from the dispatch endpoint; 'unified' opts into the
+   *  API's neutral event schema (transparently bridged back to the same rendering). */
+  events?: "legacy" | "unified";
   // Optional query param key that gates widget installation in preview mode
   previewQueryParam?: string;
   // Shadow DOM option (defaults to false for better CSS compatibility)
@@ -377,6 +380,7 @@ declare global {
     if (config.apiUrl && !widgetConfig.apiUrl) widgetConfig.apiUrl = config.apiUrl;
     if (config.clientToken && !widgetConfig.clientToken) widgetConfig.clientToken = config.clientToken;
     if (config.flowId && !widgetConfig.flowId) widgetConfig.flowId = config.flowId;
+    if (config.events && !widgetConfig.events) widgetConfig.events = config.events;
 
     const hasApiConfig = !!(widgetConfig.apiUrl || widgetConfig.clientToken);
     return { target, widgetConfig, hasApiConfig };

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -4057,6 +4057,16 @@ export type AgentWidgetConfig = {
    */
   parseSSEEvent?: AgentWidgetSSEEventParser;
   /**
+   * Wire vocabulary requested from the dispatch endpoint.
+   * - `'legacy'` (default): the current `agent_*` / `flow_*` SSE events.
+   * - `'unified'`: opt into the API's neutral unified event vocabulary by sending
+   *   `?events=unified`; incoming frames are transparently bridged back to the same
+   *   handlers, so rendering is unchanged. Requires an upstream that honors the
+   *   param — the widget detects the actual wire mode from the first stream frame
+   *   and falls back to legacy automatically if the param was ignored.
+   */
+  events?: "legacy" | "unified";
+  /**
    * Called for every parsed SSE frame (after JSON parse), before native handling.
    * Use for lightweight side effects (e.g. telemetry). Does not replace native
    * streaming; pair with {@link parseSSEEvent} only when you need to override text mapping.

--- a/packages/widget/src/utils/__fixtures__/unified-translator.oracle.ts
+++ b/packages/widget/src/utils/__fixtures__/unified-translator.oracle.ts
@@ -1,0 +1,669 @@
+/**
+ * TEST ORACLE — vendored copy of the runtype-core `createUnifiedEventWrite`
+ * translator (the api-side legacy → unified 33-event encoder).
+ *
+ * NOT shipped. Used only by `unified-event-bridge.test.ts` as the inverse
+ * reference: `legacy frames → THIS oracle → unified frames → UnifiedToLegacyBridge
+ * → legacy frames'` must be semantically equal to the original. Keeping a real
+ * copy here means the round-trip test fails loudly if the api mapping and the
+ * widget bridge ever drift.
+ *
+ * The only edit vs the api source is the removed `getLogger` import (the
+ * per-frame error log is a no-op here).
+ */
+
+type Json = Record<string, unknown>;
+
+type ExecutionKind = "agent" | "flow";
+
+interface UnifiedEventWriteOptions {
+  executionId?: string;
+}
+
+const ENVELOPE_KEYS = new Set(["type", "executionId", "seq"]);
+
+function omitEnvelope(data: Json): Json {
+  const out: Json = {};
+  for (const [k, v] of Object.entries(data)) {
+    if (!ENVELOPE_KEYS.has(k)) out[k] = v;
+  }
+  return out;
+}
+
+class UnifiedEventTranslator {
+  private executionId: string;
+  private seq = 0;
+  private kind: ExecutionKind = "flow";
+  private blockCounter = 0;
+  private openText: string | null = null;
+  private openReasoning: string | null = null;
+
+  constructor(
+    private readonly sink: (chunk: string) => void,
+    options?: UnifiedEventWriteOptions
+  ) {
+    this.executionId = options?.executionId ?? "";
+  }
+
+  private mint(prefix: string): string {
+    this.blockCounter += 1;
+    return `${prefix}_${this.blockCounter}`;
+  }
+
+  private out(type: string, payload: Json): void {
+    const frame: Json = { type, executionId: this.executionId, seq: this.seq, ...payload };
+    this.seq += 1;
+    this.sink(`event: ${type}\ndata: ${JSON.stringify(frame)}\n\n`);
+  }
+
+  private emitTextDelta(delta: unknown): void {
+    if (delta == null || delta === "") return;
+    if (!this.openText) {
+      this.openText = this.mint("text");
+      this.out("text_start", {
+        id: this.openText,
+        ...(this.kind === "agent" ? { role: "assistant" } : {}),
+      });
+    }
+    this.out("text_delta", { id: this.openText, delta: String(delta) });
+  }
+
+  private closeText(): void {
+    if (!this.openText) return;
+    this.out("text_complete", { id: this.openText });
+    this.openText = null;
+  }
+
+  private ensureReasoningOpen(scope?: "turn" | "loop"): void {
+    if (this.openReasoning) return;
+    this.openReasoning = this.mint("reason");
+    this.out("reasoning_start", { id: this.openReasoning, ...(scope ? { scope } : {}) });
+  }
+
+  private emitReasoningDelta(delta: unknown): void {
+    if (delta == null || delta === "") return;
+    this.ensureReasoningOpen();
+    this.out("reasoning_delta", { id: this.openReasoning, delta: String(delta) });
+  }
+
+  private closeReasoning(): void {
+    if (!this.openReasoning) return;
+    this.out("reasoning_complete", { id: this.openReasoning });
+    this.openReasoning = null;
+  }
+
+  private closeChannels(): void {
+    this.closeText();
+    this.closeReasoning();
+  }
+
+  private fallbackInfo(data: Json): Json | undefined {
+    const used = data.usedFallback === true;
+    const executions = Array.isArray(data.fallbackExecutions) ? data.fallbackExecutions : [];
+    if (!used && executions.length === 0) return undefined;
+    const attempts = executions.map((entry: unknown, index: number) => {
+      const e = (entry ?? {}) as Json;
+      return {
+        attempt: typeof e.attempt === "number" ? e.attempt : index + 1,
+        type: typeof e.fallbackType === "string" ? e.fallbackType : "model",
+        ...(e.fallbackModel != null ? { model: e.fallbackModel } : {}),
+        success: true,
+      };
+    });
+    return {
+      fallback: {
+        used,
+        ...(data.modelUsed != null
+          ? { model: data.modelUsed }
+          : data.fallbackModel != null
+            ? { model: data.fallbackModel }
+            : {}),
+        attempts,
+        exhausted: false,
+      },
+    };
+  }
+
+  private handle(type: string, data: Json): void {
+    switch (type) {
+      case "agent_start":
+        this.kind = "agent";
+        if (typeof data.executionId === "string") this.executionId = data.executionId;
+        this.out("execution_start", {
+          kind: "agent",
+          startedAt: data.startedAt ?? new Date().toISOString(),
+          agentId: data.agentId,
+          agentName: data.agentName,
+          maxTurns: data.maxTurns,
+          config: data.config,
+        });
+        break;
+      case "agent_iteration_start":
+      case "agent_iteration_complete":
+        break;
+      case "agent_turn_start":
+        this.closeChannels();
+        this.out("turn_start", {
+          id: data.turnId,
+          iteration: data.iteration,
+          turnIndex: data.turnIndex,
+          role: data.role ?? "assistant",
+        });
+        break;
+      case "agent_turn_delta": {
+        const contentType = data.contentType;
+        if (contentType === "thinking") this.emitReasoningDelta(data.delta);
+        else if (contentType === "tool_input")
+          this.out("tool_input_delta", {
+            toolCallId: data.turnId ?? this.mint("toolinput"),
+            delta: String(data.delta ?? ""),
+          });
+        else this.emitTextDelta(data.delta);
+        break;
+      }
+      case "agent_turn_complete":
+        this.closeChannels();
+        this.out("turn_complete", {
+          id: data.turnId,
+          iteration: data.iteration,
+          role: data.role ?? "assistant",
+          content: data.content,
+          tokens: data.tokens,
+          cost: data.cost,
+          stopReason: data.stopReason,
+          completedAt: data.completedAt,
+        });
+        break;
+      case "agent_tool_start":
+        this.out("tool_start", {
+          toolCallId: data.toolCallId,
+          toolName: data.toolName,
+          toolType: data.toolType ?? "builtin",
+          iteration: data.iteration,
+          parameters: data.parameters,
+          hiddenParameterNames: data.hiddenParameterNames,
+          origin: data.origin,
+          pageOrigin: data.pageOrigin,
+        });
+        break;
+      case "agent_tool_delta":
+        this.out("tool_output_delta", {
+          toolCallId: data.toolCallId,
+          delta: String(data.delta ?? ""),
+        });
+        break;
+      case "agent_tool_input_delta":
+        this.out("tool_input_delta", {
+          toolCallId: data.toolCallId,
+          delta: String(data.delta ?? ""),
+        });
+        break;
+      case "agent_tool_input_complete":
+        this.out("tool_input_complete", {
+          toolCallId: data.toolCallId,
+          toolName: data.toolName,
+          parameters: (data.parameters as Json) ?? {},
+          hiddenParameterNames: data.hiddenParameterNames,
+        });
+        break;
+      case "agent_tool_complete":
+        this.out("tool_complete", {
+          toolCallId: data.toolCallId,
+          toolName: data.toolName,
+          success: data.success ?? true,
+          result: data.result,
+          executionTime: data.executionTime,
+          iteration: data.iteration,
+        });
+        break;
+      case "agent_media":
+        this.emitMedia(data);
+        break;
+      case "agent_approval_start":
+        this.out("approval_start", {
+          approvalId: data.approvalId,
+          toolCallId: data.toolCallId,
+          toolName: data.toolName,
+          toolType: data.toolType,
+          description: data.description,
+          reason: data.reason,
+          parameters: data.parameters,
+          timeout: data.timeout,
+          startedAt: data.startedAt,
+          iteration: data.iteration,
+        });
+        break;
+      case "agent_approval_complete":
+        this.out("approval_complete", {
+          approvalId: data.approvalId,
+          decision: data.decision,
+          completedAt: data.completedAt,
+          resolvedBy: data.resolvedBy,
+        });
+        break;
+      case "agent_await":
+        this.out("await", {
+          toolId: data.toolId,
+          toolCallId: data.toolCallId,
+          toolName: data.toolName,
+          parameters: data.parameters,
+          awaitedAt: data.awaitedAt,
+          origin: data.origin,
+          pageOrigin: data.pageOrigin,
+        });
+        break;
+      case "agent_reflection": {
+        const id = this.mint("reason");
+        this.out("reasoning_start", { id, scope: "loop" });
+        this.out("reasoning_complete", { id, text: data.reflection, scope: "loop" });
+        break;
+      }
+      case "agent_skill_loaded": {
+        const toolCallId = (data.toolCallId as string) ?? this.mint("skill");
+        const toolName = `skill:${String(data.skill ?? "unknown")}`;
+        this.out("tool_start", {
+          toolCallId,
+          toolName,
+          toolType: "builtin",
+          iteration: data.iteration,
+        });
+        this.out("tool_complete", {
+          toolCallId,
+          toolName,
+          success: true,
+          result: {
+            kind: "skill_loaded",
+            skill: data.skill,
+            activatedCapabilities: data.activatedCapabilities ?? [],
+          },
+          iteration: data.iteration,
+        });
+        break;
+      }
+      case "agent_skill_proposed": {
+        const toolCallId = (data.toolCallId as string) ?? this.mint("propose");
+        this.out("tool_start", {
+          toolCallId,
+          toolName: "propose_skill",
+          toolType: "builtin",
+          iteration: data.iteration,
+        });
+        this.out("tool_complete", {
+          toolCallId,
+          toolName: "propose_skill",
+          success: true,
+          result: {
+            kind: "skill_proposed",
+            skill: data.skill,
+            outcome: data.outcome,
+            proposalId: data.proposalId,
+          },
+          iteration: data.iteration,
+        });
+        break;
+      }
+      case "agent_complete":
+        this.closeChannels();
+        if (data.success === false || data.stopReason === "error") {
+          this.out("execution_error", {
+            kind: "agent",
+            error: this.toErrorPayload(data.error ?? "Agent execution failed"),
+            completedAt: data.completedAt,
+          });
+        } else {
+          this.out("execution_complete", {
+            kind: "agent",
+            success: data.success ?? true,
+            iterations: data.iterations,
+            stopReason: data.stopReason,
+            completedAt: data.completedAt,
+            durationMs: data.duration,
+            finalOutput: data.finalOutput,
+            totalCost: data.totalCost,
+            totalTokens: data.totalTokens,
+          });
+        }
+        break;
+      case "agent_error":
+        if (data.recoverable)
+          this.out("error", { error: this.toErrorPayload(data.error), recoverable: true });
+        else this.out("execution_error", { kind: this.kind, error: this.toErrorPayload(data.error) });
+        break;
+      case "agent_ping":
+        this.out("ping", { timestamp: data.timestamp ?? new Date().toISOString() });
+        break;
+
+      case "flow_start":
+        this.kind = "flow";
+        if (typeof data.executionId === "string") this.executionId = data.executionId;
+        this.out("execution_start", {
+          kind: "flow",
+          startedAt: data.startedAt ?? new Date().toISOString(),
+          flowId: data.flowId,
+          flowName: data.flowName,
+          totalSteps: data.totalSteps,
+          source: data.source,
+        });
+        break;
+      case "flow_complete":
+        this.closeChannels();
+        this.out("execution_complete", {
+          kind: "flow",
+          success: data.success ?? true,
+          completedAt: data.completedAt,
+          durationMs: data.duration ?? data.executionTime,
+          finalOutput: data.finalOutput,
+          totalSteps: data.totalSteps,
+          successfulSteps: data.successfulSteps,
+          failedSteps: data.failedSteps,
+        });
+        break;
+      case "flow_error":
+        this.closeChannels();
+        this.out("execution_error", {
+          kind: "flow",
+          error: this.toErrorPayload(data.error),
+          code: data.code,
+          upgradeUrl: data.upgradeUrl,
+        });
+        break;
+      case "flow_await":
+        this.out("await", {
+          toolId: data.toolId,
+          toolCallId: data.toolCallId,
+          toolName: data.toolName,
+          parameters: data.parameters,
+          awaitedAt: data.awaitedAt,
+          origin: data.origin,
+          pageOrigin: data.pageOrigin,
+        });
+        break;
+      case "step_start":
+        this.closeChannels();
+        this.out("step_start", {
+          id: data.id ?? data.stepId,
+          name: data.name ?? data.stepName,
+          stepType: data.stepType,
+          index: data.index,
+          totalSteps: data.totalSteps,
+          startedAt: data.startedAt,
+          outputVariable: data.outputVariable,
+        });
+        break;
+      case "step_delta":
+        this.emitTextDelta(data.text ?? data.delta);
+        break;
+      case "step_complete":
+        this.closeChannels();
+        this.out("step_complete", {
+          id: data.id ?? data.stepId,
+          name: data.name ?? data.stepName,
+          stepType: data.stepType,
+          success: data.success ?? true,
+          durationMs: data.duration ?? data.durationMs ?? data.executionTime,
+          result: data.result ?? data.output,
+          stopReason: data.stopReason,
+          completedAt: data.completedAt,
+          unresolvedVariables: data.unresolvedVariables,
+          ...(this.fallbackInfo(data) ?? {}),
+        });
+        break;
+      case "step_error":
+        this.closeChannels();
+        this.out("step_complete", {
+          id: data.id ?? data.stepId,
+          name: data.name,
+          stepType: data.stepType,
+          success: false,
+          error: data.error,
+          durationMs: data.executionTime,
+        });
+        break;
+      case "step_skip":
+        this.out("step_skip", {
+          id: data.id,
+          name: data.name,
+          stepType: data.stepType,
+          index: data.index,
+          totalSteps: data.totalSteps,
+          when: data.when,
+          skippedAt: data.skippedAt,
+        });
+        break;
+      case "step_await":
+        this.out("await", {
+          toolId: data.toolId,
+          toolCallId: data.toolCallId,
+          toolName: data.toolName,
+          parameters: data.parameters,
+          awaitedAt: data.awaitedAt,
+        });
+        break;
+
+      case "tool_start":
+        this.out("tool_start", {
+          toolCallId: data.toolCallId ?? data.toolId,
+          toolName: data.toolName ?? data.name,
+          toolType: data.toolType ?? "builtin",
+          stepId: data.stepId,
+          parameters: data.parameters,
+          hiddenParameterNames: data.hiddenParameterNames,
+          startedAt: data.startedAt,
+        });
+        break;
+      case "tool_delta":
+        this.out("tool_output_delta", {
+          toolCallId: data.toolId ?? data.toolCallId,
+          delta: String(data.delta ?? ""),
+        });
+        break;
+      case "tool_input_delta":
+        this.out("tool_input_delta", {
+          toolCallId: data.toolCallId ?? data.toolId,
+          delta: String(data.delta ?? ""),
+        });
+        break;
+      case "tool_input_complete":
+        this.out("tool_input_complete", {
+          toolCallId: data.toolCallId ?? data.toolId,
+          toolName: data.toolName,
+          parameters: (data.parameters as Json) ?? {},
+          hiddenParameterNames: data.hiddenParameterNames,
+        });
+        break;
+      case "tool_complete":
+        this.out("tool_complete", {
+          toolCallId: data.toolCallId ?? data.toolId,
+          toolName: data.toolName ?? data.name,
+          success: data.success ?? true,
+          result: data.result,
+          error: data.error,
+          executionTime: data.executionTime,
+          stepId: data.stepId,
+        });
+        break;
+      case "tool_error":
+        this.out("tool_complete", {
+          toolCallId: data.toolId ?? data.toolCallId,
+          toolName: data.name,
+          success: false,
+          error: data.error,
+          executionTime: data.executionTime,
+        });
+        break;
+      case "chunk":
+        this.emitTextDelta(data.text);
+        break;
+
+      case "text_start":
+        if (!this.openText) {
+          this.openText = (data.id as string) ?? this.mint("text");
+          this.out("text_start", { id: this.openText });
+        }
+        break;
+      case "text_end":
+        this.closeText();
+        break;
+      case "reason_start":
+        this.ensureReasoningOpen();
+        break;
+      case "reason_delta":
+        this.emitReasoningDelta(data.reasoningText ?? data.delta ?? data.text);
+        break;
+      case "reason_complete":
+        this.closeReasoning();
+        break;
+      case "source":
+        this.out("source", omitEnvelope(data));
+        break;
+
+      case "fallback_start":
+        this.out("custom", {
+          name: "runtype.fallback",
+          value: { phase: "start", ...omitEnvelope(data) },
+        });
+        break;
+      case "fallback_complete":
+        this.out("custom", {
+          name: "runtype.fallback",
+          value: { phase: "complete", ...omitEnvelope(data) },
+        });
+        break;
+      case "fallback_exhausted":
+        this.out("custom", {
+          name: "runtype.fallback",
+          value: { phase: "exhausted", ...omitEnvelope(data) },
+        });
+        break;
+
+      case "artifact_start":
+        this.out("artifact_start", {
+          id: data.id,
+          artifactType: data.artifactType,
+          title: data.title,
+          component: data.component,
+        });
+        break;
+      case "artifact_delta":
+        this.out("artifact_delta", { id: data.id, delta: data.delta });
+        break;
+      case "artifact_update":
+        this.out("artifact_update", { id: data.id, component: data.component, props: data.props });
+        break;
+      case "artifact_complete":
+        this.out("artifact_complete", { id: data.id });
+        break;
+      case "artifact":
+        this.out("artifact_start", {
+          id: data.id,
+          artifactType: data.artifactType ?? "markdown",
+          title: data.title,
+          component: data.component,
+        });
+        this.out("artifact_complete", { id: data.id });
+        break;
+
+      case "dispatch_error":
+        this.closeChannels();
+        this.out("execution_error", {
+          kind: this.kind,
+          error: this.toErrorPayload(data),
+          code: data.code,
+          upgradeUrl: data.upgradeUrl,
+        });
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  private emitMedia(data: Json): void {
+    const media = Array.isArray(data.media) ? data.media : [];
+    for (const raw of media) {
+      const item = (raw ?? {}) as Json;
+      const id = this.mint("media");
+      const mediaType =
+        typeof item.mediaType === "string"
+          ? item.mediaType
+          : item.type === "image-url"
+            ? "image"
+            : "application/octet-stream";
+      this.out("media_start", {
+        id,
+        mediaType,
+        role: "assistant",
+        toolCallId: data.toolCallId,
+      });
+      const fragment =
+        typeof item.url === "string" ? item.url : typeof item.data === "string" ? item.data : "";
+      if (fragment) this.out("media_delta", { id, delta: fragment });
+      this.out("media_complete", {
+        id,
+        mediaType,
+        url: item.url,
+        data: item.data,
+        toolCallId: data.toolCallId,
+      });
+    }
+  }
+
+  private toErrorPayload(error: unknown): Json | string {
+    if (typeof error === "string") return error;
+    if (error && typeof error === "object") {
+      const e = error as Json;
+      if (typeof e.code === "string" && typeof e.message === "string") {
+        return {
+          code: e.code,
+          message: e.message,
+          ...(e.details ? { details: e.details } : {}),
+        };
+      }
+      if (typeof e.error === "string") return e.error;
+      if (typeof e.message === "string")
+        return { code: typeof e.code === "string" ? e.code : "error", message: e.message };
+    }
+    return { code: "error", message: "Execution failed" };
+  }
+
+  write(chunk: string): void {
+    const parts = chunk.split("\n\n");
+    for (const part of parts) {
+      if (!part.trim()) continue;
+      let dataStr: string | null = null;
+      for (const line of part.split("\n")) {
+        if (line.startsWith("data: ")) dataStr = line.slice(6);
+      }
+      if (dataStr === null) {
+        this.sink(`${part}\n\n`);
+        continue;
+      }
+      if (dataStr.trim() === "[DONE]") {
+        this.sink("data: [DONE]\n\n");
+        continue;
+      }
+      let data: Json;
+      try {
+        data = JSON.parse(dataStr) as Json;
+      } catch {
+        this.sink(`${part}\n\n`);
+        continue;
+      }
+      const type = data?.type;
+      if (typeof type !== "string") continue;
+      try {
+        this.handle(type, data);
+      } catch {
+        // oracle fixture: swallow per-frame translation errors (prod logs via getLogger)
+      }
+    }
+  }
+}
+
+export function createUnifiedEventWrite(
+  sink: (chunk: string) => void,
+  options?: UnifiedEventWriteOptions
+): (chunk: string) => void {
+  const translator = new UnifiedEventTranslator(sink, options);
+  return (chunk: string) => translator.write(chunk);
+}

--- a/packages/widget/src/utils/unified-event-bridge.test.ts
+++ b/packages/widget/src/utils/unified-event-bridge.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from "vitest";
+import { UnifiedToLegacyBridge, isUnifiedLifecycleStart, type LegacyEvent } from "./unified-event-bridge";
+import { createUnifiedEventWrite } from "./__fixtures__/unified-translator.oracle";
+
+type Frame = Record<string, unknown> & { type: string };
+
+/** legacy frames → api oracle → parsed unified frames */
+function legacyToUnified(legacy: Frame[], executionId?: string): Frame[] {
+  const unified: Frame[] = [];
+  const sink = (chunk: string) => {
+    for (const part of chunk.split("\n\n")) {
+      const dataLine = part.split("\n").find((l) => l.startsWith("data: "));
+      if (!dataLine) continue;
+      const json = dataLine.slice(6);
+      if (json.trim() === "[DONE]") continue;
+      try {
+        unified.push(JSON.parse(json) as Frame);
+      } catch {
+        /* ignore */
+      }
+    }
+  };
+  const write = createUnifiedEventWrite(sink, executionId ? { executionId } : undefined);
+  for (const f of legacy) write(`data: ${JSON.stringify(f)}\n\n`);
+  return unified;
+}
+
+/** unified frames → widget bridge → legacy' events */
+function unifiedToLegacy(unified: Frame[], executionId?: string): LegacyEvent[] {
+  const bridge = new UnifiedToLegacyBridge(executionId ? { executionId } : undefined);
+  const out: LegacyEvent[] = [];
+  for (const f of unified) out.push(...bridge.push(f.type, f));
+  return out;
+}
+
+/** full round-trip: legacy → unified → legacy' */
+function roundTrip(legacy: Frame[], executionId = "exec_test"): { unified: Frame[]; legacy2: LegacyEvent[] } {
+  const unified = legacyToUnified(legacy, executionId);
+  return { unified, legacy2: unifiedToLegacy(unified, executionId) };
+}
+
+const byType = (evs: LegacyEvent[], t: string) => evs.filter((e) => e.payloadType === t);
+const field = (e: LegacyEvent | undefined, k: string): unknown => e?.payload[k];
+const textOf = (evs: LegacyEvent[]) =>
+  byType(evs, "agent_turn_delta")
+    .filter((e) => e.payload.contentType === "text")
+    .map((e) => String(e.payload.delta ?? ""))
+    .join("");
+const thinkingOf = (evs: LegacyEvent[]) =>
+  byType(evs, "agent_turn_delta")
+    .filter((e) => e.payload.contentType === "thinking")
+    .map((e) => String(e.payload.delta ?? ""))
+    .join("");
+
+describe("UnifiedToLegacyBridge — round-trip against the api oracle", () => {
+  it("agent text stream preserves text, turnId, and lifecycle", () => {
+    const { unified, legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual", startedAt: "t0" },
+      { type: "agent_turn_start", turnId: "turn_1", iteration: 1 },
+      { type: "agent_turn_delta", executionId: "exec_test", iteration: 1, turnId: "turn_1", contentType: "text", delta: "Hello " },
+      { type: "agent_turn_delta", executionId: "exec_test", iteration: 1, turnId: "turn_1", contentType: "text", delta: "world" },
+      { type: "agent_turn_complete", turnId: "turn_1", iteration: 1, stopReason: "end_turn", completedAt: "t1" },
+      { type: "agent_complete", executionId: "exec_test", success: true, stopReason: "end_turn", completedAt: "t1" },
+    ]);
+
+    // the oracle really did produce the neutral vocabulary
+    expect(unified[0].type).toBe("execution_start");
+    expect(unified.some((f) => f.type === "text_delta")).toBe(true);
+
+    expect(byType(legacy2, "agent_start")).toHaveLength(1);
+    expect(textOf(legacy2)).toBe("Hello world");
+    // turnId recovered from the open turn (unified decouples block-id from turn)
+    expect(field(byType(legacy2, "agent_turn_delta")[0], "turnId")).toBe("turn_1");
+    expect(field(byType(legacy2, "agent_turn_complete")[0], "stopReason")).toBe("end_turn");
+    const complete = byType(legacy2, "agent_complete")[0];
+    expect(field(complete, "success")).toBe(true);
+    expect(field(complete, "executionId")).toBe("exec_test");
+  });
+
+  it("agent text WITHOUT an explicit turn still renders (block-id fallback)", () => {
+    // the verified minimal adapter omits agent_turn_start
+    const { legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual" },
+      { type: "agent_turn_delta", executionId: "exec_test", iteration: 1, turnId: "turn_x", contentType: "text", delta: "hi" },
+      { type: "agent_complete", executionId: "exec_test", success: true },
+    ]);
+    expect(textOf(legacy2)).toBe("hi");
+    // no turn_start → bridge falls back to the unified text block id (stable, non-empty)
+    expect(field(byType(legacy2, "agent_turn_delta")[0], "turnId")).toBeTruthy();
+  });
+
+  it("agent thinking round-trips through the reasoning channel", () => {
+    const { unified, legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual" },
+      { type: "agent_turn_start", turnId: "turn_1", iteration: 1 },
+      { type: "agent_turn_delta", executionId: "exec_test", iteration: 1, turnId: "turn_1", contentType: "thinking", delta: "let me think" },
+      { type: "agent_turn_complete", turnId: "turn_1", iteration: 1 },
+      { type: "agent_complete", executionId: "exec_test", success: true },
+    ]);
+    expect(unified.some((f) => f.type === "reasoning_delta")).toBe(true);
+    expect(thinkingOf(legacy2)).toBe("let me think");
+  });
+
+  it("agent tool call preserves name, args, result, and toolCallId", () => {
+    const { unified, legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual" },
+      { type: "agent_tool_start", executionId: "exec_test", iteration: 1, toolCallId: "tc1", toolName: "search", parameters: { q: "shoes" } },
+      { type: "agent_tool_delta", toolCallId: "tc1", delta: "partial" },
+      { type: "agent_tool_complete", toolCallId: "tc1", result: { hits: 3 }, executionTime: 42 },
+      { type: "agent_complete", executionId: "exec_test", success: true },
+    ]);
+    expect(unified.some((f) => f.type === "tool_start")).toBe(true);
+
+    const start = byType(legacy2, "agent_tool_start")[0];
+    expect(field(start, "toolCallId")).toBe("tc1");
+    expect(field(start, "toolName")).toBe("search");
+    expect(field(start, "parameters")).toEqual({ q: "shoes" });
+
+    expect(field(byType(legacy2, "agent_tool_delta")[0], "delta")).toBe("partial");
+
+    const done = byType(legacy2, "agent_tool_complete")[0];
+    expect(field(done, "result")).toEqual({ hits: 3 });
+    expect(field(done, "executionTime")).toBe(42);
+  });
+
+  it("WebMCP agent_await maps onto the 3.35.0 step_await local-tool path with the webmcp: prefix", () => {
+    const { unified, legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual" },
+      {
+        type: "agent_await",
+        executionId: "exec_test",
+        toolId: "runtime_add_to_cart_1",
+        toolName: "add_to_cart", // BARE on the wire
+        origin: "webmcp",
+        toolCallId: "toolu_123",
+        parameters: { sku: "SHOE-003" },
+        awaitedAt: "t2",
+      },
+    ]);
+    // the oracle collapses agent_await → the neutral `await`
+    expect(unified.some((f) => f.type === "await")).toBe(true);
+    expect(unified.some((f) => f.type === "agent_await")).toBe(false);
+
+    const awaitEv = byType(legacy2, "step_await")[0];
+    expect(awaitEv).toBeDefined();
+    expect(field(awaitEv, "awaitReason")).toBe("local_tool_required");
+    expect(field(awaitEv, "toolName")).toBe("webmcp:add_to_cart"); // prefix synthesized by the bridge
+    expect(field(awaitEv, "toolCallId")).toBe("toolu_123");
+    expect(field(awaitEv, "parameters")).toEqual({ sku: "SHOE-003" });
+    expect(field(awaitEv, "executionId")).toBe("exec_test");
+  });
+
+  it("tool-produced media round-trips to a single agent_media", () => {
+    const { unified, legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual" },
+      {
+        type: "agent_media",
+        executionId: "exec_test",
+        toolCallId: "tc1",
+        media: [{ type: "image-url", url: "https://x/img.png", mediaType: "image/png" }],
+      },
+      { type: "agent_complete", executionId: "exec_test", success: true },
+    ]);
+    // oracle expands to the media triad
+    expect(unified.filter((f) => f.type.startsWith("media_"))).toHaveLength(3);
+
+    const media = byType(legacy2, "agent_media");
+    expect(media).toHaveLength(1);
+    const parts = field(media[0], "media") as Array<Record<string, unknown>>;
+    expect(parts[0].type).toBe("image-url");
+    expect(parts[0].url).toBe("https://x/img.png");
+    expect(parts[0].mediaType).toBe("image/png");
+  });
+
+  it("approval round-trips", () => {
+    const { legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual" },
+      { type: "agent_approval_start", approvalId: "ap1", toolName: "delete_file", toolType: "builtin", description: "Delete?", parameters: { path: "/x" } },
+      { type: "agent_approval_complete", approvalId: "ap1", decision: "approved" },
+    ]);
+    const start = byType(legacy2, "agent_approval_start")[0];
+    expect(field(start, "approvalId")).toBe("ap1");
+    expect(field(start, "toolName")).toBe("delete_file");
+    expect(field(byType(legacy2, "agent_approval_complete")[0], "decision")).toBe("approved");
+  });
+
+  it("artifacts round-trip 1:1", () => {
+    const { legacy2 } = roundTrip([
+      { type: "agent_start", executionId: "exec_test", agentId: "virtual" },
+      { type: "artifact_start", id: "a1", artifactType: "markdown", title: "Doc" },
+      { type: "artifact_delta", id: "a1", delta: "# Hello" },
+      { type: "artifact_complete", id: "a1" },
+    ]);
+    expect(field(byType(legacy2, "artifact_start")[0], "title")).toBe("Doc");
+    expect(field(byType(legacy2, "artifact_delta")[0], "delta")).toBe("# Hello");
+    expect(byType(legacy2, "artifact_complete")).toHaveLength(1);
+  });
+});
+
+describe("UnifiedToLegacyBridge — unit: kind routing, drops, and error mapping", () => {
+  it("flow-kind text routes to step_delta (not agent_turn_delta)", () => {
+    const b = new UnifiedToLegacyBridge();
+    b.push("execution_start", { kind: "flow", executionId: "exec_test" });
+    b.push("step_start", { id: "step_1", name: "Generate" });
+    const evs = b.push("text_delta", { id: "text_1", delta: "flow text" });
+    expect(evs).toHaveLength(1);
+    expect(evs[0].payloadType).toBe("step_delta");
+    expect(evs[0].payload.id).toBe("step_1"); // recovered from the open step
+    expect(evs[0].payload.text).toBe("flow text");
+  });
+
+  it("drops events with no legacy renderer", () => {
+    const b = new UnifiedToLegacyBridge();
+    b.push("execution_start", { kind: "agent", executionId: "exec_test" });
+    expect(b.push("source", { url: "https://x" })).toHaveLength(0);
+    expect(b.push("custom", { name: "runtype.fallback", value: {} })).toHaveLength(0);
+    expect(b.push("step_skip", { id: "s2" })).toHaveLength(0);
+    expect(b.push("tool_input_complete", { toolCallId: "tc1", parameters: {} })).toHaveLength(0);
+  });
+
+  it("unified `error` (recoverable) → agent_error{recoverable:true}, never the terminal `error`", () => {
+    const b = new UnifiedToLegacyBridge();
+    b.push("execution_start", { kind: "agent", executionId: "exec_test" });
+    const evs = b.push("error", { recoverable: true, error: { message: "transient" } });
+    expect(evs[0].payloadType).toBe("agent_error");
+    expect(evs[0].payload.recoverable).toBe(true);
+  });
+
+  it("execution_error{kind:agent} → terminal agent_error{recoverable:false}", () => {
+    const b = new UnifiedToLegacyBridge();
+    b.push("execution_start", { kind: "agent", executionId: "exec_test" });
+    const evs = b.push("execution_error", { kind: "agent", error: { message: "boom" } });
+    expect(evs[0].payloadType).toBe("agent_error");
+    expect(evs[0].payload.recoverable).toBe(false);
+  });
+
+  it("loop-scoped reasoning_complete folds into agent_reflection", () => {
+    const b = new UnifiedToLegacyBridge();
+    b.push("execution_start", { kind: "agent", executionId: "exec_test" });
+    b.push("reasoning_start", { id: "reason_1", scope: "loop" });
+    const evs = b.push("reasoning_complete", { id: "reason_1", text: "I should retry", scope: "loop" });
+    expect(evs[0].payloadType).toBe("agent_reflection");
+    expect(evs[0].payload.reflection).toBe("I should retry");
+  });
+
+  it("ask_user_question (non-webmcp local tool) await keeps its bare name", () => {
+    const b = new UnifiedToLegacyBridge();
+    b.push("execution_start", { kind: "agent", executionId: "exec_test" });
+    const evs = b.push("await", { toolName: "ask_user_question", toolCallId: "tc9", parameters: {} });
+    expect(evs[0].payloadType).toBe("step_await");
+    expect(evs[0].payload.awaitReason).toBe("local_tool_required");
+    expect(evs[0].payload.toolName).toBe("ask_user_question"); // no webmcp prefix
+  });
+});
+
+describe("isUnifiedLifecycleStart", () => {
+  it("identifies the unified vocabulary from the first lifecycle frame", () => {
+    expect(isUnifiedLifecycleStart("execution_start")).toBe(true);
+    expect(isUnifiedLifecycleStart("agent_start")).toBe(false);
+    expect(isUnifiedLifecycleStart("flow_start")).toBe(false);
+    expect(isUnifiedLifecycleStart("step_start")).toBe(false);
+  });
+});

--- a/packages/widget/src/utils/unified-event-bridge.ts
+++ b/packages/widget/src/utils/unified-event-bridge.ts
@@ -1,0 +1,431 @@
+/**
+ * Unified → legacy SSE event bridge (widget consumer side).
+ *
+ * The mirror image of the runtype-core `createUnifiedEventWrite` translator: it
+ * takes frames in the neutral 33-event UNIFIED vocabulary (emitted by the API
+ * when a caller requests `?events=unified`) and maps each back onto the LEGACY
+ * `agent_*` / `flow_*` / `step_*` / `artifact_*` events the widget's existing
+ * dispatch chain (`client.ts`) already renders. The dispatch chain is untouched.
+ *
+ * Opt-in: only engaged when `events: 'unified'` is set (or auto-detected from a
+ * leading `execution_start` frame). Default `'legacy'` bypasses this module.
+ *
+ * Stateful: the unified vocabulary collapses agent/flow distinctions and
+ * decouples text/reasoning block ids from turns, so the bridge tracks `kind`,
+ * the open turn/step, and buffers the media triad — exactly inverting the api
+ * translator's state. See `docs/specs/widget-unified-event-bridge.md` for the
+ * full mapping table (every field rename is pinned to the handler that reads it).
+ */
+
+/** Canonical WebMCP wire prefix — mirrors `webmcp-bridge.ts` (WEBMCP_TOOL_PREFIX
+ *  / isWebMcpToolName). Inlined to keep this pure mapper dependency-free. */
+const WEBMCP_PREFIX = "webmcp:";
+
+export type LegacyEvent = { payloadType: string; payload: Record<string, unknown> };
+
+/** True when a frame's `type` identifies the unified vocabulary unambiguously.
+ *  `execution_start` is unified-exclusive; `agent_start` / `flow_start` are
+ *  legacy-exclusive. Used by `client.ts` to auto-detect the wire mode from the
+ *  first lifecycle frame (so the `events` flag is a request, not a commitment). */
+export function isUnifiedLifecycleStart(type: string): boolean {
+  return type === "execution_start";
+}
+
+export class UnifiedToLegacyBridge {
+  private kind: "agent" | "flow" = "agent";
+  private executionId: string;
+  private iteration = 1;
+  /** current agent turn id (from `turn_start`) — the `turnId` agent deltas need */
+  private openTurnId: string | null = null;
+  /** current flow step id (from `step_start`) — the `id` flow text attaches to */
+  private openStepId: string | null = null;
+  private openTextBlockId: string | null = null;
+  private openReasoningId: string | null = null;
+  private readonly mediaBuffers = new Map<
+    string,
+    { mediaType?: string; role?: string; toolCallId?: unknown; parts: string[] }
+  >();
+
+  constructor(opts?: { executionId?: string }) {
+    this.executionId = opts?.executionId ?? "";
+  }
+
+  /** Translate ONE decoded unified frame into 0..N legacy events, in order. */
+  push(type: string, payload: Record<string, unknown>): LegacyEvent[] {
+    // Every unified frame carries the envelope executionId/seq; iteration rides
+    // on turn/tool frames. Capture them so legacy `agent_*` payloads can be stamped.
+    if (typeof payload.executionId === "string" && payload.executionId) {
+      this.executionId = payload.executionId;
+    }
+    if (typeof payload.iteration === "number") this.iteration = payload.iteration;
+
+    switch (type) {
+      // ===== lifecycle =====
+      case "execution_start": {
+        this.kind = payload.kind === "flow" ? "flow" : "agent";
+        if (this.kind !== "agent") return []; // no flow_start handler; state only
+        return [
+          this.out("agent_start", {
+            executionId: this.executionId,
+            agentId: payload.agentId,
+            agentName: payload.agentName,
+            maxTurns: payload.maxTurns,
+            startedAt: payload.startedAt,
+          }),
+        ];
+      }
+      case "turn_start": {
+        this.openTurnId = typeof payload.id === "string" ? payload.id : null;
+        if (this.kind !== "agent") return [];
+        return [this.out("agent_turn_start", { turnId: payload.id, iteration: payload.iteration })];
+      }
+      case "turn_complete": {
+        const out =
+          this.kind === "agent"
+            ? [
+                this.out("agent_turn_complete", {
+                  turnId: payload.id,
+                  iteration: payload.iteration,
+                  stopReason: payload.stopReason,
+                  completedAt: payload.completedAt,
+                }),
+              ]
+            : [];
+        if (this.openTurnId === payload.id) this.openTurnId = null;
+        return out;
+      }
+      case "execution_complete": {
+        if ((payload.kind ?? this.kind) === "agent") {
+          return [
+            this.out("agent_complete", {
+              executionId: this.executionId,
+              success: payload.success,
+              completedAt: payload.completedAt,
+              stopReason: payload.stopReason,
+            }),
+          ];
+        }
+        return [
+          this.out("flow_complete", {
+            success: payload.success,
+            completedAt: payload.completedAt,
+            duration: payload.durationMs,
+            finalOutput: payload.finalOutput,
+            totalSteps: payload.totalSteps,
+            successfulSteps: payload.successfulSteps,
+            failedSteps: payload.failedSteps,
+          }),
+        ];
+      }
+      case "execution_error": {
+        if ((payload.kind ?? this.kind) === "agent") {
+          // API emits no execution_complete on agent failure; surface as a
+          // terminal agent_error (recoverable:false → onEvent error in client.ts).
+          return [this.out("agent_error", { recoverable: false, error: payload.error })];
+        }
+        return [
+          this.out("flow_error", {
+            error: payload.error,
+            code: payload.code,
+            upgradeUrl: payload.upgradeUrl,
+          }),
+        ];
+      }
+      case "error":
+        // Unified `error` is the NON-terminal one. Route to agent_error
+        // (recoverable → warn only), NOT legacy `error` (that branch is terminal).
+        return [this.out("agent_error", { recoverable: true, error: payload.error })];
+      case "ping":
+        return [this.out("agent_ping", { timestamp: payload.timestamp })];
+
+      // ===== text channel =====
+      case "text_start":
+        this.openTextBlockId = typeof payload.id === "string" ? payload.id : null;
+        return []; // agent bubble created lazily by the first delta
+      case "text_delta": {
+        const delta = String(payload.delta ?? "");
+        if (this.kind === "agent") {
+          return [
+            this.out("agent_turn_delta", {
+              contentType: "text",
+              delta,
+              turnId: this.openTurnId ?? payload.id,
+              iteration: this.iteration,
+              executionId: this.executionId,
+            }),
+          ];
+        }
+        return [this.out("step_delta", { id: this.openStepId ?? payload.id, text: delta, stepType: "prompt" })];
+      }
+      case "text_complete":
+        if (this.openTextBlockId === payload.id) this.openTextBlockId = null;
+        return [];
+
+      // ===== reasoning channel =====
+      case "reasoning_start":
+        this.openReasoningId = typeof payload.id === "string" ? payload.id : null;
+        if (this.kind === "flow") return [this.out("reason_start", { id: payload.id })];
+        return [];
+      case "reasoning_delta": {
+        const delta = String(payload.delta ?? "");
+        if (this.kind === "agent") {
+          return [
+            this.out("agent_turn_delta", {
+              contentType: "thinking",
+              delta,
+              turnId: this.openTurnId ?? payload.id,
+              iteration: this.iteration,
+              executionId: this.executionId,
+            }),
+          ];
+        }
+        return [this.out("reason_delta", { id: payload.id, delta })];
+      }
+      case "reasoning_complete": {
+        const hasText = typeof payload.text === "string" && payload.text.length > 0;
+        if (this.kind === "agent") {
+          // E3: scope:'loop' (or a text-carrying close) is a reflection fold.
+          if (payload.scope === "loop" || hasText) {
+            return [
+              this.out("agent_reflection", {
+                reflection: payload.text ?? "",
+                executionId: this.executionId,
+                iteration: this.iteration,
+              }),
+            ];
+          }
+          return []; // turn-scoped thinking: closed by turn_complete
+        }
+        const out: LegacyEvent[] = [];
+        if (hasText) out.push(this.out("reason_delta", { id: payload.id, delta: payload.text }));
+        out.push(this.out("reason_complete", { id: payload.id }));
+        return out;
+      }
+
+      // ===== tool channel =====
+      case "tool_start": {
+        if (this.kind === "agent") {
+          return [
+            this.out("agent_tool_start", {
+              toolCallId: payload.toolCallId,
+              toolName: payload.toolName,
+              parameters: payload.parameters,
+              executionId: this.executionId,
+              iteration: payload.iteration ?? this.iteration,
+              startedAt: payload.startedAt,
+            }),
+          ];
+        }
+        return [
+          this.out("tool_start", {
+            toolId: payload.toolCallId,
+            toolName: payload.toolName,
+            parameters: payload.parameters,
+            executionId: this.executionId,
+            iteration: payload.iteration ?? this.iteration,
+            startedAt: payload.startedAt,
+          }),
+        ];
+      }
+      case "tool_input_delta": {
+        if (this.kind === "agent") {
+          return [
+            this.out("agent_turn_delta", {
+              contentType: "tool_input",
+              delta: String(payload.delta ?? ""),
+              toolCallId: payload.toolCallId,
+            }),
+          ];
+        }
+        return []; // flow tool-input isn't surfaced to the UI
+      }
+      case "tool_input_complete":
+        return []; // args already set at tool_start; no handler
+      case "tool_output_delta": {
+        const delta = String(payload.delta ?? "");
+        if (this.kind === "agent") {
+          return [this.out("agent_tool_delta", { toolCallId: payload.toolCallId, delta })];
+        }
+        return [this.out("tool_delta", { toolId: payload.toolCallId, delta })];
+      }
+      case "tool_complete": {
+        if (this.kind === "agent") {
+          return [
+            this.out("agent_tool_complete", {
+              toolCallId: payload.toolCallId,
+              result: payload.result,
+              executionTime: payload.executionTime,
+              completedAt: payload.completedAt,
+            }),
+          ];
+        }
+        return [
+          this.out("tool_complete", {
+            toolId: payload.toolCallId,
+            result: payload.result,
+            duration: payload.executionTime,
+            completedAt: payload.completedAt,
+          }),
+        ];
+      }
+
+      // ===== media channel (triad → one agent_media) =====
+      case "media_start": {
+        const id = String(payload.id);
+        this.mediaBuffers.set(id, {
+          mediaType: typeof payload.mediaType === "string" ? payload.mediaType : undefined,
+          role: typeof payload.role === "string" ? payload.role : undefined,
+          toolCallId: payload.toolCallId,
+          parts: [],
+        });
+        return [];
+      }
+      case "media_delta": {
+        const buf = this.mediaBuffers.get(String(payload.id));
+        if (buf && typeof payload.delta === "string") buf.parts.push(payload.delta);
+        return [];
+      }
+      case "media_complete": {
+        const id = String(payload.id);
+        const buf = this.mediaBuffers.get(id);
+        this.mediaBuffers.delete(id);
+        const mediaType =
+          (typeof payload.mediaType === "string" ? payload.mediaType : undefined) ??
+          buf?.mediaType ??
+          "application/octet-stream";
+        const data = typeof payload.data === "string" ? payload.data : undefined;
+        const url =
+          typeof payload.url === "string"
+            ? payload.url
+            : buf && buf.parts.length > 0
+              ? buf.parts.join("")
+              : undefined;
+        let part: Record<string, unknown> | null = null;
+        if (data) {
+          part = { type: "media", data, mediaType };
+        } else if (url) {
+          part = { type: mediaType.startsWith("image/") ? "image-url" : "file-url", url, mediaType };
+        }
+        if (!part) return [];
+        return [
+          this.out("agent_media", {
+            media: [part],
+            executionId: this.executionId,
+            iteration: this.iteration,
+            toolCallId: payload.toolCallId ?? buf?.toolCallId,
+          }),
+        ];
+      }
+
+      // ===== approvals =====
+      case "approval_start":
+        return [
+          this.out("agent_approval_start", {
+            approvalId: payload.approvalId,
+            toolName: payload.toolName,
+            toolType: payload.toolType,
+            description: payload.description,
+            reason: payload.reason,
+            parameters: payload.parameters,
+            executionId: this.executionId,
+          }),
+        ];
+      case "approval_complete":
+        return [
+          this.out("agent_approval_complete", {
+            approvalId: payload.approvalId,
+            decision: payload.decision,
+            executionId: this.executionId,
+            toolName: payload.toolName,
+            description: payload.description,
+          }),
+        ];
+
+      // ===== await (local-tool / WebMCP pause) — onto the 3.35.0 step_await path =====
+      case "await": {
+        const raw = typeof payload.toolName === "string" ? payload.toolName : "";
+        const toolName =
+          payload.origin === "webmcp" && !raw.startsWith(WEBMCP_PREFIX) ? `${WEBMCP_PREFIX}${raw}` : raw;
+        return [
+          this.out("step_await", {
+            awaitReason: "local_tool_required",
+            toolName,
+            parameters: payload.parameters,
+            toolCallId: payload.toolCallId,
+            toolId: payload.toolId,
+            executionId: this.executionId,
+            awaitedAt: payload.awaitedAt,
+          }),
+        ];
+      }
+
+      // ===== steps (flow) =====
+      case "step_start":
+        this.openStepId = typeof payload.id === "string" ? payload.id : null;
+        return [
+          this.out("step_start", {
+            id: payload.id,
+            name: payload.name,
+            stepType: payload.stepType,
+            index: payload.index,
+            totalSteps: payload.totalSteps,
+            startedAt: payload.startedAt,
+            outputVariable: payload.outputVariable,
+          }),
+        ];
+      case "step_complete": {
+        const out = this.out("step_complete", {
+          id: payload.id,
+          name: payload.name,
+          stepType: payload.stepType,
+          success: payload.success,
+          duration: payload.durationMs,
+          result: payload.result,
+          stopReason: payload.stopReason,
+          completedAt: payload.completedAt,
+          unresolvedVariables: payload.unresolvedVariables,
+        });
+        if (this.openStepId === payload.id) this.openStepId = null;
+        return [out];
+      }
+      case "step_skip":
+        return []; // no step_skip handler
+
+      // ===== artifacts (1:1) =====
+      case "artifact_start":
+        return [
+          this.out("artifact_start", {
+            id: payload.id,
+            artifactType: payload.artifactType,
+            title: payload.title,
+            component: payload.component,
+          }),
+        ];
+      case "artifact_delta":
+        return [this.out("artifact_delta", { id: payload.id, delta: payload.delta })];
+      case "artifact_update":
+        return [
+          this.out("artifact_update", { id: payload.id, component: payload.component, props: payload.props }),
+        ];
+      case "artifact_complete":
+        return [this.out("artifact_complete", { id: payload.id })];
+
+      // ===== dropped (no legacy renderer) =====
+      case "source":
+      case "custom":
+        return [];
+
+      default:
+        return [];
+    }
+  }
+
+  /** Build a legacy event, dropping undefined fields so the payload is clean. */
+  private out(payloadType: string, payload: Record<string, unknown>): LegacyEvent {
+    const pruned: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(payload)) {
+      if (v !== undefined) pruned[k] = v;
+    }
+    return { payloadType, payload: pruned };
+  }
+}


### PR DESCRIPTION
Introduced an opt-in feature for the unified event vocabulary by adding an `events: 'unified'` option. This allows the widget to request the API's neutral unified SSE vocabulary, bridging frames back to existing event handlers for unchanged rendering. The implementation includes updates to the `AgentWidgetClient` to handle the new vocabulary and tests to ensure proper functionality and fallback to legacy mode when necessary.