### PR TITLE
feat(widget): stabilize streaming markdown tables

### DIFF
--- a/.changeset/streaming-table-stabilization.md
+++ b/.changeset/streaming-table-stabilization.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Stabilize markdown tables during streaming (Telegram-style space reservation). While a message streams, tables-in-progress now render as a real `<table>` from the first row with a stable column count instead of flipping from a paragraph and reflowing on every chunk: the delimiter row is completed as soon as it starts arriving, the trailing partial row is padded to the header's column count, and `table-layout: fixed` locks column widths so rows append vertically without horizontal jiggle. Columns relax to natural content-fit widths once streaming completes. The final, non-streaming render is unchanged.

--- a/apps/web/src/examples-nav.ts
+++ b/apps/web/src/examples-nav.ts
@@ -157,6 +157,15 @@ export const ADVANCED_EXAMPLES: readonly AdvancedExample[] = [
     modes: ["inline"],
   },
   {
+    slug: "streaming-table-demo",
+    href: "/streaming-table-demo.html",
+    title: "Streaming Markdown Tables",
+    blurb: "Telegram-style table rendering: structure and column widths reserved as rows stream in.",
+    tier: "patterns",
+    tags: ["streaming", "markdown", "tables"],
+    modes: ["inline"],
+  },
+  {
     slug: "custom-loading-indicator",
     href: "/custom-loading-indicator.html",
     title: "Replace the Loader",

--- a/apps/web/src/streaming-table-demo.ts
+++ b/apps/web/src/streaming-table-demo.ts
@@ -1,0 +1,165 @@
+/**
+ * Streaming Markdown Tables demo.
+ *
+ * Streams Markdown token-by-token into a message bubble so you can watch tables
+ * render the way they do in the live widget: the table structure is completed as
+ * soon as the first row arrives (`stabilizeStreamingTables`) and column widths
+ * are locked while the stream is in flight (the `persona-content-streaming`
+ * class → `table-layout: fixed`), so rows fill in without the header flipping
+ * from a paragraph or the columns jiggling. Widths relax to their natural,
+ * content-fit sizes once the stream completes.
+ *
+ * This uses the real widget pipeline: `createMarkdownProcessor` (marked), the
+ * default DOMPurify sanitizer, idiomorph DOM morphing, and widget.css table
+ * styles. Importing from "@runtypelabs/persona" registers marked/DOMPurify
+ * synchronously (markdown-parsers-eager), so the processors are ready on load.
+ */
+import "@runtypelabs/persona/widget.css";
+import "./index.css";
+
+import { createMarkdownProcessor, createDefaultSanitizer } from "@runtypelabs/persona";
+// Internal modules, reachable via the apps/web "@runtypelabs/persona" → src alias.
+import { stabilizeStreamingTables } from "@runtypelabs/persona/utils/streaming-table";
+import { morphMessages } from "@runtypelabs/persona/utils/morph";
+
+const md = createMarkdownProcessor();
+const sanitize = createDefaultSanitizer();
+
+const render = (markdown: string): string => sanitize(md(markdown));
+
+type Sample = { id: string; label: string; text: string };
+
+const SAMPLES: Sample[] = [
+  {
+    id: "pricing",
+    label: "Pricing comparison",
+    text: `Here's how the three tiers compare:
+
+| Plan | Price | Seats | Best for |
+| --- | --- | --- | --- |
+| Starter | $0/mo | 1 | Solo projects and trials |
+| Team | $29/mo | 10 | Growing teams that need **collaboration** |
+| Business | $99/mo | Unlimited | Companies with \`SSO\` and audit needs |
+
+The Team plan is the most popular starting point.`,
+  },
+  {
+    id: "uneven",
+    label: "Wide / uneven columns",
+    text: `A quick rundown of the API endpoints:
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| GET | /v1/messages | List messages, newest first, with cursor-based pagination |
+| POST | /v1/messages | Create a message and stream the assistant reply over SSE |
+| DELETE | /v1/messages/:id | Permanently remove a single message from the conversation |
+
+All endpoints require a bearer token.`,
+  },
+  {
+    id: "prose",
+    label: "Prose around a table",
+    text: `Sure — let me break down the quarterly results.
+
+First, some context: revenue grew steadily while costs stayed flat.
+
+| Quarter | Revenue | Growth |
+| --- | --- | --- |
+| Q1 | $1.2M | — |
+| Q2 | $1.5M | +25% |
+| Q3 | $2.1M | +40% |
+
+As you can see, *Q3* was the standout quarter, and momentum is carrying into Q4.`,
+  },
+];
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// Cancellation: each replay invalidates the previous run's token.
+let cancelToken = { cancelled: false };
+const freshCancel = () => {
+  cancelToken.cancelled = true;
+  cancelToken = { cancelled: false };
+  return cancelToken;
+};
+
+const content = document.getElementById("stream-content") as HTMLElement;
+const sampleSelector = document.getElementById("sample-selector") as HTMLElement;
+const speedSlider = document.getElementById("speed") as HTMLInputElement;
+const speedLabel = document.getElementById("speed-label") as HTMLElement;
+const playBtn = document.getElementById("btn-play") as HTMLButtonElement;
+
+// Reusable detached node that idiomorph diffs the live bubble against.
+const scratch = document.createElement("div");
+
+const paint = (acc: string, streaming: boolean) => {
+  // While streaming, lock column widths (relaxes to natural widths on the final
+  // paint) and stabilize the table-in-progress so it renders from the first row.
+  content.classList.toggle("persona-content-streaming", streaming);
+  scratch.innerHTML = render(streaming ? stabilizeStreamingTables(acc) : acc);
+  morphMessages(content, scratch, { preserveTypingAnimation: false });
+};
+
+let activeSampleId = SAMPLES[0].id;
+
+const currentSample = (): Sample =>
+  SAMPLES.find((s) => s.id === activeSampleId) ?? SAMPLES[0];
+
+const replay = async () => {
+  const token = freshCancel();
+  playBtn.disabled = true;
+
+  const { text } = currentSample();
+  const speed = parseInt(speedSlider.value, 10);
+  const step = 3; // characters revealed per tick — mimics chunky token streaming
+
+  paint("", true);
+  await sleep(150);
+
+  for (let i = step; i < text.length; i += step) {
+    if (token.cancelled) {
+      playBtn.disabled = false;
+      return;
+    }
+    paint(text.slice(0, i), true);
+    await sleep(speed);
+  }
+
+  if (token.cancelled) {
+    playBtn.disabled = false;
+    return;
+  }
+
+  // Final paint: streaming=false drops the fixed-layout class, relaxing the
+  // finished table to natural content-fit widths.
+  paint(text, false);
+  playBtn.disabled = false;
+};
+
+// --- Controls -------------------------------------------------------------
+
+SAMPLES.forEach((sample, idx) => {
+  const btn = document.createElement("button");
+  btn.className = `mode-btn${idx === 0 ? " active" : ""}`;
+  btn.dataset.sample = sample.id;
+  btn.textContent = sample.label;
+  sampleSelector.appendChild(btn);
+});
+
+sampleSelector.addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest<HTMLElement>(".mode-btn");
+  if (!btn) return;
+  sampleSelector.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
+  btn.classList.add("active");
+  activeSampleId = btn.dataset.sample ?? SAMPLES[0].id;
+  void replay();
+});
+
+speedSlider.addEventListener("input", () => {
+  speedLabel.textContent = `${speedSlider.value}ms`;
+});
+
+playBtn.addEventListener("click", () => void replay());
+
+// Boot with the first sample streamed once.
+void replay();

