### PR TITLE
fix(widget): wrap long URLs in message bubbles

### DIFF
--- a/.changeset/wrap-long-urls-in-bubbles.md
+++ b/.changeset/wrap-long-urls-in-bubbles.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Wrap long unbreakable tokens (URLs, package names) inside message bubbles instead of overflowing horizontally. Adds `overflow-wrap: break-word` to `.persona-message-bubble` so links and prose stay within the bubble's max-width.

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1745,6 +1745,9 @@
 /* Make message bubble position relative for overlay positioning */
 .persona-message-bubble {
   position: relative;
+  /* Break long unbreakable tokens (e.g. URLs, package names) so they wrap
+     inside the bubble's max-width instead of overflowing horizontally. */
+  overflow-wrap: break-word;
 }
 
 /* Fade-in animation for action buttons */


### PR DESCRIPTION
## Problem

Long unbreakable tokens (URLs, package names) overflow the message bubble horizontally instead of wrapping. On persona-chat.dev the docs agent's "Learn more" links (e.g. \`https://www.npmjs.com/package/@runtypelabs/persona\`) run off the right edge of the bubble and get clipped.

Root cause: \`.persona-message-bubble\` is capped at \`max-width: 85%\`, but only \`pre\`/\`code\` had word-breaking rules. Ordinary prose and links had none, so a single long token forces the line box past the bubble edge.

## Fix

One line — add \`overflow-wrap: break-word\` to \`.persona-message-bubble\`, cascading to all bubble text and links.

\`\`\`css
.persona-message-bubble {
  position: relative;
  /* Break long unbreakable tokens (e.g. URLs, package names) so they wrap
     inside the bubble's max-width instead of overflowing horizontally. */
  overflow-wrap: break-word;
}
\`\`\`

\`break-word\` (not \`anywhere\`) is deliberate: it breaks a token only when it would overflow, and does **not** alter intrinsic/min-content width — so short bubbles and normal layout are unchanged.

## Verification

Tested against the live widget (full stylesheet, real DOM), A/B with the rule toggled:

| Case | Before | After |
|---|---|---|
| List / prose + long URL | overflows **122px** | **0px — wraps** ✅ |
| Markdown table + long URL | overflows 160px | 160px — **identical** |

The table numbers are byte-identical with/without the rule: markdown tables use \`table-layout: auto\`, where columns expand to fit their longest token, so the cell is never width-constrained and \`overflow-wrap\` is a no-op there. **This change cannot affect table rendering.**

> Note: tables with long URLs do overflow today (pre-existing, separate issue). The naive cell-level fix (\`overflow-wrap: anywhere\`) regresses normal tables — it breaks words mid-word and reshuffles columns — so a proper table fix (horizontal-scroll wrapper) is left as a deliberate follow-up rather than bundled here.

## Changeset

Included (\`@runtypelabs/persona\` patch).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single presentational CSS rule on chat bubbles; no logic, auth, or data changes.
> 
> **Overview**
> Fixes **horizontal overflow** when assistant (or user) messages contain long unbreakable tokens—especially npm/docs URLs—that extend past the bubble’s `max-width: 85%` and get clipped.
> 
> Adds **`overflow-wrap: break-word`** on **`.persona-message-bubble`** so prose and links inherit wrapping; **`pre`/`code`** behavior is unchanged. Uses `break-word` (not `anywhere`) so tokens break only when they would overflow, without shrinking normal short bubbles.
> 
> Ships a **`@runtypelabs/persona` patch** changeset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce1a2e45c7984a844f38d7de3a0b3ed8b2d76ba9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->