### PR TITLE
Fix artifact pane first-render markdown race on the CDN build

### DIFF
--- a/.changeset/artifact-pane-parser-ready-rerender.md
+++ b/.changeset/artifact-pane-parser-ready-rerender.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix artifacts upserted immediately after init rendering as escaped plain text on the CDN build: the artifact pane now re-renders once the lazy markdown-parsers chunk loads (previously it stayed escaped until a tab switch), and no longer double-escapes the fallback through the sanitizer. Also export `loadMarkdownParsers` from the public API so hosts can await parser readiness before injecting content.

--- a/packages/widget/src/components/artifact-pane.test.ts
+++ b/packages/widget/src/components/artifact-pane.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { createArtifactPane } from "./artifact-pane";
+import * as parsersLoader from "../markdown-parsers-loader";
+import type { AgentWidgetConfig, PersonaArtifactRecord } from "../types";
+
+/**
+ * Regression tests for the parser-ready race in the artifact pane.
+ *
+ * In the IIFE/CDN build, `marked` + `DOMPurify` load lazily. An artifact
+ * upserted right after `initAgentWidget()` used to render as escaped plain
+ * text (literal `# Welcome`, `**bold**`) — and stayed that way until a tab
+ * switch forced a re-render, because unlike chat messages (which self-heal via
+ * the parser-ready re-render in `createAgentExperience`), the pane only
+ * re-renders on `update()`. Worse, the default sanitizer's own degraded
+ * fallback is `escapeHtml`, so the old blanket `sanitize(md(text))` escaped
+ * twice and displayed literal entities (`&quot;`).
+ *
+ * `vitest.setup.ts` eager-provides parsers, so `getMarkdownParsersSync()` is
+ * non-null by default -> that's the "loaded" path. The degraded path is
+ * simulated by spying on the loader module (same approach as
+ * ui.postprocess.test.ts).
+ */
+
+const MARKDOWN = '# Welcome\n\n**bold** "quoted"';
+
+const artifact = (markdown: string): PersonaArtifactRecord => ({
+  id: "a1",
+  artifactType: "markdown",
+  title: "Doc",
+  status: "complete",
+  markdown,
+});
+
+const createPane = () => {
+  const config: AgentWidgetConfig = { markdown: {} };
+  const pane = createArtifactPane(config, { onSelect: () => {} });
+  const content = pane.element.querySelector(".persona-artifact-content") as HTMLElement;
+  return { pane, content };
+};
+
+beforeAll(() => {
+  // jsdom has no matchMedia; the pane's mobile-drawer layout check needs it.
+  window.matchMedia = (query: string) =>
+    ({ matches: false, media: query }) as MediaQueryList;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("artifact pane parser-ready self-heal (parsers not loaded at first render)", () => {
+  it("renders the escaped fallback exactly once, then re-renders as markdown when the chunk lands", async () => {
+    let resolveLoad!: (mod: parsersLoader.MarkdownParsersModule) => void;
+    const loadPromise = new Promise<parsersLoader.MarkdownParsersModule>((resolve) => {
+      resolveLoad = resolve;
+    });
+    const syncSpy = vi
+      .spyOn(parsersLoader, "getMarkdownParsersSync")
+      .mockReturnValue(null);
+    const loadSpy = vi
+      .spyOn(parsersLoader, "loadMarkdownParsers")
+      .mockReturnValue(loadPromise);
+
+    const { pane, content } = createPane();
+    pane.update({ artifacts: [artifact(MARKDOWN)], selectedId: "a1" });
+
+    // Degraded first paint: escaped plain text, no markdown elements.
+    expect(content.querySelector("h1")).toBeNull();
+    expect(content.textContent).toContain("# Welcome");
+    expect(content.textContent).toContain("**bold**");
+    // Escaped exactly once: a double escape would leave a literal `&quot;`
+    // in the visible text instead of the quote character.
+    expect(content.textContent).toContain('"quoted"');
+    expect(content.textContent).not.toContain("&quot;");
+
+    // A second render while the chunk is still loading must not re-schedule.
+    pane.update({ artifacts: [artifact(MARKDOWN)], selectedId: "a1" });
+    expect(loadSpy).toHaveBeenCalledTimes(1);
+
+    // Chunk lands: the real getMarkdownParsersSync now returns the parsers
+    // eager-provided by vitest.setup.ts.
+    syncSpy.mockRestore();
+    resolveLoad(parsersLoader.getMarkdownParsersSync()!);
+    await loadPromise;
+    await Promise.resolve(); // let the scheduled .then(render) run
+
+    // Self-healed: real markdown without any user interaction.
+    expect(content.querySelector("h1")?.textContent).toBe("Welcome");
+    expect(content.querySelector("strong")?.textContent).toBe("bold");
+    expect(content.textContent).not.toContain("**bold**");
+  });
+
+  it("does not schedule a re-render when parsers are already loaded", () => {
+    const loadSpy = vi.spyOn(parsersLoader, "loadMarkdownParsers");
+
+    const { pane, content } = createPane();
+    pane.update({ artifacts: [artifact(MARKDOWN)], selectedId: "a1" });
+
+    expect(content.querySelector("h1")?.textContent).toBe("Welcome");
+    expect(loadSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/widget/src/components/artifact-pane.ts
+++ b/packages/widget/src/components/artifact-pane.ts
@@ -1,6 +1,7 @@
 import { createElement } from "../utils/dom";
 import type { AgentWidgetConfig, AgentWidgetMessage, PersonaArtifactRecord } from "../types";
 import { escapeHtml, createMarkdownProcessorFromConfig } from "../postprocessors";
+import { getMarkdownParsersSync, loadMarkdownParsers } from "../markdown-parsers-loader";
 import { resolveSanitizer } from "../utils/sanitize";
 import { componentRegistry, type ComponentContext } from "./registry";
 import { renderLucideIcon } from "../utils/icons";
@@ -47,9 +48,29 @@ export function createArtifactPane(
 
   const md = config.markdown ? createMarkdownProcessorFromConfig(config.markdown) : null;
   const sanitize = resolveSanitizer(config.sanitize);
+  // Degraded path (IIFE/CDN build before the `markdown-parsers.js` chunk
+  // resolves): the markdown processor falls back to escapeHtml, and the default
+  // sanitizer's own fallback is escapeHtml too, so sanitizing that output would
+  // escape a SECOND time and display literal entities (mirrors
+  // `buildPostprocessor` in ui.ts). Chat messages self-heal via the
+  // parser-ready re-render at the end of createAgentExperience, but this pane
+  // only re-renders on update()/user interaction — so an artifact upserted
+  // right after init would stay escaped until a tab switch. When a render takes
+  // the fallback, schedule exactly one re-render for when the chunk lands.
+  let parserRerenderScheduled = false;
   const toHtml = (text: string) => {
+    const parsersReady = getMarkdownParsersSync() !== null;
+    if (md && !parsersReady && !parserRerenderScheduled) {
+      parserRerenderScheduled = true;
+      loadMarkdownParsers()
+        .then(() => render())
+        .catch(() => {
+          /* chunk failed to load (e.g. ad blocker): keep the escaped fallback */
+        });
+    }
     const raw = md ? md(text) : escapeHtml(text);
-    return sanitize ? sanitize(raw) : raw;
+    // escapeHtml output is already inert — only real markdown HTML is sanitized.
+    return md && parsersReady && sanitize ? sanitize(raw) : raw;
   };
 
   const backdrop =

--- a/packages/widget/src/index-core.ts
+++ b/packages/widget/src/index-core.ts
@@ -188,6 +188,12 @@ export {
   createDirectivePostprocessor
 } from "./postprocessors";
 export type { MarkdownProcessorOptions } from "./postprocessors";
+// Escape hatch for the IIFE/CDN build's lazy markdown chunk: hosts that inject
+// content immediately after init can `await AgentWidget.loadMarkdownParsers()`
+// to guarantee real markdown rendering on first paint. Resolves instantly on
+// the npm build (parsers are bundled eagerly).
+export { loadMarkdownParsers } from "./markdown-parsers-loader";
+export type { MarkdownParsersModule } from "./markdown-parsers-loader";
 export {
   createDefaultSanitizer,
   resolveSanitizer


### PR DESCRIPTION
## Summary

An artifact upserted immediately after `initAgentWidget()` (via `handle.upsertArtifact({ artifactType: "markdown", ... })`) rendered as HTML-escaped plain text — literal `# Welcome`, `**bold**`, `&quot;` — and only recovered after switching artifact tabs, which forced a re-render.

Two layers to the bug, both specific to the IIFE/CDN build where `marked` + `DOMPurify` load lazily from the `markdown-parsers.js` chunk:

1. **No parser-ready re-render.** `createMarkdownProcessor()` falls back to `escapeHtml` until the chunk resolves. Chat messages self-heal via the `loadMarkdownParsers().then(...)` re-render at the end of `createAgentExperience`, but the artifact pane only re-renders on `update()` — so an early-upserted artifact stayed escaped.
2. **Double escape.** The default sanitizer's degraded fallback is *also* `escapeHtml`, so the pane's `sanitize(md(text))` escaped twice, displaying literal entities (`&quot;`). `ui.ts` already guards this with its `sanitize && parsersReady` gate; the pane didn't.

## Fix

Mirrors the established chat-message pattern in `ui.ts`:

- `artifact-pane.ts`: when `toHtml` takes the escape fallback, schedule exactly one `loadMarkdownParsers().then(() => render())` (flag-guarded against double-scheduling; a failed chunk load keeps the escaped fallback). Skip the sanitizer on fallback output — `escapeHtml` output is already inert.
- `index-core.ts`: export `loadMarkdownParsers` (+ `MarkdownParsersModule` type) from the public API / global bundle as an escape hatch, so hosts that inject content right after init can `await AgentWidget.loadMarkdownParsers()`. Resolves instantly on the npm build.

## Testing

- New `components/artifact-pane.test.ts`: degraded first paint is escaped exactly once (regression-asserts no literal `&quot;`), a second render doesn't re-schedule the load, resolving the chunk self-heals to real `<h1>`/`<strong>` with no interaction, and the loaded path never schedules.
- Full widget suite (1356 tests), lint, `tsc --noEmit`, and `pnpm build` all green; verified `loadMarkdownParsers` lands in `dist/index.d.ts`, `dist/index.global.js`, and the CJS build.
- Changeset included (patch).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the artifact pane markdown first-render race in the CDN build. The main changes are:

- Adds parser-ready re-rendering for markdown artifacts.
- Avoids sanitizing the escaped markdown fallback twice.
- Exports `loadMarkdownParsers` from the public widget API.
- Adds tests for fallback rendering and parser-ready recovery.
- Adds a patch changeset.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/widget/src/components/artifact-pane.ts | Adds lazy markdown parser readiness checks and a one-time artifact-pane re-render after parser load. |
| packages/widget/src/index-core.ts | Exports `loadMarkdownParsers` and its module type through the public entry point. |
| packages/widget/src/components/artifact-pane.test.ts | Adds tests for degraded first paint, single scheduling, self-healing render, and already-loaded parsers. |
| .changeset/artifact-pane-parser-ready-rerender.md | Adds a patch changeset for the artifact-pane markdown rendering fix. |

<sub>Reviews (1): Last reviewed commit: ["Fix artifact pane first-render markdown ..."](https://github.com/runtypelabs/persona/commit/8b3f90be77984be70f4394108ce038a2523a286a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42536346)</sub>

<!-- /greptile_comment -->