### PR TITLE
feat(web): add launch-day Product Hunt call-out to homepage hero

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -101,6 +101,11 @@
               aria-label="Copy Persona npm install command"
             ><span data-copy-label>Copy</span></button>
           </div>
+          <a class="hero-producthunt" href="https://www.producthunt.com/products/persona-12?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-persona-4fac23c1-5535-49b7-9aaa-e945f43a2edc" target="_blank" rel="noopener noreferrer" aria-label="Persona is live on Product Hunt today — give us an upvote">
+            <span class="hero-producthunt-pulse" aria-hidden="true"></span>
+            <span class="hero-producthunt-copy">We're live on Product Hunt today — your upvote means the world</span>
+            <img class="hero-producthunt-badge" alt="Persona - Add WebMCP-native AI chat to any Frontend | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1178202&amp;theme=light&amp;t=1782622272480">
+          </a>
         </section>
 
         <!-- Framework / platform logo strip -->

--- a/apps/web/src/home.css
+++ b/apps/web/src/home.css
@@ -429,6 +429,66 @@ section[id], aside[id] {
   color: var(--ink);
 }
 
+/* Launch-day Product Hunt call-out -------------------------------------------------- */
+.hero-producthunt {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+  max-width: 620px;
+  margin-top: 2px;
+  padding: 14px 18px;
+  background: var(--paper-high);
+  border: 1px solid var(--ink);
+  box-shadow: 6px 6px 0 var(--teal-dim);
+  text-decoration: none;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-producthunt:hover {
+  transform: translate(-2px, -2px);
+  box-shadow: 8px 8px 0 var(--teal-dim);
+}
+
+.hero-producthunt-pulse {
+  position: relative;
+  flex: none;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  background: #da552f;
+  box-shadow: 0 0 0 0 rgba(218, 85, 47, 0.6);
+  animation: hero-producthunt-pulse 1.8s ease-out infinite;
+}
+
+@keyframes hero-producthunt-pulse {
+  0% { box-shadow: 0 0 0 0 rgba(218, 85, 47, 0.55); }
+  70% { box-shadow: 0 0 0 12px rgba(218, 85, 47, 0); }
+  100% { box-shadow: 0 0 0 0 rgba(218, 85, 47, 0); }
+}
+
+.hero-producthunt-copy {
+  flex: 1;
+  min-width: 200px;
+  font-family: var(--font-mono);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  line-height: 1.4;
+  color: var(--ink);
+}
+
+.hero-producthunt-badge {
+  flex: none;
+  display: block;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-producthunt-pulse {
+    animation: none;
+  }
+}
+
 /* Framework / platform logo strip ----------------------------------------------- */
 
 .stack-strip {


### PR DESCRIPTION
Add temporary PH badge

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a launch-day Product Hunt call-out to the homepage hero: an animated pulsing-dot banner that links visitors to the Product Hunt listing and embeds the official PH badge image from an external CDN.

- **`apps/web/index.html`**: Inserts an anchor inside `<section class=\"hero\">` with the PH badge image, a pulsing indicator, and a short call-to-action string; the link correctly uses `target=\"_blank\" rel=\"noopener noreferrer\"` and includes an accessible `aria-label`.
- **`apps/web/src/home.css`**: Adds ~60 lines covering the flex layout, hover lift animation, keyframe pulse, mono-font copy style, and a `prefers-reduced-motion` block — though the block only disables the pulse keyframe and leaves the hover `transition: transform / box-shadow` active for users who prefer reduced motion.

<h3>Confidence Score: 4/5</h3>

Safe to merge after addressing the reduced-motion hover transition gap; the rest of the change is well-structured and self-contained.

The hover transform/box-shadow transition is not suppressed inside the prefers-reduced-motion: reduce block, so users who have opted into reduced motion will still experience animation on hover — a real accessibility defect in the changed CSS. Everything else (link security attributes, aria labels, keyframe suppression, external image sizing) is handled correctly.

apps/web/src/home.css — the prefers-reduced-motion block needs transition: none on .hero-producthunt to fully honour users' motion preferences.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/index.html | Adds a Product Hunt callout anchor inside the hero section with correct rel="noopener noreferrer" and accessible aria-label; no cleanup comment for the self-described temporary element. |
| apps/web/src/home.css | Adds 60 lines of CSS for the PH callout; prefers-reduced-motion block correctly stops the pulse animation but misses suppressing the hover transform/box-shadow transition. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    actor Visitor
    participant Browser
    participant PH_CDN as api.producthunt.com
    participant PH_Site as producthunt.com

    Browser->>PH_CDN: "GET /widgets/embed-image/v1/featured.svg?post_id=1178202&t=..."
    PH_CDN-->>Browser: SVG badge image

    Visitor->>Browser: Clicks hero-producthunt link
    Browser->>PH_Site: Opens /products/persona-12 in new tab (noopener noreferrer)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    actor Visitor
    participant Browser
    participant PH_CDN as api.producthunt.com
    participant PH_Site as producthunt.com

    Browser->>PH_CDN: "GET /widgets/embed-image/v1/featured.svg?post_id=1178202&t=..."
    PH_CDN-->>Browser: SVG badge image

    Visitor->>Browser: Clicks hero-producthunt link
    Browser->>PH_Site: Opens /products/persona-12 in new tab (noopener noreferrer)
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fhome.css%3A462-465%0A**%60prefers-reduced-motion%60%20doesn't%20cover%20the%20hover%20transition**%0A%0AThe%20%60%40media%20%28prefers-reduced-motion%3A%20reduce%29%60%20block%20stops%20the%20pulse%20keyframe%20animation%20but%20leaves%20the%20%60transition%3A%20transform%200.2s%20ease%2C%20box-shadow%200.2s%20ease%60%20on%20%60.hero-producthunt%3Ahover%60%20active.%20Users%20who%20opt%20into%20reduced%20motion%20%28typically%20because%20of%20vestibular%20disorders%29%20will%20still%20experience%20a%20translate%20%2B%20shadow%20animation%20on%20every%20hover.%20The%20fix%20is%20to%20also%20set%20%60transition%3A%20none%60%20inside%20the%20reduced-motion%20query.%0A%0A%60%60%60suggestion%0A%40media%20%28prefers-reduced-motion%3A%20reduce%29%20%7B%0A%20%20.hero-producthunt-pulse%20%7B%0A%20%20%20%20animation%3A%20none%3B%0A%20%20%7D%0A%20%20.hero-producthunt%20%7B%0A%20%20%20%20transition%3A%20none%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Findex.html%3A104-108%0A**No%20cleanup%20plan%20for%20a%20%22temporary%22%20element**%0A%0AThe%20PR%20description%20calls%20this%20a%20temporary%20launch-day%20badge%2C%20but%20there's%20no%20TODO%20comment%2C%20expiry%20date%20hint%2C%20or%20linked%20tracking%20issue%20in%20the%20code.%20Without%20a%20reminder%20anchored%20here%2C%20this%20element%20is%20likely%20to%20outlive%20launch%20day%20unnoticed.%20A%20brief%20%60%3C!--%20TODO%3A%20remove%20after%20launch%20day%20--%3E%60%20comment%20%28or%20a%20tracking%20issue%20reference%29%20would%20make%20the%20intended%20lifecycle%20explicit.%0A%0A&repo=runtypelabs%2Fpersona&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22feat%2Fproducthunt-launch-badge%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fproducthunt-launch-badge%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fhome.css%3A462-465%0A**%60prefers-reduced-motion%60%20doesn't%20cover%20the%20hover%20transition**%0A%0AThe%20%60%40media%20%28prefers-reduced-motion%3A%20reduce%29%60%20block%20stops%20the%20pulse%20keyframe%20animation%20but%20leaves%20the%20%60transition%3A%20transform%200.2s%20ease%2C%20box-shadow%200.2s%20ease%60%20on%20%60.hero-producthunt%3Ahover%60%20active.%20Users%20who%20opt%20into%20reduced%20motion%20%28typically%20because%20of%20vestibular%20disorders%29%20will%20still%20experience%20a%20translate%20%2B%20shadow%20animation%20on%20every%20hover.%20The%20fix%20is%20to%20also%20set%20%60transition%3A%20none%60%20inside%20the%20reduced-motion%20query.%0A%0A%60%60%60suggestion%0A%40media%20%28prefers-reduced-motion%3A%20reduce%29%20%7B%0A%20%20.hero-producthunt-pulse%20%7B%0A%20%20%20%20animation%3A%20none%3B%0A%20%20%7D%0A%20%20.hero-producthunt%20%7B%0A%20%20%20%20transition%3A%20none%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Findex.html%3A104-108%0A**No%20cleanup%20plan%20for%20a%20%22temporary%22%20element**%0A%0AThe%20PR%20description%20calls%20this%20a%20temporary%20launch-day%20badge%2C%20but%20there's%20no%20TODO%20comment%2C%20expiry%20date%20hint%2C%20or%20linked%20tracking%20issue%20in%20the%20code.%20Without%20a%20reminder%20anchored%20here%2C%20this%20element%20is%20likely%20to%20outlive%20launch%20day%20unnoticed.%20A%20brief%20%60%3C!--%20TODO%3A%20remove%20after%20launch%20day%20--%3E%60%20comment%20%28or%20a%20tracking%20issue%20reference%29%20would%20make%20the%20intended%20lifecycle%20explicit.%0A%0A&repo=runtypelabs%2Fpersona&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=3" height="20"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aapps%2Fweb%2Fsrc%2Fhome.css%3A462-465%0A**%60prefers-reduced-motion%60%20doesn't%20cover%20the%20hover%20transition**%0A%0AThe%20%60%40media%20%28prefers-reduced-motion%3A%20reduce%29%60%20block%20stops%20the%20pulse%20keyframe%20animation%20but%20leaves%20the%20%60transition%3A%20transform%200.2s%20ease%2C%20box-shadow%200.2s%20ease%60%20on%20%60.hero-producthunt%3Ahover%60%20active.%20Users%20who%20opt%20into%20reduced%20motion%20%28typically%20because%20of%20vestibular%20disorders%29%20will%20still%20experience%20a%20translate%20%2B%20shadow%20animation%20on%20every%20hover.%20The%20fix%20is%20to%20also%20set%20%60transition%3A%20none%60%20inside%20the%20reduced-motion%20query.%0A%0A%60%60%60suggestion%0A%40media%20%28prefers-reduced-motion%3A%20reduce%29%20%7B%0A%20%20.hero-producthunt-pulse%20%7B%0A%20%20%20%20animation%3A%20none%3B%0A%20%20%7D%0A%20%20.hero-producthunt%20%7B%0A%20%20%20%20transition%3A%20none%3B%0A%20%20%7D%0A%7D%0A%60%60%60%0A%0A%23%23%23%20Issue%202%20of%202%0Aapps%2Fweb%2Findex.html%3A104-108%0A**No%20cleanup%20plan%20for%20a%20%22temporary%22%20element**%0A%0AThe%20PR%20description%20calls%20this%20a%20temporary%20launch-day%20badge%2C%20but%20there's%20no%20TODO%20comment%2C%20expiry%20date%20hint%2C%20or%20linked%20tracking%20issue%20in%20the%20code.%20Without%20a%20reminder%20anchored%20here%2C%20this%20element%20is%20likely%20to%20outlive%20launch%20day%20unnoticed.%20A%20brief%20%60%3C!--%20TODO%3A%20remove%20after%20launch%20day%20--%3E%60%20comment%20%28or%20a%20tracking%20issue%20reference%29%20would%20make%20the%20intended%20lifecycle%20explicit.%0A%0A&pr=348&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(web): add launch-day Product Hunt c..."](https://github.com/runtypelabs/persona/commit/46f04de37f50603257021898701f2567fbc725c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40345875)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->