### PR TITLE
docs: WebMCP tool-design resources and host matrix wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ More adapters (Anthropic Claude Agent SDK, Google Gen AI, Mastra, Cloudflare Age
 
 ### Host Matrix
 
-The adapter is a plain Web `(Request) => Response`, so it runs anywhere, not just in Next.js. These four examples re-host **the same canonical agent**: `persona-wire.ts` and the adapter are byte-identical in all of them, and only the thin host wrapper changes. Diff them to see exactly what each framework needs (and what it gives you for free). All four run with **no API key** (a zero-dependency echo agent, with a documented one-line swap to a real model).
+The adapter is a plain Web `(Request) => Response`, so it runs anywhere, not just React. These four examples re-host **the same canonical agent**: each uses the same `persona-wire.ts` and adapter, and only the thin host wrapper changes. Diff them to see exactly what each framework needs (and what it gives you for free). All four run with **no API key** (a zero-dependency echo agent, with a documented one-line swap to a real model).
 
 - [**Hono**](./examples/echo-hono): one `app.fetch` handler that runs on Node, Bun, Deno, and Cloudflare Workers.
 - [**Bare HTML + `<script>`**](./examples/echo-script-tag): no framework, no bundler: the drop-in script-tag install over a bare `node:http` backend.

--- a/packages/widget/docs/EXTENDING.md
+++ b/packages/widget/docs/EXTENDING.md
@@ -316,6 +316,21 @@ import { contextProviders } from "@runtypelabs/persona/smart-dom-reader";
 WebMCP execution, approval gating, and resume semantics are documented in
 **[PROGRAMMATIC-CONTROL.md](./PROGRAMMATIC-CONTROL.md)**.
 
+### Designing good WebMCP tools
+
+A WebMCP tool is an MCP tool that happens to run in the browser, so the same
+tool-design discipline applies: clear names, focused scope, well-described
+inputs, and outputs an agent can actually act on.
+
+- **[WebMCP — Chrome for Developers](https://developer.chrome.com/docs/ai/webmcp)** —
+  Google's guide to the imperative and declarative APIs, with end-to-end examples.
+- **[WebMCP explainer (W3C Web Machine Learning CG)](https://github.com/webmachinelearning/webmcp)** —
+  the spec proposal and rationale behind `navigator.modelContext`.
+- **[Debug WebMCP tools in Chrome DevTools](https://developer.chrome.com/docs/devtools/application/webmcp)** —
+  inspect tool registration, schema validation, and invocation history.
+- **[MCP tool design patterns (Arcade)](https://www.arcade.dev/blog/mcp-tool-patterns/)** —
+  general MCP tool-design practices that apply directly to WebMCP tools too.
+
 ## Layout slots
 
 Slots inject your own UI into fixed regions of the panel without replacing the


### PR DESCRIPTION
Documentation-only updates.

- Add a "Designing good WebMCP tools" subsection to `packages/widget/docs/EXTENDING.md` linking to Google's WebMCP guides and general MCP tool-design resources.
- Refine the Host Matrix wording in `README.md` to emphasize the shared adapter.

No changeset required (docs only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only changes with no runtime, API, or security impact.
> 
> **Overview**
> Adds a **Designing good WebMCP tools** subsection under the WebMCP extension point in `EXTENDING.md`, framing browser tools as MCP tools and linking to Chrome’s WebMCP guides, the W3C explainer, DevTools debugging, and general MCP tool-design patterns.
> 
> The **Host Matrix** blurb in `README.md` now says the shared Web adapter runs beyond React (not only Next.js) and describes the four echo examples as sharing the same `persona-wire.ts` and adapter rather than claiming they are byte-identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc5b315a8836c93a78fe56383a7272328dd80e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->