### PR TITLE
Widen homepage rail

### DIFF
--- a/apps/web/src/home.css
+++ b/apps/web/src/home.css
@@ -13,7 +13,7 @@
 :root {
   --margin: clamp(16px, 4vw, 64px);
   --header-h: 72px;
-  --rail-w: 420px;
+  --rail-w: clamp(420px, 30vw, 600px);
 }
 
 *, *::before, *::after {


### PR DESCRIPTION
## Summary
- widen homepage widget rail on large screens

## Validation
- pnpm --filter web build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS layout variable change on the marketing home page with no logic or data impact.
> 
> **Overview**
> **Widens the homepage live-widget sidebar** on wide desktop layouts by making `--rail-w` responsive instead of a fixed **420px**.
> 
> The rail width is now `clamp(420px, 30vw, 600px)`, so it grows with viewport width up to **600px** while the existing **1280px** breakpoint still pins it to **380px** and stacked layouts below **1100px** are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e660c20e1d1c4c28c2396aadb3e2b3c3cb4ee002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->