### PR TITLE
fix: tables span the full chat column (table bubble width)

### DIFF
--- a/.changeset/table-bubble-full-width.md
+++ b/.changeset/table-bubble-full-width.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Markdown tables now span the full chat column. A table-bearing assistant bubble grows to fill the row (`:has(table)`) instead of shrink-wrapping to its content, which fixes the table visibly collapsing to a narrow width when the streaming column-width lock is released.

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1586,6 +1586,18 @@
 /* ============================================
    Markdown Table Styles
    ============================================ */
+/* Tables span the full chat column. The assistant bubble is a flex item that
+   sizes to its content, so a width:100% table only fills that shrunk box — and
+   once the streaming `table-layout: fixed` lock is released the table visibly
+   collapses to content width ("renders full-width, then snaps narrow"). When the
+   bubble holds a table, let it grow to fill the row so the table keeps the full
+   column width. */
+.persona-message-bubble:has(table) {
+  width: 100%;
+  max-width: 100%;
+  flex-grow: 1;
+}
+
 .persona-message-bubble table {
   width: 100%;
   border-collapse: collapse;


### PR DESCRIPTION
## What

Markdown tables now span the full chat column. A table-bearing assistant bubble grows to fill the row (`:has(table)`) instead of shrink-wrapping to its content.

## Why

The assistant bubble is a flex item that sizes to its content, so the widget's `table { width: 100% }` only fills that *shrunk* box. Once the streaming `table-layout: fixed` lock is released on the final render, the table collapses to content width — the "renders full-width, then snaps narrow" jolt. Letting the bubble grow when it holds a table keeps the table at full column width across the stream→final handoff.

## Change

A single CSS rule in `widget.css`:

```css
.persona-message-bubble:has(table) {
  width: 100%;
  max-width: 100%;
  flex-grow: 1;
}
```

`:has(table)` only matches bubbles that actually contain a table, so non-table messages are unaffected.

## Notes

- Ports a fix validated in the `mixlayer-playground` host app into the core widget so every consumer gets it.
- This is the first of a few table-stability improvements; the column-width/no-reflow work is intentionally left out of this PR.

## Testing

- `pnpm lint` / `pnpm typecheck` clean; full widget test suite passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single scoped CSS rule and a changeset; no logic or auth changes, with behavior limited to bubbles that contain tables.
> 
> **Overview**
> Fixes markdown tables **snapping narrow** after streaming finishes, when the temporary `table-layout: fixed` lock on `.persona-content-streaming` is removed.
> 
> Adds **`.persona-message-bubble:has(table)`** in `widget.css` so bubbles that contain a table use **`width` / `max-width: 100%`** and **`flex-grow: 1`**, letting the bubble fill the chat row instead of shrink-wrapping. Existing **`table { width: 100% }`** then spans the full column through the stream→final handoff. **`:has(table)`** limits the change to table messages; other bubbles keep their usual max-width behavior.
> 
> Includes a **patch changeset** for `@runtypelabs/persona` documenting the fix (ported from the playground host).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca99ad6b87db7492373b93cf4f5cd7eace308578. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->