### PR TITLE
fix(approval-demo): event-log TDZ crash

### DIFF
--- a/examples/embedded-app/src/approval-demo.ts
+++ b/examples/embedded-app/src/approval-demo.ts
@@ -138,6 +138,22 @@ const wireApprovalLogging = (controller: AgentWidgetController): void => {
 let activeStage: HTMLElement | null = null;
 let teardownActive: (() => void) | null = null;
 
+// Declared before `setupMountMode` runs: setupMountMode invokes `mount`
+// synchronously during module evaluation, which calls `createWidget()` →
+// `updateLog()`. If `logContainer` (a const) were declared below that call it
+// would still be in its temporal dead zone, throwing "Cannot access
+// 'logContainer' before initialization" and crashing the demo before the widget
+// ever mounts (so no dispatch request fires).
+const logContainer = document.getElementById("event-log");
+function updateLog(message: string): void {
+  if (!logContainer) return;
+  const entry = document.createElement("div");
+  entry.style.cssText = "padding: 0.25rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.8rem;";
+  const time = new Date().toLocaleTimeString();
+  entry.innerHTML = `<span style="color: #64748b;">[${time}]</span> ${message}`;
+  logContainer.prepend(entry);
+}
+
 const createWidget = (): void => {
   if (teardownActive) {
     teardownActive();
@@ -213,16 +229,6 @@ iconSelector?.addEventListener("click", (event) => {
   iconMode = next;
   createWidget();
 });
-
-const logContainer = document.getElementById("event-log");
-function updateLog(message: string): void {
-  if (!logContainer) return;
-  const entry = document.createElement("div");
-  entry.style.cssText = "padding: 0.25rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.8rem;";
-  const time = new Date().toLocaleTimeString();
-  entry.innerHTML = `<span style="color: #64748b;">[${time}]</span> ${message}`;
-  logContainer.prepend(entry);
-}
 
 document.getElementById("btn-approve")?.addEventListener("click", () => {
   if (!activeController) return;

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -293,6 +293,10 @@ export type RuntypeExecutionStreamEvent = ({
   reason?: string;
   seq: number;
   startedAt?: string;
+  subagent?: {
+  agentName?: string;
+  toolName: string;
+};
   timeout?: number;
   toolCallId?: string;
   toolName: string;


### PR DESCRIPTION
`setupMountMode({...})` runs its `mount` callback synchronously during module evaluation, which calls `createWidget()` → `updateLog()`. But `const logContainer = document.getElementById("event-log")` and `updateLog` were declared *below* that call, so `logContainer` was in its temporal dead zone — throwing "Cannot access … before initialization" and crashing the approval demo before the widget ever mounted (no dispatch request fired).

Fix: hoist the `logContainer` const + `updateLog` above `setupMountMode`. No behavior change. Verified the emitted bundle now has the `getElementById("event-log")` const initialized before the mount call that runs `createWidget`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only ordering fix plus generated type alignment; no auth, data, or runtime approval behavior changes in application code.
> 
> **Overview**
> **Approval demo startup crash:** `logContainer` and `updateLog` are moved above `setupMountMode` so they are initialized before the mount callback runs synchronously at module load (`createWidget` → `updateLog`). This removes the temporal-dead-zone error that prevented the widget from mounting.
> 
> **OpenAPI contract:** The generated `approval_start` stream event type now includes an optional `subagent` object (`agentName`, `toolName`) on `runtype-openapi-contract.ts`, matching the refreshed public API schema.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe1c2f0f7c54703e75c1cf66bd156125935dda62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->