### PR TITLE
fix(approval-demo): restore unified-events fix on apps/web + repair TDZ crash

### DIFF
--- a/apps/web/src/approval-demo.ts
+++ b/apps/web/src/approval-demo.ts
@@ -2,13 +2,16 @@ import "@runtypelabs/persona/widget.css";
 import { renderDemoScaffold } from "./demo-scaffold";
 
 import {
-  createLocalStorageAdapter,
   markdownPostprocessor,
   DEFAULT_WIDGET_CONFIG,
   type AgentWidgetConfig,
   type AgentWidgetController,
 } from "@runtypelabs/persona";
-import { createMockSSEResponse, createMockSSEStream } from "@runtypelabs/persona/testing";
+import {
+  createMockSSEResponse,
+  createMockSSEStream,
+  type MockSSEFrame,
+} from "@runtypelabs/persona/testing";
 import { setupMountMode, runWidgetMountWithInspector } from "./mount-mode";
 import { createDemoConfigInspector } from "./demo-config-inspector";
 // `renderApproval` plugin example: shows an alternative permission prompt
@@ -42,24 +45,56 @@ const buildApprovalPlugin = () => {
 let activeController: AgentWidgetController | null = null;
 let lastApprovalDecision: "approved" | "denied" | null = null;
 
+// The widget consumes the *unified* event vocabulary (`execution_start`,
+// `turn_start`, `text_*`, `tool_*`, `approval_*`, …). On a real deployment the
+// Runtype API translates the agent runtime's legacy `agent_*` frames into these
+// before they reach the browser, so a `customFetch` mock — which bypasses the
+// server — must emit unified frames directly. Emitting legacy `agent_*` names
+// here is silently dropped by the client and nothing renders.
+//
+// Builds one assistant turn: turn_start → text_start → text_delta(s) →
+// text_complete → turn_complete. `text_complete` seals the bubble so the
+// trailing approval/tool bubble renders below it instead of leaving an
+// open streaming bubble.
+const assistantTurn = (
+  executionId: string,
+  turnId: string,
+  iteration: number,
+  deltas: string[],
+  stopReason?: string,
+): MockSSEFrame[] => {
+  const blockId = `${turnId}-text`;
+  return [
+    { type: "turn_start", executionId, id: turnId, iteration },
+    { type: "text_start", executionId, id: blockId },
+    ...deltas.map((delta) => ({ type: "text_delta", executionId, id: blockId, delta })),
+    { type: "text_complete", executionId, id: blockId },
+    { type: "turn_complete", executionId, id: turnId, ...(stopReason ? { stopReason } : {}) },
+  ];
+};
+
 const buildConfig = (mode: Mode): AgentWidgetConfig => {
   const launcherChrome = mode === "launcher";
   return {
     ...DEFAULT_WIDGET_CONFIG,
-    storageAdapter: createLocalStorageAdapter(
-      `persona-state-approval-demo-${mode}-${variant}`,
-    ),
+    // Ephemeral: this is a canned mock demo (every send replays the same
+    // scripted approval flow), so persisting the conversation only leaves stale
+    // user bubbles on the next load — which look identical to the dark
+    // suggestion chips and suppress the real chips (they hide once any user
+    // message exists). `persistState: false` is the kill-switch: no history is
+    // read or written (the built-in localStorage adapter isn't even created), so
+    // a fresh load always shows the working chips — like the other mock-driven
+    // demo (fullscreen-assistant-demo-sse).
+    persistState: false,
     plugins: variant === "plugin" ? [buildApprovalPlugin()] : [],
     customFetch: async () => {
-      const events = [
-        { type: "agent_start", executionId: "exec-demo-1", agentId: "demo-agent", agentName: "Demo Agent", maxTurns: 3, startedAt: Date.now() },
-        { type: "agent_iteration_start", executionId: "exec-demo-1", iteration: 1 },
-        { type: "agent_turn_start", executionId: "exec-demo-1", turnId: "turn-1" },
-        { type: "agent_turn_delta", executionId: "exec-demo-1", turnId: "turn-1", delta: "Let me look that up in the documentation..." },
-        { type: "agent_turn_complete", executionId: "exec-demo-1", turnId: "turn-1" },
+      const executionId = "exec-demo-1";
+      const events: MockSSEFrame[] = [
+        { type: "execution_start", kind: "agent", executionId, agentId: "demo-agent", agentName: "Demo Agent", maxTurns: 3, startedAt: Date.now() },
+        ...assistantTurn(executionId, "turn-1", 1, ["Let me look that up in the documentation..."]),
         {
-          type: "agent_approval_start",
-          executionId: "exec-demo-1",
+          type: "approval_start",
+          executionId,
           approvalId: `approval-${Date.now()}`,
           toolName: "Search documentation",
           // `toolType` is a free-form string; the plugin renders it as the
@@ -77,25 +112,25 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
         const remember = options?.remember ? " (remember)" : "";
         updateLog(`Decision: ${decision}${remember} for tool "${data.toolName}" (approval: ${data.approvalId})`);
         if (decision === "denied") {
-          const events = [
-            { type: "agent_turn_start", executionId: data.executionId, turnId: "turn-denied" },
-            { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-denied", delta: "The tool execution was denied. I'll try to help without using that tool." },
-            { type: "agent_turn_complete", executionId: data.executionId, turnId: "turn-denied" },
-            { type: "agent_complete", executionId: data.executionId, success: true, stopReason: "complete" },
+          const events: MockSSEFrame[] = [
+            ...assistantTurn(data.executionId, "turn-denied", 2, [
+              "The tool execution was denied. I'll try to help without using that tool.",
+            ]),
+            { type: "execution_complete", kind: "agent", executionId: data.executionId, success: true, stopReason: "complete" },
           ];
           return createMockSSEStream(events, { delayMs: 150 });
         }
-        const events = [
-          { type: "agent_approval_complete", executionId: data.executionId, approvalId: data.approvalId, decision: "approved", toolName: data.toolName },
-          { type: "agent_tool_start", executionId: data.executionId, toolCallId: "tool-1", toolName: data.toolName, parameters: { query: "latest AI news 2025", numResults: 5 } },
-          { type: "agent_tool_delta", executionId: data.executionId, toolCallId: "tool-1", delta: "Searching..." },
-          { type: "agent_tool_complete", executionId: data.executionId, toolCallId: "tool-1", result: { results: ["Result 1: AI breakthrough", "Result 2: New model released"] }, executionTime: 1200 },
-          { type: "agent_turn_start", executionId: data.executionId, turnId: "turn-2" },
-          { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-2", delta: "Based on the search results, here are the latest AI developments:\n\n" },
-          { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-2", delta: "1. **AI Breakthrough** - Major advances in reasoning capabilities\n" },
-          { type: "agent_turn_delta", executionId: data.executionId, turnId: "turn-2", delta: "2. **New Model Released** - Next-gen models with improved performance\n" },
-          { type: "agent_turn_complete", executionId: data.executionId, turnId: "turn-2" },
-          { type: "agent_complete", executionId: data.executionId, success: true, stopReason: "complete" },
+        const events: MockSSEFrame[] = [
+          { type: "approval_complete", executionId: data.executionId, approvalId: data.approvalId, decision: "approved", toolName: data.toolName },
+          { type: "tool_start", executionId: data.executionId, toolCallId: "tool-1", toolName: data.toolName, parameters: { query: "latest AI news 2025", numResults: 5 } },
+          { type: "tool_output_delta", executionId: data.executionId, toolCallId: "tool-1", delta: "Searching..." },
+          { type: "tool_complete", executionId: data.executionId, toolCallId: "tool-1", result: { results: ["Result 1: AI breakthrough", "Result 2: New model released"] }, executionTime: 1200 },
+          ...assistantTurn(data.executionId, "turn-2", 2, [
+            "Based on the search results, here are the latest AI developments:\n\n",
+            "1. **AI Breakthrough** - Major advances in reasoning capabilities\n",
+            "2. **New Model Released** - Next-gen models with improved performance\n",
+          ]),
+          { type: "execution_complete", kind: "agent", executionId: data.executionId, success: true, stopReason: "complete" },
         ];
         return createMockSSEStream(events, { delayMs: 150 });
       },
@@ -137,6 +172,23 @@ const wireApprovalLogging = (controller: AgentWidgetController): void => {
 
 let activeStage: HTMLElement | null = null;
 let teardownActive: (() => void) | null = null;
+
+// Declared before `setupMountMode` runs: setupMountMode invokes `mount`
+// synchronously during module evaluation (via the synchronous portion of its
+// `applyMode` before its first `await`), which calls `createWidget()` →
+// `updateLog()`. If `logContainer` (a const) were declared below that call it
+// would still be in its temporal dead zone, throwing "Cannot access
+// 'logContainer' before initialization" and crashing the demo before the widget
+// ever mounts (so no dispatch request fires).
+const logContainer = document.getElementById("event-log");
+function updateLog(message: string): void {
+  if (!logContainer) return;
+  const entry = document.createElement("div");
+  entry.style.cssText = "padding: 0.25rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.8rem;";
+  const time = new Date().toLocaleTimeString();
+  entry.innerHTML = `<span style="color: #64748b;">[${time}]</span> ${message}`;
+  logContainer.prepend(entry);
+}
 
 const createWidget = (): void => {
   if (teardownActive) {
@@ -213,16 +265,6 @@ iconSelector?.addEventListener("click", (event) => {
   iconMode = next;
   createWidget();
 });
-
-const logContainer = document.getElementById("event-log");
-function updateLog(message: string): void {
-  if (!logContainer) return;
-  const entry = document.createElement("div");
-  entry.style.cssText = "padding: 0.25rem 0; border-bottom: 1px solid rgba(255,255,255,0.05); font-size: 0.8rem;";
-  const time = new Date().toLocaleTimeString();
-  entry.innerHTML = `<span style="color: #64748b;">[${time}]</span> ${message}`;
-  logContainer.prepend(entry);
-}
 
 document.getElementById("btn-approve")?.addEventListener("click", () => {
   if (!activeController) return;


### PR DESCRIPTION
## Why a new PR

PR #311 fixed this demo, but its changes were clobbered by the web-move (#312): #312 branched from *before* #311, moved a pre-fix snapshot of `examples/embedded-app/src/approval-demo.ts` → `apps/web/src/approval-demo.ts`, and on merge deleted the old path. Net result on `main`: #311 shows merged, but `apps/web/src/approval-demo.ts` is the **old broken** file. This PR re-applies the fix on the new path and repairs a regression the move reintroduced.

## What this fixes

**1. Unified SSE events.** The `customFetch` mock emitted the agent runtime's legacy `agent_*` vocabulary, but the Persona 4.0 widget consumes the **unified** vocabulary (`text_delta`, `approval_start`, `tool_*`, `execution_complete`). On a real deployment the API translates legacy→unified server-side; a `customFetch` mock bypasses the server, so every frame was silently dropped and nothing rendered. Rewritten to unified events via an `assistantTurn()` helper.

**2. `persistState: false`.** The demo replays one canned flow, so persisting left stale user bubbles that look like the dark suggestion chips and suppressed the real chips. Ephemeral now, matching `fullscreen-assistant-demo-sse`.

**3. TDZ crash (regression from #312).** The web-move moved the `logContainer`/`updateLog` block *below* `setupMountMode`, which runs `mount()` synchronously (via `applyMode` before its first `await`) → `createWidget()` → `updateLog()` → reads the `const logContainer` while it's still in its temporal dead zone. This reverted #305 and crashed the demo on load. Moved the block back above `setupMountMode` with a guard comment.

## Verification (local `apps/web` build)

- Loads with **no console error** (TDZ crash gone; "Widget initialized" logs from `createWidget`).
- Chip → message sends; assistant text + **Approval Required** bubble render.
- Built-in **Approve** → tool bubble + markdown response; **Deny** → fallback.
- Plugin renderer + programmatic `resolveApproval` work; reload persists nothing.

Examples/showcase-only change (`apps/web`) → no changeset required.

> Heads-up: the same TDZ-revert pattern from #312 may affect other demos whose `updateLog` helper got reordered — worth a sweep, but out of scope here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Examples-only change in `apps/web/src/approval-demo.ts`; no production API or widget library behavior changes.
> 
> **Overview**
> Re-applies the approval demo fix on `apps/web` after the web-move overwrote it: the mock `customFetch` / `onDecision` streams now emit **unified** Persona 4.0 SSE events (`execution_*`, `text_*`, `approval_*`, `tool_*`) via a shared `assistantTurn()` helper instead of legacy `agent_*` frames that the client drops when the server is bypassed.
> 
> **`persistState: false`** replaces the localStorage adapter so reloads don’t leave stale user bubbles that hide suggestion chips on this scripted replay demo.
> 
> **`logContainer` / `updateLog`** are moved above `setupMountMode` so synchronous mount → `createWidget()` → `updateLog()` no longer hits a temporal dead zone crash on load.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a02c0725f7d7ec19aa1da254d6c54a100886b665. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->