### PR TITLE
Centralize markdown parser-ready self-heal in a shared registry

### DIFF
--- a/.changeset/markdown-parsers-ready-registry.md
+++ b/.changeset/markdown-parsers-ready-registry.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix first-render markdown race for content rendered before the lazy `markdown-parsers.js` chunk loads (IIFE/CDN build). Both chat messages and the artifact pane now self-heal through a single shared `onMarkdownParsersReady` registry instead of each render surface wiring its own parser-ready re-render, so an artifact upserted right after `initAgentWidget()` no longer renders as escaped plain text (or double-escaped entities) until a tab switch. Exposes `loadMarkdownParsers` / `onMarkdownParsersReady` on the public API as a host escape hatch.

--- a/packages/widget/src/components/artifact-pane.test.ts
+++ b/packages/widget/src/components/artifact-pane.test.ts
@@ -94,6 +94,28 @@ describe("artifact pane parser-ready self-heal (parsers not loaded at first rend
     expect(content.textContent).not.toContain("**bold**");
   });
 
+  it("destroy() unsubscribes so a late chunk resolution can't re-render the torn-down pane", () => {
+    vi.spyOn(parsersLoader, "getMarkdownParsersSync").mockReturnValue(null);
+    let readyCb: (() => void) | undefined;
+    const unsubscribe = vi.fn();
+    vi.spyOn(parsersLoader, "onMarkdownParsersReady").mockImplementation((cb) => {
+      readyCb = cb;
+      return unsubscribe;
+    });
+
+    const { pane, content } = createPane();
+    pane.update({ artifacts: [artifact(MARKDOWN)], selectedId: "a1" });
+
+    pane.destroy();
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+    // Even if a stale event still fires the captured callback, the escaped
+    // fallback stands — nothing re-renders into the detached pane as markdown.
+    readyCb?.();
+    expect(content.querySelector("h1")).toBeNull();
+    expect(content.textContent).toContain("# Welcome");
+  });
+
   it("renders markdown directly when parsers are already loaded", () => {
     // No getMarkdownParsersSync spy: the eager-provided bundle is live.
     const { pane, content } = createPane();

--- a/packages/widget/src/components/artifact-pane.test.ts
+++ b/packages/widget/src/components/artifact-pane.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+import { createArtifactPane } from "./artifact-pane";
+import * as parsersLoader from "../markdown-parsers-loader";
+import type { AgentWidgetConfig, PersonaArtifactRecord } from "../types";
+
+/**
+ * Regression tests for the parser-ready race in the artifact pane.
+ *
+ * In the IIFE/CDN build, `marked` + `DOMPurify` load lazily. An artifact
+ * upserted right after `initAgentWidget()` used to render as escaped plain
+ * text (literal `# Welcome`, `**bold**`) — and stayed that way until a tab
+ * switch forced a re-render, because unlike chat messages (which self-heal via
+ * the parser-ready re-render in `createAgentExperience`), the pane only
+ * re-renders on `update()`. Worse, the default sanitizer's own degraded
+ * fallback is `escapeHtml`, so the old blanket `sanitize(md(text))` escaped
+ * twice and displayed literal entities (`&quot;`).
+ *
+ * The pane now shares the centralized `onMarkdownParsersReady` registry (same
+ * hook chat messages use). These tests spy on the loader module to (a) simulate
+ * the degraded "parsers not loaded" first paint via `getMarkdownParsersSync`,
+ * and (b) capture the subscription callback the pane registers, then invoke it
+ * to prove the pane self-heals when the chunk lands. `vitest.setup.ts`
+ * eager-provides parsers, so the un-spied `getMarkdownParsersSync()` returns the
+ * real bundle — that's the "loaded" path.
+ */
+
+const MARKDOWN = '# Welcome\n\n**bold** "quoted"';
+
+const artifact = (markdown: string): PersonaArtifactRecord => ({
+  id: "a1",
+  artifactType: "markdown",
+  title: "Doc",
+  status: "complete",
+  markdown,
+});
+
+const createPane = () => {
+  const config: AgentWidgetConfig = { markdown: {} };
+  const pane = createArtifactPane(config, { onSelect: () => {} });
+  const content = pane.element.querySelector(".persona-artifact-content") as HTMLElement;
+  return { pane, content };
+};
+
+beforeAll(() => {
+  // jsdom has no matchMedia; the pane's mobile-drawer layout check needs it.
+  window.matchMedia = (query: string) =>
+    ({ matches: false, media: query }) as MediaQueryList;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("artifact pane parser-ready self-heal (parsers not loaded at first render)", () => {
+  it("renders the escaped fallback once, then self-heals to markdown when the registry fires", async () => {
+    const syncSpy = vi
+      .spyOn(parsersLoader, "getMarkdownParsersSync")
+      .mockReturnValue(null);
+    // Capture the callback the pane registers with the shared registry.
+    let readyCb: (() => void) | undefined;
+    const readySpy = vi
+      .spyOn(parsersLoader, "onMarkdownParsersReady")
+      .mockImplementation((cb) => {
+        readyCb = cb;
+        return () => {};
+      });
+
+    const { pane, content } = createPane();
+    // The pane must subscribe exactly once, at creation.
+    expect(readySpy).toHaveBeenCalledTimes(1);
+
+    pane.update({ artifacts: [artifact(MARKDOWN)], selectedId: "a1" });
+
+    // Degraded first paint: escaped plain text, no markdown elements.
+    expect(content.querySelector("h1")).toBeNull();
+    expect(content.textContent).toContain("# Welcome");
+    expect(content.textContent).toContain("**bold**");
+    // Escaped exactly once: a double escape would leave a literal `&quot;`
+    // in the visible text instead of the quote character.
+    expect(content.textContent).toContain('"quoted"');
+    expect(content.textContent).not.toContain("&quot;");
+
+    // Chunk lands: parsers become available and the registry fires the pane's
+    // subscription — no `update()`/user interaction.
+    syncSpy.mockRestore();
+    readyCb?.();
+    await Promise.resolve();
+
+    expect(content.querySelector("h1")?.textContent).toBe("Welcome");
+    expect(content.querySelector("strong")?.textContent).toBe("bold");
+    expect(content.textContent).not.toContain("**bold**");
+  });
+
+  it("renders markdown directly when parsers are already loaded", () => {
+    // No getMarkdownParsersSync spy: the eager-provided bundle is live.
+    const { pane, content } = createPane();
+    pane.update({ artifacts: [artifact(MARKDOWN)], selectedId: "a1" });
+
+    expect(content.querySelector("h1")?.textContent).toBe("Welcome");
+    expect(content.querySelector("strong")?.textContent).toBe("bold");
+    // Single-escaped, sanitized real markdown — no literal entities.
+    expect(content.textContent).not.toContain("&quot;");
+  });
+});

--- a/packages/widget/src/components/artifact-pane.ts
+++ b/packages/widget/src/components/artifact-pane.ts
@@ -14,6 +14,8 @@ export type ArtifactPaneApi = {
   backdrop: HTMLElement | null;
   update: (state: { artifacts: PersonaArtifactRecord[]; selectedId: string | null }) => void;
   setMobileOpen: (open: boolean) => void;
+  /** Release the parser-ready subscription so a post-teardown event can't render into detached DOM. */
+  destroy: () => void;
 };
 
 function fallbackComponentCard(sel: PersonaArtifactRecord): HTMLElement {
@@ -434,11 +436,14 @@ export function createArtifactPane(
   // fallback, and this pane otherwise only re-renders on update()/interaction.
   // Chat messages share this exact hook; centralizing it means a surface can't
   // silently miss the parser-ready re-render. No-op once parsers are loaded.
-  onMarkdownParsersReady(() => render());
+  // `destroy()` unsubscribes so a late chunk resolution can't render into
+  // detached DOM (or pin the last records) after teardown.
+  const unsubscribeParsersReady = onMarkdownParsersReady(() => render());
 
   return {
     element: shell,
     backdrop,
+    destroy: unsubscribeParsersReady,
     update(state: { artifacts: PersonaArtifactRecord[]; selectedId: string | null }) {
       records = state.artifacts;
       selectedId =

--- a/packages/widget/src/components/artifact-pane.ts
+++ b/packages/widget/src/components/artifact-pane.ts
@@ -1,6 +1,7 @@
 import { createElement } from "../utils/dom";
 import type { AgentWidgetConfig, AgentWidgetMessage, PersonaArtifactRecord } from "../types";
 import { escapeHtml, createMarkdownProcessorFromConfig } from "../postprocessors";
+import { getMarkdownParsersSync, onMarkdownParsersReady } from "../markdown-parsers-loader";
 import { resolveSanitizer } from "../utils/sanitize";
 import { componentRegistry, type ComponentContext } from "./registry";
 import { renderLucideIcon } from "../utils/icons";
@@ -48,8 +49,15 @@ export function createArtifactPane(
   const md = config.markdown ? createMarkdownProcessorFromConfig(config.markdown) : null;
   const sanitize = resolveSanitizer(config.sanitize);
   const toHtml = (text: string) => {
+    const parsersReady = getMarkdownParsersSync() !== null;
     const raw = md ? md(text) : escapeHtml(text);
-    return sanitize ? sanitize(raw) : raw;
+    // Degraded path (IIFE/CDN build before the `markdown-parsers.js` chunk
+    // resolves): the markdown processor falls back to escapeHtml, and the
+    // default sanitizer's own fallback is escapeHtml too, so sanitizing that
+    // output would escape a SECOND time and display literal entities (mirrors
+    // `buildPostprocessor` in ui.ts). escapeHtml output is already inert, so
+    // only sanitize real parsed markdown.
+    return md && parsersReady && sanitize ? sanitize(raw) : raw;
   };
 
   const backdrop =
@@ -420,6 +428,13 @@ export function createArtifactPane(
       }
     }
   };
+
+  // Self-heal on the IIFE/CDN build: an artifact upserted right after init (before
+  // `markdown-parsers.js` resolves) renders as escaped plain text via `toHtml`'s
+  // fallback, and this pane otherwise only re-renders on update()/interaction.
+  // Chat messages share this exact hook; centralizing it means a surface can't
+  // silently miss the parser-ready re-render. No-op once parsers are loaded.
+  onMarkdownParsersReady(() => render());
 
   return {
     element: shell,

--- a/packages/widget/src/index-core.ts
+++ b/packages/widget/src/index-core.ts
@@ -188,6 +188,17 @@ export {
   createDirectivePostprocessor
 } from "./postprocessors";
 export type { MarkdownProcessorOptions } from "./postprocessors";
+// Markdown parser-readiness escape hatch. On the IIFE/CDN build `marked` +
+// `DOMPurify` load lazily, so content injected right after init can render as
+// escaped plain text until the chunk resolves. Hosts can `await
+// loadMarkdownParsers()` before injecting, or `onMarkdownParsersReady(cb)` to be
+// told when they land (both resolve/no-op instantly on the npm build, where the
+// parsers are bundled eagerly).
+export {
+  loadMarkdownParsers,
+  onMarkdownParsersReady
+} from "./markdown-parsers-loader";
+export type { MarkdownParsersModule } from "./markdown-parsers-loader";
 export {
   createDefaultSanitizer,
   resolveSanitizer

--- a/packages/widget/src/markdown-parsers-loader.test.ts
+++ b/packages/widget/src/markdown-parsers-loader.test.ts
@@ -94,6 +94,31 @@ describe("onMarkdownParsersReady", () => {
     expect(cb).toHaveBeenCalledTimes(1);
   });
 
+  it("drops pending subscribers and allows a retry when the chunk load rejects", async () => {
+    const loader = await freshLoader();
+    let attempt = 0;
+    loader.setMarkdownParsersLoader(() => {
+      attempt += 1;
+      return attempt === 1
+        ? Promise.reject(new Error("chunk 404"))
+        : Promise.resolve(FAKE_PARSERS);
+    });
+
+    const cb = vi.fn();
+    loader.onMarkdownParsersReady(cb);
+    await expect(loader.loadMarkdownParsers()).rejects.toThrow("chunk 404");
+    expect(cb).not.toHaveBeenCalled();
+
+    // A later subscribe re-triggers the load (rejected promise was not cached)
+    // and heals — the leak-free path.
+    const cb2 = vi.fn();
+    loader.onMarkdownParsersReady(cb2);
+    await vi.waitFor(() => expect(cb2).toHaveBeenCalledTimes(1));
+    // The dropped first subscriber stays dropped.
+    expect(cb).not.toHaveBeenCalled();
+    expect(attempt).toBe(2);
+  });
+
   it("one throwing subscriber does not starve the others", async () => {
     const loader = await freshLoader();
     loader.setMarkdownParsersLoader(() => Promise.resolve(FAKE_PARSERS));

--- a/packages/widget/src/markdown-parsers-loader.test.ts
+++ b/packages/widget/src/markdown-parsers-loader.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { MarkdownParsersModule } from "./markdown-parsers-loader";
+
+/**
+ * Tests for the parser-ready subscription registry.
+ *
+ * The loader holds module-level singleton state (`moduleCache`, subscribers), and
+ * `vitest.setup.ts` eager-provides parsers into the shared graph — which would make
+ * `onMarkdownParsersReady` no-op everywhere. So each test imports a FRESH copy of
+ * the loader via `vi.resetModules()` + dynamic import, starting from the unloaded
+ * (IIFE/CDN) state, and drives the transition itself.
+ */
+
+// A stand-in parsers module; the registry never touches its fields.
+const FAKE_PARSERS = {} as unknown as MarkdownParsersModule;
+
+const freshLoader = async () => {
+  vi.resetModules();
+  return import("./markdown-parsers-loader");
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("onMarkdownParsersReady", () => {
+  it("fires a pending subscriber once when the lazy chunk resolves", async () => {
+    const loader = await freshLoader();
+    loader.setMarkdownParsersLoader(() => Promise.resolve(FAKE_PARSERS));
+
+    const cb = vi.fn();
+    loader.onMarkdownParsersReady(cb);
+    expect(cb).not.toHaveBeenCalled(); // not yet: chunk not loaded
+
+    await loader.loadMarkdownParsers();
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("kicks the load itself so a lone surface still heals", async () => {
+    const loader = await freshLoader();
+    const load = vi.fn(() => Promise.resolve(FAKE_PARSERS));
+    loader.setMarkdownParsersLoader(load);
+
+    const cb = vi.fn();
+    // No explicit loadMarkdownParsers() call — subscribing must trigger it.
+    loader.onMarkdownParsersReady(cb);
+    await vi.waitFor(() => expect(cb).toHaveBeenCalledTimes(1));
+    expect(load).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fire (and returns a no-op) when parsers are already loaded", async () => {
+    const loader = await freshLoader();
+    loader.provideMarkdownParsers(FAKE_PARSERS); // eager/ESM steady state
+
+    const cb = vi.fn();
+    const unsub = loader.onMarkdownParsersReady(cb);
+    await Promise.resolve();
+    expect(cb).not.toHaveBeenCalled();
+    expect(() => unsub()).not.toThrow();
+  });
+
+  it("unsubscribe prevents the callback from firing", async () => {
+    const loader = await freshLoader();
+    loader.setMarkdownParsersLoader(() => Promise.resolve(FAKE_PARSERS));
+
+    const cb = vi.fn();
+    const unsub = loader.onMarkdownParsersReady(cb);
+    unsub();
+
+    await loader.loadMarkdownParsers();
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it("fires each subscriber exactly once (no re-fire on a later load call)", async () => {
+    const loader = await freshLoader();
+    loader.setMarkdownParsersLoader(() => Promise.resolve(FAKE_PARSERS));
+
+    const cb = vi.fn();
+    loader.onMarkdownParsersReady(cb);
+
+    await loader.loadMarkdownParsers();
+    await loader.loadMarkdownParsers(); // cached; must not re-notify
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("provideMarkdownParsers (eager) flushes pending subscribers", async () => {
+    const loader = await freshLoader();
+    // Subscribe while still unloaded, then have the eager path provide.
+    loader.setMarkdownParsersLoader(() => new Promise(() => {})); // never resolves
+    const cb = vi.fn();
+    loader.onMarkdownParsersReady(cb);
+
+    loader.provideMarkdownParsers(FAKE_PARSERS);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it("one throwing subscriber does not starve the others", async () => {
+    const loader = await freshLoader();
+    loader.setMarkdownParsersLoader(() => Promise.resolve(FAKE_PARSERS));
+
+    const boom = vi.fn(() => {
+      throw new Error("subscriber blew up");
+    });
+    const ok = vi.fn();
+    loader.onMarkdownParsersReady(boom);
+    loader.onMarkdownParsersReady(ok);
+
+    await loader.loadMarkdownParsers();
+    expect(boom).toHaveBeenCalledTimes(1);
+    expect(ok).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/widget/src/markdown-parsers-loader.ts
+++ b/packages/widget/src/markdown-parsers-loader.ts
@@ -61,7 +61,9 @@ export const onMarkdownParsersReady = (cb: () => void): (() => void) => {
   if (moduleCache) return () => {};
   readySubscribers.add(cb);
   // Ensure the chunk is actually being fetched; harmless if already in flight.
-  void loadMarkdownParsers();
+  // Swallow rejection here — `onLoadFailure` already drops the subscriber and
+  // the surface keeps its escaped fallback; this only avoids an unhandled reject.
+  void loadMarkdownParsers().catch(() => {});
   return () => {
     readySubscribers.delete(cb);
   };
@@ -79,15 +81,26 @@ export const provideMarkdownParsers = (mod: MarkdownParsersModule): void => {
   markParsersReady(mod);
 };
 
+// On a failed chunk load (404, ad blocker, offline), don't retain the rejected
+// promise or the waiting subscribers forever: reset so a later subscribe/load
+// can retry, and drop the pending callbacks (their surfaces keep the escaped
+// fallback, which is the documented degraded behavior). Re-throw so awaiters of
+// loadMarkdownParsers() still observe the rejection.
+const onLoadFailure = (err: unknown): never => {
+  loadPromise = null;
+  readySubscribers.clear();
+  throw err;
+};
+
 export const loadMarkdownParsers = (): Promise<MarkdownParsersModule> => {
   if (moduleCache) return Promise.resolve(moduleCache);
   if (loadPromise) return loadPromise;
   if (!loader) {
     // Fallback for regular ESM/CJS consumers (they import directly)
-    loadPromise = import("./markdown-parsers-entry").then(markParsersReady);
+    loadPromise = import("./markdown-parsers-entry").then(markParsersReady, onLoadFailure);
     return loadPromise;
   }
-  loadPromise = loader().then(markParsersReady);
+  loadPromise = loader().then(markParsersReady, onLoadFailure);
   return loadPromise;
 };
 

--- a/packages/widget/src/markdown-parsers-loader.ts
+++ b/packages/widget/src/markdown-parsers-loader.ts
@@ -10,8 +10,61 @@ let loader: (() => Promise<MarkdownParsersModule>) | null = null;
 let moduleCache: MarkdownParsersModule | null = null;
 let loadPromise: Promise<MarkdownParsersModule> | null = null;
 
+// Surfaces that want to self-heal when the lazy `markdown-parsers.js` chunk
+// lands. See `onMarkdownParsersReady` below for why this is centralized.
+const readySubscribers = new Set<() => void>();
+
+// Flip `moduleCache` and fan out to everyone waiting to re-render, exactly once
+// per subscriber. Called from BOTH the eager (`provideMarkdownParsers`) and lazy
+// (`loadMarkdownParsers`) paths so a subscriber can't miss the transition.
+const markParsersReady = (mod: MarkdownParsersModule): MarkdownParsersModule => {
+  moduleCache = mod;
+  // Snapshot + clear first: fire-once semantics, and a callback that re-subscribes
+  // (it won't — `onMarkdownParsersReady` no-ops once ready) can't loop.
+  const subs = [...readySubscribers];
+  readySubscribers.clear();
+  for (const cb of subs) {
+    // One bad subscriber must not starve the others (or leave messages escaped).
+    try {
+      cb();
+    } catch {
+      /* subscriber threw: swallow so the remaining re-renders still run */
+    }
+  }
+  return mod;
+};
+
 export const setMarkdownParsersLoader = (l: () => Promise<MarkdownParsersModule>) => {
   loader = l;
+};
+
+/**
+ * Register `cb` to run once the markdown parsers (marked + DOMPurify) become
+ * available, i.e. when the lazy `markdown-parsers.js` chunk resolves on the
+ * IIFE/CDN build. Returns an unsubscribe function.
+ *
+ * This exists so every markdown render surface (chat messages, artifact pane,
+ * and any future one) shares a SINGLE self-heal path instead of each wiring its
+ * own `loadMarkdownParsers().then(reRender)`. Before this, a new surface that
+ * forgot to do that rendered escaped plain text until a user interaction forced
+ * a re-render — the recurring first-render bug (chat messages, then the artifact
+ * pane) this centralizes away.
+ *
+ * If the parsers are ALREADY loaded, `cb` is not scheduled and a no-op
+ * unsubscribe is returned: the caller's first render already used real markdown,
+ * so there is nothing to heal (this is the ESM/CJS build's steady state, and the
+ * CDN build's state after the first chunk load). Registering also kicks the load
+ * so a surface that renders before anything else triggers it still heals.
+ * Fires at most once per subscription.
+ */
+export const onMarkdownParsersReady = (cb: () => void): (() => void) => {
+  if (moduleCache) return () => {};
+  readySubscribers.add(cb);
+  // Ensure the chunk is actually being fetched; harmless if already in flight.
+  void loadMarkdownParsers();
+  return () => {
+    readySubscribers.delete(cb);
+  };
 };
 
 /**
@@ -23,7 +76,7 @@ export const setMarkdownParsersLoader = (l: () => Promise<MarkdownParsersModule>
  * it lazy-loads the `markdown-parsers.js` chunk instead.
  */
 export const provideMarkdownParsers = (mod: MarkdownParsersModule): void => {
-  moduleCache = mod;
+  markParsersReady(mod);
 };
 
 export const loadMarkdownParsers = (): Promise<MarkdownParsersModule> => {
@@ -31,16 +84,10 @@ export const loadMarkdownParsers = (): Promise<MarkdownParsersModule> => {
   if (loadPromise) return loadPromise;
   if (!loader) {
     // Fallback for regular ESM/CJS consumers (they import directly)
-    loadPromise = import("./markdown-parsers-entry").then((mod) => {
-      moduleCache = mod;
-      return mod;
-    });
+    loadPromise = import("./markdown-parsers-entry").then(markParsersReady);
     return loadPromise;
   }
-  loadPromise = loader().then((mod) => {
-    moduleCache = mod;
-    return mod;
-  });
+  loadPromise = loader().then(markParsersReady);
   return loadPromise;
 };
 

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -2789,6 +2789,8 @@ export const createAgentExperience = (
     }
     artifactPaneApi?.element.style.removeProperty("width");
     artifactPaneApi?.element.style.removeProperty("maxWidth");
+    // Release the pane's parser-ready subscription (see artifact-pane.ts).
+    artifactPaneApi?.destroy();
   });
 
   // Event stream cleanup
@@ -8665,12 +8667,15 @@ export const createAgentExperience = (
   // the `markdownReadyAtInit` guard is redundant — kept only to skip the
   // subscription bookkeeping on the common eager path.
   if (!markdownReadyAtInit) {
-    onMarkdownParsersReady(() => {
+    const unsubscribeParsersReady = onMarkdownParsersReady(() => {
       if (!session) return;
       configVersion++;
       messageCache.clear();
       renderMessagesWithPlugins(messagesWrapper, session.getMessages(), postprocess);
     });
+    // Drop the subscription on teardown so a late chunk resolution can't clear
+    // the cache and render into a detached `messagesWrapper`.
+    destroyCallbacks.push(unsubscribeParsersReady);
   }
 
   return controller;

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1,7 +1,7 @@
 import { escapeHtml, createMarkdownProcessorFromConfig } from "./postprocessors";
 import { resolveSanitizer } from "./utils/sanitize";
 import { stabilizeStreamingTables } from "./utils/streaming-table";
-import { loadMarkdownParsers, getMarkdownParsersSync } from "./markdown-parsers-loader";
+import { onMarkdownParsersReady, getMarkdownParsersSync } from "./markdown-parsers-loader";
 import { AgentWidgetSession, AgentWidgetSessionStatus } from "./session";
 import {
   AgentWidgetConfig,
@@ -8660,18 +8660,17 @@ export const createAgentExperience = (
   // bust the message cache and re-render so they pick up real markdown. Bumping
   // `configVersion` + clearing the cache is required because the message
   // content is unchanged, so the fingerprint cache would otherwise reuse the
-  // stale escaped wrappers. No-op for the ESM build (parsers ready at init).
+  // stale escaped wrappers. `onMarkdownParsersReady` no-ops when the parsers are
+  // already loaded (the ESM build, and the CDN build after the first load), so
+  // the `markdownReadyAtInit` guard is redundant — kept only to skip the
+  // subscription bookkeeping on the common eager path.
   if (!markdownReadyAtInit) {
-    loadMarkdownParsers()
-      .then(() => {
-        if (!session) return;
-        configVersion++;
-        messageCache.clear();
-        renderMessagesWithPlugins(messagesWrapper, session.getMessages(), postprocess);
-      })
-      .catch(() => {
-        /* chunk failed to load (e.g. ad blocker): keep the escaped fallback */
-      });
+    onMarkdownParsersReady(() => {
+      if (!session) return;
+      configVersion++;
+      messageCache.clear();
+      renderMessagesWithPlugins(messagesWrapper, session.getMessages(), postprocess);
+    });
   }
 
   return controller;


### PR DESCRIPTION
## Problem

On the IIFE/CDN build, `marked` + `DOMPurify` load lazily. Anything rendered before that chunk resolves falls back to `escapeHtml` and shows as escaped plain text until something forces a re-render. Chat messages self-healed via a one-off `.then(reRender)`, but that made it opt-in per surface — the artifact pane didn't, so an artifact upserted right after init rendered escaped until a tab switch (the narrow bug in #362).

## Change

- **`onMarkdownParsersReady(cb)` registry** in `markdown-parsers-loader.ts` — fires once when parsers land (eager or lazy path), no-ops when already loaded, kicks the load on subscribe, isolates a throwing subscriber, and releases subscribers on load failure. Returns an unsubscribe.
- **Both surfaces wired through it** (chat messages + artifact pane), each unsubscribing on teardown so a late chunk resolution can't render into detached DOM.
- **Sanitize double-escape guard** in the pane: only sanitize real parsed markdown.
- **Public escape hatch**: `loadMarkdownParsers` / `onMarkdownParsersReady` exported from `index-core.ts`.

Supersedes #362 (artifact-pane-only fix); please close it in favor of this.

## Tests

New `markdown-parsers-loader.test.ts` (8) and `components/artifact-pane.test.ts` (3) cover fire-once, no-op-when-loaded, unsubscribe, load-failure drop+retry, and pane `destroy()`. Full suite: **1365 tests green**; lint + typecheck clean; build ships the new API in `dist/index.d.ts`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes markdown parser readiness so early markdown renders can self-heal. The main changes are:

- A shared `onMarkdownParsersReady` registry in the parser loader.
- Chat and artifact renders subscribed to the shared readiness path.
- Artifact markdown fallback handling updated to avoid double escaping.
- Public exports for parser loading and readiness subscription.
- Tests for registry behavior, artifact self-healing, and teardown cleanup.

<h3>Confidence Score: 4/5</h3>

This is close, but the transient parser-load failure path should be fixed before merging.

- Teardown cleanup for chat and artifact subscriptions is now wired through destroy callbacks.
- A temporary chunk failure can still leave already-rendered chat or artifact markdown stuck in escaped fallback output.
- A later successful retry does not notify the surfaces whose callbacks were cleared during the failure.

packages/widget/src/markdown-parsers-loader.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/widget/src/markdown-parsers-loader.ts | Adds the shared readiness registry and retry reset, but the failed-load path drops current surfaces before a later retry can heal them. |
| packages/widget/src/components/artifact-pane.ts | Subscribes the artifact pane to parser readiness, avoids double escaping, and exposes teardown cleanup. |
| packages/widget/src/ui.ts | Moves chat re-rendering to the shared readiness registry and releases parser-ready subscriptions during teardown. |
| packages/widget/src/index-core.ts | Exports the parser loader and readiness subscription APIs. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fmarkdown-parsers-loader.ts%3A91%0A**Retry%20Drops%20Subscribers**%0A%0AWhen%20the%20first%20lazy%20parser%20load%20fails%2C%20this%20clears%20every%20waiting%20render%20callback.%20If%20the%20failure%20is%20temporary%2C%20a%20later%20call%20can%20retry%20and%20load%20the%20parsers%2C%20but%20the%20chat%20or%20artifact%20surface%20that%20rendered%20during%20the%20first%20attempt%20is%20no%20longer%20subscribed.%20That%20surface%20stays%20escaped%20until%20another%20unrelated%20update%20happens.%20This%20keeps%20the%20same%20broken%20first-render%20state%20reachable%20after%20transient%20chunk%20failures%2C%20just%20without%20retaining%20the%20old%20callbacks.%0A%0A&repo=runtypelabs%2Fpersona&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22fix%2Fmarkdown-parsers-ready-registry%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fmarkdown-parsers-ready-registry%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fmarkdown-parsers-loader.ts%3A91%0A**Retry%20Drops%20Subscribers**%0A%0AWhen%20the%20first%20lazy%20parser%20load%20fails%2C%20this%20clears%20every%20waiting%20render%20callback.%20If%20the%20failure%20is%20temporary%2C%20a%20later%20call%20can%20retry%20and%20load%20the%20parsers%2C%20but%20the%20chat%20or%20artifact%20surface%20that%20rendered%20during%20the%20first%20attempt%20is%20no%20longer%20subscribed.%20That%20surface%20stays%20escaped%20until%20another%20unrelated%20update%20happens.%20This%20keeps%20the%20same%20broken%20first-render%20state%20reachable%20after%20transient%20chunk%20failures%2C%20just%20without%20retaining%20the%20old%20callbacks.%0A%0A&repo=runtypelabs%2Fpersona&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fmarkdown-parsers-loader.ts%3A91%0A**Retry%20Drops%20Subscribers**%0A%0AWhen%20the%20first%20lazy%20parser%20load%20fails%2C%20this%20clears%20every%20waiting%20render%20callback.%20If%20the%20failure%20is%20temporary%2C%20a%20later%20call%20can%20retry%20and%20load%20the%20parsers%2C%20but%20the%20chat%20or%20artifact%20surface%20that%20rendered%20during%20the%20first%20attempt%20is%20no%20longer%20subscribed.%20That%20surface%20stays%20escaped%20until%20another%20unrelated%20update%20happens.%20This%20keeps%20the%20same%20broken%20first-render%20state%20reachable%20after%20transient%20chunk%20failures%2C%20just%20without%20retaining%20the%20old%20callbacks.%0A%0A&pr=364&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile findings — release..."](https://github.com/runtypelabs/persona/commit/c2cd924048e7c54ac17a872a16b823666ae44384) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42904051)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->