### PR TITLE
Show LiteRT model load error in chat

### DIFF
--- a/apps/web/src/litert-slides/main.ts
+++ b/apps/web/src/litert-slides/main.ts
@@ -36,6 +36,8 @@ initializeWebMCPPolyfill();
 // `${API_PATH}/resume`) from the in-browser model. Kept off `/api/...` so the
 // Vite dev proxy never tries to forward it.
 const API_PATH = "/litert/slides/dispatch";
+const MODEL_NOT_READY_CHAT_ERROR =
+  "The on-device model is not ready yet. Pick a model in the toolbar, press Load model, and wait for the ready status before asking the Copilot to edit the deck.";
 
 const store = new DeckStore(createSeedDeck);
 
@@ -214,6 +216,20 @@ if (dockTarget) {
       ...DEFAULT_WIDGET_CONFIG,
       // The engine answers this path from the in-browser model (no network).
       apiUrl: API_PATH,
+      // The fetch patch in ./litert-engine handles the fake dispatch/resume
+      // routes. This early dispatch guard is demo UX: the widget only paints an
+      // assistant fallback bubble when dispatch rejects before an SSE stream
+      // starts, so fail fast here when the user chats before loading Gemma.
+      customFetch: async (url, init) => {
+        if (!engine.isLoaded()) {
+          throw new Error(MODEL_NOT_READY_CHAT_ERROR);
+        }
+        return fetch(url, init);
+      },
+      errorMessage: (error) =>
+        error.message === MODEL_NOT_READY_CHAT_ERROR
+          ? MODEL_NOT_READY_CHAT_ERROR
+          : `Sorry — the on-device Copilot hit an error.\n\n_Details: ${error.message}_`,
       storageAdapter: createLocalStorageAdapter("persona-state-litert-slides"),
       postprocessMessage: ({ text }) => markdownPostprocessor(text),
       colorScheme: "light",


### PR DESCRIPTION
## Summary
- show a friendly in-chat Persona error when the LiteRT slides Copilot is used before Gemma is loaded
- guard the demo dispatch with `customFetch` so the widget renders its assistant fallback bubble before any SSE stream starts
- customize the demo fallback copy for on-device model readiness errors

## Validation
- `git diff --check`
- `pnpm --filter web build`

## Changeset
- Not needed: app/demo-only change under `apps/web`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a friendly in-chat error for the LiteRT slides Copilot when the on-device model is not ready. The main changes are:

- A shared model-not-ready error message for chat fallback copy.
- A `customFetch` guard that rejects dispatch before the LiteRT engine is loaded.
- A custom `errorMessage` handler for readiness errors and generic on-device Copilot failures.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing the readiness guard.

The change is isolated to the LiteRT demo widget configuration. One contained bug lets chat dispatch during warm-up instead of showing the intended fallback.

`apps/web/src/litert-slides/main.ts`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced a readiness-window harness to verify engine creation ordering and mid-warm-up behavior, confirming Engine.create assigns the engine before warmUp/loadModel completes and that the dispatch guard can proceed mid-warm-up.
- Observed before/after Copilot UI readiness copy in the panel, showing the base state without the customized not-ready fallback and the head state with the customized copy present.

<a href="https://app.greptile.com/trex/runs/13020249/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=2"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/litert-slides/main.ts | Adds a pre-dispatch fallback for unloaded LiteRT models, but the guard uses engine-loaded state rather than full UI readiness after warm-up. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant Widget as Persona widget
participant Guard as customFetch guard
participant Engine as LiteRT engine
participant Chat as In-chat fallback

User->>Widget: Send Copilot message
Widget->>Guard: POST /litert/slides/dispatch
Guard->>Engine: isLoaded()
alt Engine not loaded
Guard-->>Widget: throw MODEL_NOT_READY_CHAT_ERROR
Widget->>Chat: Render friendly assistant fallback
else Engine loaded
Guard->>Engine: fetch dispatch route
Engine-->>Widget: SSE response
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant Widget as Persona widget
participant Guard as customFetch guard
participant Engine as LiteRT engine
participant Chat as In-chat fallback

User->>Widget: Send Copilot message
Widget->>Guard: POST /litert/slides/dispatch
Guard->>Engine: isLoaded()
alt Engine not loaded
Guard-->>Widget: throw MODEL_NOT_READY_CHAT_ERROR
Widget->>Chat: Render friendly assistant fallback
else Engine loaded
Guard->>Engine: fetch dispatch route
Engine-->>Widget: SSE response
end
```

</a>

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flitert-slides%2Fmain.ts%3A224-225%0A**Guard%20full%20readiness**%0A%60engine.isLoaded%28%29%60%20becomes%20true%20when%20%60litert-engine.ts%60%20assigns%20%60engine%60%20after%20%60Engine.create%60%2C%20but%20%60loadSelectedModel%28%29%60%20does%20not%20show%20the%20ready%20status%20until%20%60await%20engine.loadModel%28modelId%29%60%20also%20finishes%20warm-up.%20During%20that%20warm-up%20window%2C%20this%20guard%20lets%20chat%20dispatch%20start%20instead%20of%20showing%20the%20fallback%20bubble%2C%20even%20though%20the%20new%20copy%20tells%20users%20to%20wait%20for%20ready.%20Track%20readiness%20after%20%60loadModel%28%29%60%20resolves%2C%20or%20expose%20a%20ready%20state%20from%20the%20engine.%0A%0A&repo=runtypelabs%2Fpersona&pr=357&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22codex%2Flitert-model-not-ready-error%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22codex%2Flitert-model-not-ready-error%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flitert-slides%2Fmain.ts%3A224-225%0A**Guard%20full%20readiness**%0A%60engine.isLoaded%28%29%60%20becomes%20true%20when%20%60litert-engine.ts%60%20assigns%20%60engine%60%20after%20%60Engine.create%60%2C%20but%20%60loadSelectedModel%28%29%60%20does%20not%20show%20the%20ready%20status%20until%20%60await%20engine.loadModel%28modelId%29%60%20also%20finishes%20warm-up.%20During%20that%20warm-up%20window%2C%20this%20guard%20lets%20chat%20dispatch%20start%20instead%20of%20showing%20the%20fallback%20bubble%2C%20even%20though%20the%20new%20copy%20tells%20users%20to%20wait%20for%20ready.%20Track%20readiness%20after%20%60loadModel%28%29%60%20resolves%2C%20or%20expose%20a%20ready%20state%20from%20the%20engine.%0A%0A&repo=runtypelabs%2Fpersona&pr=357&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=4"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flitert-slides%2Fmain.ts%3A224-225%0A**Guard%20full%20readiness**%0A%60engine.isLoaded%28%29%60%20becomes%20true%20when%20%60litert-engine.ts%60%20assigns%20%60engine%60%20after%20%60Engine.create%60%2C%20but%20%60loadSelectedModel%28%29%60%20does%20not%20show%20the%20ready%20status%20until%20%60await%20engine.loadModel%28modelId%29%60%20also%20finishes%20warm-up.%20During%20that%20warm-up%20window%2C%20this%20guard%20lets%20chat%20dispatch%20start%20instead%20of%20showing%20the%20fallback%20bubble%2C%20even%20though%20the%20new%20copy%20tells%20users%20to%20wait%20for%20ready.%20Track%20readiness%20after%20%60loadModel%28%29%60%20resolves%2C%20or%20expose%20a%20ready%20state%20from%20the%20engine.%0A%0A&pr=357&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=4"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["Show LiteRT model load error in chat"](https://github.com/runtypelabs/persona/commit/c19c93cf76dbc3b6a7bb246dfbe4bfef761c4804) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41291835)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->