### PR TITLE
chore(proxy): set Chat Assistant demo model to moonshotai/kimi-k2.7-code

### DIFF
--- a/.changeset/chat-assistant-kimi-k2-7-code.md
+++ b/.changeset/chat-assistant-kimi-k2-7-code.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Switch the Fullscreen Assistant demo's `CHAT_ASSISTANT_AGENT` to `moonshotai/kimi-k2.7-code` (Kimi K2.7 Code via Mixlayer).

--- a/packages/proxy/src/agents/chat-assistant.ts
+++ b/packages/proxy/src/agents/chat-assistant.ts
@@ -7,7 +7,7 @@ import type { AgentConfig } from "../index.js";
  */
 export const CHAT_ASSISTANT_AGENT: AgentConfig = {
   name: "Chat Assistant",
-  model: "zai/glm-5.2",
+  model: "moonshotai/kimi-k2.7-code",
   systemPrompt:
     "You are a helpful assistant. Be friendly, concise, and helpful. If you don't know something, say so.",
   artifacts: { enabled: true, types: ["markdown", "component"] },


### PR DESCRIPTION
## What

Switches the Fullscreen Assistant demo's server-pinned `CHAT_ASSISTANT_AGENT` model to `moonshotai/kimi-k2.7-code` (Kimi K2.7 Code via Mixlayer).

## Why

Follow-up to #309 (which set glm-5.2). Kimi 2.6 isn't available through Mixlayer on this account, so this uses the K2.7 Code variant, which Mixlayer does serve.

## Notes

- `moonshotai/kimi-k2.7-code` is unique to the Mixlayer provider in the prod model catalog; verified with a live dispatch probe against `/api/chat/dispatch-assistant`.
- Includes a `@runtypelabs/persona-proxy` patch changeset.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single demo agent model string change with no auth, data, or routing logic changes.
> 
> **Overview**
> Updates the Fullscreen Assistant demo’s server-pinned **`CHAT_ASSISTANT_AGENT`** so its `model` is **`moonshotai/kimi-k2.7-code`** (Kimi K2.7 Code via Mixlayer) instead of **`zai/glm-5.2`**.
> 
> Adds a **`@runtypelabs/persona-proxy`** patch changeset for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1b971ee268ea8fd9a09268dc2520491df9fa961. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->