--- a/apps/web/streaming-table-demo.html
+++ b/apps/web/streaming-table-demo.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/demo-shared.css" />
+    <link rel="icon" href="/favicon.ico" />
+    <title>Streaming Markdown Tables: Persona</title>
+    <style>
+      .table-demo-controls {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-end;
+        gap: 1.5rem;
+        margin: 1.5rem 0 2rem;
+      }
+      .table-demo-controls .section { margin: 0; }
+      .table-demo-controls label {
+        display: block;
+        font-size: 0.8rem;
+        font-weight: 600;
+        margin-bottom: 0.4rem;
+        color: var(--muted);
+      }
+      .range-row { display: flex; align-items: center; gap: 0.6rem; }
+
+      .stream-panel {
+        max-width: 720px;
+        border: 1px solid var(--border, #e5e7eb);
+        border-radius: 0.75rem;
+        overflow: hidden;
+        background: var(--surface, #fff);
+      }
+      .stream-panel-head {
+        padding: 0.75rem 1rem;
+        border-bottom: 1px solid var(--border, #e5e7eb);
+      }
+      .stream-panel-head h3 { margin: 0; font-size: 0.95rem; }
+      .stream-panel-body { padding: 1rem; min-height: 18rem; }
+      /* Reset the persona-root wrapper (all:initial makes it inline) to a block
+         so the bubble fills the panel; widget.css supplies the table styling. */
+      .persona-render-host { display: block; }
+    </style>
+  </head>
+  <body>
+    <main class="shell-main">
+      <header class="title-strip">
+        <h1>Streaming Markdown Tables</h1>
+        <p>
+          Markdown streams into the message bubble token-by-token. The widget
+          completes the table structure as soon as the first row arrives and
+          reserves the column widths, so a real table appears immediately and
+          rows fill in without the header flipping from a paragraph or the
+          columns jiggling. Widths relax to their natural sizes once the stream
+          finishes. Pick a sample, slow the chunk delay down, and replay.
+        </p>
+      </header>
+
+      <div class="table-demo-controls">
+        <div class="section">
+          <label>Sample</label>
+          <div class="mode-group" id="sample-selector"></div>
+        </div>
+        <div class="section">
+          <label>Chunk delay</label>
+          <div class="range-row">
+            <input type="range" id="speed" min="8" max="120" step="4" value="40" />
+            <span id="speed-label">40ms</span>
+          </div>
+        </div>
+        <div class="section">
+          <button class="btn btn-primary" id="btn-play">Replay stream</button>
+        </div>
+      </div>
+
+      <div class="stream-panel">
+        <div class="stream-panel-head">
+          <h3>Assistant reply</h3>
+        </div>
+        <div class="stream-panel-body">
+          <div class="persona-render-host" data-persona-root>
+            <div class="persona-message-bubble">
+              <div class="persona-message-content" id="stream-content"></div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </main>
+
+    <script type="module" src="/src/streaming-table-demo.ts"></script>
+    <script type="module">
+      import { renderExamplesShell } from "/src/examples-nav.ts";
+      renderExamplesShell("streaming-table-demo");
+    </script>
+  </body>
+</html>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -564,6 +564,7 @@ export default defineConfig({
         'custom-loading-indicator': path.resolve(__dirname, 'custom-loading-indicator.html'),
         'tool-loading-demo': path.resolve(__dirname, 'tool-loading-demo.html'),
         'stream-animations-demo': path.resolve(__dirname, 'stream-animations-demo.html'),
+        'streaming-table-demo': path.resolve(__dirname, 'streaming-table-demo.html'),
         'ask-user-question-demo': path.resolve(__dirname, 'ask-user-question-demo.html'),
         'voice-integration-demo': path.resolve(__dirname, 'voice-integration-demo.html'),
         'custom-voice-provider-demo': path.resolve(__dirname, 'custom-voice-provider-demo.html'),

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -795,6 +795,13 @@ export const createStandardBubble = (
   const contentDiv = document.createElement("div");
   contentDiv.classList.add("persona-message-content");
 
+  // While streaming, lock table column widths (see widget.css) so rows append
+  // without per-chunk horizontal reflow. The class is dropped on the final,
+  // non-streaming render, relaxing tables to natural content-fit widths.
+  if (message.streaming) {
+    contentDiv.classList.add("persona-content-streaming");
+  }
+
   if (streamAnimationActive && streamPlugin) {
     if (streamPlugin.containerClass) {
       contentDiv.classList.add(streamPlugin.containerClass);

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1621,6 +1621,20 @@
   background-color: rgba(0, 0, 0, 0.02);
 }
 
+/* While a message is still streaming, lock table column widths so incoming rows
+   append without the per-chunk horizontal reflow (Telegram-style space
+   reservation). The class is removed on the final render, relaxing the finished
+   table to natural content-fit widths. overflow-wrap keeps long cell content
+   from spilling past the fixed columns mid-stream. */
+.persona-content-streaming table {
+  table-layout: fixed;
+}
+
+.persona-content-streaming th,
+.persona-content-streaming td {
+  overflow-wrap: break-word;
+}
+
 /* ============================================
    Markdown Horizontal Rule Styles
    ============================================ */

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1,5 +1,6 @@
 import { escapeHtml, createMarkdownProcessorFromConfig } from "./postprocessors";
 import { resolveSanitizer } from "./utils/sanitize";
+import { stabilizeStreamingTables } from "./utils/streaming-table";
 import { loadMarkdownParsers, getMarkdownParsersSync } from "./markdown-parsers-loader";
 import { AgentWidgetSession, AgentWidgetSessionStatus } from "./session";
 import {
@@ -473,8 +474,12 @@ export const buildPostprocessor = (
       // sanitizer's degraded fallback. Honors `sanitize: false` (pass-through) as before.
       html = sanitize ? sanitize(out) : out;
     } else if (markdownProcessor) {
+      // While streaming, normalize tables-in-progress so they render as a real
+      // <table> from the first row with a stable column count (Telegram-style
+      // space reservation). The final, non-streaming render is left untouched.
+      const source = context.streaming ? stabilizeStreamingTables(nextText) : nextText;
       // Already escapeHtml(text) (single, safe) while parsers are not loaded.
-      const out = markdownProcessor(nextText);
+      const out = markdownProcessor(source);
       html = sanitize && parsersReady ? sanitize(out) : out;
     } else {
       // Plain text: escapeHtml output is inert — never re-sanitize (the second escape).

--- a/packages/widget/src/utils/streaming-table.test.ts
+++ b/packages/widget/src/utils/streaming-table.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { stabilizeStreamingTables } from "./streaming-table";
+import { createMarkdownProcessor } from "../postprocessors";
+
+describe("stabilizeStreamingTables", () => {
+  it("leaves text without pipes untouched", () => {
+    const md = "# Heading\n\nA paragraph with no tables.";
+    expect(stabilizeStreamingTables(md)).toBe(md);
+  });
+
+  it("does not treat a header-only line as a table (no delimiter yet)", () => {
+    // Ambiguous: could just be inline pipe text. Leave it alone until a
+    // delimiter row starts streaming in.
+    const md = "| Name | Price |";
+    expect(stabilizeStreamingTables(md)).toBe(md);
+  });
+
+  it("completes a partial delimiter row so the table renders immediately", () => {
+    const md = "| Name | Price |\n| --";
+    expect(stabilizeStreamingTables(md)).toBe("| Name | Price |\n| --- | --- |");
+  });
+
+  it("completes a delimiter that is just a leading pipe with one dash", () => {
+    const md = "| A | B | C |\n|-";
+    expect(stabilizeStreamingTables(md)).toBe("| A | B | C |\n| --- | --- | --- |");
+  });
+
+  it("pads a partial trailing row to the header column count", () => {
+    const md = "| Name | Price |\n| --- | --- |\n| Apple";
+    expect(stabilizeStreamingTables(md)).toBe(
+      "| Name | Price |\n| --- | --- |\n| Apple |  |"
+    );
+  });
+
+  it("keeps a complete table stable (idempotent)", () => {
+    const md = "| Name | Price |\n| --- | --- |\n| Apple | $1 |";
+    expect(stabilizeStreamingTables(md)).toBe(md);
+    expect(stabilizeStreamingTables(stabilizeStreamingTables(md))).toBe(md);
+  });
+
+  it("counts columns from a header without outer pipes", () => {
+    const md = "Name | Price\n---";
+    expect(stabilizeStreamingTables(md)).toBe("Name | Price\n| --- | --- |");
+  });
+
+  it("normalizes rows with extra cells down to the header column count", () => {
+    const md = "| A | B |\n| --- | --- |\n| 1 | 2 | 3 |";
+    expect(stabilizeStreamingTables(md)).toBe("| A | B |\n| --- | --- |\n| 1 | 2 |");
+  });
+
+  it("stops the table region at a blank line and leaves following text alone", () => {
+    const md = "| A | B |\n| --- | --- |\n| 1 | 2 |\n\nSome | trailing | text";
+    expect(stabilizeStreamingTables(md)).toBe(md);
+  });
+
+  it("preserves leading prose before a streaming table", () => {
+    const md = "Here you go:\n\n| A | B |\n| -";
+    expect(stabilizeStreamingTables(md)).toBe("Here you go:\n\n| A | B |\n| --- | --- |");
+  });
+
+  it("handles two separate tables in one stream", () => {
+    const md =
+      "| A | B |\n| --- | --- |\n| 1 | 2 |\n\nmiddle\n\n| C | D | E |\n| --";
+    expect(stabilizeStreamingTables(md)).toBe(
+      "| A | B |\n| --- | --- |\n| 1 | 2 |\n\nmiddle\n\n| C | D | E |\n| --- | --- | --- |"
+    );
+  });
+
+  it("preserves alignment-colon delimiters as a valid table start", () => {
+    const md = "| A | B |\n| :-";
+    // Detection accepts colons; the synthesized delimiter normalizes to dashes
+    // (alignment reappears in the untouched final render).
+    expect(stabilizeStreamingTables(md)).toBe("| A | B |\n| --- | --- |");
+  });
+});
+
+describe("stabilizeStreamingTables → marked integration", () => {
+  const md = createMarkdownProcessor();
+
+  it("renders a <table> from a header + partial delimiter that marked alone would not", () => {
+    const partial = "| Name | Price |\n| --";
+
+    // Without stabilization marked sees no complete delimiter → no table.
+    expect(md(partial)).not.toContain("<table");
+
+    const html = md(stabilizeStreamingTables(partial));
+    expect(html).toContain("<table");
+    expect(html).toContain("<th>Name</th>");
+    expect(html).toContain("<th>Price</th>");
+  });
+
+  it("renders a body row for a partial trailing row", () => {
+    const partial = "| Name | Price |\n| --- | --- |\n| Apple";
+    const html = md(stabilizeStreamingTables(partial));
+    expect(html).toContain("<table");
+    expect(html).toContain("<td>Apple</td>");
+    // The padded empty cell keeps the column count stable.
+    expect(html.match(/<td/g)?.length).toBe(2);
+  });
+});

--- a/packages/widget/src/utils/streaming-table.ts
+++ b/packages/widget/src/utils/streaming-table.ts
@@ -1,0 +1,103 @@
+/**
+ * Streaming markdown table stabilizer (Telegram-style space reservation).
+ *
+ * During SSE streaming the full accumulated markdown is re-parsed by `marked`
+ * on every chunk. For GFM tables that produces two jarring jolts:
+ *
+ *  1. The paragraph→table flip. GFM only recognizes a table once the *delimiter*
+ *     row (`| --- | --- |`) has arrived, so a freshly-streamed header line first
+ *     renders as a plain paragraph and then snaps into a `<table>`.
+ *  2. Partial-row flicker. The in-flight last row grows cell-by-cell.
+ *
+ * This module rewrites table-in-progress regions so a real `<table>` renders
+ * from the first row onward with a stable column count: it completes the
+ * delimiter row as soon as it starts streaming and pads the trailing partial
+ * row to the header's column count. Combined with `table-layout: fixed` while
+ * streaming (see `.persona-content-streaming table` in widget.css), columns lock
+ * to even widths so rows append vertically without horizontal reflow.
+ *
+ * It runs ONLY while a message is streaming; the final render uses the real,
+ * untouched `marked` output, so correctness is never affected.
+ */
+
+/**
+ * A GFM delimiter row, full or still streaming in: only delimiter characters
+ * (`-`, `:`, `|`, whitespace) and at least one dash. Matches `|`-led partials
+ * like `| -`, `|--`, `| :--`, and complete rows like `| --- | :--: |`.
+ */
+const DELIMITER_RE = /^\s*\|?[\s:|-]*-[\s:|-]*$/;
+
+/** A candidate table row contains at least one pipe. */
+const hasPipe = (line: string): boolean => line.includes("|");
+
+/** Split a markdown table row into trimmed cell strings, ignoring outer pipes. */
+const splitCells = (line: string): string[] => {
+  let s = line.trim();
+  if (s.startsWith("|")) s = s.slice(1);
+  if (s.endsWith("|")) s = s.slice(0, -1);
+  return s.split("|").map((cell) => cell.trim());
+};
+
+/** Render cells back into a normalized, pipe-delimited row. */
+const buildRow = (cells: string[]): string => `| ${cells.join(" | ")} |`;
+
+/** Build a complete delimiter row with the given column count. */
+const buildDelimiter = (cols: number): string =>
+  `| ${Array.from({ length: cols }, () => "---").join(" | ")} |`;
+
+/** Pad (or trim) a row's cells to exactly `cols` columns. */
+const fitCells = (cells: string[], cols: number): string[] => {
+  if (cells.length >= cols) return cells.slice(0, cols);
+  return cells.concat(Array.from({ length: cols - cells.length }, () => ""));
+};
+
+/**
+ * Normalize any streaming-in-progress GFM tables in `markdown` so they render as
+ * complete tables with a stable column count. Returns the input unchanged when
+ * there is nothing to stabilize (cheap fast-path for the common no-table case).
+ */
+export const stabilizeStreamingTables = (markdown: string): string => {
+  if (!markdown || !markdown.includes("|")) return markdown;
+
+  const lines = markdown.split("\n");
+  let changed = false;
+
+  for (let i = 0; i < lines.length - 1; i++) {
+    const header = lines[i];
+    const delimiter = lines[i + 1];
+
+    // A table starts at a header line (has a pipe, is not itself a delimiter)
+    // immediately followed by a delimiter row that is full or still streaming.
+    if (!hasPipe(header) || DELIMITER_RE.test(header)) continue;
+    if (!DELIMITER_RE.test(delimiter)) continue;
+
+    const cols = splitCells(header).length;
+    if (cols < 1) continue;
+
+    // Complete the delimiter to match the header's column count so `marked`
+    // recognizes the table immediately instead of waiting for it to finish.
+    const fullDelimiter = buildDelimiter(cols);
+    if (lines[i + 1] !== fullDelimiter) {
+      lines[i + 1] = fullDelimiter;
+      changed = true;
+    }
+
+    // Normalize body rows (including a partial trailing one) to `cols` columns
+    // so each row occupies its slot instead of growing cell-by-cell. The region
+    // ends at the first blank or pipe-less line.
+    let j = i + 2;
+    for (; j < lines.length; j++) {
+      const row = lines[j];
+      if (row.trim() === "" || !hasPipe(row)) break;
+      const normalized = buildRow(fitCells(splitCells(row), cols));
+      if (lines[j] !== normalized) {
+        lines[j] = normalized;
+        changed = true;
+      }
+    }
+
+    i = j - 1; // resume scanning after this table region
+  }
+
+  return changed ? lines.join("\n") : markdown;
+};


### PR DESCRIPTION
## What

Telegram-style streaming for markdown tables. Today the widget re-parses the full accumulated markdown with `marked` on every SSE chunk, which makes tables jank as they stream:

1. **Paragraph→table flip** — GFM only recognizes a table once the `| --- |` delimiter row arrives, so the header first renders as a paragraph and then snaps into a `<table>`.
2. **Column thrashing** — `table-layout: auto` re-flows every column on each new row.
3. **Partial-row flicker** — the in-flight last row grows cell-by-cell.

This reserves the table's structure and column widths as soon as the first row streams in, so rows fill in without the flip or the horizontal jiggle.

## How

Scoped to **streaming only** — the final, non-streaming render is the untouched `marked` output, so correctness is unaffected.

- **`stabilizeStreamingTables(md)`** (`packages/widget/src/utils/streaming-table.ts`): completes the delimiter row as soon as it starts streaming and pads the trailing partial row to the header's column count, so a real `<table>` renders from the first row with a stable column count. Runs in `buildPostprocessor` (`ui.ts`) only when `context.streaming` and the markdown path is active.
- **Column lock**: the content div gets a `persona-content-streaming` class while streaming (`message-bubble.ts`); CSS locks columns with `table-layout: fixed` (`widget.css`). Columns relax to natural content-fit widths on completion (one settle, no per-chunk shift).

Default-on, no new config surface.

## Demo

New **Streaming Markdown Tables** page in the `apps/web` gallery (Patterns tier) streams sample tables token-by-token so you can watch the structure and columns reserve as rows arrive. Slow the chunk-delay slider down to see it clearly.

## Tests

- `streaming-table.test.ts` — 14 tests: string normalization (partial delimiter completion, row padding, column counting, idempotency, multi-table, region boundaries) + `marked` integration (renders a real `<table>` from a partial delimiter that `marked` alone would not).
- Full widget suite green (1279 tests); `pnpm lint` / `typecheck` / `build:widget` clean. `apps/web` vite build + browser-verified.

## Changeset

`minor` for `@runtypelabs/persona`. (`apps/web` changes need no changeset.)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to streaming markdown display only; final parsed output is untouched and behavior is covered by unit/integration tests.
> 
> **Overview**
> Streaming assistant messages with GFM tables no longer jump between paragraph and table layouts or reflow columns on every chunk. **While `context.streaming` is true**, markdown passed to `marked` is preprocessed with new **`stabilizeStreamingTables`**: partial delimiter rows are completed to match the header column count, and the in-flight last row is padded so `marked` emits a real `<table>` early with stable columns. The **final** non-streaming render still uses the raw markdown (no stabilization).
> 
> **Column width lock:** streaming bubbles add **`persona-content-streaming`** on the content div (`message-bubble.ts`), with **`table-layout: fixed`** and cell **`overflow-wrap`** in `widget.css` so rows stack vertically without horizontal jiggle; the class is removed when streaming ends so widths settle to content.
> 
> Also ships a **Streaming Markdown Tables** gallery demo (`apps/web`), vite entry + examples nav link, Vitest coverage for normalization and `marked` integration, and a **minor** changeset for `@runtypelabs/persona`. Default-on, no new config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79607ffafede2b5edc5316347067ca34cdb9241a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->