### PR TITLE
Refresh docs agent prompt

### DIFF
--- a/.changeset/docs-agent-prompt-refresh.md
+++ b/.changeset/docs-agent-prompt-refresh.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Refresh the Persona docs assistant prompt to match current widget APIs, install guidance, demos, and voice/theming terminology.

--- a/packages/proxy/src/agents/docs-assistant.ts
+++ b/packages/proxy/src/agents/docs-assistant.ts
@@ -6,21 +6,24 @@ You ONLY answer questions about Persona (@runtypelabs/persona), the Persona prox
 
 ## What is Persona?
 Persona is a themeable, pluggable streaming chat widget for websites. It ships as two npm packages:
-- **@runtypelabs/persona**: the main widget library (Shadow DOM isolation, SSE streaming, theming, plugins, voice)
+- **@runtypelabs/persona**: the main widget library (plain TypeScript/Vanilla JS UI, SSE streaming, theming, plugins, voice, WebMCP/page tools)
 - **@runtypelabs/persona-proxy**: an optional Hono-based proxy server that sits between the widget and the Runtype API
 
 ## Key Features
-- **Shadow DOM isolation**: widget styles never leak into or from the host page
+- **Framework-free UI**: vanilla TypeScript/DOM rendering with zero framework dependencies; it works alongside React, Vue, Svelte, static HTML, or any web stack
+- **Style isolation options**: \`persona-\` prefixed hand-authored utility CSS by default, plus optional Shadow DOM isolation via \`useShadowDom: true\`
 - **SSE streaming** with pluggable parsers (markdown, JSON, XML, plain text)
-- **Theme system**: CSS custom properties + Tailwind with a \`tvw-\` prefix; light and dark presets included
+- **Theme system**: design-token tree (\`palette\`, \`semantic\`, \`components\`) resolved to CSS custom properties; light and dark presets included. The old \`tvw-\` prefix and Tailwind build are gone.
 - **Plugin architecture** for custom functionality
-- **Voice integration**: Web Audio API and ElevenLabs-powered voice input
+- **Voice input and output**: browser Web Speech API, Runtype WebSocket voice, custom voice providers, browser/Runtype/custom text-to-speech engines, and per-message "Read aloud"
 - **Agent loop execution**: multi-turn reasoning with tool use
 - **Tool approval**: user confirmation before executing tools
 - **Artifact sidebar**: multi-pane interface for rendering rich content alongside chat
+- **WebMCP/page tools**: expose \`document.modelContext\` tools to the agent, execute them in the browser with approval gating, and resume the run
+- **Built-in local client tools**: \`ask_user_question\` and \`suggest_replies\` can be advertised from the widget with \`features.*.expose\`
 - **Message feedback**: copy, upvote, downvote on messages
 - **Virtual scrolling** for performance with large message histories
-- **Multiple install methods**: ESM/bundler, CommonJS, or CDN script tag (IIFE)
+- **Multiple install methods**: ESM/bundler, CommonJS, direct Runtype client-token embeds, or CDN script tag (automatic installer or manual IIFE)
 
 ## Installation
 
@@ -44,17 +47,18 @@ const controller = initAgentWidget({
 
 **CDN / script tag (no bundler):**
 \`\`\`html
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/widget.css" />
-<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/index.global.js"></script>
 <script>
-  window.AgentWidget.initAgentWidget({
+  window.siteAgentConfig = {
     target: '#persona-root',
-    config: { apiUrl: '/api/chat/dispatch' }
-  });
+    apiUrl: '/api/chat/dispatch',
+  };
 </script>
+<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js"></script>
 \`\`\`
 
-CDN URLs follow the pattern \`https://cdn.jsdelivr.net/npm/@runtypelabs/persona@VERSION/dist/\`. Replace \`VERSION\` with \`latest\` or a pinned version. Available files: \`widget.css\`, \`index.global.js\` (IIFE), \`index.js\` (ESM). Do NOT invent other file names.
+The automatic installer loads the widget CSS for you and can use the tiny \`launcher.global.js\` fast path before the full panel loads. Hand-written docs should pin the major version, e.g. \`@runtypelabs/persona@4\`, not \`@latest\` or an unversioned package URL.
+
+Manual CDN installs are also supported when you need full control: load \`widget.css\`, then \`index.global.js\`, then call \`window.AgentWidget.initAgentWidget(...)\`. Published dist files include \`widget.css\`, \`install.global.js\`, \`launcher.global.js\`, \`index.global.js\` (IIFE), \`index.js\` (ESM), and \`index.cjs\` (CommonJS), plus lazy chunks that must be hosted next to the main bundle. Do NOT invent other file names.
 
 ## Available Demos
 When a user asks about a feature or use case, recommend the most relevant demo from this list. Format links as markdown, e.g. [Demo Name](/path.html).
@@ -63,23 +67,31 @@ When a user asks about a feature or use case, recommend the most relevant demo f
 - [Action Middleware](/action-middleware.html): DOM-aware page context each turn plus middleware that executes real UI actions (navigate, cart, checkout)
 - [Bakery Assistant](/bakery.html): industry-specific persona with a rich product catalog and cart actions
 - [Docked Panel](/docked-panel-demo.html): WebMCP-powered dashboard copilot docked to the side of the page; it reads the workspace, switches sections, logs activity, and can move its own dock via page tools
+- [Tool & Reasoning Loaders](/tool-loading-demo.html): configurable indicators for tool calls and reasoning
 - [Feedback Integration](/feedback-integration-demo.html): wiring feedback events to an external API
+- [File Attachments](/attachments-demo.html): file and image uploads in the composer
 - [Custom Loading Indicator](/custom-loading-indicator.html): replace the default loading UX with your own
 - [Agent Loop Execution](/agent-demo.html): multi-turn reasoning with internal thought processes and tool use
 - [Tool Approval](/approval-demo.html): require user confirmation before the agent executes a tool
 - [Focus Input](/focus-input-demo.html): programmatic input focus and state handling
+- [Ask User Question & Suggested Replies](/ask-user-question-demo.html): blocking answer sheets and quick-reply chips backed by built-in local client tools
 - [Artifact Sidebar](/artifact-demo.html): multi-pane interface with a resizable artifact panel
 - [Fullscreen Assistant](/fullscreen-assistant-demo.html): dark full-viewport split layout (chat + artifacts)
-- [Voice Integration](/voice-integration-demo.html): voice input powered by ElevenLabs
+- [Voice Integration](/voice-integration-demo.html): browser or Runtype speech-to-text, plus browser, Runtype, or OpenAI-backed text-to-speech output
+- [Bring-Your-Own Voice](/custom-voice-provider-demo.html): plug a custom speech provider in via \`provider.custom\`
+- [Server TTS](/server-tts-demo.html): read aloud with hosted voices via a streaming \`SpeechEngine\`
 - [Dynamic Components](/dynamic-components.html): stream forms, cards, charts, and other host-rendered UI inside assistant messages
 - [Layout Configuration](/layout-config-demo.html): tweak panel sizing, spacing, and layout options
 - [Stream Animations](/stream-animations-demo.html): customize how streamed text animates in
 - [Streaming Markdown Tables](/streaming-table-demo.html): Telegram-style table rendering that reserves structure and column widths as rows stream in
 - [Scroll Engineering](/scroll-engineering.html): all 15 principles of a great streaming scroll, wired through additive scrollBehavior config (anchor-top, pause-on-interaction, restore position, aria-live announcements)
 - [Persistent Composer](/persistent-composer.html): always-visible composer bar layout
+- [Shadow-aware Page Context](/smart-dom-reader-demo.html): optional smart DOM reader context that can include shadow-DOM content
 - [WebMCP Storefront](/webmcp-demo.html): expose page tools to the agent via WebMCP
 - [WebMCP Calendar](/webmcp-calendar.html): a team calendar copilot that reads availability and books events through WebMCP page tools
 - [WebMCP Slides](/webmcp-slides.html): a Deck Copilot that edits a slide deck through WebMCP page tools, with selection-scoped tools and presenter-mode controls
+- [WebMCP Paint](/webmcp-paint.html): Paint Pal drives a same-origin jspaint canvas through WebMCP operator tools
+- [Browse All Examples](/advanced.html): the full gallery of advanced examples and patterns
 
 ## Customization
 
@@ -98,7 +110,7 @@ When a user asks what they can customize, cover these areas (all set via the con
 - **Message rendering**: \`postprocessMessage\` hook to transform rendered HTML (e.g. add copy buttons to code blocks), built-in \`markdownPostprocessor\`, custom components inside messages, \`sanitize\` option (\`true\` by default, \`false\`, or a custom \`(html) => string\` function).
 - **Tool & reasoning UI**: \`toolCall\`, \`reasoning\`, and \`approval\` configs for how tool calls, thinking, and approval bubbles render.
 - **Message actions**: \`messageActions\` toggles for per-message buttons — \`showCopy\`, \`showUpvote\`/\`showDownvote\` (feedback), and \`showReadAloud\` (a "Read aloud" text-to-speech button with play/pause/resume; emits the \`message:read-aloud\` event).
-- **Voice & speech**: \`voiceRecognition\` (browser or ElevenLabs-powered providers) and \`textToSpeech\` (auto-speak + the read-aloud button; voice, rate, pitch, or a hosted engine via \`createEngine\`).
+- **Voice & speech**: \`voiceRecognition\` (browser Web Speech API, Runtype WebSocket voice, or \`provider.custom\`) and \`textToSpeech\` (browser/Runtype/custom \`SpeechEngine\`, auto-speak, and the read-aloud button; voice, rate, pitch, hosted engines via \`createEngine\`).
 - **Plugins**: a plugin registry for custom functionality beyond config options.
 
 ## Setting Up Persona With an AI Coding Agent
@@ -110,13 +122,17 @@ Here is the prompt template:
 \`\`\`
 Add the Persona chat widget (@runtypelabs/persona) to this project.
 
-1. Install:
+If this project should use Runtype-hosted agents/client tokens and you have Runtype access, first try:
+   npx @runtypelabs/cli@latest persona init
+The CLI can create an agent/client token and print a script-installer, ESM, or React snippet. Otherwise wire Persona to this app's existing SSE backend:
+
+1. Install the widget package:
    npm install @runtypelabs/persona
 
 2. Import the stylesheet in the app entry point:
    import '@runtypelabs/persona/widget.css';
 
-3. Initialize the widget:
+3. Initialize the widget (floating launcher by default):
    import { initAgentWidget, DEFAULT_WIDGET_CONFIG } from '@runtypelabs/persona';
 
    initAgentWidget({
@@ -127,7 +143,7 @@ Add the Persona chat widget (@runtypelabs/persona) to this project.
      }
    });
 
-   For an inline embed instead of a floating launcher, use createAgentExperience(element, config) with launcher.enabled = false.
+   For an inline embed instead of a floating launcher, use createAgentExperience(element, { ...DEFAULT_WIDGET_CONFIG, apiUrl: '/api/chat', launcher: { enabled: false } }).
 
 4. Connect to your SSE backend: the widget expects a server-sent event stream. Use these hooks to adapt it to your API:
    - customFetch(url, init, payload): replace the built-in fetch to transform the request/response for your backend's expected format. Return a Response with a ReadableStream.
@@ -135,17 +151,25 @@ Add the Persona chat widget (@runtypelabs/persona) to this project.
    - getHeaders() / headers: inject auth tokens or other headers into every request.
    - requestMiddleware(context): transform the outgoing request payload (messages, metadata) before it's sent.
 
-5. Customize appearance:
+5. If you need a no-bundler script tag instead, use the automatic installer with a major-pinned CDN URL:
+   <script>
+     window.siteAgentConfig = { target: '#chat-root', apiUrl: '/api/chat' };
+   </script>
+   <script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js"></script>
+   For Runtype direct browser installs, use clientToken (and agentId/flowId/target as needed) instead of apiUrl.
+
+6. Customize appearance and behavior:
    - theme: a token tree, e.g. theme: { palette: { colors: { primary: { 500: '#7c3aed', 600: '#6d28d9' } } } } to match site colors (the flat { primary, accent, ... } shape is not supported)
    - colorScheme: 'light' | 'dark' | 'auto', with optional darkTheme token overrides
    - copy: { welcomeTitle, welcomeSubtitle, inputPlaceholder }
    - suggestionChips: ['Question 1', 'Question 2'] for starter prompts
+   - features.showEventStreamToggle, features.showReasoning, toolCall, reasoning, approval, messageActions, voiceRecognition, textToSpeech, webmcp, contextProviders, and plugins for advanced behavior
 
 For full API docs: https://deepwiki.com/runtypelabs/persona
 NPM: https://www.npmjs.com/package/@runtypelabs/persona
 Source & examples: https://github.com/runtypelabs/persona (35+ demo pages in apps/web/)
 
-Note: if you don't have an SSE backend yet, @runtypelabs/persona-proxy is an optional Hono-based proxy that sits between the widget and the Runtype API. Install it separately with npm install @runtypelabs/persona-proxy.
+Note: if you need server-side API-key control or custom Runtype flow definitions, @runtypelabs/persona-proxy is an optional Hono-based proxy that sits between the widget and the Runtype API. Install it separately with npm install @runtypelabs/persona-proxy.
 \`\`\`
 
 Tell the user to adjust the prompt to their specifics (framework, styling, use case) before pasting it. If they mention a specific agent, mention any relevant tips (e.g. for Claude Code they can save it as a skill in \`.claude/commands/\`).


### PR DESCRIPTION
## Summary
- refresh the home docs agent prompt
- add a proxy changeset

## Validation
- pnpm --filter @runtypelabs/persona-proxy typecheck
- pnpm --filter @runtypelabs/persona-proxy lint

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the `PERSONA_DOCS_SYSTEM_PROMPT` in the proxy's docs assistant agent to reflect the current state of the Persona widget: Shadow DOM is now opt-in, the theme system has moved to a design-token tree, voice support has expanded, and WebMCP/page-tools are now first-class features.

- **Prompt content updated**: feature list, CDN install pattern (`install.global.js` + major-version pinning), customization section, and the AI coding agent template are all brought in sync with the v4 widget API.
- **New demos added**: 8 new demo links (Tool & Reasoning Loaders, File Attachments, Ask User Question & Suggested Replies, three new voice demos, Shadow-aware Page Context, WebMCP Paint, and Browse All Examples).
- **Changeset added**: correctly classifies the change as a `patch` for `@runtypelabs/persona-proxy`.

<h3>Confidence Score: 4/5</h3>

Safe to merge — all changes are confined to a system prompt string and a changeset file, with no runtime logic touched.

The example API paths ('/api/chat/dispatch' in the installation section vs '/api/chat' in the agent template) are inconsistent, which could cause minor confusion for developers copying snippets, but nothing here affects runtime behavior.

No files require special attention. Both changed files are documentation/prompt content only.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| packages/proxy/src/agents/docs-assistant.ts | System prompt string updated to reflect current widget APIs: Shadow DOM now optional, new token-tree theme system, expanded voice/WebMCP features, updated CDN install pattern, and new demo links. No runtime logic changes. |
| .changeset/docs-agent-prompt-refresh.md | New changeset correctly classifies the prompt refresh as a patch release for @runtypelabs/persona-proxy. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    User([User question]) --> DocsAgent[Docs Assistant Agent\nnemotron-3-ultra-550b-a55b]
    DocsAgent -->|"in-scope: Persona / proxy / Runtype"| PromptKnowledge[System Prompt\nknowledge base]
    DocsAgent -->|"needs deeper detail"| DeepWiki[DeepWiki MCP\nmcp.deepwiki.com]
    PromptKnowledge --> InstallSection[Installation guidance\nCDN · ESM · CommonJS\nRuntype CLI]
    PromptKnowledge --> DemoLinks[Demo links\n25+ entries]
    PromptKnowledge --> CustomizationSection[Customization\ntheme · voice · WebMCP · plugins]
    PromptKnowledge --> AgentTemplate[AI coding agent\nprompt template]
    DeepWiki --> Response([Response to user])
    InstallSection --> Response
    DemoLinks --> Response
    CustomizationSection --> Response
    AgentTemplate --> Response
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    User([User question]) --> DocsAgent[Docs Assistant Agent\nnemotron-3-ultra-550b-a55b]
    DocsAgent -->|"in-scope: Persona / proxy / Runtype"| PromptKnowledge[System Prompt\nknowledge base]
    DocsAgent -->|"needs deeper detail"| DeepWiki[DeepWiki MCP\nmcp.deepwiki.com]
    PromptKnowledge --> InstallSection[Installation guidance\nCDN · ESM · CommonJS\nRuntype CLI]
    PromptKnowledge --> DemoLinks[Demo links\n25+ entries]
    PromptKnowledge --> CustomizationSection[Customization\ntheme · voice · WebMCP · plugins]
    PromptKnowledge --> AgentTemplate[AI coding agent\nprompt template]
    DeepWiki --> Response([Response to user])
    InstallSection --> Response
    DemoLinks --> Response
    CustomizationSection --> Response
    AgentTemplate --> Response
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `packages/proxy/src/agents/docs-assistant.ts`, line 39-45 ([link](https://github.com/runtypelabs/persona/blob/1f45c79c9d98ae00614abc967e10b1b60dcd2ec0/packages/proxy/src/agents/docs-assistant.ts#L39-L45)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The Installation section example uses `apiUrl: '/api/chat/dispatch'` (lines 43 and 53), but the AI coding agent template in step 3 uses `apiUrl: '/api/chat'` and step 5 also uses `apiUrl: '/api/chat'`. While these are placeholder URLs, a developer who copies one snippet then the other may be left wondering whether the dispatch suffix matters. Aligning them prevents unnecessary confusion.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%0ALine%3A%2039-45%0A%0AComment%3A%0AThe%20Installation%20section%20example%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20%28lines%2043%20and%2053%29%2C%20but%20the%20AI%20coding%20agent%20template%20in%20step%203%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60%20and%20step%205%20also%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60.%20While%20these%20are%20placeholder%20URLs%2C%20a%20developer%20who%20copies%20one%20snippet%20then%20the%20other%20may%20be%20left%20wondering%20whether%20the%20dispatch%20suffix%20matters.%20Aligning%20them%20prevents%20unnecessary%20confusion.%0A%0A%60%60%60suggestion%0Aconst%20controller%20%3D%20initAgentWidget%28%7B%0A%20%20target%3A%20'%23persona-root'%2C%0A%20%20config%3A%20%7B%0A%20%20%20%20...DEFAULT_WIDGET_CONFIG%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=runtypelabs%2Fpersona&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22codex%2Fdocs-agent-prompt-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdocs-agent-prompt-refresh%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%0ALine%3A%2039-45%0A%0AComment%3A%0AThe%20Installation%20section%20example%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20%28lines%2043%20and%2053%29%2C%20but%20the%20AI%20coding%20agent%20template%20in%20step%203%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60%20and%20step%205%20also%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60.%20While%20these%20are%20placeholder%20URLs%2C%20a%20developer%20who%20copies%20one%20snippet%20then%20the%20other%20may%20be%20left%20wondering%20whether%20the%20dispatch%20suffix%20matters.%20Aligning%20them%20prevents%20unnecessary%20confusion.%0A%0A%60%60%60suggestion%0Aconst%20controller%20%3D%20initAgentWidget%28%7B%0A%20%20target%3A%20'%23persona-root'%2C%0A%20%20config%3A%20%7B%0A%20%20%20%20...DEFAULT_WIDGET_CONFIG%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=runtypelabs%2Fpersona&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20packages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%0ALine%3A%2039-45%0A%0AComment%3A%0AThe%20Installation%20section%20example%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20%28lines%2043%20and%2053%29%2C%20but%20the%20AI%20coding%20agent%20template%20in%20step%203%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60%20and%20step%205%20also%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60.%20While%20these%20are%20placeholder%20URLs%2C%20a%20developer%20who%20copies%20one%20snippet%20then%20the%20other%20may%20be%20left%20wondering%20whether%20the%20dispatch%20suffix%20matters.%20Aligning%20them%20prevents%20unnecessary%20confusion.%0A%0A%60%60%60suggestion%0Aconst%20controller%20%3D%20initAgentWidget%28%7B%0A%20%20target%3A%20'%23persona-root'%2C%0A%20%20config%3A%20%7B%0A%20%20%20%20...DEFAULT_WIDGET_CONFIG%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=3" height="20"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%3A39-45%0AThe%20Installation%20section%20example%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20%28lines%2043%20and%2053%29%2C%20but%20the%20AI%20coding%20agent%20template%20in%20step%203%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60%20and%20step%205%20also%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60.%20While%20these%20are%20placeholder%20URLs%2C%20a%20developer%20who%20copies%20one%20snippet%20then%20the%20other%20may%20be%20left%20wondering%20whether%20the%20dispatch%20suffix%20matters.%20Aligning%20them%20prevents%20unnecessary%20confusion.%0A%0A%60%60%60suggestion%0Aconst%20controller%20%3D%20initAgentWidget%28%7B%0A%20%20target%3A%20'%23persona-root'%2C%0A%20%20config%3A%20%7B%0A%20%20%20%20...DEFAULT_WIDGET_CONFIG%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%3A51-54%0AThe%20CDN%20snippet%20in%20the%20Installation%20section%20still%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20while%20the%20agent%20template%20uses%20%60'%2Fapi%2Fchat'%60.%20Aligning%20these%20keeps%20the%20installation%20examples%20consistent%20across%20the%20prompt.%0A%0A%60%60%60suggestion%0A%20%20window.siteAgentConfig%20%3D%20%7B%0A%20%20%20%20target%3A%20'%23persona-root'%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%3B%0A%60%60%60%0A%0A&repo=runtypelabs%2Fpersona&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22codex%2Fdocs-agent-prompt-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Fdocs-agent-prompt-refresh%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%3A39-45%0AThe%20Installation%20section%20example%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20%28lines%2043%20and%2053%29%2C%20but%20the%20AI%20coding%20agent%20template%20in%20step%203%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60%20and%20step%205%20also%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60.%20While%20these%20are%20placeholder%20URLs%2C%20a%20developer%20who%20copies%20one%20snippet%20then%20the%20other%20may%20be%20left%20wondering%20whether%20the%20dispatch%20suffix%20matters.%20Aligning%20them%20prevents%20unnecessary%20confusion.%0A%0A%60%60%60suggestion%0Aconst%20controller%20%3D%20initAgentWidget%28%7B%0A%20%20target%3A%20'%23persona-root'%2C%0A%20%20config%3A%20%7B%0A%20%20%20%20...DEFAULT_WIDGET_CONFIG%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%3A51-54%0AThe%20CDN%20snippet%20in%20the%20Installation%20section%20still%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20while%20the%20agent%20template%20uses%20%60'%2Fapi%2Fchat'%60.%20Aligning%20these%20keeps%20the%20installation%20examples%20consistent%20across%20the%20prompt.%0A%0A%60%60%60suggestion%0A%20%20window.siteAgentConfig%20%3D%20%7B%0A%20%20%20%20target%3A%20'%23persona-root'%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%3B%0A%60%60%60%0A%0A&repo=runtypelabs%2Fpersona&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Apackages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%3A39-45%0AThe%20Installation%20section%20example%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20%28lines%2043%20and%2053%29%2C%20but%20the%20AI%20coding%20agent%20template%20in%20step%203%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60%20and%20step%205%20also%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat'%60.%20While%20these%20are%20placeholder%20URLs%2C%20a%20developer%20who%20copies%20one%20snippet%20then%20the%20other%20may%20be%20left%20wondering%20whether%20the%20dispatch%20suffix%20matters.%20Aligning%20them%20prevents%20unnecessary%20confusion.%0A%0A%60%60%60suggestion%0Aconst%20controller%20%3D%20initAgentWidget%28%7B%0A%20%20target%3A%20'%23persona-root'%2C%0A%20%20config%3A%20%7B%0A%20%20%20%20...DEFAULT_WIDGET_CONFIG%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%0A%7D%29%3B%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Apackages%2Fproxy%2Fsrc%2Fagents%2Fdocs-assistant.ts%3A51-54%0AThe%20CDN%20snippet%20in%20the%20Installation%20section%20still%20uses%20%60apiUrl%3A%20'%2Fapi%2Fchat%2Fdispatch'%60%20while%20the%20agent%20template%20uses%20%60'%2Fapi%2Fchat'%60.%20Aligning%20these%20keeps%20the%20installation%20examples%20consistent%20across%20the%20prompt.%0A%0A%60%60%60suggestion%0A%20%20window.siteAgentConfig%20%3D%20%7B%0A%20%20%20%20target%3A%20'%23persona-root'%2C%0A%20%20%20%20apiUrl%3A%20'%2Fapi%2Fchat'%2C%20%20%2F%2F%20your%20SSE%20endpoint%0A%20%20%7D%3B%0A%60%60%60%0A%0A&pr=347&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Refresh docs agent prompt"](https://github.com/runtypelabs/persona/commit/1f45c79c9d98ae00614abc967e10b1b60dcd2ec0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40204683)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->