### PR TITLE
feat(widget): passive indicator for auto-resuming durable pauses

### DIFF
--- a/.changeset/durable-pause-await-reason.md
+++ b/.changeset/durable-pause-await-reason.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Suppress the resume affordance for auto-resuming durable pauses. The unified `await` SSE event now carries an `awaitReason` discriminator (`crawl_pending` / `durable_poll`, open-ended for forward-compat). When it is present, the server resumes the stream itself, so the widget renders a passive, non-interactive "working in the background" indicator (a new `"pause"` message variant) instead of a resume/input control, and settles it once the stream resumes. Awaits without `awaitReason` (local-tool / WebMCP) keep today's interactive behavior unchanged. Indicator copy is overridable via `config.copy.durablePauseLabels`.

--- a/apps/web/durable-pause-demo.html
+++ b/apps/web/durable-pause-demo.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <link rel="stylesheet" href="/src/demo-shared.css">
+  <link rel="icon" href="/favicon.ico" sizes="any" />
+  <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+  <title>Durable Pause Demo</title>
+</head>
+<body>
+  <main class="shell-main">
+    <div class="stage">
+      <aside class="stage-controls">
+        <header class="demo-meta">
+          <h1>Durable Pause</h1>
+          <p>Some pauses resume themselves. When the API emits an <code>await</code> event with an <code>awaitReason</code> (e.g. <code>crawl_pending</code> or <code>durable_poll</code>), the server — not the user — continues the stream. The widget shows a passive "working in the background" indicator and waits; it never renders a resume/input affordance.</p>
+          <div class="mount-toolbar" data-mount-toolbar></div>
+        </header>
+
+        <div class="info-section">
+          <h3>Pause kind</h3>
+          <p>Both are auto-resuming server pauses — only the indicator copy differs. The suppression of the resume affordance is driven by the <em>presence</em> of <code>awaitReason</code>, not by matching a specific value.</p>
+          <div class="mode-group" id="kind-selector" style="margin-top: 0.5rem;">
+            <button class="mode-btn active" data-kind="crawl_pending">crawl_pending</button>
+            <button class="mode-btn" data-kind="durable_poll">durable_poll</button>
+          </div>
+        </div>
+
+        <div data-config-inspector></div>
+      </aside>
+
+      <div class="stage-widget"></div>
+    </div>
+
+    <section class="notes">
+      <h2 class="notes-heading">Notes</h2>
+
+      <div class="notes-section">
+        <h3 class="notes-section-title">How it works</h3>
+        <p>The unified <code>await</code> SSE event carries an optional <code>awaitReason</code> discriminator. When it is absent, the await is client-resolvable (a local tool / WebMCP call) and the widget renders the usual interactive affordance the client must fulfil. When it is a non-empty string, the pause is <strong>auto-resuming</strong>: the server (CrawlPollerDO for crawl, the wait-until Workflow for durable poll) resumes the same stream on its own, so the widget renders a passive <code>variant: "pause"</code> bubble and simply waits for subsequent frames.</p>
+      </div>
+
+      <div class="notes-section">
+        <h3 class="notes-section-title">Why no resume button</h3>
+        <p>An auto-resuming pause has nothing for the client to fulfil — any resume action would have no payload to send. Showing a resume/input control there is a dead end, so the widget suppresses it and shows a non-interactive indicator instead. <code>awaitReason</code> is treated as UX context only, never a control signal: it decides how to render, never authorization, gating, or auto-resume logic.</p>
+      </div>
+
+      <div class="notes-section">
+        <h3 class="notes-section-title">Forward compatibility</h3>
+        <p>Suppression keys on <code>awaitReason</code> being present and non-empty — not on an exact enum match — so a future durable-pause kind suppresses the affordance correctly without an SDK release. Copy can still special-case known kinds (and you can override it per-reason via <code>config.copy.durablePauseLabels</code>).</p>
+      </div>
+
+      <div class="notes-section">
+        <h3 class="notes-section-title">This demo</h3>
+        <p>A <code>customFetch</code> replays a scripted stream: an intro reply, an <code>await</code> frame with the selected <code>awaitReason</code>, a few keep-alive pings (which must not settle the indicator), then the resumed answer and <code>execution_complete</code> — all on one stream. Watch the passive indicator appear, hold, and then disappear as the answer streams in. No backend or API key required.</p>
+      </div>
+    </section>
+  </main>
+
+  <script type="module" src="/src/durable-pause-demo.ts"></script>
+  <script type="module">
+    import { renderExamplesShell } from "/src/examples-nav.ts";
+    renderExamplesShell("durable-pause-demo");
+  </script>
+</body>
+</html>

