### PR TITLE
Remove launch-day Product Hunt call-out from homepage hero

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -101,11 +101,6 @@
               aria-label="Copy Persona npm install command"
             ><span data-copy-label>Copy</span></button>
           </div>
-          <a class="hero-producthunt" href="https://www.producthunt.com/products/persona-12?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-persona-4fac23c1-5535-49b7-9aaa-e945f43a2edc" target="_blank" rel="noopener noreferrer" aria-label="Persona is live on Product Hunt today — give us an upvote">
-            <span class="hero-producthunt-pulse" aria-hidden="true"></span>
-            <span class="hero-producthunt-copy">We're live on Product Hunt today — your upvote means the world</span>
-            <img class="hero-producthunt-badge" alt="Persona - Add WebMCP-native AI chat to any Frontend | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1178202&amp;theme=light&amp;t=1782622272480">
-          </a>
         </section>
 
         <!-- Framework / platform logo strip -->

--- a/apps/web/src/home.css
+++ b/apps/web/src/home.css
@@ -429,66 +429,6 @@ section[id], aside[id] {
   color: var(--ink);
 }
 
-/* Launch-day Product Hunt call-out -------------------------------------------------- */
-.hero-producthunt {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  flex-wrap: wrap;
-  max-width: 620px;
-  margin-top: 2px;
-  padding: 14px 18px;
-  background: var(--paper-high);
-  border: 1px solid var(--ink);
-  box-shadow: 6px 6px 0 var(--teal-dim);
-  text-decoration: none;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.hero-producthunt:hover {
-  transform: translate(-2px, -2px);
-  box-shadow: 8px 8px 0 var(--teal-dim);
-}
-
-.hero-producthunt-pulse {
-  position: relative;
-  flex: none;
-  width: 11px;
-  height: 11px;
-  border-radius: 50%;
-  background: #da552f;
-  box-shadow: 0 0 0 0 rgba(218, 85, 47, 0.6);
-  animation: hero-producthunt-pulse 1.8s ease-out infinite;
-}
-
-@keyframes hero-producthunt-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(218, 85, 47, 0.55); }
-  70% { box-shadow: 0 0 0 12px rgba(218, 85, 47, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(218, 85, 47, 0); }
-}
-
-.hero-producthunt-copy {
-  flex: 1;
-  min-width: 200px;
-  font-family: var(--font-mono);
-  font-size: 13px;
-  font-weight: 500;
-  letter-spacing: 0.04em;
-  line-height: 1.4;
-  color: var(--ink);
-}
-
-.hero-producthunt-badge {
-  flex: none;
-  display: block;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .hero-producthunt-pulse {
-    animation: none;
-  }
-}
-
 /* Framework / platform logo strip ----------------------------------------------- */
 
 .stack-strip {


### PR DESCRIPTION
Removes the Product Hunt badge added in #348 now that launch day is over. Reverts the hero call-out markup in `apps/web/index.html` and its styles in `apps/web/src/home.css`.

No changeset needed — `apps/web` only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Removes the temporary Product Hunt launch-day call-out that was introduced in #348. Both the HTML anchor block and its companion CSS rules are deleted in full.

- `apps/web/index.html`: the `.hero-producthunt` anchor (badge image, pulse dot, copy text) is removed from the hero section, leaving the install-row as the last child of `<section class="hero">`.
- `apps/web/src/home.css`: all six rule-sets added for the launch banner (`.hero-producthunt`, `:hover`, `.hero-producthunt-pulse`, `@keyframes hero-producthunt-pulse`, `.hero-producthunt-copy`, `.hero-producthunt-badge`, and the `prefers-reduced-motion` override) are deleted cleanly.

<h3>Confidence Score: 5/5</h3>

Straightforward cleanup — removes a temporary promotional element and all its associated styles, leaving the hero section clean and functional.

The change is a complete, symmetrical removal: every HTML node added in #348 is deleted from `index.html` and every corresponding CSS rule is deleted from `home.css`. No classes are referenced that still have styles, no styles are left that reference removed classes, and the surrounding markup is structurally intact.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/index.html | Removes the `.hero-producthunt` anchor element (5 lines); surrounding hero markup is untouched and well-formed. |
| apps/web/src/home.css | Deletes all 66 lines of launch-day CSS (selectors, keyframe animation, reduced-motion override); no orphaned rules remain. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Hero Section] --> B[h1 .hero-display]
    A --> C[p .hero-sub]
    A --> D[div .hero-install-row]
    D --> D1[code npm install command]
    D --> D2[button .hero-copy-btn]
    E[REMOVED: a .hero-producthunt] -. was child of A .-> A
    E --> E1[span .hero-producthunt-pulse]
    E --> E2[span .hero-producthunt-copy]
    E --> E3[img .hero-producthunt-badge]
    style E fill:#f8d7da,stroke:#dc3545,color:#721c24
    style E1 fill:#f8d7da,stroke:#dc3545,color:#721c24
    style E2 fill:#f8d7da,stroke:#dc3545,color:#721c24
    style E3 fill:#f8d7da,stroke:#dc3545,color:#721c24
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Hero Section] --> B[h1 .hero-display]
    A --> C[p .hero-sub]
    A --> D[div .hero-install-row]
    D --> D1[code npm install command]
    D --> D2[button .hero-copy-btn]
    E[REMOVED: a .hero-producthunt] -. was child of A .-> A
    E --> E1[span .hero-producthunt-pulse]
    E --> E2[span .hero-producthunt-copy]
    E --> E3[img .hero-producthunt-badge]
    style E fill:#f8d7da,stroke:#dc3545,color:#721c24
    style E1 fill:#f8d7da,stroke:#dc3545,color:#721c24
    style E2 fill:#f8d7da,stroke:#dc3545,color:#721c24
    style E3 fill:#f8d7da,stroke:#dc3545,color:#721c24
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Revert &quot;feat(web): add launch-day Produc..."](https://github.com/runtypelabs/persona/commit/d711f9f27995ee944b6405227cb265b18f3a0312) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40431881)</sub>

<!-- /greptile_comment -->