### PR TITLE
feat(widget): neutral surface card as the default approval UI

### DIFF
--- a/.changeset/built-in-approval-redesign.md
+++ b/.changeset/built-in-approval-redesign.md
@@ -1,0 +1,29 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Redesign the default tool-approval bubble as a neutral surface card
+
+The built-in approval UI is now a neutral "permission card" — a tool icon, a
+"The assistant wants to use **tool**" title, the call arguments collapsed behind
+a "show more" disclosure, and a primary action anchored to the brand
+`--persona-primary` token. On resolve, approved approvals disappear (the tool
+call takes over the transcript) and denied/timed-out ones collapse to a subtle
+one-line trace.
+
+New `config.approval.enableAlwaysAllow` (default `false`): when enabled, the
+primary becomes a split **Always allow / Allow once** control with a dropdown and
+keyboard shortcuts (Enter / Cmd-Ctrl+Enter / Esc), forwarding `{ remember: true }`
+to your `onDecision` handler. Keep it off unless your backend persists the
+don't-ask-again policy.
+
+**Visual change for un-configured widgets:** the default look shifts from the
+yellow "Approval Required / Approve / Deny" bubble to the neutral card (primary
+button from green to the brand primary). All `config.approval.*` overrides still
+function and the `--persona-approval-*` CSS variables are honored fallback-first,
+so themed widgets are unaffected. To restore the old look, set
+`config.approval.backgroundColor`/`borderColor` (or the
+`components.approval.requested.*` tokens) back to the warning palette. Note:
+`config.approval.title` no longer renders in the default card — use
+`formatDescription` to customize the summary line. A custom `renderApproval`
+plugin still fully overrides the default.

--- a/.changeset/built-in-approval-redesign.md
+++ b/.changeset/built-in-approval-redesign.md
@@ -5,9 +5,9 @@
 Redesign the default tool-approval bubble as a neutral surface card
 
 The built-in approval UI is now a neutral "permission card" — a tool icon, a