--- a/apps/web/src/durable-pause-demo.ts
+++ b/apps/web/src/durable-pause-demo.ts
@@ -1,0 +1,194 @@
+import "@runtypelabs/persona/widget.css";
+import { renderDemoScaffold } from "./demo-scaffold";
+
+import {
+  markdownPostprocessor,
+  DEFAULT_WIDGET_CONFIG,
+  type AgentWidgetConfig,
+} from "@runtypelabs/persona";
+import {
+  createMockSSEResponse,
+  type MockSSEFrame,
+} from "@runtypelabs/persona/testing";
+import { setupMountMode, runWidgetMountWithInspector } from "./mount-mode";
+import { createDemoConfigInspector } from "./demo-config-inspector";
+import type { Mode } from "./examples-nav";
+
+renderDemoScaffold({ slug: "durable-pause-demo" });
+
+const configInspector = createDemoConfigInspector({ title: "Durable Pause" });
+let mountMode: Mode = "inline";
+
+// Which durable-pause kind the mock stream emits. Both are auto-resuming server
+// pauses (the SERVER resumes the stream), so neither shows a resume affordance —
+// only the passive indicator copy differs. `awaitReason` is UX context only,
+// never a control signal.
+type PauseKind = "crawl_pending" | "durable_poll";
+let pauseKind: PauseKind = "crawl_pending";
+
+// One assistant turn: turn_start → text_start → text_delta(s) → text_complete →
+// turn_complete. Mirrors the approval demo's helper; `text_complete` seals the
+// bubble so the durable-pause bubble (and the resumed answer) render below it.
+const assistantTurn = (
+  executionId: string,
+  turnId: string,
+  iteration: number,
+  deltas: string[],
+): MockSSEFrame[] => {
+  const blockId = `${turnId}-text`;
+  return [
+    { type: "turn_start", executionId, id: turnId, iteration },
+    { type: "text_start", executionId, id: blockId },
+    ...deltas.map((delta) => ({ type: "text_delta", executionId, id: blockId, delta })),
+    { type: "text_complete", executionId, id: blockId },
+    { type: "turn_complete", executionId, id: turnId },
+  ];
+};
+
+// The scripted durable-pause stream. The widget renders a passive "working in
+// the background" indicator on the `await` frame (because `awaitReason` is
+// present and there are no tool fields), holds it through the keep-alive pings,
+// then settles it the moment the resumed assistant text begins — all on the
+// SAME stream, exactly as CrawlPollerDO / the wait-until Workflow drive it
+// server-side. No resume button ever appears; the client just waits for frames.
+const buildPauseStream = (): MockSSEFrame[] => {
+  const executionId = "exec-durable-1";
+  const crawl = pauseKind === "crawl_pending";
+  const pauseFrame: MockSSEFrame = crawl
+    ? {
+        type: "await",
+        executionId,
+        awaitReason: "crawl_pending",
+        crawlId: "crawl_a1b2c3",
+        stepId: "step-research",
+      }
+    : {
+        type: "await",
+        executionId,
+        awaitReason: "durable_poll",
+        stepId: "step-wait-until",
+      };
+
+  const intro = crawl
+    ? "Sure — let me crawl acme.com and pull the latest positioning signals."
+    : "On it — I'll wait for the upstream job to finish, then summarize.";
+  const answer = crawl
+    ? [
+        "Done — I read across the site. Here's what stands out:\n\n",
+        "1. **Positioning** — leads with reliability and time-to-value.\n",
+        "2. **Audience** — mid-market ops teams, not enterprise IT.\n",
+        "3. **Proof** — case studies emphasize migration speed.\n",
+      ]
+    : [
+        "The background job finished. Summary:\n\n",
+        "- **Status:** completed successfully\n",
+        "- **Records processed:** 12,480\n",
+        "- **Next step:** results are ready to export.\n",
+      ];
+
+  return [
+    { type: "execution_start", kind: "agent", executionId, agentId: "demo-agent", agentName: "Research Agent", maxTurns: 3, startedAt: Date.now() },
+    ...assistantTurn(executionId, "turn-1", 1, [intro]),
+    // Enter the auto-resuming durable pause.
+    pauseFrame,
+    // Keep-alive heartbeats while the server works (these must NOT settle the
+    // passive indicator — they keep the stream open during the pause).
+    { type: "ping" },
+    { type: "ping" },
+    { type: "ping" },
+    { type: "ping" },
+    // Server resumes the SAME stream with the answer — the indicator settles
+    // (and hides) as the first resumed frame arrives.
+    ...assistantTurn(executionId, "turn-2", 2, answer),
+    { type: "execution_complete", kind: "agent", executionId, success: true, stopReason: "complete" },
+  ];
+};
+
+const buildConfig = (mode: Mode): AgentWidgetConfig => {
+  const launcherChrome = mode === "launcher";
+  return {
+    ...DEFAULT_WIDGET_CONFIG,
+    // Ephemeral: canned mock (every send replays the same scripted stream), so
+    // persisting only leaves stale bubbles on reload. Matches approval-demo.
+    persistState: false,
+    customFetch: async () =>
+      // Slow-ish cadence so the passive pause indicator is clearly visible
+      // before the stream resumes.
+      createMockSSEResponse(buildPauseStream(), { delayMs: 450 }),
+    launcher: {
+      ...DEFAULT_WIDGET_CONFIG.launcher,
+      enabled: launcherChrome,
+      width: launcherChrome ? "min(420px, 95vw)" : "100%",
+      title: launcherChrome ? "Durable Pause" : undefined,
+    },
+    theme: {
+      ...DEFAULT_WIDGET_CONFIG.theme,
+      primary: "#0f172a",
+      accent: "#2563eb",
+      surface: "#f8fafc",
+      muted: "#64748b",
+    },
+    copy: {
+      ...DEFAULT_WIDGET_CONFIG.copy,
+      welcomeTitle: "Durable Pause Demo",
+      welcomeSubtitle:
+        "Send any message to trigger an auto-resuming durable pause. The widget shows a passive 'working in the background' indicator — never a resume button — and continues on its own when the stream resumes.",
+      inputPlaceholder: "Send a message to trigger a durable pause...",
+    },
+    features: { showToolCalls: true, showReasoning: true },
+    suggestionChips:
+      pauseKind === "crawl_pending"
+        ? ["Crawl acme.com", "Summarize their positioning"]
+        : ["Run the nightly export", "Wait for the job"],
+    postprocessMessage: ({ text }) => markdownPostprocessor(text),
+  };
+};
+
+let activeStage: HTMLElement | null = null;
+let teardownActive: (() => void) | null = null;
+
+const createWidget = (): void => {
+  if (teardownActive) {
+    teardownActive();
+    teardownActive = null;
+  }
+  const stage = activeStage;
+  if (!stage) return;
+  const { teardown } = runWidgetMountWithInspector(
+    configInspector,
+    mountMode,
+    stage,
+    buildConfig,
+  );
+  teardownActive = teardown;
+};
+
+setupMountMode({
+  slug: "durable-pause-demo",
+  modes: ["inline", "launcher"],
+  mount: (mode, { stage }) => {
+    mountMode = mode;
+    activeStage = stage;
+    createWidget();
+    return () => {
+      if (teardownActive) {
+        teardownActive();
+        teardownActive = null;
+      }
+    };
+  },
+});
+
+// Durable-pause kind selector (crawl_pending vs durable_poll) — switches the
+// scripted `awaitReason` and the passive indicator copy.
+const kindSelector = document.getElementById("kind-selector");
+kindSelector?.addEventListener("click", (event) => {
+  const btn = (event.target as HTMLElement).closest<HTMLElement>(".mode-btn");
+  if (!btn) return;
+  const next = btn.dataset.kind as PauseKind | undefined;
+  if (!next || next === pauseKind) return;
+  kindSelector.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
+  btn.classList.add("active");
+  pauseKind = next;
+  createWidget();
+});

