### PR TITLE
chore(proxy): set Chat Assistant demo model to zai/glm-5.2

### DIFF
--- a/.changeset/chat-assistant-glm-5-2.md
+++ b/.changeset/chat-assistant-glm-5-2.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Switch the Fullscreen Assistant demo's `CHAT_ASSISTANT_AGENT` to `zai/glm-5.2`.

--- a/packages/proxy/src/agents/chat-assistant.ts
+++ b/packages/proxy/src/agents/chat-assistant.ts
@@ -7,7 +7,7 @@ import type { AgentConfig } from "../index.js";
  */
 export const CHAT_ASSISTANT_AGENT: AgentConfig = {
   name: "Chat Assistant",
-  model: "nemotron-3-ultra-550b-a55b",
+  model: "zai/glm-5.2",
   systemPrompt:
     "You are a helpful assistant. Be friendly, concise, and helpful. If you don't know something, say so.",
   artifacts: { enabled: true, types: ["markdown", "component"] },


### PR DESCRIPTION
## What

Switches the Fullscreen Assistant demo's server-pinned `CHAT_ASSISTANT_AGENT` model from `nemotron-3-ultra-550b-a55b` to `zai/glm-5.2`.

## Why

Requested model for the fullscreen-assistant demo (`/api/chat/dispatch-assistant`).

## Notes

- `zai/glm-5.2` is the canonical platform model id (verified against the prod model list and a live dispatch probe).
- Includes a `@runtypelabs/persona-proxy` patch changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single demo agent model swap with no auth, data, or routing logic changes.
> 
> **Overview**
> Updates the server-pinned **Fullscreen Assistant** agent so `/api/chat/dispatch-assistant` routes demo chat through **`zai/glm-5.2`** instead of **`nemotron-3-ultra-550b-a55b`**.
> 
> Adds a **`@runtypelabs/persona-proxy`** patch changeset for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d41f63a168a8de7b32ef69897f94d664567298e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->