-"The assistant wants to use **tool**" title, the call arguments collapsed behind
-a "show more" disclosure, and a primary action anchored to the brand
-`--persona-primary` token. On resolve, approved approvals disappear (the tool
+"The assistant wants to use **tool**" title, the agent-facing description and
+call arguments collapsed behind a "show more" disclosure, and a primary action
+anchored to the brand `--persona-primary` token. On resolve, approved approvals disappear (the tool
 call takes over the transcript) and denied/timed-out ones collapse to a subtle
 one-line trace.
 

--- a/apps/web/approval-demo.html
+++ b/apps/web/approval-demo.html
@@ -19,10 +19,17 @@
 
         <div class="info-section">
           <h3>Renderer</h3>
-          <p>Built-in bubble vs. a <code>renderApproval</code> plugin that shows an alternative "Always allow / Allow once / Deny" prompt.</p>
+          <p>The built-in approval card, or a <code>renderApproval</code> plugin that fully customizes it (e.g. a source icon and different copy).</p>
           <div class="mode-group" id="variant-selector" style="margin-top: 0.5rem;">
             <button class="mode-btn active" data-variant="builtin">Built-in</button>
             <button class="mode-btn" data-variant="plugin">Plugin (alternative)</button>
+          </div>
+          <div id="always-allow-row" style="margin-top: 0.85rem;">
+            <p style="margin: 0 0 0.4rem; font-size: 0.85rem;">"Always allow" affordance (<code>approval.enableAlwaysAllow</code>). Off by default — it needs a backend to persist the don't-ask-again policy.</p>
+            <div class="mode-group" id="always-allow-selector">
+              <button class="mode-btn active" data-always="off">Allow / Deny</button>
+              <button class="mode-btn" data-always="on">Always allow + dropdown</button>
+            </div>
           </div>
           <div id="icon-mode-row" style="margin-top: 0.85rem; display: none;">
             <p style="margin: 0 0 0.4rem; font-size: 0.85rem;">Source icon: explicit <code>icons</code> map vs. Google favicon service vs. the built-in default tool icon.</p>

--- a/apps/web/src/approval-demo.ts
+++ b/apps/web/src/approval-demo.ts
@@ -29,6 +29,10 @@ const configInspector = createDemoConfigInspector({ title: "Tool Approval" });
 let approvalMountMode: Mode = "inline";
 type ApprovalVariant = "builtin" | "plugin";
 let variant: ApprovalVariant = "builtin";
+// Built-in renderer only: offer the "Always allow" split control + keyboard
+// shortcuts. Off by default — it forwards `remember` to onDecision for a
+// backend to persist, which the mock here just logs.
+let alwaysAllow = false;
 
 // Icon source for the plugin renderer's source-icon box. Mirrors the three
 // resolution paths in approval-actions-plugin: explicit `icons` map, the
@@ -107,6 +111,7 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
       return createMockSSEResponse(events, { delayMs: 200 });
     },
     approval: {
+      enableAlwaysAllow: alwaysAllow,
       onDecision: async (data, decision, options) => {
         lastApprovalDecision = decision;
         const remember = options?.remember ? " (remember)" : "";
@@ -228,12 +233,31 @@ setupMountMode({
   },
 });
 
-// The icon-source toggle only applies to the plugin renderer.
+// The icon-source toggle only applies to the plugin renderer; the always-allow
+// toggle only applies to the built-in renderer.
 const iconModeRow = document.getElementById("icon-mode-row");
+const alwaysAllowRow = document.getElementById("always-allow-row");
 const syncIconRow = (): void => {
   if (iconModeRow) iconModeRow.style.display = variant === "plugin" ? "" : "none";
+  if (alwaysAllowRow) alwaysAllowRow.style.display = variant === "builtin" ? "" : "none";
 };
 syncIconRow();
+
+// "Always allow" toggle (built-in renderer): single Allow/Deny vs. the split
+// "Always allow / Allow once" control with keyboard shortcuts.
+const alwaysAllowSelector = document.getElementById("always-allow-selector");
+alwaysAllowSelector?.addEventListener("click", (event) => {
+  const btn = (event.target as HTMLElement).closest<HTMLElement>(".mode-btn");
+  if (!btn) return;
+  const next = btn.dataset.always === "on";
+  if (next === alwaysAllow) return;
+  alwaysAllowSelector
+    .querySelectorAll(".mode-btn")
+    .forEach((b) => b.classList.remove("active"));
+  btn.classList.add("active");
+  alwaysAllow = next;
+  createWidget();
+});
 
 // Renderer variant selector (built-in bubble vs. renderApproval plugin).
 const variantSelector = document.getElementById("variant-selector");

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -14,7 +14,7 @@
   {
     "name": "⛔ CRITICAL · browser stylesheet (widget.css)",
     "path": "dist/widget.css",
-    "limit": "21 kB",
+    "limit": "22 kB",
     "gzip": true
   },
   {

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -345,27 +345,36 @@ Semantic tokens provide intent-based naming that references palette values.
 
 ### Approval (`components.approval.*`)
 
+The default approval renderer is a neutral surface card whose primary action
+anchors to the brand primary. Defaults map to semantic tokens (so the card
+tracks your theme), not the old warning/success/error palette:
+
 | Token | Default Reference |
 |-------|-------------------|
-| `requested.background` | `palette.colors.warning.50` |
-| `requested.border` | `palette.colors.warning.200` |
+| `requested.background` | `semantic.colors.surface` |
+| `requested.border` | `semantic.colors.border` |
 | `requested.text` | `palette.colors.gray.900` |
-| `requested.shadow` | `"0 5px 15px rgba(15, 23, 42, 0.08)"` |
-| `approve.background` | `palette.colors.success.500` |
-| `approve.foreground` | `palette.colors.gray.50` |
-| `deny.background` | `palette.colors.error.500` |
-| `deny.foreground` | `palette.colors.gray.50` |
+| `requested.shadow` | `"0 1px 2px 0 rgba(11,11,11,0.06), 0 2px 8px 0 rgba(11,11,11,0.04)"` |
+| `approve.background` | `semantic.colors.primary` (→ `--persona-button-primary-bg`) |
+| `approve.foreground` | `semantic.colors.textInverse` (→ `--persona-button-primary-fg`) |
+| `deny.background` | `semantic.colors.container` |
+| `deny.foreground` | `semantic.colors.text` |
 
 **Per-widget overrides (`config.approval.*`)** take precedence over the tokens above:
 
 | Property | Description |
 |----------|-------------|
-| `backgroundColor` / `borderColor` | Bubble container styling |
-| `shadow` | Box-shadow for the bubble; pass `"none"` to remove it. Overrides the `requested.shadow` token / `--persona-approval-shadow` |
-| `title` / `titleColor` / `descriptionColor` | Title and description text |
+| `enableAlwaysAllow` | `false` by default. `true` adds the split "Always allow / Allow once" control + keyboard shortcuts; forwards `{ remember: true }` to `onDecision` (needs a backend to persist the policy) |
+| `detailsDisplay` | `"collapsed"` (default) / `"expanded"` / `"hidden"` — initial state of the tool-arguments disclosure |
+| `showDetailsLabel` / `hideDetailsLabel` | Disclosure toggle labels |
+| `backgroundColor` / `borderColor` | Card container styling |
+| `shadow` | Box-shadow for the card; pass `"none"` to remove it. Overrides the `requested.shadow` token / `--persona-approval-shadow` |
+| `titleColor` / `descriptionColor` | Title and summary text (`title` no longer renders in the default card — use `formatDescription` to customize the summary line) |
 | `parameterBackgroundColor` / `parameterTextColor` | Parameters code block |
-| `approveLabel` / `approveButtonColor` / `approveButtonTextColor` | Approve button |
-| `denyLabel` / `denyButtonColor` / `denyButtonTextColor` | Deny button (text color also drives the outline) |
+| `approveLabel` / `approveButtonColor` / `approveButtonTextColor` | Primary (Allow / Always allow) button + caret |
+| `denyLabel` / `denyButtonColor` / `denyButtonTextColor` | Deny button |
+
+> The legacy yellow look: set `config.approval.backgroundColor`/`borderColor` (or the `components.approval.requested.*` tokens) back to the warning palette to restore it. The `--persona-approval-*` aliases are still honored fallback-first.
 
 ### Attachment (`components.attachment.*`)
 

--- a/packages/widget/src/components/approval-actions.test.ts
+++ b/packages/widget/src/components/approval-actions.test.ts
@@ -182,6 +182,19 @@ describe("built-in approval — flag on (enableAlwaysAllow)", () => {
     expect(first.approve).toHaveBeenCalledWith({ remember: true });
   });
 
+  it("re-rendering an older approval does not steal shortcuts from the newest", () => {
+    const { plugin } = makePlugin();
+    const first = renderWith(plugin, cfg, makeMessage({}, "msg-A"));
+    const second = renderWith(plugin, cfg, makeMessage({}, "msg-B"));
+    // Older card (A) re-renders, e.g. via idiomorph — it must NOT claim the
+    // shortcuts back from the newer card B at the bottom of the thread.
+    const reA = renderWith(plugin, cfg, makeMessage({}, "msg-A"));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(first.approve).not.toHaveBeenCalled();
+    expect(reA.approve).not.toHaveBeenCalled();
+    expect(second.approve).toHaveBeenCalledWith({ remember: true });
+  });
+
   it("tearing down one widget leaves another widget's approval shortcuts intact", () => {
     const widgetA = makePlugin();
     const widgetB = makePlugin();
@@ -216,6 +229,25 @@ describe("built-in approval — parameters disclosure", () => {
     const { el } = render({ approval: { detailsDisplay: "hidden" } }, withParams());
     expect(el?.querySelector('[data-role="params"]')).toBeNull();
     expect(el?.querySelector('[data-action="toggle-params"]')).toBeNull();
+  });
+
+  it("honors config show/hideDetailsLabel as the toggle's accessible label", () => {
+    const { el } = render(
+      { approval: { showDetailsLabel: "Reveal call", hideDetailsLabel: "Hide call" } },
+      withParams()
+    );
+    const head = el?.querySelector<HTMLElement>('[data-action="toggle-params"]');
+    expect(head?.getAttribute("aria-label")).toBe("Reveal call");
+    click(head);
+    expect(head?.getAttribute("aria-label")).toBe("Hide call");
+  });
+
+  it("defaults the toggle's accessible label to Show/Hide details", () => {
+    const { el } = render({}, withParams());
+    const head = el?.querySelector<HTMLElement>('[data-action="toggle-params"]');
+    expect(head?.getAttribute("aria-label")).toBe("Show details");
+    click(head);
+    expect(head?.getAttribute("aria-label")).toBe("Hide details");
   });
 });
 

--- a/packages/widget/src/components/approval-actions.test.ts
+++ b/packages/widget/src/components/approval-actions.test.ts
@@ -1,16 +1,14 @@
 // @vitest-environment jsdom
 
 import { afterEach, describe, expect, it, vi } from "vitest";
-import {
-  createBuiltInApprovalPlugin,
-  teardownAllBuiltInApprovals,
-} from "./approval-actions";
+import { createBuiltInApprovalPlugin } from "./approval-actions";
 import { approvalDetailsExpansionState } from "./approval-bubble";
 import type {
   AgentWidgetApproval,
   AgentWidgetConfig,
   AgentWidgetMessage,
 } from "../types";
+import type { AgentWidgetPlugin } from "../plugins/types";
 
 const makeMessage = (
   approval: Partial<AgentWidgetApproval> = {},
@@ -33,13 +31,24 @@ const makeMessage = (
   },
 });
 
-const render = (
+// Each widget owns its own plugin instance + teardown (state is per-instance).
+// Track teardowns so afterEach can release any leftover document listeners.
+let teardowns: Array<() => void> = [];
+
+const makePlugin = (): { plugin: AgentWidgetPlugin; teardown: () => void } => {
+  const handle = createBuiltInApprovalPlugin();
+  teardowns.push(handle.teardown);
+  return handle;
+};
+
+const renderWith = (
+  plugin: AgentWidgetPlugin,
   config: AgentWidgetConfig = {},
   message: AgentWidgetMessage = makeMessage()
 ) => {
   const approve = vi.fn();
   const deny = vi.fn();
-  const el = createBuiltInApprovalPlugin().renderApproval!({
+  const el = plugin.renderApproval!({
     message,
     defaultRenderer: () => document.createElement("div"),
     config,
@@ -50,12 +59,19 @@ const render = (
   return { el, approve, deny };
 };
 
+// Convenience for single-render tests: fresh widget instance each call.
+const render = (
+  config: AgentWidgetConfig = {},
+  message: AgentWidgetMessage = makeMessage()
+) => renderWith(makePlugin().plugin, config, message);
+
 const click = (el: Element | null | undefined): void => {
   el?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
 };
 
 afterEach(() => {
-  teardownAllBuiltInApprovals();
+  teardowns.forEach((t) => t());
+  teardowns = [];
   approvalDetailsExpansionState.clear();
   document.body.innerHTML = "";
 });
@@ -138,19 +154,43 @@ describe("built-in approval — flag on (enableAlwaysAllow)", () => {
     expect(approve).not.toHaveBeenCalled();
   });
 
-  it("teardownAllBuiltInApprovals releases the document keydown listener", () => {
-    const { approve } = render(cfg);
-    teardownAllBuiltInApprovals();
+  it("teardown releases the document keydown listener", () => {
+    const { plugin, teardown } = makePlugin();
+    const { approve } = renderWith(plugin, cfg);
+    teardown();
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(approve).not.toHaveBeenCalled();
   });
 
-  it("only the latest pending approval owns the keyboard shortcuts", () => {
-    const first = render(cfg, makeMessage({}, "msg-A"));
-    const second = render(cfg, makeMessage({}, "msg-B"));
+  it("within one widget, only the latest pending approval owns the keyboard shortcuts", () => {
+    const { plugin } = makePlugin();
+    const first = renderWith(plugin, cfg, makeMessage({}, "msg-A"));
+    const second = renderWith(plugin, cfg, makeMessage({}, "msg-B"));
     document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
     expect(first.approve).not.toHaveBeenCalled();
     expect(second.approve).toHaveBeenCalledWith({ remember: true });
+  });
+
+  it("promotes an older pending approval to keyboard owner when the latest resolves", () => {
+    const { plugin } = makePlugin();
+    const first = renderWith(plugin, cfg, makeMessage({}, "msg-A"));
+    const second = renderWith(plugin, cfg, makeMessage({}, "msg-B"));
+    // Resolve the current owner (B); A should inherit the shortcuts.
+    click(second.el?.querySelector('[data-action="deny"]'));
+    expect(second.deny).toHaveBeenCalledTimes(1);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(first.approve).toHaveBeenCalledWith({ remember: true });
+  });
+
+  it("tearing down one widget leaves another widget's approval shortcuts intact", () => {
+    const widgetA = makePlugin();
+    const widgetB = makePlugin();
+    const a = renderWith(widgetA.plugin, cfg, makeMessage({}, "msg-A"));
+    const b = renderWith(widgetB.plugin, cfg, makeMessage({}, "msg-B"));
+    widgetA.teardown(); // destroy only widget A
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(a.approve).not.toHaveBeenCalled();
+    expect(b.approve).toHaveBeenCalledWith({ remember: true });
   });
 });
 
@@ -172,8 +212,44 @@ describe("built-in approval — parameters disclosure", () => {
     expect(el?.querySelector<HTMLElement>('[data-role="params"]')?.hidden).toBe(false);
   });
 
-  it("detailsDisplay:'hidden' omits the params block and header toggle", () => {
+  it("detailsDisplay:'hidden' omits the disclosure and header toggle", () => {
     const { el } = render({ approval: { detailsDisplay: "hidden" } }, withParams());
+    expect(el?.querySelector('[data-role="params"]')).toBeNull();
+    expect(el?.querySelector('[data-action="toggle-params"]')).toBeNull();
+  });
+});
+
+describe("built-in approval — agent description in disclosure", () => {
+  it("surfaces approval.description in the collapsible details even without parameters", () => {
+    const { el } = render(
+      {},
+      makeMessage({ description: "Reads your calendar", parameters: undefined })
+    );
+    const details = el?.querySelector<HTMLElement>('[data-role="params"]');
+    expect(details).not.toBeNull();
+    expect(el?.querySelector('[data-action="toggle-params"]')).not.toBeNull();
+    expect(details?.querySelector(".persona-approval-desc")?.textContent).toContain(
+      "Reads your calendar"
+    );
+  });
+
+  it("shows the description alongside the parameters block", () => {
+    const { el } = render(
+      {},
+      makeMessage({ description: "Reads your calendar", parameters: { when: "today" } })
+    );
+    const details = el?.querySelector<HTMLElement>('[data-role="params"]');
+    expect(details?.querySelector(".persona-approval-desc")?.textContent).toContain(
+      "Reads your calendar"
+    );
+    expect(details?.querySelector(".persona-approval-params")?.textContent).toContain("today");
+  });
+
+  it("detailsDisplay:'hidden' omits the description disclosure too", () => {
+    const { el } = render(
+      { approval: { detailsDisplay: "hidden" } },
+      makeMessage({ description: "Reads your calendar", parameters: undefined })
+    );
     expect(el?.querySelector('[data-role="params"]')).toBeNull();
     expect(el?.querySelector('[data-action="toggle-params"]')).toBeNull();
   });

--- a/packages/widget/src/components/approval-actions.test.ts
+++ b/packages/widget/src/components/approval-actions.test.ts
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  createBuiltInApprovalPlugin,
+  teardownAllBuiltInApprovals,
+} from "./approval-actions";
+import { approvalDetailsExpansionState } from "./approval-bubble";
+import type {
+  AgentWidgetApproval,
+  AgentWidgetConfig,
+  AgentWidgetMessage,
+} from "../types";
+
+const makeMessage = (
+  approval: Partial<AgentWidgetApproval> = {},
+  id = "msg-1"
+): AgentWidgetMessage => ({
+  id,
+  role: "assistant",
+  content: "",
+  createdAt: new Date().toISOString(),
+  variant: "approval",
+  streaming: false,
+  approval: {
+    id: "appr-1",
+    status: "pending",
+    agentId: "agent-1",
+    executionId: "exec-1",
+    toolName: "search_docs",
+    description: "Search the docs",
+    ...approval,
+  },
+});
+
+const render = (
+  config: AgentWidgetConfig = {},
+  message: AgentWidgetMessage = makeMessage()
+) => {
+  const approve = vi.fn();
+  const deny = vi.fn();
+  const el = createBuiltInApprovalPlugin().renderApproval!({
+    message,
+    defaultRenderer: () => document.createElement("div"),
+    config,
+    approve,
+    deny,
+  });
+  if (el) document.body.appendChild(el);
+  return { el, approve, deny };
+};
+
+const click = (el: Element | null | undefined): void => {
+  el?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+};
+
+afterEach(() => {
+  teardownAllBuiltInApprovals();
+  approvalDetailsExpansionState.clear();
+  document.body.innerHTML = "";
+});
+
+describe("built-in approval — flag off (default)", () => {
+  it("renders a single Allow + Deny, no split control", () => {
+    const { el } = render();
+    expect(el?.querySelector('[data-action="allow"]')?.textContent).toContain("Allow");
+    expect(el?.querySelector('[data-action="deny"]')).not.toBeNull();
+    expect(el?.querySelector('[data-action="always"]')).toBeNull();
+    expect(el?.querySelector('[data-action="toggle-menu"]')).toBeNull();
+    expect(el?.textContent).not.toContain("Always allow");
+  });
+
+  it("Allow resolves approved without remember; Deny denies", () => {
+    const { el, approve, deny } = render();
+    click(el?.querySelector('[data-action="allow"]'));
+    expect(approve).toHaveBeenCalledTimes(1);
+    expect(approve.mock.calls[0]).toEqual([]); // no { remember } argument
+    click(el?.querySelector('[data-action="deny"]'));
+    expect(deny).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the title from the tool name and an optional source", () => {
+    const { el } = render({}, makeMessage({ toolName: "search_docs", toolType: "Runtype" }));
+    const title = el?.querySelector(".persona-approval-title");
+    expect(title?.textContent).toContain("Search docs");
+    expect(title?.textContent).toContain("from");
+    expect(title?.textContent).toContain("Runtype");
+  });
+
+  it("honors config.approval.approveLabel / denyLabel", () => {
+    const { el } = render({ approval: { approveLabel: "Permit", denyLabel: "Refuse" } });
+    expect(el?.querySelector('[data-action="allow"]')?.textContent).toContain("Permit");
+    expect(el?.querySelector('[data-action="deny"]')?.textContent).toContain("Refuse");
+  });
+});
+
+describe("built-in approval — flag on (enableAlwaysAllow)", () => {
+  const cfg: AgentWidgetConfig = { approval: { enableAlwaysAllow: true } };
+
+  it("renders the split Always allow + caret + Deny", () => {
+    const { el } = render(cfg);
+    expect(el?.querySelector('[data-action="always"]')?.textContent).toContain("Always allow");
+    expect(el?.querySelector('[data-action="toggle-menu"]')).not.toBeNull();
+    expect(el?.querySelector('[data-action="deny"]')).not.toBeNull();
+    expect(el?.querySelector('[data-action="allow"]')).toBeNull();
+  });
+
+  it("Always allow resolves with { remember: true }", () => {
+    const { el, approve } = render(cfg);
+    click(el?.querySelector('[data-action="always"]'));
+    expect(approve).toHaveBeenCalledWith({ remember: true });
+  });
+
+  it("Enter triggers Always allow", () => {
+    const { approve } = render(cfg);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(approve).toHaveBeenCalledWith({ remember: true });
+  });
+
+  it("Escape denies", () => {
+    const { deny } = render(cfg);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    expect(deny).toHaveBeenCalledTimes(1);
+  });
+
+  it("Cmd/Ctrl+Enter triggers Allow once (no remember)", () => {
+    const { approve } = render(cfg);
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", metaKey: true, bubbles: true }));
+    expect(approve).toHaveBeenCalledTimes(1);
+    expect(approve.mock.calls[0]).toEqual([]);
+  });
+
+  it("ignores keyboard shortcuts while typing in an editable field", () => {
+    const { approve } = render(cfg);
+    const input = document.createElement("input");
+    document.body.appendChild(input);
+    input.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(approve).not.toHaveBeenCalled();
+  });
+
+  it("teardownAllBuiltInApprovals releases the document keydown listener", () => {
+    const { approve } = render(cfg);
+    teardownAllBuiltInApprovals();
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(approve).not.toHaveBeenCalled();
+  });
+
+  it("only the latest pending approval owns the keyboard shortcuts", () => {
+    const first = render(cfg, makeMessage({}, "msg-A"));
+    const second = render(cfg, makeMessage({}, "msg-B"));
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(first.approve).not.toHaveBeenCalled();
+    expect(second.approve).toHaveBeenCalledWith({ remember: true });
+  });
+});
+
+describe("built-in approval — parameters disclosure", () => {
+  const withParams = () => makeMessage({ parameters: { query: "x", n: 5 } });
+
+  it("collapses parameters by default and expands on header click", () => {
+    const { el } = render({}, withParams());
+    const pre = el?.querySelector<HTMLElement>('[data-role="params"]');
+    expect(pre).not.toBeNull();
+    expect(pre?.hidden).toBe(true);
+    click(el?.querySelector(".persona-approval-head"));
+    expect(pre?.hidden).toBe(false);
+    expect(approvalDetailsExpansionState.get("msg-1")).toBe(true);
+  });
+
+  it("detailsDisplay:'expanded' shows params up front", () => {
+    const { el } = render({ approval: { detailsDisplay: "expanded" } }, withParams());
+    expect(el?.querySelector<HTMLElement>('[data-role="params"]')?.hidden).toBe(false);
+  });
+
+  it("detailsDisplay:'hidden' omits the params block and header toggle", () => {
+    const { el } = render({ approval: { detailsDisplay: "hidden" } }, withParams());
+    expect(el?.querySelector('[data-role="params"]')).toBeNull();
+    expect(el?.querySelector('[data-action="toggle-params"]')).toBeNull();
+  });
+});
+
+describe("built-in approval — resolved states", () => {
+  it("approved renders nothing visible (the tool call takes over)", () => {
+    const { el } = render({}, makeMessage({ status: "approved" }));
+    expect(el?.style.display).toBe("none");
+    expect(el?.querySelector("[data-action]")).toBeNull();
+  });
+
+  it("denied renders a subtle one-line trace, no action buttons", () => {
+    const { el } = render({}, makeMessage({ status: "denied" }));
+    expect(el?.classList.contains("persona-approval-resolved")).toBe(true);
+    expect(el?.textContent).toContain("Search docs");
+    expect(el?.textContent).toContain("denied");
+    expect(el?.querySelector("[data-action]")).toBeNull();
+  });
+
+  it("timeout renders a timed-out trace", () => {
+    const { el } = render({}, makeMessage({ status: "timeout" }));
+    expect(el?.textContent).toContain("timed out");
+  });
+});

--- a/packages/widget/src/components/approval-actions.ts
+++ b/packages/widget/src/components/approval-actions.ts
@@ -1,0 +1,372 @@
+/**
+ * Built-in default approval renderer.
+ *
+ * Renders the neutral "permission card": a tool icon, a "The assistant wants to
+ * use <tool>" title, the call arguments collapsed behind a "show more" header
+ * chevron, and an action row. By default the row is a single "Allow" (allow
+ * once) + "Deny". When `config.approval.enableAlwaysAllow` is true it becomes a
+ * split "Always allow ⏎" primary with an "Allow once ⌘⏎" dropdown plus
+ * "Deny Esc", with keyboard shortcuts — that affordance is opt-in because
+ * "Always allow" only means anything if the integrator persists the policy via
+ * `onDecision`'s `remember` flag (needs a backend).
+ *
+ * Installed as an internal `renderApproval` plugin (see ui.ts) so it rides the
+ * existing plugin stub-and-hydrate + teardown path and survives idiomorph
+ * re-renders. A user-supplied `renderApproval` plugin still fully overrides it.
+ *
+ * Resolved states mirror the example plugin: approved → render nothing (the
+ * tool call takes over the transcript); denied/timeout → a subtle one-line
+ * trace.
+ */
+import { createElement } from "../utils/dom";
+import { renderLucideIcon } from "../utils/icons";
+import { formatUnknownValue } from "../utils/formatting";
+import { WEBMCP_TOOL_PREFIX, getWebMcpToolDisplayTitle } from "../webmcp-bridge";
+import { createPopover, isEditableEventTarget, type PopoverHandle } from "../plugin-kit";
+import type {
+  AgentWidgetMessage,
+  AgentWidgetConfig,
+  AgentWidgetApprovalConfig,
+} from "../types";
+import type { AgentWidgetPlugin } from "../plugins/types";
+import { humanizeToolName, approvalDetailsExpansionState } from "./approval-bubble";
+
+type Approval = NonNullable<AgentWidgetMessage["approval"]>;
+type Decide = (options?: { remember?: boolean }) => void;
+
+// Per-message runtime state. The document `keydown` handler (re-bound on each
+// render to the freshest approve/deny closures) and the "Allow once" popover
+// are torn down when the approval resolves, the bubble rebuilds, or the widget
+// is destroyed.
+const keyHandlers = new Map<string, (e: KeyboardEvent) => void>();
+const popovers = new Map<string, PopoverHandle>();
+// Only the most-recently-built pending approval owns the keyboard shortcuts, so
+// Enter/Esc don't fire on every pending card at once.
+let latestPendingApprovalId: string | null = null;
+
+const teardownMessage = (messageId: string): void => {
+  const prevKey = keyHandlers.get(messageId);
+  if (prevKey) {
+    document.removeEventListener("keydown", prevKey);
+    keyHandlers.delete(messageId);
+  }
+  const popover = popovers.get(messageId);
+  if (popover) {
+    popover.destroy();
+    popovers.delete(messageId);
+  }
+  if (latestPendingApprovalId === messageId) latestPendingApprovalId = null;
+};
+
+/** Release every pending approval's global listener + popover. Pushed into the widget's destroy callbacks. */
+export const teardownAllBuiltInApprovals = (): void => {
+  for (const id of [...keyHandlers.keys(), ...popovers.keys()]) teardownMessage(id);
+  latestPendingApprovalId = null;
+};
+
+const resolveApprovalConfig = (
+  config?: AgentWidgetConfig
+): AgentWidgetApprovalConfig | undefined =>
+  config?.approval !== false ? config?.approval : undefined;
+
+const isDetailsExpanded = (
+  messageId: string,
+  approvalConfig?: AgentWidgetApprovalConfig
+): boolean => {
+  const mode = approvalConfig?.detailsDisplay ?? "collapsed";
+  return approvalDetailsExpansionState.get(messageId) ?? mode === "expanded";
+};
+
+const kbd = (label: string): HTMLElement => {
+  const el = createElement("span", "persona-approval-kbd");
+  el.textContent = label;
+  return el;
+};
+
+// Title: "The assistant wants to use <tool>" with an optional "from <source>"
+// when a non-WebMCP `toolType` source label is present. `formatDescription`
+// fully overrides the line. Mirrors the built-in bubble's label priority
+// (formatDescription → declared WebMCP title → humanized tool name).
+const buildTitle = (
+  approval: Approval,
+  approvalConfig?: AgentWidgetApprovalConfig
+): HTMLElement => {
+  const title = createElement("span", "persona-approval-title");
+  if (approvalConfig?.titleColor) title.style.color = approvalConfig.titleColor;
+
+  const isWebMcp =
+    approval.toolType === "webmcp" || approval.toolName.startsWith(WEBMCP_TOOL_PREFIX);
+  const declaredTitle = isWebMcp
+    ? getWebMcpToolDisplayTitle(approval.toolName)
+    : undefined;
+
+  const custom = approvalConfig?.formatDescription?.({
+    toolName: approval.toolName,
+    toolType: approval.toolType,
+    description: approval.description ?? "",
+    parameters: approval.parameters,
+    ...(declaredTitle ? { displayTitle: declaredTitle } : {}),
+    ...(approval.reason ? { reason: approval.reason } : {}),
+  });
+  if (custom) {
+    title.textContent = custom;
+    return title;
+  }
+
+  const toolDisplay = declaredTitle ?? humanizeToolName(approval.toolName);
+  const source =
+    approval.toolType && approval.toolType !== "webmcp" ? approval.toolType : null;
+  title.append("The assistant wants to use ");
+  const toolStrong = document.createElement("strong");
+  toolStrong.textContent = toolDisplay;
+  title.appendChild(toolStrong);
+  if (source) {
+    title.append(" from ");
+    const srcStrong = document.createElement("strong");
+    srcStrong.textContent = source;
+    title.appendChild(srcStrong);
+  }
+  return title;
+};
+
+const buildResolvedTrace = (approval: Approval): HTMLElement => {
+  const row = createElement("div", "persona-approval-resolved");
+  const icon = renderLucideIcon("ban", 15, "currentColor", 2);
+  if (icon) row.appendChild(icon);
+  const name = createElement("span", "persona-approval-resolved-name");
+  name.textContent = approval.toolName ? humanizeToolName(approval.toolName) : "Tool";
+  row.append(name, document.createTextNode(approval.status === "timeout" ? " timed out" : " denied"));
+  return row;
+};
+
+const buildPending = (
+  message: AgentWidgetMessage,
+  approval: Approval,
+  approvalConfig: AgentWidgetApprovalConfig | undefined,
+  approve: Decide,
+  deny: Decide,
+  enableAlways: boolean
+): HTMLElement => {
+  const card = createElement("div", "persona-approval-card persona-shadow-sm");
+  card.id = `bubble-${message.id}`;
+  card.setAttribute("data-message-id", message.id);
+  card.setAttribute("data-bubble-type", "approval");
+  if (approvalConfig?.backgroundColor) card.style.background = approvalConfig.backgroundColor;
+  if (approvalConfig?.borderColor) card.style.borderColor = approvalConfig.borderColor;
+  if (approvalConfig?.shadow !== undefined) {
+    card.style.boxShadow = approvalConfig.shadow.trim() === "" ? "none" : approvalConfig.shadow;
+  }
+
+  const detailsMode = approvalConfig?.detailsDisplay ?? "collapsed";
+  const hasParams = approval.parameters != null && detailsMode !== "hidden";
+  const expanded = hasParams && isDetailsExpanded(message.id, approvalConfig);
+
+  // Header. When params exist, the whole header toggles their visibility.
+  const head = createElement("button", "persona-approval-head") as HTMLButtonElement;
+  head.type = "button";
+  if (hasParams) {
+    head.setAttribute("data-action", "toggle-params");
+    head.setAttribute("aria-expanded", expanded ? "true" : "false");
+  } else {
+    head.setAttribute("data-static", "true");
+  }
+
+  const logo = createElement("span", "persona-approval-logo");
+  const glyph = renderLucideIcon("shield-check", 16, "currentColor", 2);
+  if (glyph) logo.appendChild(glyph);
+  head.appendChild(logo);
+
+  const title = buildTitle(approval, approvalConfig);
+  if (hasParams) {
+    const toggle = createElement("span", "persona-approval-toggle");
+    toggle.setAttribute("aria-hidden", "true");
+    const chevron = renderLucideIcon("chevron-down", 14, "currentColor", 2);
+    if (chevron) toggle.appendChild(chevron);
+    title.append(" ");
+    title.appendChild(toggle);
+  }
+  head.appendChild(title);
+  card.appendChild(head);
+
+  const body = createElement("div", "persona-approval-body");
+
+  if (hasParams) {
+    const pre = createElement("pre", "persona-approval-params");
+    pre.setAttribute("data-role", "params");
+    pre.hidden = !expanded;
+    if (approvalConfig?.parameterBackgroundColor) pre.style.background = approvalConfig.parameterBackgroundColor;
+    if (approvalConfig?.parameterTextColor) pre.style.color = approvalConfig.parameterTextColor;
+    pre.textContent = formatUnknownValue(approval.parameters);
+    body.appendChild(pre);
+  }
+
+  // Agent-authored justification: attacker-writable, so plain text + attributed.
+  if (approval.reason) {
+    const reasonLine = createElement("p", "persona-approval-reason");
+    if (approvalConfig?.reasonColor) reasonLine.style.color = approvalConfig.reasonColor;
+    else if (approvalConfig?.descriptionColor) reasonLine.style.color = approvalConfig.descriptionColor;
+    const label = createElement("span", "persona-approval-reason-label");
+    label.textContent = `${approvalConfig?.reasonLabel ?? "Agent's stated reason:"} `;
+    reasonLine.append(label, document.createTextNode(approval.reason));
+    body.appendChild(reasonLine);
+  }
+
+  const actions = createElement("div", "persona-approval-actions");
+  let popover: PopoverHandle | null = null;
+
+  const applyPrimaryColors = (el: HTMLElement): void => {
+    if (approvalConfig?.approveButtonColor) el.style.background = approvalConfig.approveButtonColor;
+    if (approvalConfig?.approveButtonTextColor) el.style.color = approvalConfig.approveButtonTextColor;
+  };
+  const denyBtn = createElement("button", "persona-approval-deny") as HTMLButtonElement;
+  denyBtn.type = "button";
+  denyBtn.setAttribute("data-action", "deny");
+  if (approvalConfig?.denyButtonColor) denyBtn.style.background = approvalConfig.denyButtonColor;
+  if (approvalConfig?.denyButtonTextColor) denyBtn.style.color = approvalConfig.denyButtonTextColor;
+  denyBtn.append(approvalConfig?.denyLabel ?? "Deny");
+
+  if (enableAlways) {
+    const split = createElement("div", "persona-approval-split");
+    const primary = createElement("button", "persona-approval-primary") as HTMLButtonElement;
+    primary.type = "button";
+    primary.setAttribute("data-action", "always");
+    applyPrimaryColors(primary);
+    primary.append(approvalConfig?.approveLabel ?? "Always allow", kbd("⏎"));
+
+    const caret = createElement("button", "persona-approval-caret") as HTMLButtonElement;
+    caret.type = "button";
+    caret.setAttribute("data-action", "toggle-menu");
+    caret.setAttribute("aria-label", "More options");
+    applyPrimaryColors(caret);
+    const caretIcon = renderLucideIcon("chevron-down", 15, "currentColor", 2);
+    if (caretIcon) caret.appendChild(caretIcon);
+
+    split.append(primary, caret);
+    actions.append(split, denyBtn);
+    denyBtn.append(kbd("Esc"));
+
+    // "Allow once" menu, portaled out of the transcript by createPopover so it
+    // overlays the rest of the UI and isn't clipped by the scroll container.
+    const menu = createElement("div", "persona-approval-menu");
+    const once = createElement("button", "persona-approval-menu-item") as HTMLButtonElement;
+    once.type = "button";
+    once.append("Allow once", kbd("⌘⏎"));
+    menu.appendChild(once);
+    popover = createPopover({
+      anchor: split,
+      content: menu,
+      placement: "bottom-start",
+      matchAnchorWidth: true,
+    });
+    popovers.set(message.id, popover);
+    once.addEventListener("click", () => {
+      teardownMessage(message.id);
+      approve(); // Allow once
+    });
+  } else {
+    const allow = createElement(
+      "button",
+      "persona-approval-primary persona-approval-primary--solo"
+    ) as HTMLButtonElement;
+    allow.type = "button";
+    allow.setAttribute("data-action", "allow");
+    applyPrimaryColors(allow);
+    allow.append(approvalConfig?.approveLabel ?? "Allow");
+    actions.append(allow, denyBtn);
+  }
+
+  body.appendChild(actions);
+  card.appendChild(body);
+
+  // Single delegated click listener; survives morph via the plugin hydrate path.
+  card.addEventListener("click", (e) => {
+    const target = e.target instanceof Element ? e.target.closest("[data-action]") : null;
+    if (!target) return;
+    const action = target.getAttribute("data-action");
+    if (action === "toggle-params") {
+      const pre = card.querySelector<HTMLElement>('[data-role="params"]');
+      if (pre) {
+        const willOpen = pre.hidden;
+        pre.hidden = !willOpen;
+        head.setAttribute("aria-expanded", willOpen ? "true" : "false");
+        approvalDetailsExpansionState.set(message.id, willOpen);
+      }
+      return;
+    }
+    if (action === "toggle-menu") {
+      popover?.toggle();
+      return;
+    }
+    if (action === "always") {
+      teardownMessage(message.id);
+      approve({ remember: true });
+      return;
+    }
+    if (action === "allow") {
+      teardownMessage(message.id);
+      approve();
+      return;
+    }
+    if (action === "deny") {
+      teardownMessage(message.id);
+      deny();
+      return;
+    }
+  });
+
+  return card;
+};
+
+/**
+ * The built-in approval renderer, shaped as a plugin so ui.ts can run it through
+ * the same `renderApproval` pipeline as user plugins (which still take
+ * precedence). Reads `config` from the render context, so a single instance
+ * serves every widget.
+ */
+export const createBuiltInApprovalPlugin = (): AgentWidgetPlugin => ({
+  id: "persona-built-in-approval",
+  renderApproval: ({ message, approve, deny, config }) => {
+    const approval = message?.approval;
+    if (!approval) return null;
+    const approvalConfig = resolveApprovalConfig(config);
+
+    if (approval.status !== "pending") {
+      teardownMessage(message.id);
+      // Approved → render nothing; the tool call takes over the transcript.
+      // (An empty hidden element, not null, suppresses the legacy fallback.)
+      if (approval.status === "approved") {
+        const hidden = document.createElement("div");
+        hidden.style.display = "none";
+        return hidden;
+      }
+      return buildResolvedTrace(approval);
+    }
+
+    // Rebuild: drop any prior listener/popover before (re)binding fresh closures.
+    teardownMessage(message.id);
+    const enableAlways = approvalConfig?.enableAlwaysAllow === true;
+    const card = buildPending(message, approval, approvalConfig, approve, deny, enableAlways);
+
+    if (enableAlways) {
+      latestPendingApprovalId = message.id;
+      const onKeydown = (e: KeyboardEvent): void => {
+        if (isEditableEventTarget(e)) return;
+        if (message.id !== latestPendingApprovalId) return;
+        if (e.key === "Escape") {
+          e.preventDefault();
+          teardownMessage(message.id);
+          deny();
+        } else if (e.key === "Enter") {
+          e.preventDefault();
+          teardownMessage(message.id);
+          if (e.metaKey || e.ctrlKey) approve(); // Allow once
+          else approve({ remember: true }); // Always allow
+        }
+      };
+      keyHandlers.set(message.id, onKeydown);
+      document.addEventListener("keydown", onKeydown);
+    }
+
+    return card;
+  },
+});

--- a/packages/widget/src/components/approval-actions.ts
+++ b/packages/widget/src/components/approval-actions.ts
@@ -34,34 +34,46 @@ import { humanizeToolName, approvalDetailsExpansionState } from "./approval-bubb
 type Approval = NonNullable<AgentWidgetMessage["approval"]>;
 type Decide = (options?: { remember?: boolean }) => void;
 
-// Per-message runtime state. The document `keydown` handler (re-bound on each
-// render to the freshest approve/deny closures) and the "Allow once" popover
-// are torn down when the approval resolves, the bubble rebuilds, or the widget
-// is destroyed.
-const keyHandlers = new Map<string, (e: KeyboardEvent) => void>();
-const popovers = new Map<string, PopoverHandle>();
-// Only the most-recently-built pending approval owns the keyboard shortcuts, so
-// Enter/Esc don't fire on every pending card at once.
-let latestPendingApprovalId: string | null = null;
+/**
+ * Per-widget-instance runtime state. The document `keydown` handler (re-bound on
+ * each render to the freshest approve/deny closures) and the "Allow once"
+ * popover are torn down when the approval resolves, the bubble rebuilds, or the
+ * widget is destroyed. This lives on the plugin instance (NOT module scope) so
+ * tearing down one widget never clears listeners/popovers another widget on the
+ * same page still owns.
+ */
+interface InstanceState {
+  keyHandlers: Map<string, (e: KeyboardEvent) => void>;
+  popovers: Map<string, PopoverHandle>;
+  // Only one pending approval owns the keyboard shortcuts at a time, so Enter/Esc
+  // don't fire on every pending card at once.
+  latestPendingApprovalId: string | null;
+}
 
-const teardownMessage = (messageId: string): void => {
-  const prevKey = keyHandlers.get(messageId);
+const createInstanceState = (): InstanceState => ({
+  keyHandlers: new Map(),
+  popovers: new Map(),
+  latestPendingApprovalId: null,
+});
+
+const teardownMessage = (state: InstanceState, messageId: string): void => {
+  const prevKey = state.keyHandlers.get(messageId);
   if (prevKey) {
     document.removeEventListener("keydown", prevKey);
-    keyHandlers.delete(messageId);
+    state.keyHandlers.delete(messageId);
   }
-  const popover = popovers.get(messageId);
+  const popover = state.popovers.get(messageId);
   if (popover) {
     popover.destroy();
-    popovers.delete(messageId);
+    state.popovers.delete(messageId);
   }
-  if (latestPendingApprovalId === messageId) latestPendingApprovalId = null;
-};
-
-/** Release every pending approval's global listener + popover. Pushed into the widget's destroy callbacks. */
-export const teardownAllBuiltInApprovals = (): void => {
-  for (const id of [...keyHandlers.keys(), ...popovers.keys()]) teardownMessage(id);
-  latestPendingApprovalId = null;
+  // If the keyboard owner just went away, promote the most-recently-registered
+  // approval that still has a live handler so Enter/Esc keep working instead of
+  // going dead while another pending card remains.
+  if (state.latestPendingApprovalId === messageId) {
+    const remaining = [...state.keyHandlers.keys()];
+    state.latestPendingApprovalId = remaining.length ? remaining[remaining.length - 1] : null;
+  }
 };
 
 const resolveApprovalConfig = (
@@ -140,6 +152,7 @@ const buildResolvedTrace = (approval: Approval): HTMLElement => {
 };
 
 const buildPending = (
+  state: InstanceState,
   message: AgentWidgetMessage,
   approval: Approval,
   approvalConfig: AgentWidgetApprovalConfig | undefined,
@@ -158,13 +171,20 @@ const buildPending = (
   }
 
   const detailsMode = approvalConfig?.detailsDisplay ?? "collapsed";
+  // The disclosure surfaces the agent-facing description (prompt prose, usage
+  // rules) and the raw call parameters. `buildTitle` never falls back to the
+  // raw description (it uses formatDescription → declared title → humanized
+  // name), so the description is only ever visible here. Mirrors the legacy
+  // bubble, which also opened a disclosure when only a description was present.
+  const hasDescription = Boolean(approval.description) && detailsMode !== "hidden";
   const hasParams = approval.parameters != null && detailsMode !== "hidden";
-  const expanded = hasParams && isDetailsExpanded(message.id, approvalConfig);
+  const hasDetails = hasDescription || hasParams;
+  const expanded = hasDetails && isDetailsExpanded(message.id, approvalConfig);
 
-  // Header. When params exist, the whole header toggles their visibility.
+  // Header. When a disclosure exists, the whole header toggles its visibility.
   const head = createElement("button", "persona-approval-head") as HTMLButtonElement;
   head.type = "button";
-  if (hasParams) {
+  if (hasDetails) {
     head.setAttribute("data-action", "toggle-params");
     head.setAttribute("aria-expanded", expanded ? "true" : "false");
   } else {
@@ -177,7 +197,7 @@ const buildPending = (
   head.appendChild(logo);
 
   const title = buildTitle(approval, approvalConfig);
-  if (hasParams) {
+  if (hasDetails) {
     const toggle = createElement("span", "persona-approval-toggle");
     toggle.setAttribute("aria-hidden", "true");
     const chevron = renderLucideIcon("chevron-down", 14, "currentColor", 2);
@@ -190,14 +210,27 @@ const buildPending = (
 
   const body = createElement("div", "persona-approval-body");
 
-  if (hasParams) {
-    const pre = createElement("pre", "persona-approval-params");
-    pre.setAttribute("data-role", "params");
-    pre.hidden = !expanded;
-    if (approvalConfig?.parameterBackgroundColor) pre.style.background = approvalConfig.parameterBackgroundColor;
-    if (approvalConfig?.parameterTextColor) pre.style.color = approvalConfig.parameterTextColor;
-    pre.textContent = formatUnknownValue(approval.parameters);
-    body.appendChild(pre);
+  if (hasDetails) {
+    const details = createElement("div", "persona-approval-details");
+    details.setAttribute("data-role", "params");
+    details.hidden = !expanded;
+
+    if (hasDescription) {
+      const desc = createElement("p", "persona-approval-desc");
+      if (approvalConfig?.descriptionColor) desc.style.color = approvalConfig.descriptionColor;
+      desc.textContent = approval.description as string;
+      details.appendChild(desc);
+    }
+
+    if (hasParams) {
+      const pre = createElement("pre", "persona-approval-params");
+      if (approvalConfig?.parameterBackgroundColor) pre.style.background = approvalConfig.parameterBackgroundColor;
+      if (approvalConfig?.parameterTextColor) pre.style.color = approvalConfig.parameterTextColor;
+      pre.textContent = formatUnknownValue(approval.parameters);
+      details.appendChild(pre);
+    }
+
+    body.appendChild(details);
   }
 
   // Agent-authored justification: attacker-writable, so plain text + attributed.
@@ -258,9 +291,9 @@ const buildPending = (
       placement: "bottom-start",
       matchAnchorWidth: true,
     });
-    popovers.set(message.id, popover);
+    state.popovers.set(message.id, popover);
     once.addEventListener("click", () => {
-      teardownMessage(message.id);
+      teardownMessage(state, message.id);
       approve(); // Allow once
     });
   } else {
@@ -298,17 +331,17 @@ const buildPending = (
       return;
     }
     if (action === "always") {
-      teardownMessage(message.id);
+      teardownMessage(state, message.id);
       approve({ remember: true });
       return;
     }
     if (action === "allow") {
-      teardownMessage(message.id);
+      teardownMessage(state, message.id);
       approve();
       return;
     }
     if (action === "deny") {
-      teardownMessage(message.id);
+      teardownMessage(state, message.id);
       deny();
       return;
     }
@@ -320,53 +353,74 @@ const buildPending = (
 /**
  * The built-in approval renderer, shaped as a plugin so ui.ts can run it through
  * the same `renderApproval` pipeline as user plugins (which still take
- * precedence). Reads `config` from the render context, so a single instance
- * serves every widget.
+ * precedence). Reads `config` from the render context, so a single plugin
+ * serves every render for one widget instance.
+ *
+ * Returns the plugin alongside a `teardown` the host pushes into its destroy
+ * callbacks — both close over the SAME per-instance state, so destroying one
+ * widget never disturbs another widget's open approvals on the same page.
  */
-export const createBuiltInApprovalPlugin = (): AgentWidgetPlugin => ({
-  id: "persona-built-in-approval",
-  renderApproval: ({ message, approve, deny, config }) => {
-    const approval = message?.approval;
-    if (!approval) return null;
-    const approvalConfig = resolveApprovalConfig(config);
+export const createBuiltInApprovalPlugin = (): {
+  plugin: AgentWidgetPlugin;
+  teardown: () => void;
+} => {
+  const state = createInstanceState();
 
-    if (approval.status !== "pending") {
-      teardownMessage(message.id);
-      // Approved → render nothing; the tool call takes over the transcript.
-      // (An empty hidden element, not null, suppresses the legacy fallback.)
-      if (approval.status === "approved") {
-        const hidden = document.createElement("div");
-        hidden.style.display = "none";
-        return hidden;
-      }
-      return buildResolvedTrace(approval);
-    }
+  const plugin: AgentWidgetPlugin = {
+    id: "persona-built-in-approval",
+    renderApproval: ({ message, approve, deny, config }) => {
+      const approval = message?.approval;
+      if (!approval) return null;
+      const approvalConfig = resolveApprovalConfig(config);
 
-    // Rebuild: drop any prior listener/popover before (re)binding fresh closures.
-    teardownMessage(message.id);
-    const enableAlways = approvalConfig?.enableAlwaysAllow === true;
-    const card = buildPending(message, approval, approvalConfig, approve, deny, enableAlways);
-
-    if (enableAlways) {
-      latestPendingApprovalId = message.id;
-      const onKeydown = (e: KeyboardEvent): void => {
-        if (isEditableEventTarget(e)) return;
-        if (message.id !== latestPendingApprovalId) return;
-        if (e.key === "Escape") {
-          e.preventDefault();
-          teardownMessage(message.id);
-          deny();
-        } else if (e.key === "Enter") {
-          e.preventDefault();
-          teardownMessage(message.id);
-          if (e.metaKey || e.ctrlKey) approve(); // Allow once
-          else approve({ remember: true }); // Always allow
+      if (approval.status !== "pending") {
+        teardownMessage(state, message.id);
+        // Approved → render nothing; the tool call takes over the transcript.
+        // (An empty hidden element, not null, suppresses the legacy fallback.)
+        if (approval.status === "approved") {
+          const hidden = document.createElement("div");
+          hidden.style.display = "none";
+          return hidden;
         }
-      };
-      keyHandlers.set(message.id, onKeydown);
-      document.addEventListener("keydown", onKeydown);
-    }
+        return buildResolvedTrace(approval);
+      }
 
-    return card;
-  },
-});
+      // Rebuild: drop any prior listener/popover before (re)binding fresh closures.
+      teardownMessage(state, message.id);
+      const enableAlways = approvalConfig?.enableAlwaysAllow === true;
+      const card = buildPending(state, message, approval, approvalConfig, approve, deny, enableAlways);
+
+      if (enableAlways) {
+        state.latestPendingApprovalId = message.id;
+        const onKeydown = (e: KeyboardEvent): void => {
+          if (isEditableEventTarget(e)) return;
+          if (message.id !== state.latestPendingApprovalId) return;
+          if (e.key === "Escape") {
+            e.preventDefault();
+            teardownMessage(state, message.id);
+            deny();
+          } else if (e.key === "Enter") {
+            e.preventDefault();
+            teardownMessage(state, message.id);
+            if (e.metaKey || e.ctrlKey) approve(); // Allow once
+            else approve({ remember: true }); // Always allow
+          }
+        };
+        state.keyHandlers.set(message.id, onKeydown);
+        document.addEventListener("keydown", onKeydown);
+      }
+
+      return card;
+    },
+  };
+
+  // Release every pending approval's global listener + popover for THIS widget.
+  const teardown = (): void => {
+    for (const id of [...state.keyHandlers.keys(), ...state.popovers.keys()]) {
+      teardownMessage(state, id);
+    }
+    state.latestPendingApprovalId = null;
+  };
+
+  return { plugin, teardown };
+};

--- a/packages/widget/src/components/approval-actions.ts
+++ b/packages/widget/src/components/approval-actions.ts
@@ -45,18 +45,25 @@ type Decide = (options?: { remember?: boolean }) => void;
 interface InstanceState {
   keyHandlers: Map<string, (e: KeyboardEvent) => void>;
   popovers: Map<string, PopoverHandle>;
-  // Only one pending approval owns the keyboard shortcuts at a time, so Enter/Esc
-  // don't fire on every pending card at once.
+  // Order in which approvals FIRST became pending — not re-render order. The
+  // newest pending approval (bottom of the thread) owns the keyboard shortcuts,
+  // so Enter/Esc don't fire on every pending card at once, and an older card
+  // re-rendering can't steal ownership from a newer one.
+  pendingOrder: string[];
   latestPendingApprovalId: string | null;
 }
 
 const createInstanceState = (): InstanceState => ({
   keyHandlers: new Map(),
   popovers: new Map(),
+  pendingOrder: [],
   latestPendingApprovalId: null,
 });
 
-const teardownMessage = (state: InstanceState, messageId: string): void => {
+// Drop a message's transient listener + popover WITHOUT touching its place in
+// the pending order. Used when a still-pending card re-renders and rebinds fresh
+// closures (so a rebuild of an older card doesn't reorder it to "newest").
+const detachMessage = (state: InstanceState, messageId: string): void => {
   const prevKey = state.keyHandlers.get(messageId);
   if (prevKey) {
     document.removeEventListener("keydown", prevKey);
@@ -67,12 +74,20 @@ const teardownMessage = (state: InstanceState, messageId: string): void => {
     popover.destroy();
     state.popovers.delete(messageId);
   }
-  // If the keyboard owner just went away, promote the most-recently-registered
-  // approval that still has a live handler so Enter/Esc keep working instead of
-  // going dead while another pending card remains.
+};
+
+// Fully retire a message (resolved, denied, or widget destroyed): detach its
+// listener/popover AND remove it from the pending order. If the keyboard owner
+// just went away, promote the newest remaining pending approval so Enter/Esc
+// keep working instead of going dead while another pending card remains.
+const teardownMessage = (state: InstanceState, messageId: string): void => {
+  detachMessage(state, messageId);
+  const idx = state.pendingOrder.indexOf(messageId);
+  if (idx !== -1) state.pendingOrder.splice(idx, 1);
   if (state.latestPendingApprovalId === messageId) {
-    const remaining = [...state.keyHandlers.keys()];
-    state.latestPendingApprovalId = remaining.length ? remaining[remaining.length - 1] : null;
+    state.latestPendingApprovalId = state.pendingOrder.length
+      ? state.pendingOrder[state.pendingOrder.length - 1]
+      : null;
   }
 };
 
@@ -181,12 +196,20 @@ const buildPending = (
   const hasDetails = hasDescription || hasParams;
   const expanded = hasDetails && isDetailsExpanded(message.id, approvalConfig);
 
+  // The card uses the whole header as the disclosure toggle (chevron-only, no
+  // separate text button), but the legacy `showDetailsLabel`/`hideDetailsLabel`
+  // strings are still honored as the toggle's accessible label so integrators
+  // who localized them keep a meaningful, customizable name on the control.
+  const showDetailsLabel = approvalConfig?.showDetailsLabel ?? "Show details";
+  const hideDetailsLabel = approvalConfig?.hideDetailsLabel ?? "Hide details";
+
   // Header. When a disclosure exists, the whole header toggles its visibility.
   const head = createElement("button", "persona-approval-head") as HTMLButtonElement;
   head.type = "button";
   if (hasDetails) {
     head.setAttribute("data-action", "toggle-params");
     head.setAttribute("aria-expanded", expanded ? "true" : "false");
+    head.setAttribute("aria-label", expanded ? hideDetailsLabel : showDetailsLabel);
   } else {
     head.setAttribute("data-static", "true");
   }
@@ -322,6 +345,7 @@ const buildPending = (
         const willOpen = pre.hidden;
         pre.hidden = !willOpen;
         head.setAttribute("aria-expanded", willOpen ? "true" : "false");
+        head.setAttribute("aria-label", willOpen ? hideDetailsLabel : showDetailsLabel);
         approvalDetailsExpansionState.set(message.id, willOpen);
       }
       return;
@@ -385,25 +409,36 @@ export const createBuiltInApprovalPlugin = (): {
         return buildResolvedTrace(approval);
       }
 
-      // Rebuild: drop any prior listener/popover before (re)binding fresh closures.
-      teardownMessage(state, message.id);
+      // Rebuild: drop any prior listener/popover before (re)binding fresh
+      // closures, but KEEP this approval's place in the pending order so a
+      // re-render of an older card doesn't reorder it ahead of a newer one.
+      detachMessage(state, message.id);
       const enableAlways = approvalConfig?.enableAlwaysAllow === true;
       const card = buildPending(state, message, approval, approvalConfig, approve, deny, enableAlways);
 
       if (enableAlways) {
-        state.latestPendingApprovalId = message.id;
+        if (!state.pendingOrder.includes(message.id)) state.pendingOrder.push(message.id);
+        // The newest first-seen pending approval owns the shortcuts, regardless
+        // of which card happens to be re-rendering right now.
+        state.latestPendingApprovalId = state.pendingOrder[state.pendingOrder.length - 1];
         const onKeydown = (e: KeyboardEvent): void => {
           if (isEditableEventTarget(e)) return;
           if (message.id !== state.latestPendingApprovalId) return;
+          if (e.key !== "Escape" && e.key !== "Enter") return;
+          e.preventDefault();
+          // Resolving here promotes the next-newest pending approval to owner.
+          // Stop immediate propagation so the SAME keypress doesn't then reach
+          // that freshly-promoted card's listener and resolve it too — one
+          // keypress resolves exactly one approval; the next owner waits for the
+          // next press.
+          e.stopImmediatePropagation();
+          teardownMessage(state, message.id);
           if (e.key === "Escape") {
-            e.preventDefault();
-            teardownMessage(state, message.id);
             deny();
-          } else if (e.key === "Enter") {
-            e.preventDefault();
-            teardownMessage(state, message.id);
-            if (e.metaKey || e.ctrlKey) approve(); // Allow once
-            else approve({ remember: true }); // Always allow
+          } else if (e.metaKey || e.ctrlKey) {
+            approve(); // Allow once
+          } else {
+            approve({ remember: true }); // Always allow
           }
         };
         state.keyHandlers.set(message.id, onKeydown);

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -2469,8 +2469,20 @@
   padding: 0.5rem 0.6rem 0.35rem calc(24px + 0.75rem + 0.6rem);
 }
 
-.persona-approval-params {
+.persona-approval-details {
   margin: 0 0 0.75rem;
+}
+.persona-approval-details[hidden] { display: none; }
+
+.persona-approval-desc {
+  margin: 0 0 0.5rem;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: var(--persona-muted, #6b7280);
+}
+
+.persona-approval-params {
+  margin: 0;
   padding: 0.7rem 0.85rem;
   border-radius: 0.625rem;
   background: var(--persona-container, rgba(11, 11, 11, 0.04));
@@ -2480,7 +2492,6 @@
   overflow-x: auto;
   max-height: 9rem;
 }
-.persona-approval-params[hidden] { display: none; }
 
 .persona-approval-reason {
   margin: 0 0 0.6rem;

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -2392,6 +2392,219 @@
 }
 
 /* ============================================
+   Approval card (default renderer, components/approval-actions.ts)
+   Neutral surface card. Every color is a --persona-* token; the legacy
+   --persona-approval-* shorthands are honored fallback-first so a consumer who
+   themed them still wins, then the new semantic default applies.
+   ============================================ */
+.persona-approval-card {
+  width: 100%;
+  max-width: 100%;
+  box-sizing: border-box;
+  background: var(--persona-approval-bg, var(--persona-surface, #ffffff));
+  border: 0.5px solid var(--persona-approval-border, var(--persona-border, rgba(11, 11, 11, 0.1)));
+  border-radius: 0.75rem;
+  padding: 0.5rem;
+}
+.persona-approval-card.persona-shadow-sm {
+  box-shadow: var(--persona-approval-shadow, 0 1px 2px 0 rgba(11, 11, 11, 0.06), 0 2px 8px 0 rgba(11, 11, 11, 0.04));
+}
+
+.persona-approval-head {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  width: 100%;
+  border: none;
+  background: transparent;
+  padding: 0.4rem 0.6rem;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+  color: var(--persona-text, #0b0b0b);
+  border-radius: 0.5rem;
+  transition: background 0.12s ease;
+}
+.persona-approval-head:hover { background: var(--persona-container, rgba(11, 11, 11, 0.04)); }
+.persona-approval-head[data-static="true"] { cursor: default; }
+.persona-approval-head[data-static="true"]:hover { background: transparent; }
+
+.persona-approval-logo {
+  flex-shrink: 0;
+  width: 24px;
+  height: 24px;
+  display: grid;
+  place-items: center;
+  box-sizing: border-box;
+  border: 0.5px solid var(--persona-border, rgba(11, 11, 11, 0.12));
+  border-radius: 6.5px;
+  background: var(--persona-surface, #ffffff);
+  box-shadow: 0 1px 2px 0 rgba(11, 11, 11, 0.08);
+  color: var(--persona-muted, #6b7280);
+  overflow: hidden;
+}
+.persona-approval-logo svg { width: 15px; height: 15px; display: block; }
+
+.persona-approval-title {
+  flex: 1;
+  min-width: 0;
+  font-size: 0.875rem;
+  line-height: 1.4;
+  color: var(--persona-text, #0b0b0b);
+}
+.persona-approval-title strong { font-weight: 600; }
+
+.persona-approval-toggle {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 0.25rem;
+  color: var(--persona-muted, #6b7280);
+  vertical-align: middle;
+  transition: transform 0.15s ease;
+}
+.persona-approval-toggle svg { width: 0.85rem; height: 0.85rem; display: block; }
+.persona-approval-head[aria-expanded="false"] .persona-approval-toggle { transform: rotate(-90deg); }
+
+.persona-approval-body {
+  padding: 0.5rem 0.6rem 0.35rem calc(24px + 0.75rem + 0.6rem);
+}
+
+.persona-approval-params {
+  margin: 0 0 0.75rem;
+  padding: 0.7rem 0.85rem;
+  border-radius: 0.625rem;
+  background: var(--persona-container, rgba(11, 11, 11, 0.04));
+  color: var(--persona-text, #1f2937);
+  font-size: 0.75rem;
+  line-height: 1rem;
+  overflow-x: auto;
+  max-height: 9rem;
+}
+.persona-approval-params[hidden] { display: none; }
+
+.persona-approval-reason {
+  margin: 0 0 0.6rem;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  color: var(--persona-muted, #6b7280);
+}
+.persona-approval-reason-label { font-weight: 500; }
+
+.persona-approval-resolved {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  margin: 0.5rem 0;
+  padding: 0.3rem 0.15rem;
+  font-size: 0.8rem;
+  color: var(--persona-muted, #6b7280);
+}
+.persona-approval-resolved svg { width: 0.95rem; height: 0.95rem; display: block; flex-shrink: 0; }
+.persona-approval-resolved-name { font-weight: 600; }
+
+.persona-approval-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+.persona-approval-split { position: relative; display: inline-flex; }
+
+.persona-approval-primary,
+.persona-approval-caret,
+.persona-approval-deny {
+  border: none;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.875rem;
+  font-weight: 500;
+  height: 2rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  transition: background 0.12s ease, box-shadow 0.12s ease;
+}
+/* Primary anchors to the brand token via the established button-primary pair. */
+.persona-approval-primary {
+  background: var(--persona-approval-approve-bg, var(--persona-button-primary-bg, var(--persona-primary, #111827)));
+  color: var(--persona-button-primary-fg, var(--persona-text-inverse, #ffffff));
+  padding: 0 0.75rem;
+  border-radius: 0.5rem 0 0 0.5rem;
+}
+.persona-approval-primary--solo { border-radius: 0.5rem; }
+.persona-approval-caret {
+  position: relative;
+  background: var(--persona-approval-approve-bg, var(--persona-button-primary-bg, var(--persona-primary, #111827)));
+  color: var(--persona-button-primary-fg, var(--persona-text-inverse, #ffffff));
+  width: 2rem;
+  justify-content: center;
+  padding: 0;
+  border-radius: 0 0.5rem 0.5rem 0;
+}
+.persona-approval-caret svg { width: 0.95rem; height: 0.95rem; display: block; }
+.persona-approval-caret::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 4px;
+  bottom: 4px;
+  width: 1px;
+  background: var(--persona-button-primary-fg, #ffffff);
+  opacity: 0.25;
+  transition: opacity 0.12s ease;
+}
+.persona-approval-caret:hover::before,
+.persona-approval-primary:hover + .persona-approval-caret::before { opacity: 0; }
+.persona-approval-primary:hover,
+.persona-approval-caret:hover { box-shadow: inset 0 0 0 999px rgba(255, 255, 255, 0.16); }
+
+.persona-approval-deny {
+  background: var(--persona-approval-deny-bg, var(--persona-container, rgba(11, 11, 11, 0.04)));
+  color: var(--persona-text, #1f2937);
+  padding: 0 0.75rem;
+  border-radius: 0.5rem;
+  box-shadow: inset 0 0 0 0.5px var(--persona-border, rgba(0, 0, 0, 0.1));
+}
+.persona-approval-deny:hover { box-shadow: inset 0 0 0 0.5px var(--persona-border, rgba(0, 0, 0, 0.1)), inset 0 0 0 999px rgba(11, 11, 11, 0.04); }
+
+.persona-approval-menu {
+  width: max-content;
+  max-width: 18rem;
+  box-sizing: border-box;
+  background: var(--persona-surface, #ffffff);
+  border: 0.5px solid var(--persona-border, rgba(11, 11, 11, 0.1));
+  border-radius: 0.625rem;
+  box-shadow: 0 8px 24px rgba(11, 11, 11, 0.12), 0 2px 6px rgba(11, 11, 11, 0.08);
+  padding: 0.25rem;
+  white-space: nowrap;
+}
+.persona-approval-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  width: 100%;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.875rem;
+  color: var(--persona-text, #1f2937);
+  padding: 0.45rem 0.6rem;
+  border-radius: 0.4rem;
+  text-align: left;
+  transition: background 0.12s ease;
+}
+.persona-approval-menu-item:hover { background: var(--persona-container, rgba(11, 11, 11, 0.06)); }
+.persona-approval-kbd {
+  font-family: inherit;
+  font-size: 0.75rem;
+  line-height: 1;
+  opacity: 0.7;
+  margin-left: 0.25rem;
+}
+.persona-approval-menu-item .persona-approval-kbd { margin-left: auto; }
+
+/* ============================================
    Visibility (Tailwind parity: prefix persona-)
    Shipped widget.css is hand-maintained; these utilities are used in TS but not generated by Tailwind at build time.
    ============================================ */

--- a/packages/widget/src/theme-reference.ts
+++ b/packages/widget/src/theme-reference.ts
@@ -227,9 +227,9 @@ export const THEME_TOKEN_DOCS = {
     },
     approval: {
       description:
-        'Tool approval bubble styling and behavior. Set to false to disable.',
+        'Tool approval card styling and behavior. Neutral surface card; the primary action anchors to the brand --persona-primary token. Set to false to disable. Set enableAlwaysAllow: true to add the split "Always allow / Allow once" control (needs a backend to persist the policy via onDecision\'s remember).',
       properties:
-        'backgroundColor, borderColor, titleColor, descriptionColor, reasonColor, reasonLabel, approveButtonColor, approveButtonTextColor, denyButtonColor, denyButtonTextColor, parameterBackgroundColor, parameterTextColor, title, approveLabel, denyLabel.',
+        'enableAlwaysAllow, detailsDisplay ("collapsed" | "expanded" | "hidden"), showDetailsLabel, hideDetailsLabel, backgroundColor, borderColor, titleColor, descriptionColor, reasonColor, reasonLabel, approveButtonColor, approveButtonTextColor, denyButtonColor, denyButtonTextColor, parameterBackgroundColor, parameterTextColor, approveLabel, denyLabel, formatDescription. (title no longer renders in the default card; use formatDescription to customize the summary.)',
     },
     copy: {
       description: 'Widget text content.',

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -2297,6 +2297,21 @@ export type AgentWidgetApprovalConfig = {
   /** Label for the toggle that hides the technical details */
   hideDetailsLabel?: string;
   /**
+   * Offer an "Always allow" affordance in the default approval bubble.
+   *
+   * Default `false`. When `false`, the bubble shows a single "Allow" (allow
+   * once) plus "Deny". When `true`, the primary action becomes a split control:
+   * "Always allow" (resolves with `{ remember: true }`) with a dropdown for
+   * "Allow once", plus "Deny", and keyboard shortcuts (Enter = Always allow,
+   * Cmd/Ctrl+Enter = Allow once, Esc = Deny).
+   *
+   * Keep this off unless your backend actually persists the don't-ask-again
+   * policy: "Always allow" only resolves the *current* approval — honoring it
+   * for *future* calls is up to your `onDecision` handler (which receives
+   * `options.remember`). Showing it without that wiring would mislead users.
+   */
+  enableAlwaysAllow?: boolean;
+  /**
    * Build the user-facing summary line for an approval request. Overrides the
    * default "The assistant wants to use “Tool name”." copy. Return a falsy
    * value to fall back to the default for that approval. `displayTitle` is

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -98,6 +98,7 @@ import {
 } from "./suggest-replies-tool";
 import { formatElapsedMs } from "./utils/formatting";
 import { approvalDetailsExpansionState, createApprovalBubble, updateApprovalDetailsUI } from "./components/approval-bubble";
+import { createBuiltInApprovalPlugin, teardownAllBuiltInApprovals } from "./components/approval-actions";
 import { createSuggestions } from "./components/suggestions";
 import { EventStreamBuffer } from "./utils/event-stream-buffer";
 import { EventStreamStore } from "./utils/event-stream-store";
@@ -537,7 +538,12 @@ export const createAgentExperience = (
 
   // Get plugins for this instance
   const plugins = pluginRegistry.getForInstance(config.plugins);
-  
+
+  // The built-in approval renderer, shaped as a plugin. Resolved as a FALLBACK
+  // (not pushed into `plugins`) so a user `renderApproval` plugin always wins
+  // and a later config-update plugin push can't reorder ahead of it.
+  const builtInApprovalPlugin = createBuiltInApprovalPlugin();
+
   // Register components from config
   if (config.components) {
     componentRegistry.registerAll(config.components);
@@ -2738,6 +2744,10 @@ export const createAgentExperience = (
     }
   });
 
+  // Release any pending built-in approval's global keydown listener + "Allow
+  // once" popover if the widget is destroyed while an approval is still open.
+  destroyCallbacks.push(teardownAllBuiltInApprovals);
+
   // Activate the stream-animation plugin for this widget instance. Plugins
   // with `styles` inject their CSS into the widget root once; plugins with
   // `onAttach` (e.g., glyph-cycle's MutationObserver for real glyph tick
@@ -3413,7 +3423,10 @@ export const createAgentExperience = (
     // interactivity), and idiomorph imports nodes via `document.importNode`,
     // which strips them. So we build the live element, append a stub during
     // morph, and inject the live element afterward.
-    const hasApprovalPlugin = plugins.some((p) => p.renderApproval) && config.approval !== false;
+    // The built-in approval renderer is always available (as a fallback plugin),
+    // so every approval flows through the stub-and-hydrate path whenever
+    // approvals are enabled — a user `renderApproval` plugin just overrides it.
+    const hasApprovalPlugin = config.approval !== false;
     type ApprovalPluginHydrate = {
       messageId: string;
       fingerprint: string;
@@ -3633,7 +3646,8 @@ export const createAgentExperience = (
         // any accordion listeners survive idiomorph's `importNode`. Gate the
         // rebuild on fingerprint so interactive state (e.g. a collapsed
         // accordion) is preserved while the approval stays pending.
-        const approvalPlugin = plugins.find((p) => typeof p.renderApproval === "function");
+        const approvalPlugin =
+          plugins.find((p) => typeof p.renderApproval === "function") ?? builtInApprovalPlugin;
         const lastFp = lastApprovalBubbleFingerprint.get(message.id);
         const needsRebuild = lastFp !== fingerprint;
         let liveBubble: HTMLElement | null = null;

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -98,7 +98,7 @@ import {
 } from "./suggest-replies-tool";
 import { formatElapsedMs } from "./utils/formatting";
 import { approvalDetailsExpansionState, createApprovalBubble, updateApprovalDetailsUI } from "./components/approval-bubble";
-import { createBuiltInApprovalPlugin, teardownAllBuiltInApprovals } from "./components/approval-actions";
+import { createBuiltInApprovalPlugin } from "./components/approval-actions";
 import { createSuggestions } from "./components/suggestions";
 import { EventStreamBuffer } from "./utils/event-stream-buffer";
 import { EventStreamStore } from "./utils/event-stream-store";
@@ -542,7 +542,8 @@ export const createAgentExperience = (
   // The built-in approval renderer, shaped as a plugin. Resolved as a FALLBACK
   // (not pushed into `plugins`) so a user `renderApproval` plugin always wins
   // and a later config-update plugin push can't reorder ahead of it.
-  const builtInApprovalPlugin = createBuiltInApprovalPlugin();
+  const { plugin: builtInApprovalPlugin, teardown: teardownBuiltInApprovals } =
+    createBuiltInApprovalPlugin();
 
   // Register components from config
   if (config.components) {
@@ -2744,9 +2745,10 @@ export const createAgentExperience = (
     }
   });
 
-  // Release any pending built-in approval's global keydown listener + "Allow
-  // once" popover if the widget is destroyed while an approval is still open.
-  destroyCallbacks.push(teardownAllBuiltInApprovals);
+  // Release this widget's pending built-in approval listeners + "Allow once"
+  // popovers if it's destroyed while an approval is still open. Scoped to this
+  // instance's state, so other widgets on the page are unaffected.
+  destroyCallbacks.push(teardownBuiltInApprovals);
 
   // Activate the stream-animation plugin for this widget instance. Plugins
   // with `styles` inject their CSS into the widget root once; plugins with

--- a/packages/widget/src/utils/tokens.ts
+++ b/packages/widget/src/utils/tokens.ts
@@ -384,22 +384,25 @@ export const DEFAULT_COMPONENTS: ComponentTokens = {
       icon: 'palette.colors.success.500',
     },
   },
+  // Neutral surface card (components/approval-actions.ts). The primary action
+  // anchors to the brand primary; deny is a neutral tinted button. Consumers who
+  // themed these (or set config.approval.* color overrides) still win.
   approval: {
     requested: {
-      background: 'palette.colors.warning.50',
-      border: 'palette.colors.warning.200',
+      background: 'semantic.colors.surface',
+      border: 'semantic.colors.border',
       text: 'palette.colors.gray.900',
-      shadow: '0 5px 15px rgba(15, 23, 42, 0.08)',
+      shadow: '0 1px 2px 0 rgba(11, 11, 11, 0.06), 0 2px 8px 0 rgba(11, 11, 11, 0.04)',
     },
     approve: {
-      background: 'palette.colors.success.500',
-      foreground: 'palette.colors.gray.50',
+      background: 'semantic.colors.primary',
+      foreground: 'semantic.colors.textInverse',
       borderRadius: 'palette.radius.md',
       padding: 'semantic.spacing.sm',
     },
     deny: {
-      background: 'palette.colors.error.500',
-      foreground: 'palette.colors.gray.50',
+      background: 'semantic.colors.container',
+      foreground: 'semantic.colors.text',
       borderRadius: 'palette.radius.md',
       padding: 'semantic.spacing.sm',
     },
@@ -681,12 +684,12 @@ export function themeToCssVariables(theme: PersonaTheme): Record<string, string>
   cssVars['--persona-voice-processing-icon'] = cssVars['--persona-components-voice-processing-icon'] ?? cssVars['--persona-palette-colors-primary-500'];
   cssVars['--persona-voice-speaking-icon'] = cssVars['--persona-components-voice-speaking-icon'] ?? cssVars['--persona-palette-colors-success-500'];
 
-  cssVars['--persona-approval-bg'] = cssVars['--persona-components-approval-requested-background'] ?? cssVars['--persona-palette-colors-warning-50'];
-  cssVars['--persona-approval-border'] = cssVars['--persona-components-approval-requested-border'] ?? cssVars['--persona-palette-colors-warning-200'];
+  cssVars['--persona-approval-bg'] = cssVars['--persona-components-approval-requested-background'] ?? cssVars['--persona-surface'];
+  cssVars['--persona-approval-border'] = cssVars['--persona-components-approval-requested-border'] ?? cssVars['--persona-border'];
   cssVars['--persona-approval-text'] = cssVars['--persona-components-approval-requested-text'] ?? cssVars['--persona-palette-colors-gray-900'];
-  cssVars['--persona-approval-shadow'] = cssVars['--persona-components-approval-requested-shadow'] ?? '0 5px 15px rgba(15, 23, 42, 0.08)';
-  cssVars['--persona-approval-approve-bg'] = cssVars['--persona-components-approval-approve-background'] ?? cssVars['--persona-palette-colors-success-500'];
-  cssVars['--persona-approval-deny-bg'] = cssVars['--persona-components-approval-deny-background'] ?? cssVars['--persona-palette-colors-error-500'];
+  cssVars['--persona-approval-shadow'] = cssVars['--persona-components-approval-requested-shadow'] ?? '0 1px 2px 0 rgba(11, 11, 11, 0.06), 0 2px 8px 0 rgba(11, 11, 11, 0.04)';
+  cssVars['--persona-approval-approve-bg'] = cssVars['--persona-components-approval-approve-background'] ?? cssVars['--persona-button-primary-bg'];
+  cssVars['--persona-approval-deny-bg'] = cssVars['--persona-components-approval-deny-background'] ?? cssVars['--persona-container'];
 
   cssVars['--persona-attachment-image-bg'] = cssVars['--persona-components-attachment-image-background'] ?? cssVars['--persona-palette-colors-gray-100'];
   cssVars['--persona-attachment-image-border'] = cssVars['--persona-components-attachment-image-border'] ?? cssVars['--persona-palette-colors-gray-200'];


### PR DESCRIPTION
Promotes the example "approval actions" design to the **default built-in** tool-approval renderer.

## What changes

- **New default card.** Neutral surface card: tool icon, "The assistant wants to use **tool**" title, call arguments **collapsed behind a "show more" disclosure**, and a primary action anchored to the brand **`--persona-primary`** token. Resolved approvals follow the example plugin — **approved disappears** (the tool call takes over the transcript), **denied/timeout collapse to a one-line trace**.
- **`config.approval.enableAlwaysAllow`** (default **off**): adds the split **Always allow / Allow once** control with a dropdown + keyboard shortcuts (Enter / Cmd-Ctrl+Enter / Esc), forwarding `{ remember: true }` to `onDecision`. Off by default because the don't-ask-again policy needs a backend to persist — showing it without that wiring would mislead users.

## Architecture

Shipped as an **internal `renderApproval` plugin** (`components/approval-actions.ts`), resolved as a **fallback** in `ui.ts` (not pushed into the plugins array). This reuses the existing, idiomorph-proven **stub-and-hydrate + teardown** path instead of bolting popover/keyboard lifecycle into the render hot path, and a user `renderApproval` plugin **still fully overrides** it. The popover/keyboard reuse plugin-kit (`createPopover`, `isEditableEventTarget`); `teardownAllBuiltInApprovals` is wired into the widget destroy hook so the global keydown listener + popover can't leak.

## Design system

Every color is a `--persona-*` token; the primary reuses the established `--persona-button-primary-bg/-fg` pair. Repointed the `components.approval.*` and `--persona-approval-*` shorthand **defaults** from the warning/success/error palette to neutral/brand, kept emitting the shorthands, and consume them **fallback-first** so existing overrides win.

## Backward compatibility

- A custom `renderApproval` plugin still fully overrides the default.
- `config.approval === false` unchanged; `createApprovalBubble` stays as the `defaultRenderer`/opt-out fallback.
- Every `config.approval.*` field still functions; only the **default look** changes for un-configured widgets (yellow→neutral, green→brand). `--persona-approval-*` overrides honored fallback-first. Restore the old look via `config.approval.backgroundColor`/`borderColor` (or `components.approval.requested.*`).
- `config.approval.title` no longer renders in the default card — use `formatDescription` for the summary line (documented).

## Verification

- **Local `apps/web` (built-in renderer), all paths confirmed:** flag-off Allow/Deny; disclosure expands params; **Approve → card disappears + tool/response**; **Deny → one-line trace**; flag-on split **Always allow** + caret **Allow once** popover (not clipped); **Allow once → no remember**, **Enter → Always allow (remember)**, composer-Enter correctly guarded (`isEditableEventTarget`); programmatic `resolveApproval`. Console clean, no listener leak across repeated runs.
- **Tests:** new `approval-actions.test.ts` (18 tests); existing `approval-bubble.test.ts` + `ui.approval-plugin.test.ts` unchanged and green. Full suite **1283 passing**; lint, typecheck, build all green.
- Demo updated with an `enableAlwaysAllow` toggle; `THEME-CONFIG.md` + `theme-reference.ts` updated; **minor** changeset.

Screenshots: flag-off = brand-primary Allow / Deny card; flag-on = split "Always allow ⏎ ▾ / Deny Esc" with an "Allow once ⌘⏎" dropdown.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Default approval visuals and copy change for unconfigured embeds; keyboard shortcuts and document listeners add interaction surface but are scoped per widget with teardown tests.
> 
> **Overview**
> Replaces the default inline tool-approval UI with a **neutral permission card** (icon, “The assistant wants to use **tool**” summary, collapsible description/arguments, brand-primary **Allow** / neutral **Deny**). **Approved** requests render nothing so the tool call owns the transcript; **denied** / **timeout** collapse to a one-line trace.
> 
> Implementation is a new internal **`renderApproval` fallback** (`approval-actions.ts`) wired in `ui.ts` so it uses the existing stub-and-hydrate path, per-widget teardown, and still loses to a custom `renderApproval` plugin. Optional **`config.approval.enableAlwaysAllow`** adds split **Always allow / Allow once** (popover + Enter / ⌘⏎ / Esc), passing `{ remember: true }` to approve when appropriate.
> 
> **Theme defaults** for `components.approval.*` and `--persona-approval-*` shift from warning/green/red to semantic surface/primary; overrides and `config.approval.*` still apply fallback-first. **`config.approval.title`** no longer shows on the default card—use **`formatDescription`**. Docs, demo toggle, CSS, size limit (+1 kB stylesheet), and **`approval-actions.test.ts`** accompany the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eefd651ce42774429e0aaa1e5cd8b03b83f6100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->