### PR TITLE
fix(approval-demo): event-log TDZ crash

### DIFF
--- a/examples/embedded-app/src/approval-demo.ts
+++ b/examples/embedded-app/src/approval-demo.ts
@@ -138,6 +138,22 @@ const wireApprovalLogging = (controller: AgentWidgetController): void => {
 let activeStage: HTMLElement | null = null;
 let teardownActive: (() => void) | null = null;
 
+// Declared before `setupMountMode` runs: setupMountMode invokes `mount`
+// synchronously during module evaluation, which calls `createWidget()` →
+// `updateLog()`. If `logContainer` (a const) were declared below that call it
+// would still be in its temporal dead zone, throwing "Cannot access
+// 'logContainer' before initialization" and crashing the demo before the widget
+// ever mounts (so no dispatch request fires).
+const logContainer = document.getElementById("event-log");
+function updateLog(message: string): void {
+  if (!logContainer) return;
+  const entry = document.createElement("div");
+  entry.style.cssText = "padding: 0.25rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.8rem;";
+  const time = new Date().toLocaleTimeString();
+  entry.innerHTML = `<span style="color: #64748b;">[${time}]</span> ${message}`;
+  logContainer.prepend(entry);
+}
+
 const createWidget = (): void => {
   if (teardownActive) {
     teardownActive();
@@ -213,16 +229,6 @@ iconSelector?.addEventListener("click", (event) => {
   iconMode = next;
   createWidget();
 });
-
-const logContainer = document.getElementById("event-log");
-function updateLog(message: string): void {
-  if (!logContainer) return;
-  const entry = document.createElement("div");
-  entry.style.cssText = "padding: 0.25rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.8rem;";
-  const time = new Date().toLocaleTimeString();
-  entry.innerHTML = `<span style="color: #64748b;">[${time}]</span> ${message}`;
-  logContainer.prepend(entry);
-}
 
 document.getElementById("btn-approve")?.addEventListener("click", () => {
   if (!activeController) return;


### PR DESCRIPTION
Re-targets the fix from #304 (which merged into `persona-4.0`) at `main`.

`setupMountMode({...})` runs its `mount` callback synchronously during module evaluation, which calls `createWidget()` → `updateLog()`. But `const logContainer = document.getElementById("event-log")` and `updateLog` were declared *below* that call, so `logContainer` was in its temporal dead zone — throwing "Cannot access … before initialization" and crashing the approval demo before the widget ever mounted (no dispatch request fired).

Fix: hoist the `logContainer` const + `updateLog` above `setupMountMode`. No behavior change.

Note: the OpenAPI `subagent` types portion of #304 is already present on `main`, so this PR contains only the approval-demo fix. Demo-only change (`examples/embedded-app`), so no changeset required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Demo-only change in `examples/embedded-app` with no library or production runtime impact.
> 
> **Overview**
> Fixes a **module-load crash** in the approval embedded demo by moving `logContainer` and `updateLog` **above** `setupMountMode`.
> 
> `setupMountMode` calls the `mount` callback immediately during evaluation, which runs `createWidget()` and then `updateLog()`. When those bindings lived below that call, `logContainer` was still in the temporal dead zone and the page threw before the widget could mount.
> 
> Behavior is unchanged aside from the demo loading successfully; a short comment documents why the hoist is required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09ecfba67b3b422fed9763748a4e12b6ff7f967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->