### PR TITLE
fix: regenerate Runtype OpenAPI contract types

### DIFF
--- a/.changeset/sync-runtype-openapi-types.md
+++ b/.changeset/sync-runtype-openapi-types.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Regenerate the Runtype OpenAPI contract to add the optional `untrustedContentHint` field on chat requests, syncing the committed types with the live spec.

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -1190,6 +1190,7 @@ export type RuntypeClientChatRequest = {
   type: "object";
   [key: string]: unknown;
 };
+  untrustedContentHint?: boolean;
 }>;
   clientToolsFingerprint?: string;
   inputs?: Record<string, unknown>;


### PR DESCRIPTION
## Problem

[CI on `main` is failing](https://github.com/runtypelabs/persona/actions/runs/27650910223/job/81774420581) at the **type checking** step. The `check:runtype-types` step (run as part of `pnpm typecheck`) re-fetches the live OpenAPI spec from `api.runtype.com` and fails when the committed contract is out of date:

```
src/generated/runtype-openapi-contract.ts is out of date.
Run pnpm --filter @runtypelabs/persona generate:runtype-types.
```

## Cause

Upstream added an optional `untrustedContentHint?: boolean` field on chat requests. The committed `runtype-openapi-contract.ts` had drifted from the live spec.

## Fix

Regenerated the contract via `pnpm generate:runtype-types`. The only change is the new optional field. `pnpm typecheck` now passes locally for both packages.

A patch changeset is included since this touches published widget types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Optional generated-type field only; no application logic or security behavior changes in this diff.
> 
> **Overview**
> Regenerates the committed **`runtype-openapi-contract.ts`** so it matches the live Runtype OpenAPI spec and unblocks **`check:runtype-types`** / CI typecheck.
> 
> The generated **`RuntypeClientChatRequest`** type now includes optional **`untrustedContentHint?: boolean`** on each **`clientTools`** entry, reflecting an upstream API addition. No runtime or widget logic changes—only the synced contract and a **patch** changeset for **`@runtypelabs/persona`** because published widget types changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 437a979cbe9ff963f909cc444eec44edbc6a4dc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->