### PR TITLE
fix(widget): trim stray newlines when manually copying message text

### DIFF
--- a/.changeset/copy-selection-trim.md
+++ b/.changeset/copy-selection-trim.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix manual text copy (triple-click + Ctrl/Cmd-C) from message bubbles attaching stray leading/trailing blank lines. The widget now normalizes the clipboard's plain text to match the visible selection, while preserving interior newlines and first-line indentation.

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -36,6 +36,7 @@ import { resolveTokenValue } from "./utils/tokens";
 import { renderLucideIcon } from "./utils/icons";
 import { createElement, createElementInDocument } from "./utils/dom";
 import { morphMessages } from "./utils/morph";
+import { normalizeCopiedSelectionText } from "./utils/copy-selection";
 import {
   navigateComposerHistory,
   INITIAL_HISTORY_STATE,
@@ -1353,6 +1354,26 @@ export const createAgentExperience = (
       event.preventDefault();
       handleBubbleExpansion(event);
     }
+  });
+
+  // Normalize manual (triple-click + Ctrl/Cmd-C) copies of message text. The
+  // browser serializes the DOM selection, and block-level markdown elements
+  // (<p>, <li>, <pre>, …) emit surrounding newlines — so a single-message copy
+  // arrives with stray trailing/leading blank lines. Rewrite the clipboard's
+  // plain text to the trimmed selection so the buffer matches what was visibly
+  // highlighted. (The Copy action button is unaffected; it uses message.content.)
+  messagesWrapper.addEventListener('copy', (event) => {
+    const { clipboardData } = event;
+    if (!clipboardData) return;
+    const root = messagesWrapper.getRootNode() as { getSelection?: () => Selection | null };
+    const selection =
+      typeof root.getSelection === 'function' ? root.getSelection() : window.getSelection();
+    if (!selection || selection.isCollapsed) return;
+    const raw = selection.toString();
+    const normalized = normalizeCopiedSelectionText(raw);
+    if (!normalized || normalized === raw) return;
+    clipboardData.setData('text/plain', normalized);
+    event.preventDefault();
   });
 
   // Add event delegation for message action buttons (upvote, downvote, copy)

--- a/packages/widget/src/utils/copy-selection.test.ts
+++ b/packages/widget/src/utils/copy-selection.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { normalizeCopiedSelectionText } from "./copy-selection";
+
+describe("normalizeCopiedSelectionText", () => {
+  it("strips a single trailing newline left by block-element serialization", () => {
+    const raw = "Create a markdown document titled \"Bridge Test Report\".\n";
+    expect(normalizeCopiedSelectionText(raw)).toBe(
+      "Create a markdown document titled \"Bridge Test Report\"."
+    );
+  });
+
+  it("strips multiple trailing blank lines and whitespace", () => {
+    expect(normalizeCopiedSelectionText("hello\n\n  \n")).toBe("hello");
+  });
+
+  it("strips leading blank lines", () => {
+    expect(normalizeCopiedSelectionText("\n\nhello")).toBe("hello");
+  });
+
+  it("preserves interior newlines (multi-paragraph / multi-message selection)", () => {
+    expect(normalizeCopiedSelectionText("first\n\nsecond\n")).toBe("first\n\nsecond");
+  });
+
+  it("preserves leading indentation on the first line (copied code)", () => {
+    expect(normalizeCopiedSelectionText("    indented line\nnext\n")).toBe(
+      "    indented line\nnext"
+    );
+  });
+
+  it("returns an unchanged string when there is nothing to trim", () => {
+    expect(normalizeCopiedSelectionText("clean text")).toBe("clean text");
+  });
+
+  it("returns an empty string for whitespace-only input", () => {
+    expect(normalizeCopiedSelectionText("\n\n  \n")).toBe("");
+  });
+});

--- a/packages/widget/src/utils/copy-selection.ts
+++ b/packages/widget/src/utils/copy-selection.ts
@@ -1,0 +1,19 @@
+/**
+ * Normalize text pulled from a native browser selection before it is written to
+ * the clipboard.
+ *
+ * When a user triple-clicks a chat bubble and presses Ctrl/Cmd-C, the browser
+ * serializes the DOM selection itself. Markdown is rendered into block-level
+ * elements (`<p>`, `<li>`, `<pre>`, …), and browsers emit surrounding newlines
+ * for those blocks — so copying a single message drags along stray leading
+ * blank lines and a trailing newline that the user never visually selected.
+ *
+ * This trims the outer whitespace so the clipboard matches the visible
+ * selection, while preserving:
+ *   - interior newlines (a multi-paragraph or multi-message selection keeps its
+ *     line breaks), and
+ *   - leading indentation on the first line (e.g. copied code keeps its indent;
+ *     only fully-blank leading lines are dropped).
+ */
+export const normalizeCopiedSelectionText = (text: string): string =>
+  text.replace(/^\n+/, "").replace(/\s+$/, "");


### PR DESCRIPTION
## Problem

Selecting message text with triple-click + Ctrl/Cmd-C and pasting attaches stray trailing (and sometimes leading) blank lines — e.g. copying a single user bubble yields `"...Render it as an artifact in the panel.\n\n"`.

**Cause:** a manual copy serializes the DOM selection itself. Markdown renders into block-level elements (`<p>`, `<li>`, `<pre>`, …), and a real triple-click extends the range past the content `<div>` into the bubble's inter-element whitespace, so the browser emits surrounding newlines the user never visually selected. (The Copy **button** is unaffected — it copies `message.content`.)

Reproduced on the live demo: a real triple-click of a user bubble produces `selection.toString()` ending in `\n\n`.

## Fix

- **`utils/copy-selection.ts`** (new) — `normalizeCopiedSelectionText()` strips leading blank lines and all trailing whitespace, while preserving interior newlines (multi-paragraph / multi-message selections) and first-line indentation (copied code keeps its indent).
- **`ui.ts`** — a `copy` listener on `messagesWrapper` reads the live selection (shadow-DOM-aware via `getRootNode().getSelection()`, falling back to `window.getSelection()`); if normalization changes anything, it rewrites the clipboard's `text/plain` and `preventDefault()`s. No-ops when the selection is collapsed or already clean.

## Scope note

Only `text/plain` is rewritten, so a manual bubble copy no longer carries rich HTML formatting — the intuitive result for chat text. Can extend to trim the HTML flavor too if desired.

## Testing

- New `copy-selection.test.ts` (7 cases: reported newline case, interior-newline preservation, leading-indent preservation, no-op, whitespace-only).
- Full widget suite green (1286 passed); `tsc --noEmit` clean; ESLint clean on touched files.
- Manually verified against the live demo: the reproduced `"...callout.\n\n"` selection normalizes to `"...callout."`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized clipboard handling on message copy with no auth or data-model changes; Copy-button behavior is explicitly untouched.
> 
> **Overview**
> Fixes **manual copy** (triple-click + Ctrl/Cmd-C) from message bubbles pasting with extra leading/trailing blank lines caused by DOM/block-markdown serialization.
> 
> Adds **`normalizeCopiedSelectionText()`** to trim outer blank lines and trailing whitespace while keeping interior newlines and first-line indentation. A **`copy`** handler on **`messagesWrapper`** rewrites **`text/plain`** when normalization changes the selection (shadow-DOM-aware selection lookup); it no-ops for collapsed or already-clean selections. The Copy **action button** path is unchanged.
> 
> Includes unit tests for the normalizer and a patch changeset for **`@runtypelabs/persona`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ac8f08b0260044a19c5cc2dcd5adfc1415170f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->