### PR TITLE
chore: upgrade to pnpm 11

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -30,8 +30,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -71,8 +69,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -20,5 +20,6 @@
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
     "concurrently": "^8.2.2"
-  }
+  },
+  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3249,7 +3249,7 @@ packages:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jspaint@https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666:
-    resolution: {tarball: https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666}
     version: 1.1.0
     hasBin: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,7 @@ packages:
   - packages/*
   - apps/*
   - examples/*
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## What does this PR do?

Upgrades the repo tooling to pnpm 11:

- pins the root package manager to `pnpm@11.9.0`
- removes duplicated `pnpm/action-setup` version pins so CI uses the root `packageManager` version
- refreshes pnpm 11 lockfile metadata
- records approved install-time builds for `esbuild`, `sharp`, and `workerd` so clean pnpm 11 installs pass

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Tooling / CI

## Checklist

- [x] `pnpm install --frozen-lockfile` passes
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run`)
- [x] Changeset not required: tooling / CI only, no published package source changes
- [x] Docs updated if I changed public API or behavior: not applicable

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades repository tooling to pnpm 11. The main changes are:

- Pins the root package manager to `pnpm@11.9.0` with integrity metadata.
- Lets GitHub Actions resolve pnpm from the root `packageManager` field.
- Refreshes pnpm lockfile metadata for the GitHub-hosted `jspaint` dependency.
- Adds approved install-time builds for `esbuild`, `sharp`, and `workerd`.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are limited to package-manager metadata and CI workflow setup. The omitted pnpm action version is supported when `packageManager` is present.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Observed that the base environment had no packageManager and the isolated pnpm install failed with ERR\_PNPM\_IGNORED\_BUILDS for esbuild, sharp, and workerd.
- Observed that the head environment now includes packageManager pnpm@11.9.0+sha512..., Corepack resolves to pnpm 11.9.0, pnpm-workspace.yaml specifies allowBuilds for esbuild, sharp, and workerd, and the isolated install succeeds with install/postinstall scripts executed.
- Checked the pre-change GitHub Actions PNPM setup; the log shows packageManager absent and every pnpm/action-setup@v4 step set with.version: 10, resolving major 10.
- Checked the post-change GitHub Actions PNPM setup; the log shows packageManager pnpm@11.9.0+sha512... and each pnpm/action-setup@v4 step has no explicit version, resolving major 11 from packageManager.
- Collected log artifacts documenting both pre-change and post-change states to support review.

<a href="https://app.greptile.com/trex/runs/13003498/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/bundle-size.yml | Removes the explicit pnpm 10 setup so the action can resolve the pinned `packageManager` version before bundle-size checks. |
| .github/workflows/ci.yml | Updates CI pnpm setup to rely on the root `packageManager` pin for installs, builds, linting, typechecking, and tests. |
| .github/workflows/r2-release.yml | Updates the manual R2 release workflow to use the repository-pinned pnpm version during dependency installation and widget build. |
| .github/workflows/release.yml | Updates both release jobs to use the repository-pinned pnpm version for publish and CDN upload paths. |
| package.json | Adds the root `packageManager` field pinning pnpm 11.9.0 with integrity metadata. |
| pnpm-lock.yaml | Refreshes pnpm lockfile metadata for the GitHub-hosted `jspaint` dependency without changing resolved package versions. |
| pnpm-workspace.yaml | Adds pnpm 11 approved install-time builds for `esbuild`, `sharp`, and `workerd`. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Workflow as GitHub Actions workflow
participant Setup as pnpm/action-setup@v4
participant Package as package.json
participant Workspace as pnpm-workspace.yaml
participant Install as pnpm install --frozen-lockfile

Workflow->>Setup: Run Setup pnpm without explicit version
Setup->>Package: Read packageManager pin
Package-->>Setup: "pnpm@11.9.0 + integrity"
Workflow->>Install: Install dependencies
Install->>Workspace: Read allowBuilds approvals
Workspace-->>Install: esbuild, sharp, workerd allowed
Install-->>Workflow: Frozen install completes with pnpm 11 metadata
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Workflow as GitHub Actions workflow
participant Setup as pnpm/action-setup@v4
participant Package as package.json
participant Workspace as pnpm-workspace.yaml
participant Install as pnpm install --frozen-lockfile

Workflow->>Setup: Run Setup pnpm without explicit version
Setup->>Package: Read packageManager pin
Package-->>Setup: "pnpm@11.9.0 + integrity"
Workflow->>Install: Install dependencies
Install->>Workspace: Read allowBuilds approvals
Workspace-->>Install: esbuild, sharp, workerd allowed
Install-->>Workflow: Frozen install completes with pnpm 11 metadata
```

</a>

<sub>Reviews (1): Last reviewed commit: ["chore: upgrade to pnpm 11"](https://github.com/runtypelabs/persona/commit/b75ed8a54241e0d48af97c3de20dabe443ddf96a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41261444)</sub>

<!-- /greptile_comment -->