--- a/apps/web/src/examples-nav.ts
+++ b/apps/web/src/examples-nav.ts
@@ -137,6 +137,15 @@ export const ADVANCED_EXAMPLES: readonly AdvancedExample[] = [
     modes: ["inline", "launcher"],
   },
   {
+    slug: "durable-pause-demo",
+    href: "/durable-pause-demo.html",
+    title: "Durable Pause",
+    blurb: "Auto-resuming server pauses (awaitReason): a passive indicator, no resume button.",
+    tier: "patterns",
+    tags: ["agent", "streaming", "interaction"],
+    modes: ["inline", "launcher"],
+  },
+  {
     slug: "action-middleware",
     href: "/action-middleware.html",
     title: "Tool Action Handlers",

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -658,6 +658,8 @@ export default defineConfig({
         'context-mentions-demo': path.resolve(__dirname, 'context-mentions-demo.html'),
         'slash-commands-demo': path.resolve(__dirname, 'slash-commands-demo.html'),
         'approval-demo': path.resolve(__dirname, 'approval-demo.html'),
+        // Durable pause (auto-resuming server pause; awaitReason)
+        'durable-pause-demo': path.resolve(__dirname, 'durable-pause-demo.html'),
         // Focus input demo
         'focus-input-demo': path.resolve(__dirname, 'focus-input-demo.html'),
         // Optional smart-dom-reader page-context provider (shadow DOM / iframes)

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -2986,6 +2986,51 @@ describe('AgentWidgetClient: durable-pause (awaitReason) parsing', () => {
     const text = messages.find((m) => !m.variant && m.content.includes('Done crawling.'));
     expect(text).toBeDefined();
   });
+
+  it('settles the pause if the stream fails at the read layer before any further frame', async () => {
+    // The server pauses, then the SSE connection dies (network drop / reader
+    // throw) before a content frame arrives. The per-frame settler never runs
+    // again, so without the finally-block settle the indicator would linger.
+    // `pull` delivers the await frame on the first read, then errors on the
+    // next read — a queued chunk would be discarded if we errored eagerly in
+    // `start`, so the frame must land before the failure.
+    let delivered = false;
+    const failingStream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        if (!delivered) {
+          delivered = true;
+          controller.enqueue(
+            encoder.encode(
+              `event: await\ndata: ${JSON.stringify({ type: 'await', executionId: 'exec_abc', awaitReason: 'crawl_pending', crawlId: 'crawl_1', stepId: 'step_1' })}\n\n`
+            )
+          );
+          return;
+        }
+        controller.error(new Error('network drop'));
+      },
+    });
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, body: failingStream });
+
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    const events: AgentWidgetEvent[] = [];
+    // The stream read rejects, so dispatch rejects too (existing behavior — the
+    // caller handles it). The point of the fix is that the durable pause is
+    // settled in the finally block BEFORE the error propagates.
+    await expect(
+      client.dispatch(
+        { messages: [{ id: 'u1', role: 'user', content: 'hi', createdAt: new Date().toISOString() }] },
+        (e) => events.push(e)
+      )
+    ).rejects.toThrow('network drop');
+
+    const pauseEmissions = events
+      .filter((e) => e.type === 'message')
+      .map((e) => (e as { message: AgentWidgetMessage }).message)
+      .filter((m) => m.variant === 'pause');
+    expect(pauseEmissions.length).toBeGreaterThan(0);
+    // The final pause emission is resolved → the passive indicator is cleared.
+    expect(pauseEmissions[pauseEmissions.length - 1].durablePause?.resolved).toBe(true);
+  });
 });
 
 // ============================================================================

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -2867,6 +2867,128 @@ describe('AgentWidgetClient: step_await parsing', () => {
 });
 
 // ============================================================================
