### PR TITLE
Fix anchor-top: keep follow-on assistant content pinned (no late-embed yank)

### DIFF
--- a/.changeset/anchor-top-followon-pinned.md
+++ b/.changeset/anchor-top-followon-pinned.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix `anchor-top` scroll: keep follow-on assistant content pinned instead of yanking the viewport to the bottom. Once a user send has anchored the conversation, the anchor now holds across the whole turn — a multi-part reply, an injected embed (tweet/image), or a tool result no longer re-arms the follow-to-bottom fallback, so a late-loading embed can't pop the scroll down to itself. The fallback now applies only when nothing has anchored the conversation yet (first-load or proactive-first streaming).

--- a/packages/widget/src/ui.scroll-additive.test.ts
+++ b/packages/widget/src/ui.scroll-additive.test.ts
@@ -145,6 +145,11 @@ const anchorUserTurn = (
 const baseConfig = (overrides: AgentWidgetConfig): AgentWidgetConfig => ({
   apiUrl: "https://api.example.com/chat",
   launcher: { enabled: false },
+  // Hermetic: never restore persisted history at construction. Otherwise a
+  // prior test's transcript (sharing message ids like "u1") leaks via
+  // localStorage and a user send reads as already-seen, so the anchor never
+  // takes and the assertion sees a follow-to-bottom instead.
+  persistState: false,
   ...overrides,
 });
 
@@ -302,24 +307,25 @@ describe("scrollBehavior anchor-top no-anchor fallback", () => {
     controller.destroy();
   });
 
-  it("re-arms the fallback for a proactive turn after an anchored turn", () => {
+  it("keeps follow-on assistant content in an anchored turn pinned (no late-embed yank)", () => {
     const mount = createMount();
     const controller = makeAnchorTop(mount);
     const sc = getScrollContainer(mount);
     const metrics = installScrollMetrics(sc, { scrollHeight: 1000, clientHeight: 400 });
 
-    // Complete an anchored turn, then a later proactive assistant message with
-    // no fresh user send re-arms the fallback and follows to the bottom.
-    anchorUserTurn(controller);
+    anchorUserTurn(controller); // user send → anchor
     raf.flush();
     emitAssistantMessage(controller, "a1", "Anchored answer");
     raf.flush();
-    metrics.setScrollTop(0);
+    metrics.setScrollTop(0); // reading the pinned question from the top
 
-    emitStreamingAssistant(controller, "a2", "Proactive follow-up");
+    // A second assistant message in the same anchored conversation — a
+    // multi-part reply or a late-injected embed (tweet/image/tool result) — must
+    // NOT re-arm the fallback or yank the viewport to the bottom.
+    emitStreamingAssistant(controller, "a2", "Late-injected embed content");
     raf.flush();
 
-    expect(metrics.getScrollTop()).toBe(metrics.getBottom());
+    expect(metrics.getScrollTop()).toBe(0);
     controller.destroy();
   });
 });

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2929,17 +2929,20 @@ export const createAgentExperience = (
   let scrollSendSeeded = false;
   let suppressScrollSend = false;
   let lastSentUserMessageId: string | null = null;
-  // anchor-top no-anchor fallback: anchor-top only pins on a fresh USER send.
-  // Assistant-initiated turns (proactive greeting, injectAssistantMessage,
-  // resubmit, first-load streaming) have no anchor, so they fall back to
-  // follow-to-bottom for that turn — otherwise their content streams in
-  // off-screen. `true` by default (no anchor yet); a user send sets it false
-  // (the anchor takes over); a new assistant turn with no preceding user send
-  // re-arms it. Inert in follow/none mode (see `isFollowEffective`).
+  // anchor-top no-anchor fallback: anchor-top pins on a USER send. An assistant
+  // message that streams when NO user send has anchored the conversation yet
+  // (first-load / proactive-first streaming) has nothing to anchor to, so it
+  // falls back to follow-to-bottom — otherwise its content streams in
+  // off-screen. `true` by default (nothing anchored yet); a user send clears it
+  // and the anchor takes over. Inert in follow/none mode (see
+  // `isFollowEffective`).
   let followFallbackActive = true;
-  // Set when a user send anchors in anchor-top; the next NEW assistant message
-  // is that anchored response (so it keeps the anchor, not the fallback).
-  let awaitingAnchorResponse = false;
+  // True once a user send has anchored the current conversation (until the chat
+  // is cleared). While anchored, follow-on assistant content — the response, a
+  // multi-part reply, an injected embed (tweet/image), a tool result — stays
+  // pinned and never re-arms the fallback, so a late-loading embed can't yank
+  // the viewport down to the bottom.
+  let currentTurnAnchored = false;
   // Dedupes assistant-turn detection across token-by-token re-renders.
   let lastHandledAssistantId: string | null = null;
 
@@ -3455,23 +3458,25 @@ export const createAgentExperience = (
       resumeAutoScroll();
       scheduleAutoScroll(true);
     } else if (mode === "anchor-top") {
-      // A real anchor now drives this turn: disarm the no-anchor fallback and
-      // mark the next new assistant message as this send's anchored response.
+      // A real anchor now drives the conversation: disarm the no-anchor
+      // fallback. Every follow-on assistant message stays anchored until the
+      // next user send.
       followFallbackActive = false;
-      awaitingAnchorResponse = true;
+      currentTurnAnchored = true;
       scheduleAnchorToUserMessage(messageId);
     }
   };
 
-  // Reacts to a new assistant turn that arrived without a fresh user send.
-  // Only meaningful in anchor-top: if the turn is the response to a just-sent
-  // user message it keeps the anchor; otherwise (proactive greeting, injected
-  // assistant message, resubmit) it has no anchor, so fall back to
-  // follow-to-bottom for the turn instead of streaming in off-screen.
+  // Reacts to a new assistant message that arrived without a fresh user send.
+  // Only meaningful in anchor-top. While the conversation is anchored (a user
+  // has sent at least once), follow-on assistant content — the response, a
+  // multi-part reply, an injected embed, a tool result — keeps the anchor so a
+  // late-loading embed never yanks the viewport. Only when nothing has anchored
+  // yet (first-load / proactive-first streaming) does it fall back to
+  // follow-to-bottom so the content isn't stranded off-screen.
   const handleAssistantTurnStarted = () => {
     if (getScrollMode() !== "anchor-top") return;
-    if (awaitingAnchorResponse) {
-      awaitingAnchorResponse = false;
+    if (currentTurnAnchored) {
       followFallbackActive = false;
       return;
     }
@@ -5192,9 +5197,9 @@ export const createAgentExperience = (
       // send; clearing the chat resets any anchor spacer.
       if (messages.length === 0) {
         resetAnchorState();
-        // Cleared: no anchor, so re-arm the no-anchor follow fallback.
+        // Cleared: nothing anchored, so re-arm the no-anchor follow fallback.
         followFallbackActive = true;
-        awaitingAnchorResponse = false;
+        currentTurnAnchored = false;
       }
       if (!scrollSendSeeded || suppressScrollSend) {
         scrollSendSeeded = true;
@@ -5251,9 +5256,6 @@ export const createAgentExperience = (
       }
       if (!streaming) {
         scheduleAutoScroll(true);
-        // Turn complete: clear the one-shot "next assistant is the anchored
-        // response" arm so a later proactive/injected turn still falls back.
-        awaitingAnchorResponse = false;
       }
       // Keep the "streaming below" hint and its announcement in sync with the
       // streaming lifecycle (Principles 8 + 15).


### PR DESCRIPTION
Follow-up to #342.

## Problem
With `anchor-top` now the default, a late-loading embed injected as a separate assistant message mid-conversation (e.g. the tweet card in the Scroll Engineering demo's "Long reply + tweet embed" scenario) **popped the scroll down to itself** when it hydrated — the opposite of the anchor-top "keep your place" philosophy.

## Root cause
The no-anchor follow fallback was armed per-message: any new assistant message without a *fresh* user send re-armed follow-to-bottom. A multi-part reply or an injected embed/tool-result is a separate assistant message but still part of the **anchored turn**, so it wrongly re-armed the fallback. When the embed later hydrated, the content-resize handler (now in "effective follow") chased the bottom.

## Fix
Once a user send has anchored the conversation, the anchor holds across the whole turn. Replaced the per-message `awaitingAnchorResponse` arming with a sticky `currentTurnAnchored` flag:

- **Anchored conversation** → follow-on assistant content (multi-part replies, injected embeds, tool results) stays pinned; never re-arms the fallback.
- **Nothing anchored yet** (first-load / proactive-first streaming) → still falls back to follow-to-bottom so content isn't stranded off-screen.

## Tests
- The no-anchor fallback suite now covers the late-embed case: a follow-on assistant message stays at the anchored position, not the bottom.
- Made those configs hermetic (`persistState: false`) so leaked localStorage history can't make a reused message id read as already-seen (was a flaky cross-file failure).
- Full widget suite: **1335 passing**; lint + typecheck clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a viewport-yank regression introduced by the `anchor-top` default: a late-loading embed (tweet card, image, tool result) injected as a separate assistant message was re-arming the follow-to-bottom fallback and pulling the scroll position away from the user's reading point.

- Replaces the one-shot `awaitingAnchorResponse` flag with a sticky `currentTurnAnchored` boolean that is set on any user send and never reset until the chat is cleared; `handleAssistantTurnStarted` now keeps `followFallbackActive = false` for the entire conversation lifetime once a user has sent a message.
- Updates the test suite: the old \"re-arms fallback for proactive turn after anchored turn\" case is replaced with a \"late-embed stays pinned\" assertion, and `persistState: false` is added to `baseConfig` to prevent localStorage cross-contamination between tests that share message ids.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge; the scroll fix is logically consistent and the test suite is updated to match the new behaviour.

The core state-machine change is correct and hermetic. The one observation worth tracking is that `currentTurnAnchored` is effectively conversation-scoped rather than turn-scoped: once set, it never resets between turns, so a genuinely proactive server-pushed assistant message arriving after the user has sent at least one message will no longer auto-scroll to the bottom. This is intentional for the embed-yank fix, but slightly broader in effect than the PR description implies — the variable name and a comment say 'current turn' while the actual scope is 'entire conversation.' No data loss or crash risk.

packages/widget/src/ui.ts — the `currentTurnAnchored` variable and its reset paths are the only places that need a second look.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/widget/src/ui.ts | Replaces one-shot `awaitingAnchorResponse` flag with sticky `currentTurnAnchored`; only resets on chat clear, making the anchor hold for the entire conversation once a user send has occurred |
| packages/widget/src/ui.scroll-additive.test.ts | Replaces the old 're-arms fallback for proactive turn' test with a 'late-embed stays pinned' test; adds `persistState: false` to `baseConfig` to prevent localStorage leakage across tests sharing message ids |
| .changeset/anchor-top-followon-pinned.md | Changeset entry describing the patch fix; accurate description of the new behavior |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New assistant message arrives] --> B{getScrollMode === anchor-top?}
    B -- No --> C[Return — inert in follow/none]
    B -- Yes --> D{currentTurnAnchored?}
    D -- Yes\n(user has sent ≥1 message) --> E[followFallbackActive = false\nKeep pinned — no yank]
    D -- No\n(first-load / proactive-first) --> F[followFallbackActive = true\nresetAnchorState\nresumeAutoScroll\nscheduleAutoScroll → follow-to-bottom]

    G[User sends message] --> H[followFallbackActive = false\ncurrentTurnAnchored = true\nscheduleAnchorToUserMessage]

    I[Chat cleared — messages.length === 0] --> J[followFallbackActive = true\ncurrentTurnAnchored = false\nresetAnchorState]

    style E fill:#d4edda,stroke:#28a745
    style F fill:#fff3cd,stroke:#ffc107
    style J fill:#f8d7da,stroke:#dc3545
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[New assistant message arrives] --> B{getScrollMode === anchor-top?}
    B -- No --> C[Return — inert in follow/none]
    B -- Yes --> D{currentTurnAnchored?}
    D -- Yes\n(user has sent ≥1 message) --> E[followFallbackActive = false\nKeep pinned — no yank]
    D -- No\n(first-load / proactive-first) --> F[followFallbackActive = true\nresetAnchorState\nresumeAutoScroll\nscheduleAutoScroll → follow-to-bottom]

    G[User sends message] --> H[followFallbackActive = false\ncurrentTurnAnchored = true\nscheduleAnchorToUserMessage]

    I[Chat cleared — messages.length === 0] --> J[followFallbackActive = true\ncurrentTurnAnchored = false\nresetAnchorState]

    style E fill:#d4edda,stroke:#28a745
    style F fill:#fff3cd,stroke:#ffc107
    style J fill:#f8d7da,stroke:#dc3545
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/widget/src/ui.ts`, line 3477-3487 ([link](https://github.com/runtypelabs/persona/blob/5c1a1784e13cba67d02b89357582156e9ad33f98/packages/widget/src/ui.ts#L3477-L3487)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`currentTurnAnchored` is conversation-wide, not turn-scoped**

   `currentTurnAnchored` is set `true` on the first user send and stays `true` until the chat is explicitly cleared — it is never reset between turns. This means any proactive or server-pushed assistant message injected after the user has sent at least one message will no longer follow-to-bottom; it silently stays at the current scroll position. The PR description and the inline comment on `handleUserMessageSent` say "until the next user send," but no code path resets the flag on a new user send — it is simply set to `true` again (already `true`). The behaviour is intentional for the late-embed fix, but the scope is broader than "the current turn": it covers the full lifetime of the conversation.

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fwidget%2Fsrc%2Fui.ts%0ALine%3A%203477-3487%0A%0AComment%3A%0A**%60currentTurnAnchored%60%20is%20conversation-wide%2C%20not%20turn-scoped**%0A%0A%60currentTurnAnchored%60%20is%20set%20%60true%60%20on%20the%20first%20user%20send%20and%20stays%20%60true%60%20until%20the%20chat%20is%20explicitly%20cleared%20%E2%80%94%20it%20is%20never%20reset%20between%20turns.%20This%20means%20any%20proactive%20or%20server-pushed%20assistant%20message%20injected%20after%20the%20user%20has%20sent%20at%20least%20one%20message%20will%20no%20longer%20follow-to-bottom%3B%20it%20silently%20stays%20at%20the%20current%20scroll%20position.%20The%20PR%20description%20and%20the%20inline%20comment%20on%20%60handleUserMessageSent%60%20say%20%22until%20the%20next%20user%20send%2C%22%20but%20no%20code%20path%20resets%20the%20flag%20on%20a%20new%20user%20send%20%E2%80%94%20it%20is%20simply%20set%20to%20%60true%60%20again%20%28already%20%60true%60%29.%20The%20behaviour%20is%20intentional%20for%20the%20late-embed%20fix%2C%20but%20the%20scope%20is%20broader%20than%20%22the%20current%20turn%22%3A%20it%20covers%20the%20full%20lifetime%20of%20the%20conversation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=runtypelabs%2Fpersona&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22claude%2Fanchor-top-followon-pinned%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fanchor-top-followon-pinned%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fwidget%2Fsrc%2Fui.ts%0ALine%3A%203477-3487%0A%0AComment%3A%0A**%60currentTurnAnchored%60%20is%20conversation-wide%2C%20not%20turn-scoped**%0A%0A%60currentTurnAnchored%60%20is%20set%20%60true%60%20on%20the%20first%20user%20send%20and%20stays%20%60true%60%20until%20the%20chat%20is%20explicitly%20cleared%20%E2%80%94%20it%20is%20never%20reset%20between%20turns.%20This%20means%20any%20proactive%20or%20server-pushed%20assistant%20message%20injected%20after%20the%20user%20has%20sent%20at%20least%20one%20message%20will%20no%20longer%20follow-to-bottom%3B%20it%20silently%20stays%20at%20the%20current%20scroll%20position.%20The%20PR%20description%20and%20the%20inline%20comment%20on%20%60handleUserMessageSent%60%20say%20%22until%20the%20next%20user%20send%2C%22%20but%20no%20code%20path%20resets%20the%20flag%20on%20a%20new%20user%20send%20%E2%80%94%20it%20is%20simply%20set%20to%20%60true%60%20again%20%28already%20%60true%60%29.%20The%20behaviour%20is%20intentional%20for%20the%20late-embed%20fix%2C%20but%20the%20scope%20is%20broader%20than%20%22the%20current%20turn%22%3A%20it%20covers%20the%20full%20lifetime%20of%20the%20conversation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=runtypelabs%2Fpersona&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fwidget%2Fsrc%2Fui.ts%0ALine%3A%203477-3487%0A%0AComment%3A%0A**%60currentTurnAnchored%60%20is%20conversation-wide%2C%20not%20turn-scoped**%0A%0A%60currentTurnAnchored%60%20is%20set%20%60true%60%20on%20the%20first%20user%20send%20and%20stays%20%60true%60%20until%20the%20chat%20is%20explicitly%20cleared%20%E2%80%94%20it%20is%20never%20reset%20between%20turns.%20This%20means%20any%20proactive%20or%20server-pushed%20assistant%20message%20injected%20after%20the%20user%20has%20sent%20at%20least%20one%20message%20will%20no%20longer%20follow-to-bottom%3B%20it%20silently%20stays%20at%20the%20current%20scroll%20position.%20The%20PR%20description%20and%20the%20inline%20comment%20on%20%60handleUserMessageSent%60%20say%20%22until%20the%20next%20user%20send%2C%22%20but%20no%20code%20path%20resets%20the%20flag%20on%20a%20new%20user%20send%20%E2%80%94%20it%20is%20simply%20set%20to%20%60true%60%20again%20%28already%20%60true%60%29.%20The%20behaviour%20is%20intentional%20for%20the%20late-embed%20fix%2C%20but%20the%20scope%20is%20broader%20than%20%22the%20current%20turn%22%3A%20it%20covers%20the%20full%20lifetime%20of%20the%20conversation.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fui.ts%3A3477-3487%0A**%60currentTurnAnchored%60%20is%20conversation-wide%2C%20not%20turn-scoped**%0A%0A%60currentTurnAnchored%60%20is%20set%20%60true%60%20on%20the%20first%20user%20send%20and%20stays%20%60true%60%20until%20the%20chat%20is%20explicitly%20cleared%20%E2%80%94%20it%20is%20never%20reset%20between%20turns.%20This%20means%20any%20proactive%20or%20server-pushed%20assistant%20message%20injected%20after%20the%20user%20has%20sent%20at%20least%20one%20message%20will%20no%20longer%20follow-to-bottom%3B%20it%20silently%20stays%20at%20the%20current%20scroll%20position.%20The%20PR%20description%20and%20the%20inline%20comment%20on%20%60handleUserMessageSent%60%20say%20%22until%20the%20next%20user%20send%2C%22%20but%20no%20code%20path%20resets%20the%20flag%20on%20a%20new%20user%20send%20%E2%80%94%20it%20is%20simply%20set%20to%20%60true%60%20again%20%28already%20%60true%60%29.%20The%20behaviour%20is%20intentional%20for%20the%20late-embed%20fix%2C%20but%20the%20scope%20is%20broader%20than%20%22the%20current%20turn%22%3A%20it%20covers%20the%20full%20lifetime%20of%20the%20conversation.%0A%0A&repo=runtypelabs%2Fpersona&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22claude%2Fanchor-top-followon-pinned%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22claude%2Fanchor-top-followon-pinned%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fui.ts%3A3477-3487%0A**%60currentTurnAnchored%60%20is%20conversation-wide%2C%20not%20turn-scoped**%0A%0A%60currentTurnAnchored%60%20is%20set%20%60true%60%20on%20the%20first%20user%20send%20and%20stays%20%60true%60%20until%20the%20chat%20is%20explicitly%20cleared%20%E2%80%94%20it%20is%20never%20reset%20between%20turns.%20This%20means%20any%20proactive%20or%20server-pushed%20assistant%20message%20injected%20after%20the%20user%20has%20sent%20at%20least%20one%20message%20will%20no%20longer%20follow-to-bottom%3B%20it%20silently%20stays%20at%20the%20current%20scroll%20position.%20The%20PR%20description%20and%20the%20inline%20comment%20on%20%60handleUserMessageSent%60%20say%20%22until%20the%20next%20user%20send%2C%22%20but%20no%20code%20path%20resets%20the%20flag%20on%20a%20new%20user%20send%20%E2%80%94%20it%20is%20simply%20set%20to%20%60true%60%20again%20%28already%20%60true%60%29.%20The%20behaviour%20is%20intentional%20for%20the%20late-embed%20fix%2C%20but%20the%20scope%20is%20broader%20than%20%22the%20current%20turn%22%3A%20it%20covers%20the%20full%20lifetime%20of%20the%20conversation.%0A%0A&repo=runtypelabs%2Fpersona&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fui.ts%3A3477-3487%0A**%60currentTurnAnchored%60%20is%20conversation-wide%2C%20not%20turn-scoped**%0A%0A%60currentTurnAnchored%60%20is%20set%20%60true%60%20on%20the%20first%20user%20send%20and%20stays%20%60true%60%20until%20the%20chat%20is%20explicitly%20cleared%20%E2%80%94%20it%20is%20never%20reset%20between%20turns.%20This%20means%20any%20proactive%20or%20server-pushed%20assistant%20message%20injected%20after%20the%20user%20has%20sent%20at%20least%20one%20message%20will%20no%20longer%20follow-to-bottom%3B%20it%20silently%20stays%20at%20the%20current%20scroll%20position.%20The%20PR%20description%20and%20the%20inline%20comment%20on%20%60handleUserMessageSent%60%20say%20%22until%20the%20next%20user%20send%2C%22%20but%20no%20code%20path%20resets%20the%20flag%20on%20a%20new%20user%20send%20%E2%80%94%20it%20is%20simply%20set%20to%20%60true%60%20again%20%28already%20%60true%60%29.%20The%20behaviour%20is%20intentional%20for%20the%20late-embed%20fix%2C%20but%20the%20scope%20is%20broader%20than%20%22the%20current%20turn%22%3A%20it%20covers%20the%20full%20lifetime%20of%20the%20conversation.%0A%0A&pr=344&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix(widget): keep anchor-top pinned for ..."](https://github.com/runtypelabs/persona/commit/5c1a1784e13cba67d02b89357582156e9ad33f98) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40174199)</sub>

<!-- /greptile_comment -->