### PR TITLE
fix(widget): dedup final message on flow continuation streams

### DIFF
--- a/.changeset/flow-resume-final-message-dedup.md
+++ b/.changeset/flow-resume-final-message-dedup.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix duplicated final assistant message on flow continuation streams. A tool-driven `/resume` continues a flow on a fresh stream that does not re-emit `execution_start`, so the stream defaulted to agent mode and mis-routed the final prompt-step finalization — rendering the streamed text once and then a second time from `step_complete.result.response`. The client now recovers the flow execution kind from the leading `step_*` frame when `execution_start` is absent, so the finalization reconciles in place. Agent streams are unaffected (they carry no `stepType`).

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -1784,6 +1784,134 @@ describe('AgentWidgetClient - partId Text/Tool Interleaving', () => {
   });
 });
 
+describe('AgentWidgetClient - flow continuation stream without execution_start', () => {
+  // A tool-driven `/resume` continues a flow on a brand-new stream that does NOT
+  // re-emit `execution_start` (`flow_start`). Each stream resolves its execution
+  // kind independently and defaults to `"agent"`, so the continuation used to
+  // mis-route the final prompt-step finalization: the streamed text block was
+  // sealed via the agent path (which never records it as the sealed flow bubble),
+  // then `step_complete.result.response` re-rendered the same text as a SECOND
+  // bubble. The client now recovers the flow kind from the leading `step_*`
+  // frame (a `stepType` is flow-only), so the finalization reconciles in place.
+  function collectAssistantTexts(events: AgentWidgetEvent[]) {
+    const messagesById = new Map<string, AgentWidgetMessage>();
+    for (const event of events) {
+      if (event.type === 'message') messagesById.set(event.message.id, event.message);
+    }
+    return Array.from(messagesById.values())
+      .filter(m => m.role === 'assistant' && !m.variant)
+      .sort((a, b) => (a.sequence ?? 0) - (b.sequence ?? 0));
+  }
+
+  it('does not duplicate the final message when a flow resumes without execution_start', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    // No `flow_start`/`execution_start`: this is exactly the wire a tool-driven
+    // `/resume` continuation delivers.
+    global.fetch = createAgentStreamFetch([
+      sseEvent('step_start', { id: 's1', name: 'Prompt', stepType: 'prompt', index: 0, totalSteps: 1 }),
+      sseEvent('text_start', { messageId: 'msg_s1' }),
+      sseEvent('step_delta', { id: 's1', text: 'Done! Added to your cart.' }),
+      sseEvent('text_end', { messageId: 'msg_s1' }),
+      // The authoritative final response mirrors the streamed text.
+      sseEvent('step_complete', { id: 's1', name: 'Prompt', stepType: 'prompt', success: true, result: { response: 'Done! Added to your cart.' }, executionTime: 500 }),
+      sseEvent('flow_complete', { success: true }),
+    ]);
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'add it to my cart', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const assistantTexts = collectAssistantTexts(events);
+
+    // Exactly ONE assistant bubble — not duplicated by the step_complete finalization.
+    expect(assistantTexts.length).toBe(1);
+    expect(assistantTexts[0].content).toBe('Done! Added to your cart.');
+    expect(assistantTexts[0].streaming).toBe(false);
+  });
+
+  it('still reconciles in place when execution_start IS present (initial flow stream)', async () => {
+    const events: AgentWidgetEvent[] = [];
+
+    // Same shape but WITH flow_start — the pre-existing, already-correct path.
+    global.fetch = createAgentStreamFetch([
+      sseEvent('flow_start', { flowId: 'f1', flowName: 'Test', totalSteps: 1, executionId: 'exec_f1' }),
+      sseEvent('step_start', { id: 's1', name: 'Prompt', stepType: 'prompt', index: 0, totalSteps: 1 }),
+      sseEvent('text_start', { messageId: 'msg_s1' }),
+      sseEvent('step_delta', { id: 's1', text: 'Done! Added to your cart.' }),
+      sseEvent('text_end', { messageId: 'msg_s1' }),
+      sseEvent('step_complete', { id: 's1', name: 'Prompt', stepType: 'prompt', success: true, result: { response: 'Done! Added to your cart.' }, executionTime: 500 }),
+      sseEvent('flow_complete', { success: true }),
+    ]);
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'add it to my cart', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const assistantTexts = collectAssistantTexts(events);
+    expect(assistantTexts.length).toBe(1);
+    expect(assistantTexts[0].content).toBe('Done! Added to your cart.');
+    expect(assistantTexts[0].streaming).toBe(false);
+  });
+
+  it('does not misclassify an agent stream as a flow (no stepType present)', async () => {
+    const events: AgentWidgetEvent[] = [];
+    const execId = 'exec_a1';
+
+    // Agent loops use `agent_*`/turn_* frames and never carry a `stepType`, so the
+    // flow recovery must not engage. A single streamed turn yields exactly one
+    // bubble (regression guard so the recovery can't over-fire on agents).
+    global.fetch = createAgentStreamFetch([
+      sseEvent('agent_start', {
+        executionId: execId, agentId: 'virtual', agentName: 'Test',
+        maxTurns: 1, startedAt: new Date().toISOString(), seq: 1,
+      }),
+      sseEvent('agent_iteration_start', {
+        executionId: execId, iteration: 1, maxTurns: 1,
+        startedAt: new Date().toISOString(), seq: 2,
+      }),
+      sseEvent('agent_turn_start', {
+        executionId: execId, iteration: 1, turnIndex: 0,
+        role: 'assistant', turnId: 'turn_1', seq: 3,
+      }),
+      sseEvent('agent_turn_delta', {
+        executionId: execId, iteration: 1, delta: 'Hi there!',
+        contentType: 'text', turnId: 'turn_1', seq: 4,
+      }),
+      sseEvent('agent_turn_complete', {
+        executionId: execId, iteration: 1, role: 'assistant',
+        turnId: 'turn_1', completedAt: new Date().toISOString(), seq: 5,
+      }),
+      sseEvent('agent_iteration_complete', {
+        executionId: execId, iteration: 1, toolCallsMade: 0,
+        stopConditionMet: false, completedAt: new Date().toISOString(), seq: 6,
+      }),
+      sseEvent('agent_complete', {
+        executionId: execId, agentId: 'virtual', success: true,
+        iterations: 1, stopReason: 'max_iterations',
+        completedAt: new Date().toISOString(), seq: 7,
+      }),
+    ]);
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+    });
+    await client.dispatch(
+      { messages: [{ id: 'usr_1', role: 'user', content: 'hi', createdAt: new Date().toISOString() }] },
+      (event) => events.push(event)
+    );
+
+    const assistantTexts = collectAssistantTexts(events);
+    expect(assistantTexts.length).toBe(1);
+    expect(assistantTexts[0].content).toBe('Hi there!');
+  });
+});
+
 describe('AgentWidgetClient - nested flow-as-tool (parentToolCallId)', () => {
   // PR #4602: a flow running as a tool enriches its streamed text/reasoning with
   // toolContext.toolId; the unified wire surfaces it as text_start/reasoning_start

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1969,6 +1969,15 @@ export class AgentWidgetClient {
     // Execution kind, resolved from the leading `execution_start` frame. Drives
     // the agent-vs-flow branches that the single unified vocabulary collapses.
     let executionKind: "agent" | "flow" = "agent";
+    // Whether `executionKind` was set authoritatively by an `execution_start`
+    // frame. Continuation streams (e.g. a tool-driven `/resume`) do NOT re-emit
+    // `execution_start`, so a fresh `streamResponse` for the continuation starts
+    // with the default `"agent"`. For a flow that mis-routes the final
+    // prompt-step finalization and duplicates the last message (the streamed
+    // text block is sealed, then `step_complete.result.response` re-renders it as
+    // a second bubble). When `execution_start` is absent we recover the flow kind
+    // from the first flow `step_*` frame below.
+    let executionKindResolved = false;
     // Open turn id (from `turn_start`). Unified text/reasoning deltas carry their
     // own block id, not the turn id, so the turn id is threaded onto agentMetadata
     // from here.
@@ -1986,6 +1995,21 @@ export class AgentWidgetClient {
       for (let i = 0; i < seqReadyQueue.length; i++) {
         const payloadType = seqReadyQueue[i].payloadType;
         const payload = seqReadyQueue[i].payload;
+
+        // Recover the execution kind on continuation streams that omit
+        // `execution_start` (e.g. a tool-driven `/resume`). Flow `step_*` frames
+        // carry a `stepType`; agent loops never do (they use `turn_*`). Without
+        // this, the continuation defaults to `"agent"` and a flow's final
+        // prompt-step finalization is duplicated. We only infer when no
+        // `execution_start` resolved the kind, so an explicit `agent` is never
+        // overridden.
+        if (
+          !executionKindResolved &&
+          executionKind !== "flow" &&
+          typeof (payload as { stepType?: unknown }).stepType === "string"
+        ) {
+          executionKind = "flow";
+        }
 
         if (payloadType === "reasoning_start") {
           // Nested flow-as-tool thinking (PR #4602): route to the parent tool's row.
@@ -2543,6 +2567,7 @@ export class AgentWidgetClient {
         // ================================================================
         } else if (payloadType === "execution_start") {
           executionKind = payload.kind === "flow" ? "flow" : "agent";
+          executionKindResolved = true;
           if (executionKind === "agent") {
             agentExecution = {
               executionId: payload.executionId,


### PR DESCRIPTION
## Problem

When a flow uses tools, each tool call is executed client-side and the result is posted back via `/resume`, which **continues the flow on a brand-new stream**. That continuation stream does **not** re-emit `execution_start` (only the initial stream carries it).

Inside `streamResponse`, the execution kind is a per-stream local that defaults to `"agent"` and is only upgraded to `"flow"` by `execution_start`:

```ts
let executionKind: "agent" | "flow" = "agent";
// ...only set here:
executionKind = payload.kind === "flow" ? "flow" : "agent";
```

So on every tool-driven `/resume`, a **flow** is processed as if it were an **agent**. That matters for the final prompt step, whose answer legitimately arrives twice in one stream — once as the streamed text block (`text_*`) and once as the authoritative `step_complete.result.response`. The reconciliation that collapses those into one bubble is gated on `executionKind === "flow"`:

- `text_complete`: only the flow branch records the sealed bubble as `lastSealedFlowBubble`.
- `step_complete`: with no sealed flow bubble found, it falls into the "buffered" branch and creates a **second** bubble from `result.response`.

**Result:** the final assistant message renders **twice** on any tool-driven turn of a flow. Agents are unaffected (the `"agent"` default is already correct for them, and they emit no `step_complete.result.response`). It also only surfaces after a tool call, since only tools trigger the `/resume` continuation.

## Fix

Recover the flow execution kind on continuation streams that omit `execution_start`. Flow `step_*` frames carry a `stepType`; agent loops never do (they use `turn_*`). When no `execution_start` has authoritatively resolved the kind, the first frame bearing a `stepType` flips the stream to flow mode — early enough (it precedes `text_complete`) for the finalization to reconcile in place.

The inference is guarded by an `executionKindResolved` flag so an explicit `execution_start` (agent or flow) is **never** overridden — the recovery only engages on streams that never declared their kind.

## Tests

`client.test.ts` adds a `flow continuation stream without execution_start` block:

1. **Repro/fix** — a flow stream that omits `execution_start` (mirrors a `/resume` continuation) emits exactly one final assistant bubble. *Verified to fail before the fix (`expected 2 to be 1`) and pass after.*
2. **No regression on the happy path** — the same stream **with** `execution_start` still reconciles to one bubble.
3. **No over-firing on agents** — an agent stream (no `stepType`) is unaffected.

Full `client.test.ts`, `session.test.ts`, and `session.webmcp.test.ts` suites pass (197 tests); `tsc --noEmit` and `eslint` are clean. Changeset included (patch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped widget SSE routing change with guarded inference and targeted tests; no auth or API contract changes.
> 
> **Overview**
> Fixes **duplicate final assistant bubbles** after tool-driven flow `/resume` continuations, when the new SSE stream omits `execution_start`.
> 
> `streamResponse` used to default each stream to **agent** mode until `execution_start` arrived; resume streams never send it, so flow prompt finalization ran on the wrong path—streamed text sealed once, then `step_complete.result.response` added a second bubble.
> 
> The client now tracks **`executionKindResolved`** and, only when `execution_start` never ran, infers **flow** from the first event whose payload has **`stepType`** (flow `step_*` only; agent streams unchanged). Explicit `execution_start` still wins.
> 
> Adds regression tests for resume-without-`execution_start`, the normal flow-with-`flow_start` path, and agent streams without `stepType`. Patch changeset for `@runtypelabs/persona`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 961e0d06de94bee6d23db0b72d69a6e2413a44b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->