+// await (AUTO-RESUMING durable pause) — `awaitReason` present, NO tool fields.
+// The server resumes the stream itself (CrawlPollerDO / wait-until Workflow), so
+// the client renders a passive `variant: "pause"` indicator and NEVER a resume
+// affordance. Discriminator is the PRESENCE of a non-empty `awaitReason`, not an
+// enum match (forward-compat). `awaitReason` is render-only, never a control
+// signal — see the persona-await-reason-rendering handoff.
+// ============================================================================
+
+describe('AgentWidgetClient: durable-pause (awaitReason) parsing', () => {
+  const encoder = new TextEncoder();
+  const buildFrameStream = (frames: Array<Record<string, unknown>>): ReadableStream<Uint8Array> => {
+    const body = frames
+      .map((frame) => `event: ${frame.type}\ndata: ${JSON.stringify(frame)}\n\n`)
+      .join('');
+    return new ReadableStream({
+      start(controller) {
+        controller.enqueue(encoder.encode(body));
+        controller.close();
+      },
+    });
+  };
+
+  const collectMessages = async (
+    frames: Array<Record<string, unknown>>
+  ): Promise<AgentWidgetMessage[]> => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: true, body: buildFrameStream(frames) });
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000' });
+    const events: AgentWidgetEvent[] = [];
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+    return events
+      .filter((e) => e.type === 'message')
+      .map((e) => (e as { message: AgentWidgetMessage }).message);
+  };
+
+  it.each(['crawl_pending', 'durable_poll'])(
+    'emits a passive pause message (no resume affordance) for awaitReason=%s',
+    async (awaitReason) => {
+      const messages = await collectMessages([
+        {
+          type: 'await',
+          executionId: 'exec_abc',
+          awaitReason,
+          crawlId: 'crawl_1',
+          stepId: 'step_1',
+        },
+      ]);
+
+      const pause = messages.find((m) => m.variant === 'pause');
+      expect(pause).toBeDefined();
+      expect(pause!.durablePause?.awaitReason).toBe(awaitReason);
+      expect(pause!.durablePause?.resolved).toBe(false);
+      expect(pause!.durablePause?.crawlId).toBe('crawl_1');
+      expect(pause!.durablePause?.stepId).toBe('step_1');
+      expect(pause!.agentMetadata?.executionId).toBe('exec_abc');
+      // A durable pause is NOT a client-resolvable tool await: no tool call and
+      // no `awaitingLocalTool` flag (which would drive the /resume affordance).
+      expect(pause!.toolCall).toBeUndefined();
+      expect(pause!.agentMetadata?.awaitingLocalTool).toBeUndefined();
+      // No tool-variant await message is produced for the durable pause.
+      expect(messages.some((m) => m.agentMetadata?.awaitingLocalTool)).toBe(false);
+    }
+  );
+
+  it('suppresses the resume affordance for a future (unknown) awaitReason (presence check, not enum)', async () => {
+    const messages = await collectMessages([
+      { type: 'await', executionId: 'exec_abc', awaitReason: 'some_future_kind', stepId: 'step_9' },
+    ]);
+
+    const pause = messages.find((m) => m.variant === 'pause');
+    expect(pause).toBeDefined();
+    expect(pause!.durablePause?.awaitReason).toBe('some_future_kind');
+    expect(pause!.durablePause?.resolved).toBe(false);
+    expect(messages.some((m) => m.agentMetadata?.awaitingLocalTool)).toBe(false);
+  });
+
+  it('keeps the interactive tool await for an `await` with no awaitReason (unchanged behavior)', async () => {
+    const messages = await collectMessages([
+      {
+        type: 'await',
+        executionId: 'exec_abc',
+        toolId: 'runtime_ask_user_question_1',
+        toolName: 'ask_user_question',
+        parameters: { questions: [] },
+      },
+    ]);
+
+    // No passive pause bubble; the existing client-resolvable tool await stands.
+    expect(messages.some((m) => m.variant === 'pause')).toBe(false);
+    const toolMsg = messages.find((m) => m.agentMetadata?.awaitingLocalTool);
+    expect(toolMsg).toBeDefined();
+    expect(toolMsg!.toolCall?.name).toBe('ask_user_question');
+  });
+
+  it('settles the pause (resolved=true) once the stream resumes with content', async () => {
+    const messages = await collectMessages([
+      { type: 'execution_start', kind: 'agent', executionId: 'exec_abc', agentId: 'a', agentName: 'A', maxTurns: 3 },
+      { type: 'await', executionId: 'exec_abc', awaitReason: 'crawl_pending', crawlId: 'crawl_1', stepId: 'step_1' },
+      { type: 'ping' },
+      { type: 'turn_start', executionId: 'exec_abc', id: 'turn-1', iteration: 1 },
+      { type: 'text_start', executionId: 'exec_abc', id: 'blk-1' },
+      { type: 'text_delta', executionId: 'exec_abc', id: 'blk-1', delta: 'Done crawling.' },
+      { type: 'text_complete', executionId: 'exec_abc', id: 'blk-1' },
+      { type: 'turn_complete', executionId: 'exec_abc', id: 'turn-1' },
+      { type: 'execution_complete', kind: 'agent', executionId: 'exec_abc', success: true, stopReason: 'complete' },
+    ]);
+
+    // The LAST emission of the pause bubble must be resolved (indicator stops,
+    // bubble hides). The ping must not have settled it prematurely.
+    const pauseEmissions = messages.filter((m) => m.variant === 'pause');
+    expect(pauseEmissions.length).toBeGreaterThan(0);
+    expect(pauseEmissions[pauseEmissions.length - 1].durablePause?.resolved).toBe(true);
+
+    // The resumed assistant text still renders.
+    const text = messages.find((m) => !m.variant && m.content.includes('Done crawling.'));
+    expect(text).toBeDefined();
+  });
+});
+
+// ============================================================================
 // agent_await (AGENT-dispatch LOCAL tool pause) — resolves through the same
 // path as step_await; carries a bare tool name + origin instead of a webmcp:
 // prefix + awaitReason.

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -3460,14 +3460,15 @@ export class AgentWidgetClient {
       seqReadyQueue.length = 0;
     };
 
-    // eslint-disable-next-line no-constant-condition
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
+    try {
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
 
-      buffer += decoder.decode(value, { stream: true });
-      const events = buffer.split("\n\n");
-      buffer = events.pop() ?? "";
+        buffer += decoder.decode(value, { stream: true });
+        const events = buffer.split("\n\n");
+        buffer = events.pop() ?? "";
 
       for (const event of events) {
         const lines = event.split("\n");
@@ -3555,8 +3556,17 @@ export class AgentWidgetClient {
         drainReadyQueue();
         advanceCursor();
       }
-    }
+      }
 
