### PR TITLE
fix(embedded-app): bundle command-palette entry so it loads in prod

### DIFF
--- a/examples/embedded-app/vite.config.ts
+++ b/examples/embedded-app/vite.config.ts
@@ -465,17 +465,25 @@ function galleryFonts(): Plugin {
 function commandPaletteEntry(): Plugin {
   return {
     name: "persona-command-palette-entry",
-    transformIndexHtml(html) {
-      if (html.includes("/src/command-palette-entry.ts")) return;
-      const isHome = html.includes('src="/src/main.ts"') || html.includes("src/home.css");
-      if (isHome) return;
-      return [
-        {
-          tag: "script",
-          attrs: { type: "module", src: "/src/command-palette-entry.ts" },
-          injectTo: "body",
-        },
-      ] satisfies HtmlTagDescriptor[];
+    // Must run `pre` so the injected tag is present when Vite scans the HTML
+    // for module inputs. With the default (post) ordering the build emits the
+    // `/src/command-palette-entry.ts` src verbatim, and it 404s in production
+    // because the raw TS source isn't served — it only works under the dev
+    // server. Running `pre` lets Vite bundle/hash it like a hand-written tag.
+    transformIndexHtml: {
+      order: "pre",
+      handler(html) {
+        if (html.includes("command-palette-entry")) return;
+        const isHome = html.includes('src="/src/main.ts"') || html.includes("src/home.css");
+        if (isHome) return;
+        return [
+          {
+            tag: "script",
+            attrs: { type: "module", src: "/src/command-palette-entry.ts" },
+            injectTo: "body",
+          },
+        ] satisfies HtmlTagDescriptor[];
+      },
     },
   };
 }


### PR DESCRIPTION
## Problem

Every non-home page on `www.persona-chat.dev` logs:

```
GET https://www.persona-chat.dev/src/command-palette-entry.ts net::ERR_ABORTED 404 (Not Found)
```

## Root cause

`examples/embedded-app/vite.config.ts` has a `commandPaletteEntry()` plugin that injects the command-palette script into non-home pages via `transformIndexHtml`:

```ts
{ tag: "script", attrs: { type: "module", src: "/src/command-palette-entry.ts" }, injectTo: "body" }
```

The hook ran with the **default (post) ordering**, which runs *after* Vite has already scanned the HTML for module inputs. As a result the tag was emitted into the built HTML **verbatim** rather than being bundled into a hashed asset. It only worked under the dev server, which transpiles TS on the fly — in the production build the raw `.ts` source isn't served, so the browser 404s.

The entry is also not a `rollupOptions.input`, so it was never built as a standalone chunk either.

## Fix

Run the hook with `order: "pre"` so the injected `<script>` is present when Vite scans the HTML for module inputs. Vite then treats it like a hand-written module tag and bundles it.

## Verification

Built `examples/embedded-app` before/after:

- **Before:** built HTML contained literal `src="/src/command-palette-entry.ts"` (the 404).
- **After:** no raw `.ts` reference remains; the entry is bundled to `assets/command-palette-entry-<hash>.js`, statically imported by each page's main chunk and `modulepreload`ed.

## Changeset

Not required — `examples/` only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples-only Vite build hook ordering change; no auth, data, or shared package behavior.
> 
> **Overview**
> Fixes production **404s** for the command palette on non-home embedded-app pages by changing when Vite sees the injected script tag.
> 
> The `commandPaletteEntry()` plugin still injects a module script for `command-palette-entry.ts` on non-home HTML, but **`transformIndexHtml` now runs with `order: "pre"`** so Vite includes that URL during its HTML module scan and emits a **hashed bundled asset** instead of leaving `src="/src/command-palette-entry.ts"` in the built HTML. The skip-if-present check now matches any HTML that already references **`command-palette-entry`**, not only the exact `/src/...` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98bb212a1dd27dd9727041f184f371f8ad0bd042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->