### PR TITLE
Tidy homepage copy

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -100,12 +100,6 @@
               aria-label="Copy Persona init command"
             ><span data-copy-label>Copy</span></button>
           </div>
-          <div class="hero-meta" aria-label="Why Persona">
-            <span>MIT License</span>
-            <span>Zero Framework Deps</span>
-            <span>Voice Built In</span>
-            <span>Any Backend</span>
-          </div>
         </section>
 
         <!-- Framework / platform logo strip -->
@@ -129,7 +123,7 @@
 
         <!-- Showcase carousel -->
         <section id="showcase">
-          <span class="label-caps">01 / Demos that make you [and your browser] happy</span>
+          <span class="label-caps">Demos that make you [and your browser] happy</span>
           <div class="carousel-3d" id="hero-carousel" role="region" aria-roledescription="carousel" aria-label="Live demo gallery">
             <div class="carousel-3d-scene">
               <div class="carousel-3d-card">
@@ -203,23 +197,23 @@
         <section id="capabilities" class="reveal-el">
           <div class="modules-grid">
             <div class="module">
-              <span class="label-caps">02 / Agentic</span>
-              <h3>Operates Your Page</h3>
+              <span class="label-caps">Agentic</span>
+              <h3>Operates Your App</h3>
               <p>Expose page actions, search, carts, bookings, forms, as WebMCP tools and the agent drives them directly, with user approval built in. No backend integration required.</p>
             </div>
             <div class="module">
-              <span class="label-caps">03 / Isolation</span>
+              <span class="label-caps">Isolation</span>
               <h3>Won't Break Your Styles</h3>
               <p>Shadow DOM rendering and prefixed CSS keep widget and host styles fully separate. Drop it into any page: nothing leaks in, nothing leaks out.</p>
             </div>
             <div class="module">
-              <span class="label-caps">04 / Transport</span>
+              <span class="label-caps">Transport</span>
               <h3>Streams From Any Backend</h3>
               <p>SSE streaming with pluggable parsers. Adapt any request or event shape with <code>customFetch</code> and <code>parseSSEEvent</code>: Runtype is the fast path, not a requirement.</p>
             </div>
             <div class="module">
-              <span class="label-caps">05 / Theming</span>
-              <h3>Yours, Down To The Token</h3>
+              <span class="label-caps">Theming</span>
+              <h3>Style It Like It Belongs</h3>
               <p>A three-layer token tree, palette, semantic, component, with dark mode and a live theme editor. Match your brand without forking the widget.</p>
             </div>
           </div>
@@ -228,7 +222,7 @@
         <!-- Quick start -->
         <section id="quick-start" class="reveal-el">
           <div class="section-head">
-            <span class="label-caps">06 / Quick Start</span>
+            <span class="label-caps">Quick Start</span>
             <h2 class="editorial-h">Choose Your Integration Path</h2>
             <p class="body-copy">Start from a pre-built example for your stack, or ship a hosted widget with Runtype.</p>
           </div>
@@ -533,7 +527,7 @@ document.modelContext.registerTool({
               </div>
             </div>
             <div class="webmcp-body">
-              <span class="label-caps">07 / WebMCP Standard</span>
+              <span class="label-caps">WebMCP Standard</span>
               <h3>Let Agents Use The Tools Already On Your Page</h3>
               <p class="body-copy"><a href="https://github.com/webmachinelearning/webmcp" target="_blank" rel="noopener">WebMCP</a> gives the browser a standard place for page tools: <code>document.modelContext</code>. Persona discovers those tools, asks the user before calling them, and streams the result back into the conversation. Search, carts, bookings, and forms stay in your page code. The chat UI just becomes another way to use them.</p>
               <div class="webmcp-actions">
@@ -547,7 +541,7 @@ document.modelContext.registerTool({
         <!-- Demos & patterns -->
         <section id="demos" class="reveal-el">
           <div class="section-head">
-            <span class="label-caps">08 / Demos &amp; Patterns</span>
+            <span class="label-caps">Demos &amp; Patterns</span>
             <h2 class="editorial-h">See What Persona Can Do</h2>
             <p class="body-copy">Agentic, layout, voice, and business scenarios: every demo is a working page you can open and inspect.</p>
           </div>

--- a/apps/web/src/home.css
+++ b/apps/web/src/home.css
@@ -423,24 +423,6 @@ section[id], aside[id] {
   color: var(--ink);
 }
 
-.hero-meta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 12px 28px;
-  font-family: var(--font-mono);
-  font-size: 11px;
-  font-weight: 500;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: rgba(29, 28, 23, 0.55);
-}
-
-.hero-meta span::before {
-  content: '/';
-  margin-right: 10px;
-  color: var(--teal-dim);
-}
-
 /* Framework / platform logo strip ----------------------------------------------- */
 
 .stack-strip {
@@ -752,9 +734,11 @@ section[id], aside[id] {
   font-size: clamp(26px, 2.6vw, 38px);
   font-weight: 500;
   letter-spacing: 0.08em;
-  line-height: 1.15;
+  line-height: 1.32;
   color: var(--ink);
-  margin: 0 0 20px;
+  margin: 0 0 18px;
+  overflow: visible;
+  padding-bottom: 0.08em;
 }
 
 .module p {


### PR DESCRIPTION
## Summary
- remove extra homepage badge/number chrome
- update capability copy
- give module headings more descender room

## Validation
- pnpm --filter web build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static marketing HTML/CSS only; no runtime or API behavior changes.
> 
> **Overview**
> Marketing-only updates to `apps/web/index.html` and `apps/web/src/home.css`.
> 
> The hero no longer shows the **MIT License / Zero Framework Deps** badge row (`.hero-meta` markup and styles removed). Section **label-caps** across showcase, capabilities, quick start, WebMCP, and demos drop the `NN /` numbering prefix for a cleaner editorial look.
> 
> Capability module copy shifts **Operates Your Page** → **Operates Your App** and **Yours, Down To The Token** → **Style It Like It Belongs**. `.module h3` gets slightly looser line-height, bottom padding, and `overflow: visible` so descenders on editorial headings are not clipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b4f47b294162d7ba74dd110d7367cbf5b4969c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->