-    drainReadyQueue();
+      drainReadyQueue();
+    } finally {
+      // Always clear an active durable pause when the stream ends — normal
+      // completion, an HTTP/read-layer failure (network drop, malformed body,
+      // reader throw), or an abort. The per-frame settler only fires when a
+      // later frame arrives; if the stream dies first, this is the only path
+      // that stops the passive "working in the background" indicator from
+      // lingering forever. Any error is still surfaced via its own error event.
+      settleDurablePause();
+    }
   }
 }

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -1,6 +1,7 @@
 import {
   AgentWidgetConfig,
   AgentWidgetMessage,
+  AgentWidgetDurablePause,
   AgentWidgetEvent,
   AgentWidgetStreamParser,
   AgentWidgetStreamParserResult,
@@ -1551,6 +1552,26 @@ export class AgentWidgetClient {
     };
 
     let assistantMessage: AgentWidgetMessage | null = null;
+    // The active auto-resuming durable-pause bubble (unified `await` +
+    // `awaitReason`), if any. The server resumes THIS stream on its own, so the
+    // bubble is a passive "working in the background" indicator with no resume
+    // affordance. It is settled (its indicator stopped, bubble hidden) the
+    // moment the stream resumes — see `settleDurablePause`.
+    let durablePauseMessage: AgentWidgetMessage | null = null;
+    // Flip the active durable pause to resolved and re-emit it. Called when any
+    // content frame arrives after the pause (the implicit "stream resumed"
+    // signal — the wire has no explicit pause-resolved event) and at
+    // execution_complete. No-op when there is no active pause.
+    const settleDurablePause = () => {
+      if (!durablePauseMessage || durablePauseMessage.durablePause?.resolved) return;
+      durablePauseMessage.streaming = false;
+      durablePauseMessage.durablePause = {
+        ...(durablePauseMessage.durablePause as AgentWidgetDurablePause),
+        resolved: true,
+      };
+      emitMessage(durablePauseMessage);
+      durablePauseMessage = null;
+    };
     // Tracks the most recently touched assistant text message for the
     // current agent turn so `agent_turn_complete.stopReason` can attach
     // to the final visible text segment even after `assistantMessage`
@@ -2209,6 +2230,22 @@ export class AgentWidgetClient {
           executionKind = "flow";
         }
 
+        // Settle any active durable pause as soon as the stream resumes. The
+        // wire has no explicit pause-resolved frame: the server simply continues
+        // emitting content after CrawlPollerDO / the wait-until Workflow finishes.
+        // So the first frame that is NEITHER a keep-alive `ping` NOR another
+        // durable-await poll for the same pause means "work resumed" — stop the
+        // passive indicator. (A `ping` keeps streaming during the pause; a fresh
+        // durable `await` with `awaitReason` just refreshes the same bubble.)
+        if (durablePauseMessage && payloadType !== "ping") {
+          const isDurableAwaitFrame =
+            payloadType === "await" &&
+            typeof payload.awaitReason === "string" &&
+            (payload.awaitReason as string).length > 0 &&
+            !payload.toolName;
+          if (!isDurableAwaitFrame) settleDurablePause();
+        }
+
         if (payloadType === "reasoning_start") {
           // Nested flow-as-tool thinking (PR #4602): route to the parent tool's row.
           const rStartBlockId = typeof payload.id === "string" ? payload.id : null;
@@ -2568,6 +2605,51 @@ export class AgentWidgetClient {
             ...(toolCallId ? { webMcpToolCallId: toolCallId } : {}),
           };
           emitMessage(toolMessage);
+        } else if (
+          payloadType === "await" &&
+          typeof payload.awaitReason === "string" &&
+          (payload.awaitReason as string).length > 0 &&
+          !payload.toolName
+        ) {
+          // AUTO-RESUMING durable pause (unified `await` + `awaitReason`:
+          // `crawl_pending` / `durable_poll` today, open-ended for fwd-compat).
+          // The server resumes THIS stream on its own (CrawlPollerDO for crawl,
+          // the wait-until Workflow for durable poll), so — unlike the local-tool
+          // / WebMCP await above — there is NO resume affordance to render and
+          // nothing for the client to fulfil. Render a passive "working in the
+          // background" bubble and wait for subsequent frames; it is settled the
+          // moment the stream resumes (see `settleDurablePause`).
+          //
+          // Discriminator is the PRESENCE of a non-empty `awaitReason` (durable
+          // pauses carry no `toolName`/`toolId`), NOT an enum match — a future
+          // durable-pause kind suppresses correctly without an SDK release.
+          // `awaitReason` is UX context only, never a control signal: we branch
+          // on it to choose rendering, and never auto-fire a resume from it.
+          const awaitReason = payload.awaitReason as string;
+          const executionId =
+            typeof payload.executionId === "string" ? payload.executionId : undefined;
+          const pauseId = `durable-pause-${executionId ?? `local-${nextSequence()}`}`;
+          const message: AgentWidgetMessage =
+            durablePauseMessage ?? {
+              id: pauseId,
+              role: "assistant",
+              variant: "pause",
+              content: "",
+              createdAt: new Date().toISOString(),
+              sequence: nextSequence(),
+            };
+          message.streaming = true;
+          message.durablePause = {
+            awaitReason,
+            crawlId: typeof payload.crawlId === "string" ? payload.crawlId : undefined,
+            stepId: typeof payload.stepId === "string" ? payload.stepId : undefined,
+            resolved: false,
+          };
+          if (executionId) {
+            message.agentMetadata = { ...message.agentMetadata, executionId };
+          }
+          durablePauseMessage = message;
+          emitMessage(message);
         } else if (payloadType === "text_start") {
           // Nested flow-as-tool text (PR #4602): a `parentToolCallId` means this
           // block belongs to a flow running as that tool — record the mapping and

--- a/packages/widget/src/components/messages.ts
+++ b/packages/widget/src/components/messages.ts
@@ -4,6 +4,7 @@ import { MessageTransform, MessageActionCallbacks } from "./message-bubble";
 import { createStandardBubble } from "./message-bubble";
 import { createReasoningBubble } from "./reasoning-bubble";
 import { createToolBubble } from "./tool-bubble";
+import { createPauseBubble } from "./pause-bubble";
 import {
   ensureAskUserQuestionSheet,
   isAskUserQuestionMessage,
@@ -56,6 +57,10 @@ export const renderMessages = (
     } else if (message.variant === "tool" && message.toolCall) {
       if (!showToolCalls) return;
       bubble = createToolBubble(message, config);
+    } else if (message.variant === "pause") {
+      // Passive auto-resuming durable pause: a non-interactive "working in the
+      // background" indicator. It self-hides once `durablePause.resolved` flips.
+      bubble = createPauseBubble(message, config);
     } else {
       bubble = createStandardBubble(
         message, 

--- a/packages/widget/src/components/pause-bubble.test.ts
+++ b/packages/widget/src/components/pause-bubble.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from "vitest";
+import { createPauseBubble, resolveDurablePauseLabel } from "./pause-bubble";
+import type {
+  AgentWidgetConfig,
+  AgentWidgetDurablePause,
+  AgentWidgetMessage,
+} from "../types";
+
+const makeMessage = (
+  durablePause: Partial<AgentWidgetDurablePause> & { awaitReason: string }
+): AgentWidgetMessage => ({
+  id: "pause-1",
+  role: "assistant",
+  content: "",
+  createdAt: new Date().toISOString(),
+  variant: "pause",
+  streaming: true,
+  durablePause: { resolved: false, ...durablePause },
+});
+
+describe("createPauseBubble", () => {
+  it("renders a passive, non-interactive indicator while paused", () => {
+    const bubble = createPauseBubble(makeMessage({ awaitReason: "crawl_pending" }));
+    expect(bubble.style.display).not.toBe("none");
+    // Passive: no buttons / inputs / resume affordance of any kind.
+    expect(bubble.querySelectorAll("button, input, [role='button']").length).toBe(0);
+    // Announces itself as a live status, not an interactive control.
+    expect(bubble.getAttribute("role")).toBe("status");
+    expect(bubble.getAttribute("data-bubble-type")).toBe("pause");
+  });
+
+  it("uses reason-specific default copy", () => {
+    const crawl = createPauseBubble(makeMessage({ awaitReason: "crawl_pending" }));
+    expect(crawl.textContent).toContain("Fetching pages");
+    const poll = createPauseBubble(makeMessage({ awaitReason: "durable_poll" }));
+    expect(poll.textContent).toContain("background");
+  });
+
+  it("falls back to generic copy for an unknown (forward-compat) reason", () => {
+    const bubble = createPauseBubble(makeMessage({ awaitReason: "some_future_kind" }));
+    expect(bubble.textContent).toContain("Working");
+  });
+
+  it("hides the bubble once the pause is resolved", () => {
+    const bubble = createPauseBubble(
+      makeMessage({ awaitReason: "crawl_pending", resolved: true })
+    );
+    expect(bubble.style.display).toBe("none");
+    expect(bubble.getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("honors config.copy.durablePauseLabels overrides (per-reason and default)", () => {
+    const durablePauseLabels: Record<string, string> = {};
+    durablePauseLabels["crawl_pending"] = "Reading the site…";
+    durablePauseLabels["default"] = "Hang tight…";
+    const config = { copy: { durablePauseLabels } } as AgentWidgetConfig;
+    expect(resolveDurablePauseLabel("crawl_pending", config)).toBe("Reading the site…");
+    expect(resolveDurablePauseLabel("brand_new_reason", config)).toBe("Hang tight…");
+  });
+});

--- a/packages/widget/src/components/pause-bubble.ts
+++ b/packages/widget/src/components/pause-bubble.ts
@@ -1,0 +1,105 @@
+import { createElement } from "../utils/dom";
+import { AgentWidgetConfig, AgentWidgetMessage } from "../types";
+
+/**
+ * Default copy for a passive durable-pause indicator, keyed by the known
+ * `awaitReason` values. Any unknown (forward-compat) reason falls back to the
+ * generic "Working…" label — the suppression of the resume affordance is driven
+ * by the presence of `awaitReason`, never by this map matching.
+ */
+const DEFAULT_PAUSE_LABELS = new Map<string, string>([
+  ["crawl_pending", "Fetching pages…"],
+  ["durable_poll", "Working in the background…"],
+]);
+
+const DEFAULT_PAUSE_LABEL = "Working…";
+
+/**
+ * Resolve the label shown next to the spinner for a durable pause. A consumer
+ * can override per-reason (and the fallback) via `config.copy.durablePauseLabels`.
+ */
+export const resolveDurablePauseLabel = (
+  awaitReason: string,
+  config?: AgentWidgetConfig
+): string => {
+  const overrides = config?.copy?.durablePauseLabels;
+  return (
+    overrides?.[awaitReason] ??
+    DEFAULT_PAUSE_LABELS.get(awaitReason) ??
+    overrides?.["default"] ??
+    DEFAULT_PAUSE_LABEL
+  );
+};
+
+const appendSpinnerDots = (container: HTMLElement): void => {
+  [0, 200, 400].forEach((delay) => {
+    const dot = createElement(
+      "div",
+      "persona-animate-typing persona-rounded-full persona-h-1.5 persona-w-1.5"
+    );
+    dot.style.backgroundColor = "currentColor";
+    dot.style.opacity = "0.45";
+    dot.style.animationDelay = `${delay}ms`;
+    container.appendChild(dot);
+  });
+};
+
+/**
+ * Renders the passive, NON-INTERACTIVE indicator for an auto-resuming durable
+ * pause (variant `"pause"`). There is deliberately no resume / input control:
+ * the server resumes the stream on its own, so this bubble only communicates
+ * "still working" and then disappears once `durablePause.resolved` flips true.
+ */
+export const createPauseBubble = (
+  message: AgentWidgetMessage,
+  config?: AgentWidgetConfig
+): HTMLElement => {
+  const pause = message.durablePause;
+  const bubble = createElement(
+    "div",
+    [
+      "persona-message-bubble",
+      "persona-pause-bubble",
+      "persona-flex",
+      "persona-items-center",
+      "persona-gap-2",
+      "persona-max-w-[85%]",
+      "persona-rounded-2xl",
+      "persona-bg-persona-surface",
+      "persona-border",
+      "persona-border-persona-message-border",
+      "persona-text-persona-muted",
+      "persona-shadow-sm",
+      "persona-px-4",
+      "persona-py-3",
+    ].join(" ")
+  );
+  // id + data attribute for idiomorph matching across re-emits.
+  bubble.id = `bubble-${message.id}`;
+  bubble.setAttribute("data-message-id", message.id);
+  bubble.setAttribute("data-bubble-type", "pause");
+
+  // Once the stream resumes (or the execution completes) the pause has served
+  // its purpose; collapse it so it leaves no trace in the transcript.
+  if (!pause || pause.resolved) {
+    bubble.style.display = "none";
+    bubble.setAttribute("aria-hidden", "true");
+    return bubble;
+  }
+
+  bubble.setAttribute("role", "status");
+  bubble.setAttribute("aria-live", "polite");
+
+  const dots = createElement("div", "persona-flex persona-items-center persona-space-x-1");
+  appendSpinnerDots(dots);
+
+  const label = createElement(
+    "span",
+    "persona-text-xs persona-text-persona-muted persona-tool-loading-pulse"
+  );
+  label.style.setProperty("--persona-tool-anim-duration", "2000ms");
+  label.textContent = resolveDurablePauseLabel(pause.awaitReason, config);
+
+  bubble.append(dots, label);
+  return bubble;
+};

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -5279,6 +5279,14 @@ export type AgentWidgetConfig = {
      * key to an empty string to suppress the notice for that reason.
      */
     stopReasonNotice?: Partial<Record<StopReasonKind, string>>;
+    /**
+     * Label for the passive indicator shown during an auto-resuming durable
+     * pause (variant `"pause"`), keyed by the wire `awaitReason`
+     * (`crawl_pending` / `durable_poll` today; open-ended for fwd-compat). Use
+     * the `"default"` key to override the fallback label for unknown reasons.
+     * Omitted keys fall back to the built-in copy.
+     */
+    durablePauseLabels?: Record<string, string>;
   };
   /**
    * Semantic design tokens (`palette`, `semantic`, `components`).
@@ -5948,7 +5956,45 @@ export type AgentWidgetApproval = {
   resolvedAt?: number;
 };
 
-export type AgentWidgetMessageVariant = "assistant" | "reasoning" | "tool" | "approval";
+export type AgentWidgetMessageVariant =
+  | "assistant"
+  | "reasoning"
+  | "tool"
+  | "approval"
+  | "pause";
+
+/**
+ * Passive state for a message with variant `"pause"` — an auto-resuming durable
+ * pause on the unified `await` event (`awaitReason` present, e.g. `crawl_pending`
+ * or `durable_poll`). Unlike a tool/WebMCP await, the SERVER resumes the same
+ * stream on its own (CrawlPollerDO for crawl, the wait-until Workflow for durable
+ * poll); the client renders a non-interactive "working in the background"
+ * indicator and waits for subsequent frames — it never shows a resume/input
+ * affordance and never auto-fires a resume off this data.
+ *
+ * `awaitReason` is **UX context only, never a control signal**: it decides how to
+ * render, never authorization, gating, or resume logic.
+ */
+export type AgentWidgetDurablePause = {
+  /**
+   * The durable-pause kind from the wire (`crawl_pending` / `durable_poll`
+   * today; open string for forward-compat). Suppression of the resume
+   * affordance is keyed on this being a non-empty string — NOT on an exact
+   * enum match — so a future durable-pause kind suppresses without an SDK
+   * release. Copy may still special-case known kinds.
+   */
+  awaitReason: string;
+  /** Present for `crawl_pending`: the async-crawl id the server is polling. */
+  crawlId?: string;
+  /** Present for `crawl_pending` and `durable_poll`: the paused step id. */
+  stepId?: string;
+  /**
+   * `false` while the execution is paused; flipped to `true` once the stream
+   * resumes (a subsequent content frame) or the execution completes. The UI
+   * stops the active indicator (and hides the bubble) once resolved.
+   */
+  resolved?: boolean;
+};
 
 /**
  * Per-turn / per-step stop reason emitted by the runtime on
@@ -6021,6 +6067,8 @@ export type AgentWidgetMessage = {
   tools?: AgentWidgetToolCall[];
   /** Approval data for messages with variant "approval" */
   approval?: AgentWidgetApproval;
+  /** Durable-pause data for messages with variant "pause" (auto-resuming server pause) */
+  durablePause?: AgentWidgetDurablePause;
   viaVoice?: boolean;
   /**
    * Set to `true` on placeholder messages injected during Runtype voice processing.

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -5993,7 +5993,7 @@ export type AgentWidgetDurablePause = {
    * resumes (a subsequent content frame) or the execution completes. The UI
    * stops the active indicator (and hides the bubble) once resolved.
    */
-  resolved?: boolean;
+  resolved: boolean;
 };
 
 /**

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -109,6 +109,7 @@ import { MessageTransform, MessageActionCallbacks, LoadingIndicatorRenderer } fr
 import { createStandardBubble, createTypingIndicator, getBubbleClasses } from "./components/message-bubble";
 import { createReasoningBubble, reasoningExpansionState, updateReasoningBubbleUI } from "./components/reasoning-bubble";
 import { createToolBubble, toolExpansionState, updateToolBubbleUI } from "./components/tool-bubble";
+import { createPauseBubble } from "./components/pause-bubble";
 import {
   buildStructuredAnswers,
   ensureAskUserQuestionSheet,
@@ -5355,6 +5356,11 @@ export const createAgentExperience = (
         } else if (message.variant === "approval" && message.approval) {
           if (config.approval === false) return;
           bubble = createApprovalBubble(message, config);
+        } else if (message.variant === "pause") {
+          // Passive auto-resuming durable pause (server resumes the stream
+          // itself): a non-interactive "working in the background" indicator
+          // that self-hides once `durablePause.resolved` flips true.
+          bubble = createPauseBubble(message, config);
         } else {
           // Check for custom message renderers in layout config
           const messageLayoutConfig = config.layout?.messages;

--- a/packages/widget/src/utils/__fixtures__/unified-translator.oracle.ts
+++ b/packages/widget/src/utils/__fixtures__/unified-translator.oracle.ts
@@ -290,6 +290,11 @@ class UnifiedEventTranslator {
           awaitedAt: data.awaitedAt,
           origin: data.origin,
           pageOrigin: data.pageOrigin,
+          // Durable-pause discriminator (additive; undefined → dropped by
+          // JSON.stringify). Present iff an auto-resuming pause, not a tool await.
+          awaitReason: data.awaitReason,
+          crawlId: data.crawlId,
+          stepId: data.stepId,
         });
         break;
       case "agent_reflection": {
@@ -416,6 +421,11 @@ class UnifiedEventTranslator {
           awaitedAt: data.awaitedAt,
           origin: data.origin,
           pageOrigin: data.pageOrigin,
+          // Durable-pause discriminator (additive; undefined → dropped by
+          // JSON.stringify). Present iff an auto-resuming pause, not a tool await.
+          awaitReason: data.awaitReason,
+          crawlId: data.crawlId,
+          stepId: data.stepId,
         });
         break;
       case "step_start":
@@ -477,6 +487,11 @@ class UnifiedEventTranslator {
           toolName: data.toolName,
           parameters: data.parameters,
           awaitedAt: data.awaitedAt,
+          // Durable-pause discriminator (additive; undefined → dropped by
+          // JSON.stringify). Present iff an auto-resuming pause, not a tool await.
+          awaitReason: data.awaitReason,
+          crawlId: data.crawlId,
+          stepId: data.stepId,
         });
         break;
 

--- a/packages/widget/src/utils/message-fingerprint.ts
+++ b/packages/widget/src/utils/message-fingerprint.ts
@@ -26,6 +26,7 @@ export type FingerprintableMessage = {
   reasoning?: { chunks?: string[]; status?: string; [key: string]: unknown };
   contentParts?: unknown[];
   stopReason?: string;
+  durablePause?: { awaitReason?: string; resolved?: boolean; [key: string]: unknown };
 };
 
 export type MessageCacheEntry = {
@@ -72,6 +73,8 @@ export function computeMessageFingerprint(
     message.reasoning?.chunks?.[message.reasoning.chunks.length - 1]?.slice(-32) ?? "",
     message.contentParts?.length ?? 0,
     message.stopReason ?? "",
+    message.durablePause?.awaitReason ?? "",
+    message.durablePause?.resolved ? "1" : "0",
     configVersion,
   ].join("\x00");
 }


### PR DESCRIPTION
The unified `await` SSE event can now carry an `awaitReason`. When present, the pause resumes on its own — so the widget shows a passive, non-interactive "working in the background" indicator (new `"pause"` message variant) instead of a resume button, and clears it once the stream continues.

Awaits **without** `awaitReason` (local-tool / WebMCP) keep today's interactive behavior unchanged. Suppression keys on `awaitReason` being present (not a specific value), so future pause kinds work without a release. Indicator copy is overridable via `config.copy.durablePauseLabels`.

### Try it
A new mock-driven demo: **Advanced Examples → Durable Pause** (`apps/web/durable-pause-demo.html`), with a toggle for the two pause kinds. No backend needed.

### Notes
- New unit tests for the event handler and the pause bubble; full widget suite, lint, and typecheck pass.
- Changeset included (minor).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a passive "working in the background" indicator for auto-resuming durable pauses on the unified `await` SSE event. When `awaitReason` is present and non-empty, the widget renders a non-interactive `variant:"pause"` bubble instead of a resume button, and clears it once the stream continues or fails.

- A new `AgentWidgetDurablePause` type and `"pause"` message variant carry the pause state; `resolved` is required (per the prior review thread), and the fingerprint cache is updated so the transition from active → hidden triggers a re-render.
- Settlement is driven by three paths: per-frame early check (any non-ping, non-durable-await frame), `execution_complete`, and a `try/finally` block that clears the bubble on any HTTP/read-layer failure — the latter fixing the network-drop regression flagged in the previous review.
- A mock-driven demo and a unit test suite (including a `pull`-based stream that errors mid-read) cover the happy path, forward-compat unknown reasons, unchanged interactive-await behavior, and the read-layer failure regression.

<h3>Confidence Score: 5/5</h3>

- Safe to merge. The core settlement logic is correct across all exit paths, the prior review's two findings (required `resolved` field, finally-block settle) are both addressed, and the new test suite validates the regression fix directly.
- All three settlement paths (per-frame, execution_complete, stream failure) are exercised by tests and the logic is consistent. The two style-level observations (duplicated guard condition and potential ID collision for sequential pauses in the same execution) are both edge cases with no present misbehavior on the typical single-pause-per-execution path.
- No files require special attention. The two observations in `client.ts` are both in code that handles an uncommon edge (multiple sequential durable pauses in one execution), not the primary path.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/widget/src/client.ts | Core durable-pause logic: adds `durablePauseMessage` state, `settleDurablePause()` helper, per-frame early-settle check (skips `ping`, skips refresh durable-await), and a `try/finally` to clear the bubble on any stream exit. Logic is sound and matches the test suite. |
| packages/widget/src/components/pause-bubble.ts | New passive indicator component. Correctly non-interactive (no buttons/inputs), hides when `resolved`, sets `role="status"` for accessibility, and delegates label resolution to `resolveDurablePauseLabel`. Config override chain is well-ordered. |
| packages/widget/src/types.ts | Adds `AgentWidgetDurablePause` type with required `resolved` field (addressed per prior review thread), new `"pause"` variant, and optional `durablePauseLabels` copy config. Type definitions are clean and well-documented. |
| packages/widget/src/client.test.ts | New test suite covers: known `awaitReason` values, forward-compat unknown reasons, unchanged interactive-tool behavior, stream-resume settlement, and the HTTP read-layer failure regression (using a `pull`-based `ReadableStream` that errors after delivering the await frame). Good coverage. |
| packages/widget/src/utils/message-fingerprint.ts | Adds `awaitReason` and `resolved` to the fingerprint so the cache correctly invalidates when the pause bubble transitions (active → hidden). Both fields are included as distinct segments separated by the `\x00` delimiter. |
| packages/widget/src/utils/__fixtures__/unified-translator.oracle.ts | Propagates `awaitReason`, `crawlId`, and `stepId` through the oracle translator for all three `await`-bearing event types. Additive change; undefined fields are dropped by `JSON.stringify`, so no regression for existing non-durable await frames. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Server as Server (SSE)
    participant Client as client.ts (frame loop)
    participant UI as pause-bubble / UI

    Server->>Client: "await {awaitReason:"crawl_pending", ...}"
    Note over Client: durablePauseMessage created<br/>variant:"pause", resolved:false
    Client->>UI: emitMessage(pause, resolved:false)
    UI-->>UI: show passive indicator

    loop keep-alive
        Server->>Client: ping
        Note over Client: payloadType==="ping" → skip early-settle
    end

    Server->>Client: turn_start (stream resumes)
    Note over Client: payloadType!=="ping" & not durable-await<br/>→ settleDurablePause()
    Client->>UI: emitMessage(pause, resolved:true)
    UI-->>UI: hide bubble (display:none)

    Server->>Client: text_delta / text_complete
    Client->>UI: emitMessage(assistantMessage)
    UI-->>UI: render resumed text

    Server->>Client: execution_complete
    Note over Client: finally block → settleDurablePause() (no-op)
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address Greptile findings"](https://github.com/runtypelabs/persona/commit/002745b64523b63f8acd74b12e4628397b359802) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40400525)</sub>

<!-- /greptile_comment -->