### PR TITLE
docs(proxy): surface streaming demos in docs assistant

### DIFF
--- a/.changeset/docs-assistant-streaming-demos.md
+++ b/.changeset/docs-assistant-streaming-demos.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Docs assistant: recommend the Streaming Markdown Tables and Scroll Engineering demos for streaming questions.

--- a/packages/proxy/src/agents/docs-assistant.ts
+++ b/packages/proxy/src/agents/docs-assistant.ts
@@ -74,6 +74,8 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Dynamic Components](/dynamic-components.html): stream forms, cards, charts, and other host-rendered UI inside assistant messages
 - [Layout Configuration](/layout-config-demo.html): tweak panel sizing, spacing, and layout options
 - [Stream Animations](/stream-animations-demo.html): customize how streamed text animates in
+- [Streaming Markdown Tables](/streaming-table-demo.html): Telegram-style table rendering that reserves structure and column widths as rows stream in
+- [Scroll Engineering](/scroll-engineering.html): all 15 principles of a great streaming scroll, wired through additive scrollBehavior config (anchor-top, pause-on-interaction, restore position, aria-live announcements)
 - [Persistent Composer](/persistent-composer.html): always-visible composer bar layout
 - [WebMCP Storefront](/webmcp-demo.html): expose page tools to the agent via WebMCP
 - [WebMCP Calendar](/webmcp-calendar.html): a team calendar copilot that reads availability and books events through WebMCP page tools


### PR DESCRIPTION
Add Streaming Markdown Tables and Scroll Engineering to the docs assistant's Available Demos list so "how does streaming work" recommends them. Prompt-only change in `docs-assistant.ts`; changeset included.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two new streaming-related demo entries — `Streaming Markdown Tables` and `Scroll Engineering` — to the `Available Demos` list in the docs assistant's system prompt, so that questions about streaming behavior now surface these demos as recommendations. The changeset is correctly scoped as a patch for `@runtypelabs/persona-proxy`.

- **`docs-assistant.ts`**: Two lines added to the demo list, following the established format and URL convention. The new entries are positioned logically after the existing `Stream Animations` demo.
- **`.changeset/docs-assistant-streaming-demos.md`**: New changeset file with the correct package name and a clear patch description.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is two new lines in a system prompt string, with no logic, config, or runtime behavior altered.

The diff is entirely additive text inside a template-literal system prompt. The two new demo entries follow the established format and URL convention, the changeset is correctly scoped, and there are no runtime, logic, or security concerns.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/proxy/src/agents/docs-assistant.ts | Added two streaming-related demo entries to the Available Demos list in the system prompt — no logic changes, prompt-only update. |
| .changeset/docs-assistant-streaming-demos.md | New changeset file correctly tagging this as a patch for @runtypelabs/persona-proxy; description matches the actual change. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User asks about streaming] --> B{Docs assistant evaluates intent}
    B --> C[Checks Available Demos list in system prompt]
    C --> D[Streaming Markdown Tables\n/streaming-table-demo.html]
    C --> E[Scroll Engineering\n/scroll-engineering.html]
    C --> F[Stream Animations\n/stream-animations-demo.html]
    D --> G[Returns relevant demo links to user]
    E --> G
    F --> G
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User asks about streaming] --> B{Docs assistant evaluates intent}
    B --> C[Checks Available Demos list in system prompt]
    C --> D[Streaming Markdown Tables\n/streaming-table-demo.html]
    C --> E[Scroll Engineering\n/scroll-engineering.html]
    C --> F[Stream Animations\n/stream-animations-demo.html]
    D --> G[Returns relevant demo links to user]
    E --> G
    F --> G
```

</a>

<sub>Reviews (1): Last reviewed commit: ["docs(proxy): recommend streaming-table +..."](https://github.com/runtypelabs/persona/commit/f92a4f8c66f14197e48faf522b4b953d80630b8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40201269)</sub>

<!-- /greptile_comment -->