### PR TITLE
Refactor event stream toolbar and enhance layout mode documentation

### DIFF
--- a/.changeset/event-stream-fullscreen-takeover.md
+++ b/.changeset/event-stream-fullscreen-takeover.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix the event stream inspector reappearing stacked above the chat messages when the window is resized across the mobile/fullscreen breakpoint. The fullscreen layout reset was wiping the `display: none` that hides the messages body while the stream is open; it's now preserved, so the event panel keeps taking over the full chat area at every width.

--- a/.changeset/responsive-throughput-label.md
+++ b/.changeset/responsive-throughput-label.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Simplify and fix the event stream toolbar so it no longer overflows in narrow panels. The total event count now lives in the "All events (N)" filter option (matching the per-type options) instead of a separate count badge, and the redundant "Events" and "Throughput" labels are removed (the tok/s value is self-describing and the throughput's accessible name is preserved via aria-label). At very narrow widths the "Copy All" button collapses to icon-only as a last resort.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,10 @@ Use `patch` for bug fixes, `minor` for new features, and `major` for breaking ch
 
 **Does NOT need a changeset:** Changes to `examples/`, `docs/`, CI config, tooling, or `CLAUDE.md`.
 
+### Major version bumps and doc CDN URLs
+
+The hand-written docs (`README.md`, `apps/web/index.html`) pin their jsDelivr script-tag install URLs to the **major** range, e.g. `@runtypelabs/persona@4/dist/install.global.js` (never `@latest` or unversioned). On a **major** release these must move to `@5`, etc.
+
 ## Architecture
 
 ### Widget Package (`packages/widget/src/`)

--- a/README.md
+++ b/README.md
@@ -109,6 +109,52 @@ npm install @runtypelabs/persona        # widget
 npm install @runtypelabs/persona-proxy   # proxy (optional)
 ```
 
+## Three primary layouts
+
+While Persona supports much more, the majority of the frontend AI experiences you see fit into the three buckets below. We recommend starting here.
+
+You move between them by changing the `launcher` config:
+
+- **Floating** (the default): a launcher in the corner that opens a floating panel. The entry point for support, docs, sales, or onboarding, no layout config required.
+- **Docked:** a copilot docked beside your app. Wrap a page region and reveal a side panel that resizes, pushes, or overlays your layout.
+- **Fullscreen:** a full-height assistant that owns the page. Fill a container as an app surface, with an optional artifact split.
+
+**With npm** (any bundler):
+
+```ts
+import { initAgentWidget } from "@runtypelabs/persona";
+
+// 1. Floating: the launcher in the corner is the default
+initAgentWidget({ target: "#chat", config: { apiUrl } });
+
+// 2. Docked: wrap a region, reveal a side panel
+initAgentWidget({
+  target: "#workspace",
+  config: { apiUrl, launcher: { mountMode: "docked", dock: { side: "right", width: "420px" } } },
+});
+
+// 3. Fullscreen: turn the launcher off, let the widget own the page
+initAgentWidget({
+  target: "#app",
+  config: { apiUrl, launcher: { enabled: false, fullHeight: true } },
+});
+```
+
+**Or with a script tag** (no build step): the same config via `window.siteAgentConfig`, and the installer loads the widget and its CSS for you. Swap in the same `launcher` field for docked or fullscreen.
+
+```html
+<script>
+  window.siteAgentConfig = {
+    target: "#chat",
+    apiUrl: "https://your-api.com/chat",
+    // floating launcher is the default
+  };
+</script>
+<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js"></script>
+```
+
+See the live [launcher](https://persona-chat.dev/launcher-demo.html), [docked panel](https://persona-chat.dev/docked-panel-demo.html), and [fullscreen assistant](https://persona-chat.dev/fullscreen-assistant-demo.html) demos. The [widget configuration reference](./packages/widget/README.md) covers `mountMode`, every `dock.reveal` mode (`resize`, `emerge`, `overlay`, `push`), and the docked height contract. 
+
 ## Features
 
 Everything below is opt-in and configurable via the widget config, feature flags, or the plugin system.

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -58,7 +58,6 @@
       <img src="/persona-js.svg" alt="" width="124" height="39">
     </a>
     <nav class="site-nav" aria-label="Page sections">
-      <a href="#quick-start">Quick Start</a>
       <a href="#webmcp">WebMCP</a>
       <a href="#demos">Demos</a>
       <a href="/theme.html">Theme Editor</a>
@@ -192,6 +191,177 @@
             </div>
             <p class="carousel-3d-hint" aria-hidden="true">Click a card to open it full size</p>
             <span class="visually-hidden" aria-live="polite" data-carousel-status></span>
+          </div>
+        </section>
+
+        <!-- Layout modes: one widget, three shapes -->
+        <section id="layouts" class="reveal-el">
+          <div class="section-head">
+            <span class="label-caps">Start in a few lines</span>
+            <h2 class="editorial-h">Floating, docked, or fullscreen UX</h2>
+            <p class="body-copy">Pick your jump-off point and customize from there: a launcher floating in the corner, a copilot docked beside your app, or a fullscreen assistant. You move between them by changing the <code>launcher</code> config, not your agent or app.</p>
+          </div> 
+
+          <div class="layout-modes-controls">
+            <div class="quick-start-tabs layout-modes-tabs" role="tablist" aria-label="Layout">
+              <button
+                type="button"
+                class="quick-start-tab"
+                id="layout-mode-tab-floating"
+                role="tab"
+                aria-selected="true"
+                aria-controls="layout-mode-panel-floating"
+                data-layout-mode-tab="floating"
+              >
+                Floating
+              </button>
+              <button
+                type="button"
+                class="quick-start-tab"
+                id="layout-mode-tab-docked"
+                role="tab"
+                aria-selected="false"
+                aria-controls="layout-mode-panel-docked"
+                data-layout-mode-tab="docked"
+                tabindex="-1"
+              >
+                Docked
+              </button>
+              <button
+                type="button"
+                class="quick-start-tab"
+                id="layout-mode-tab-fullscreen"
+                role="tab"
+                aria-selected="false"
+                aria-controls="layout-mode-panel-fullscreen"
+                data-layout-mode-tab="fullscreen"
+                tabindex="-1"
+              >
+                Fullscreen
+              </button>
+            </div>
+            <div class="layout-delivery" role="group" aria-label="Install method">
+              <span class="layout-delivery-label">Install via</span>
+              <div class="quick-start-tabs layout-delivery-tabs">
+                <button
+                  type="button"
+                  class="quick-start-tab"
+                  data-delivery-tab="npm"
+                  aria-pressed="true"
+                >
+                  npm
+                </button>
+                <button
+                  type="button"
+                  class="quick-start-tab"
+                  data-delivery-tab="script"
+                  aria-pressed="false"
+                >
+                  Script tag
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <div
+            class="layout-modes-panel"
+            id="layout-mode-panel-floating"
+            role="tabpanel"
+            aria-labelledby="layout-mode-tab-floating"
+            data-layout-mode-panel="floating"
+          >
+            <p class="layout-mode-caption">A launcher in the corner that opens a floating panel. The drop-in default for support, docs, sales, or onboarding. No layout config required.</p>
+            <div class="code-showcase layout-delivery-block" data-delivery="npm">
+              <pre><code><span class="code-keyword">import</span> <span class="code-string">"@runtypelabs/persona/widget.css"</span>;
+<span class="code-keyword">import</span> { <span class="code-function">initAgentWidget</span> } <span class="code-keyword">from</span> <span class="code-string">"@runtypelabs/persona"</span>;
+
+<span class="code-function">initAgentWidget</span>({
+  <span class="code-keyword">target</span>: <span class="code-string">"#chat"</span>,
+  <span class="code-keyword">config</span>: {
+    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
+    <span class="code-diff"><span class="code-comment">// floating launcher is the default</span></span>
+  },
+});</code></pre>
+            </div>
+            <div class="code-showcase layout-delivery-block" data-delivery="script" hidden>
+              <pre><code>&lt;script&gt;
+  window.siteAgentConfig = {
+    target: <span class="code-string">"#chat"</span>,
+    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
+    <span class="code-diff"><span class="code-comment">// floating launcher is the default</span></span>
+  };
+&lt;/script&gt;
+&lt;script src=<span class="code-string">"https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js"</span>&gt;&lt;/script&gt;</code></pre>
+            </div>
+            <div class="layout-mode-actions">
+              <a class="btn-caps" href="/launcher-demo.html" data-demo-lightbox data-demo-title="Floating launcher demo">Open Launcher Demo</a>
+            </div>
+          </div>
+
+          <div
+            class="layout-modes-panel"
+            id="layout-mode-panel-docked"
+            role="tabpanel"
+            aria-labelledby="layout-mode-tab-docked"
+            data-layout-mode-panel="docked"
+            hidden
+          >
+            <p class="layout-mode-caption">A copilot docked beside your app: wrap a page region and Persona reveals a side panel that resizes, pushes, or overlays your layout. Point <code>target</code> at the column to wrap.</p>
+            <div class="code-showcase layout-delivery-block" data-delivery="npm">
+              <pre><code><span class="code-function">initAgentWidget</span>({
+  <span class="code-keyword">target</span>: <span class="code-string">"#workspace"</span>,
+  <span class="code-keyword">config</span>: {
+    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
+    <span class="code-diff">launcher: { mountMode: <span class="code-string">"docked"</span>, dock: { side: <span class="code-string">"right"</span>, width: <span class="code-string">"420px"</span> } },</span>
+  },
+});</code></pre>
+            </div>
+            <div class="code-showcase layout-delivery-block" data-delivery="script" hidden>
+              <pre><code>&lt;script&gt;
+  window.siteAgentConfig = {
+    target: <span class="code-string">"#workspace"</span>,
+    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
+    <span class="code-diff">launcher: { mountMode: <span class="code-string">"docked"</span>, dock: { side: <span class="code-string">"right"</span>, width: <span class="code-string">"420px"</span> } },</span>
+  };
+&lt;/script&gt;
+&lt;script src=<span class="code-string">"https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js"</span>&gt;&lt;/script&gt;</code></pre>
+            </div>
+            <div class="layout-mode-actions">
+              <a class="btn-caps" href="/docked-panel-demo.html" data-demo-lightbox data-demo-title="Docked panel demo">Open Docked Demo</a>
+            </div>
+          </div>
+
+          <div
+            class="layout-modes-panel"
+            id="layout-mode-panel-fullscreen"
+            role="tabpanel"
+            aria-labelledby="layout-mode-tab-fullscreen"
+            data-layout-mode-panel="fullscreen"
+            hidden
+          >
+            <p class="layout-mode-caption">A full-height assistant that owns the page: fill a container as an app surface, with an optional artifact split. Turn the launcher off.</p>
+            <div class="code-showcase layout-delivery-block" data-delivery="npm">
+              <pre><code><span class="code-function">initAgentWidget</span>({
+  <span class="code-keyword">target</span>: <span class="code-string">"#app"</span>,
+  <span class="code-keyword">config</span>: {
+    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
+    <span class="code-diff">launcher: { enabled: <span class="code-keyword">false</span>, fullHeight: <span class="code-keyword">true</span> },</span>
+  },
+});</code></pre>
+            </div>
+            <div class="code-showcase layout-delivery-block" data-delivery="script" hidden>
+              <pre><code>&lt;script&gt;
+  window.siteAgentConfig = {
+    target: <span class="code-string">"#app"</span>,
+    apiUrl: <span class="code-string">"https://your-api.com/chat"</span>,
+    <span class="code-diff">launcher: { enabled: <span class="code-keyword">false</span>, fullHeight: <span class="code-keyword">true</span> },</span>
+  };
+&lt;/script&gt;
+&lt;script src=<span class="code-string">"https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js"</span>&gt;&lt;/script&gt;</code></pre>
+            </div>
+            <div class="layout-mode-actions">
+              <a class="btn-caps" href="/fullscreen-assistant-demo.html" data-demo-lightbox data-demo-title="Fullscreen assistant demo">Open Fullscreen Demo</a>
+            </div>
           </div>
         </section>
 
@@ -492,7 +662,7 @@
                 </div>
                 <div class="code-showcase">
                   <pre><code>&lt;script
-  src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/install.global.js"
+  src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js"
   data-runtype-token="ct_test_..."
 &gt;&lt;/script&gt;</code></pre>
                 </div>
@@ -737,6 +907,72 @@ document.modelContext.registerTool({
           return tab.getAttribute('aria-selected') === 'true';
         }) || quickStartTabs[0];
         activateQuickStartTab(defaultTab.getAttribute('data-quick-start-tab'));
+      }
+
+      // Layout mode tabs (one widget, three shapes)
+      var layoutModeTabs = Array.prototype.slice.call(document.querySelectorAll('[data-layout-mode-tab]'));
+      var layoutModePanels = Array.prototype.slice.call(document.querySelectorAll('[data-layout-mode-panel]'));
+
+      function activateLayoutMode(name) {
+        layoutModeTabs.forEach(function(tab) {
+          var isActive = tab.getAttribute('data-layout-mode-tab') === name;
+          tab.setAttribute('aria-selected', isActive ? 'true' : 'false');
+          tab.tabIndex = isActive ? 0 : -1;
+        });
+
+        layoutModePanels.forEach(function(panel) {
+          panel.hidden = panel.getAttribute('data-layout-mode-panel') !== name;
+        });
+      }
+
+      layoutModeTabs.forEach(function(tab, index) {
+        tab.addEventListener('click', function() {
+          activateLayoutMode(tab.getAttribute('data-layout-mode-tab'));
+        });
+
+        tab.addEventListener('keydown', function(event) {
+          if (event.key !== 'ArrowRight' && event.key !== 'ArrowLeft') return;
+          event.preventDefault();
+          var direction = event.key === 'ArrowRight' ? 1 : -1;
+          var nextIndex = (index + direction + layoutModeTabs.length) % layoutModeTabs.length;
+          var nextTab = layoutModeTabs[nextIndex];
+          activateLayoutMode(nextTab.getAttribute('data-layout-mode-tab'));
+          nextTab.focus();
+        });
+      });
+
+      if (layoutModeTabs.length && layoutModePanels.length) {
+        var defaultLayoutTab = layoutModeTabs.find(function(tab) {
+          return tab.getAttribute('aria-selected') === 'true';
+        }) || layoutModeTabs[0];
+        activateLayoutMode(defaultLayoutTab.getAttribute('data-layout-mode-tab'));
+      }
+
+      // Delivery toggle (npm vs script tag): swaps every layout panel's code
+      // block. The config is identical across both, only the loader differs.
+      var deliveryTabs = Array.prototype.slice.call(document.querySelectorAll('[data-delivery-tab]'));
+      var deliveryBlocks = Array.prototype.slice.call(document.querySelectorAll('[data-delivery]'));
+
+      function activateDelivery(name) {
+        deliveryTabs.forEach(function(tab) {
+          tab.setAttribute('aria-pressed', tab.getAttribute('data-delivery-tab') === name ? 'true' : 'false');
+        });
+        deliveryBlocks.forEach(function(block) {
+          block.hidden = block.getAttribute('data-delivery') !== name;
+        });
+      }
+
+      deliveryTabs.forEach(function(tab) {
+        tab.addEventListener('click', function() {
+          activateDelivery(tab.getAttribute('data-delivery-tab'));
+        });
+      });
+
+      if (deliveryTabs.length) {
+        var defaultDelivery = deliveryTabs.find(function(tab) {
+          return tab.getAttribute('aria-pressed') === 'true';
+        }) || deliveryTabs[0];
+        activateDelivery(defaultDelivery.getAttribute('data-delivery-tab'));
       }
 
       var quickStartFlagsDialog = document.querySelector('[data-quick-start-flags-dialog]');

--- a/apps/web/src/home.css
+++ b/apps/web/src/home.css
@@ -833,6 +833,83 @@ section[id], aside[id] {
 .code-showcase .code-string  { color: #7eb1ff; }
 .code-showcase .code-function { color: #26fedc; }
 
+/* The one line that changes between layout modes; highlighted so the small
+   delta between pill / docked / fullscreen is obvious when switching tabs. */
+.code-showcase .code-diff {
+  background: rgba(38, 254, 220, 0.13);
+  box-shadow: inset 2px 0 0 var(--teal);
+  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
+  padding: 1px 6px 1px 8px;
+}
+
+/* Layout modes (one widget, three shapes) -------------------------------------- */
+
+/* Two segmented controls on one row: layout (left) + delivery (right). */
+.layout-modes-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px 24px;
+  margin-bottom: 32px;
+}
+
+.layout-modes-controls .quick-start-tabs {
+  margin-bottom: 0;
+}
+
+.layout-modes-tabs {
+  flex-wrap: wrap;
+}
+
+/* Delivery toggle (npm vs script tag): same config, different loader. */
+.layout-delivery {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.layout-delivery-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+}
+
+.layout-delivery-tabs .quick-start-tab[aria-pressed='true'] {
+  background: var(--black);
+  color: var(--teal);
+}
+
+.layout-modes-panel[hidden] {
+  display: none;
+}
+
+.layout-mode-caption {
+  font-family: var(--font-body);
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--ink-soft);
+  border-left: 2px solid var(--teal-dim);
+  padding: 4px 0 4px 18px;
+  margin-bottom: 24px;
+  max-width: 620px;
+}
+
+.layout-mode-caption code {
+  font-family: var(--font-mono);
+  font-size: 0.88em;
+  background: var(--paper-high);
+  padding: 1px 5px;
+}
+
+.layout-mode-actions {
+  margin-top: 24px;
+}
+
 /* Quick start ------------------------------------------------------------------ */
 
 .quick-start-tabs {

--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -627,11 +627,19 @@ function initDemoLightbox() {
   const iframe = lightbox.querySelector('.demo-lightbox-iframe') as HTMLIFrameElement;
   let closedByPopstate = false;
 
+  const openLightbox = (href: string, title: string) => {
+    iframe.src = href;
+    iframe.title = title || 'Demo preview';
+    lightbox.showModal();
+    history.pushState({ demoLightbox: true }, '');
+  };
+
   document.querySelectorAll('.carousel-3d-card-link').forEach(link => {
     link.addEventListener('click', (e) => {
       e.preventDefault();
 
-      // Clicking a back card brings it to the front instead of opening it:      // its visible edge reads as a "next card" affordance, not a link.
+      // Clicking a back card brings it to the front instead of opening it:
+      // its visible edge reads as a "next card" affordance, not a link.
       const card = link.closest('.carousel-3d-card') as HTMLElement | null;
       const win = window as Window & {
         __heroCarouselStack?: HTMLElement[];
@@ -646,10 +654,16 @@ function initDemoLightbox() {
       }
 
       const anchor = link as HTMLAnchorElement;
-      iframe.src = anchor.href;
-      iframe.title = link.querySelector('.carousel-3d-card-title')?.textContent || 'Demo preview';
-      lightbox.showModal();
-      history.pushState({ demoLightbox: true }, '');
+      openLightbox(anchor.href, link.querySelector('.carousel-3d-card-title')?.textContent || 'Demo preview');
+    });
+  });
+
+  // Layout-mode "Open demo" buttons reuse the same modal instead of navigating
+  // away. The href stays a real link, so it still works without JS.
+  document.querySelectorAll<HTMLAnchorElement>('[data-demo-lightbox]').forEach(link => {
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      openLightbox(link.href, link.dataset.demoTitle || link.textContent?.trim() || 'Demo preview');
     });
   });
 

--- a/packages/widget/src/components/event-stream-view.test.ts
+++ b/packages/widget/src/components/event-stream-view.test.ts
@@ -223,7 +223,10 @@ async function loadModule() {
 // Helper: navigate the new DOM structure
 // container.children = [toolbarOuter, truncationBanner, eventsListWrapper]
 // toolbarOuter.children = [headerBar, searchBar]
-// headerBar.children = [title, countBadge, spacer, filterSelect, copyAllBtn]
+// headerBar.children = [spacer, filterSelect, copyAllBtn]
+//   (the total event count is shown in the "All events (N)" filter option; an
+//   optional throughput readout is prepended only when a getThroughput option
+//   is passed, which these tests don't)
 // searchBar.children = [searchIconWrapper, searchInput, searchClearBtn]
 // eventsListWrapper.children = [eventsList, noResultsMsg, scrollIndicator]
 
@@ -236,17 +239,15 @@ function getHeaderBar(element: any) {
 function getSearchBar(element: any) {
   return getToolbar(element).children[1]; // searchBar
 }
-function getTitle(element: any) {
-  return getHeaderBar(element).children[0]; // title span
-}
-function getCountBadge(element: any) {
-  return getHeaderBar(element).children[1]; // count badge span
-}
 function getFilterSelect(element: any) {
-  return getHeaderBar(element).children[3]; // filterSelect (after title, badge, spacer)
+  return getHeaderBar(element).children[1]; // filterSelect (after spacer)
 }
 function getCopyAllBtn(element: any) {
-  return getHeaderBar(element).children[4]; // copyAllBtn
+  return getHeaderBar(element).children[2]; // copyAllBtn
+}
+// The total count is carried by the "All events (N)" option, not a badge.
+function getAllEventsOptionText(element: any) {
+  return getFilterSelect(element).options[0].textContent;
 }
 function getSearchInput(element: any) {
   return getSearchBar(element).children[1]; // searchInput (after searchIconWrapper)
@@ -290,7 +291,7 @@ describe("createEventStreamView", () => {
   });
 
   describe("header bar", () => {
-    it("should show 'Event Stream' title and count badge", async () => {
+    it("should carry the total in the All events option (no title or count badge)", async () => {
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
       const buffer = createMockBuffer(events);
@@ -298,11 +299,10 @@ describe("createEventStreamView", () => {
 
       update();
 
-      expect(getTitle(element).textContent).toBe("Events");
-      expect(getCountBadge(element).textContent).toBe("1");
+      expect(getAllEventsOptionText(element)).toBe("All events (1)");
     });
 
-    it("should update count badge when events change", async () => {
+    it("should update the total in the All events option when events change", async () => {
       vi.useFakeTimers();
       const { createEventStreamView } = await loadModule();
       const events = [makeEvent("step_chunk", 1)];
@@ -310,13 +310,13 @@ describe("createEventStreamView", () => {
       const { element, update } = createEventStreamView({ buffer: buffer as any });
 
       update();
-      expect(getCountBadge(element).textContent).toBe("1");
+      expect(getAllEventsOptionText(element)).toBe("All events (1)");
 
       vi.advanceTimersByTime(150);
       buffer.push(makeEvent("step_chunk", 2));
       update();
 
-      expect(getCountBadge(element).textContent).toBe("2");
+      expect(getAllEventsOptionText(element)).toBe("All events (2)");
       vi.useRealTimers();
     });
   });
@@ -336,9 +336,9 @@ describe("createEventStreamView", () => {
 
       const filterSelect = getFilterSelect(element);
 
-      // Should have "All events" + 2 type options
+      // Should have "All events" (with total) + 2 type options
       expect(filterSelect.options.length).toBe(3);
-      expect(filterSelect.options[0].textContent).toBe("All events");
+      expect(filterSelect.options[0].textContent).toBe("All events (3)");
       expect(filterSelect.options[1].textContent).toBe("flow_complete (1)");
       expect(filterSelect.options[2].textContent).toBe("step_chunk (2)");
     });
@@ -353,7 +353,7 @@ describe("createEventStreamView", () => {
       update();
 
       const filterSelect = getFilterSelect(element);
-      expect(filterSelect.options[0].textContent).toBe("All events");
+      expect(filterSelect.options[0].textContent).toBe("All events (1)");
       expect(filterSelect.options[1].textContent).toBe("step_chunk (1)");
 
       // Add another event and advance past throttle window
@@ -361,6 +361,7 @@ describe("createEventStreamView", () => {
       vi.advanceTimersByTime(150);
       update();
 
+      expect(filterSelect.options[0].textContent).toBe("All events (2)");
       expect(filterSelect.options[1].textContent).toBe("step_chunk (2)");
       vi.useRealTimers();
     });
@@ -1073,15 +1074,15 @@ describe("createEventStreamView", () => {
       update();
 
       const filterSelect = getFilterSelect(element);
-      expect(filterSelect.options[0].textContent).toBe("All events");
+      expect(filterSelect.options[0].textContent).toBe("All events (2)");
 
       // Simulate clearChat: buffer.clear() + view.update()
       vi.advanceTimersByTime(150);
       buffer.clear();
       update();
 
-      // Filter should show "All events"
-      expect(filterSelect.options[0].textContent).toBe("All events");
+      // Filter should show "All events" with a zero total
+      expect(filterSelect.options[0].textContent).toBe("All events (0)");
       // No type-specific options remain
       expect(filterSelect.options.length).toBe(1);
       vi.useRealTimers();
@@ -1102,7 +1103,7 @@ describe("createEventStreamView", () => {
       update();
 
       const filterSelect = getFilterSelect(element);
-      expect(filterSelect.options[0].textContent).toBe("All events");
+      expect(filterSelect.options[0].textContent).toBe("All events (0)");
 
       // New events arrive in new session
       vi.advanceTimersByTime(150);

--- a/packages/widget/src/components/event-stream-view.ts
+++ b/packages/widget/src/components/event-stream-view.ts
@@ -507,7 +507,6 @@ export function createEventStreamView(
 
     // Elements we need references to across functions
     // These are assigned inside buildDefaultToolbar() which always runs
-    let countBadge!: HTMLElement;
     let filterSelect!: HTMLSelectElement;
     let copyAllBtn!: HTMLButtonElement;
     let searchInput!: HTMLInputElement;
@@ -522,7 +521,7 @@ export function createEventStreamView(
     function buildDefaultToolbar(): HTMLElement {
       const toolbarOuter = createElement(
         "div",
-        "persona-relative persona-flex persona-flex-col persona-flex-shrink-0"
+        "persona-event-toolbar persona-relative persona-flex persona-flex-col persona-flex-shrink-0"
       );
 
       // --- Header bar ---
@@ -532,36 +531,20 @@ export function createEventStreamView(
       );
       applyCustomClasses(headerBar, customClasses?.headerBar);
 
-      // Title
-      const title = createElement(
-        "span",
-        "persona-text-sm persona-font-medium persona-text-persona-primary persona-whitespace-nowrap"
-      );
-      title.textContent = "Events";
+      // The header leads straight into the controls. Context already names
+      // itself: the "All events (N)" filter option carries the total, the search
+      // placeholder names event payloads, and every row is an event.
 
-      // Count badge
-      countBadge = createElement(
-        "span",
-        "persona-text-[11px] persona-font-mono persona-bg-persona-container persona-text-persona-muted persona-px-2 persona-py-0.5 persona-rounded persona-border persona-border-persona-border"
-      );
-      countBadge.textContent = "0";
-
-      // Inline throughput group: "Throughput  146.3 tok/s", grouped with the
-      // Events count. Hover reveals tokens · duration · source via a custom
-      // tooltip (shown instantly, unlike the slow native `title` delay).
+      // Inline throughput value, e.g. "146.3 tok/s". The "tok/s" unit is
+      // self-describing for this developer-facing inspector, so the value stands
+      // alone; its accessible name ("Throughput: <value>") and detailed breakdown
+      // live on the container's aria-label / hover tooltip (see updateThroughputSummary).
       if (getThroughput) {
         throughputContainer = createElement(
           "div",
-          "persona-relative persona-flex persona-items-center persona-gap-1.5 persona-whitespace-nowrap persona-ml-1"
+          "persona-relative persona-flex persona-items-center persona-gap-1.5 persona-whitespace-nowrap"
         );
         throughputContainer.style.cursor = "help";
-        // Label styled to match the "Events" title.
-        const throughputLabel = createElement(
-          "span",
-          "persona-text-sm persona-font-medium persona-text-persona-primary persona-whitespace-nowrap"
-        );
-        throughputLabel.textContent = "Throughput";
-        // Same bounding box + styling as the Events count badge.
         throughputValueEl = createElement(
           "span",
           "persona-text-[11px] persona-font-mono persona-bg-persona-container persona-text-persona-muted persona-px-2 persona-py-0.5 persona-rounded persona-border persona-border-persona-border persona-tabular-nums"
@@ -594,7 +577,6 @@ export function createEventStreamView(
         throughputContainer.addEventListener("mouseenter", showTooltip);
         throughputContainer.addEventListener("mouseleave", hideTooltip);
 
-        throughputContainer.appendChild(throughputLabel);
         throughputContainer.appendChild(throughputValueEl);
       }
 
@@ -607,7 +589,7 @@ export function createEventStreamView(
       ) as HTMLSelectElement;
       const allOption = createElement("option", "") as HTMLOptionElement;
       allOption.value = "";
-      allOption.textContent = "All events";
+      allOption.textContent = "All events (0)";
       filterSelect.appendChild(allOption);
 
       // Copy All button
@@ -629,13 +611,11 @@ export function createEventStreamView(
       if (copyAllIcon) copyAllBtn.appendChild(copyAllIcon);
       const copyAllLabel = createElement(
         "span",
-        "persona-text-xs"
+        "persona-event-copy-all persona-text-xs"
       );
       copyAllLabel.textContent = "Copy All";
       copyAllBtn.appendChild(copyAllLabel);
 
-      headerBar.appendChild(title);
-      headerBar.appendChild(countBadge);
       if (throughputContainer) headerBar.appendChild(throughputContainer);
       headerBar.appendChild(headerSpacer);
       headerBar.appendChild(filterSelect);
@@ -734,20 +714,21 @@ export function createEventStreamView(
     function updateThroughputSummary(): void {
       if (!getThroughput || !throughputValueEl || !throughputContainer) return;
       const metric = getThroughput();
-      throughputValueEl.textContent = formatThroughputValue(metric);
-      // Detailed breakdown is revealed on hover via the custom tooltip; mirror
-      // it into aria-label for assistive tech. When there's nothing to show,
-      // hide the tooltip so an empty box never flashes on hover.
+      const value = formatThroughputValue(metric);
+      throughputValueEl.textContent = value;
+      // There's no visible "Throughput" label, so the accessible name carries it
+      // (plus the value). The detailed breakdown is revealed on hover via the
+      // custom tooltip and appended to the aria-label for assistive tech; when
+      // there's nothing to show, hide the tooltip so an empty box never flashes.
       const meta = formatThroughputMeta(metric);
       if (throughputTooltipEl) {
         throughputTooltipEl.textContent = meta;
         if (!meta) throughputTooltipEl.style.display = "none";
       }
-      if (meta) {
-        throughputContainer.setAttribute("aria-label", meta);
-      } else {
-        throughputContainer.removeAttribute("aria-label");
-      }
+      throughputContainer.setAttribute(
+        "aria-label",
+        meta ? `Throughput: ${value}, ${meta}` : `Throughput: ${value}`
+      );
     }
 
     // ========================================================================
@@ -838,8 +819,10 @@ export function createEventStreamView(
 
       const currentValue = filterSelect.value;
 
-      // Update "All events" option
-      filterSelect.options[0].textContent = `All events`;
+      // Update "All events" option. The total is carried here (like each type
+      // option carries its own count) so a narrow panel can hide the standalone
+      // "Events" label + count badge without losing the total.
+      filterSelect.options[0].textContent = `All events (${allEvents.length})`;
 
       if (typesChanged) {
         while (filterSelect.options.length > 1) {
@@ -939,11 +922,6 @@ export function createEventStreamView(
       filteredEvents = getFilteredEvents();
       const newCount = filteredEvents.length;
       const bufferHasEvents = buffer.getSize() > 0;
-
-      // Update count badge
-      if (countBadge) {
-        countBadge.textContent = String(buffer.getSize());
-      }
 
       // Show/hide no-results message
       if (newCount === 0 && bufferHasEvents && hasActiveFilters()) {

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -4028,15 +4028,8 @@
   }
 }
 
-/* ---------------------------------------------------------------------------
- * Event stream toolbar: responsive header
- *
- * The header is text-lean by design: the total count rides in the "All events
- * (N)" option, and the tok/s value plus surrounding context are self-describing,
- * so the toolbar stays compact enough to fit tablet widths. The toolbar is a
- * size container so that in a very narrow panel the "Copy All" word can drop to
- * an icon-only button as a last resort before the filter dropdown gets clipped.
- * ------------------------------------------------------------------------- */
+/* Event stream toolbar: a size container so "Copy All" collapses to icon-only
+ * in a narrow panel before the filter dropdown gets clipped. */
 [data-persona-root] .persona-event-toolbar {
   container-type: inline-size;
 }

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -4027,3 +4027,22 @@
     animation: none !important;
   }
 }
+
+/* ---------------------------------------------------------------------------
+ * Event stream toolbar: responsive header
+ *
+ * The header is text-lean by design: the total count rides in the "All events
+ * (N)" option, and the tok/s value plus surrounding context are self-describing,
+ * so the toolbar stays compact enough to fit tablet widths. The toolbar is a
+ * size container so that in a very narrow panel the "Copy All" word can drop to
+ * an icon-only button as a last resort before the filter dropdown gets clipped.
+ * ------------------------------------------------------------------------- */
+[data-persona-root] .persona-event-toolbar {
+  container-type: inline-size;
+}
+
+@container (max-width: 390px) {
+  [data-persona-root] .persona-event-copy-all {
+    display: none;
+  }
+}

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2408,6 +2408,15 @@ export const createAgentExperience = (
     body.style.cssText = '';
     footer.style.cssText = '';
 
+    // Preserve the event-stream takeover across a layout-mode change. The
+    // cssText reset above wiped the `display: none` that toggleEventStreamOn
+    // set on the messages body, and none of the per-mode reapply branches below
+    // touch `display` — so without this the messages would reappear and stack
+    // above the event panel when the window crosses the fullscreen breakpoint.
+    if (eventStreamVisible) {
+      body.style.display = "none";
+    }
+
     const restoreBodyScrollTop = (): void => {
       if (prevBodyScrollTop <= 0) return;
       const ownerWindow = body.ownerDocument.defaultView ?? window;


### PR DESCRIPTION
## What does this PR do?

**1. Layout-mode onboarding (docs + showcase).** Makes it clear, up front, that the same install ships three ways and you move between them by changing the `launcher` config, not your backend or integration:
- New "three primary layouts" section on the homepage (`apps/web`), placed right under the carousel and above the capability modules. It has a Floating / Docked / Fullscreen tab set plus an "Install via" npm / script-tag toggle. The highlighted config line is identical across both deliveries, so it reads as "same config, either loader."
- The three modes are named by placement (Floating / Docked / Fullscreen), not by use case, so none of them implies a specific scenario.
- "Open demo" buttons now open in the existing carousel lightbox instead of navigating away (with the real `href` kept as a no-JS fallback).
- Parallel "One widget, three layouts" section added to the root `README.md` with npm and script-tag snippets.
- Script-tag CDN URLs are pinned to the major range (`@runtypelabs/persona@4/dist/...`) instead of `@latest`, matching the version-pinning the CLI already does. Added a CLAUDE.md note so the `@N` is bumped on a major release.

**2. Fix: event stream takeover on layout changes.** The event stream inspector reappeared stacked above the chat messages when the window was resized across the mobile/fullscreen breakpoint. The fullscreen layout reset was wiping the `display: none` that hides the messages body while the stream is open; it's now preserved, so the panel keeps taking over the full chat area at every width.

**3. Refactor: event stream toolbar responsiveness.** The toolbar no longer overflows in narrow panels. The total event count moved into the "All events (N)" filter option (matching the per-type options), the redundant "Events" and "Throughput" labels were removed (the tok/s value is self-describing; the throughput's accessible name is preserved via `aria-label`), and "Copy All" collapses to icon-only at very narrow widths as a last resort.

Closes #

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Tooling / CI

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run`) and I added tests for new behavior _(1323 passing; the toolbar refactor updated `event-stream-view.test.ts`. The resize-takeover fix is DOM-resize behavior, verified manually across the breakpoint.)_
- [x] **Changeset added if I touched `packages/widget` or `packages/proxy`** (`pnpm changeset`). _Not required for changes only under `examples/`, `docs/`, CI, or tooling_ _(two patch changesets cover the widget changes; the docs/`apps/web`/CLAUDE.md work needs none)_
- [x] Docs updated if I changed public API or behavior _(no public API change; behavior changes are captured in the changesets, and the onboarding docs are part of this PR)_