### PR TITLE
Refresh docked-panel demo with a commerce admin and inline charts

### DIFF
--- a/apps/web/docked-panel-demo.html
+++ b/apps/web/docked-panel-demo.html
@@ -666,11 +666,34 @@
       padding-left: 2px !important;
     }
 
-    /* Tool group — a quiet "steps" strip, not a loud debug console. */
+    /* Tool group — a quiet "steps" strip with a slow violet gradient accent
+       flowing along the top edge (the running step itself gets the widget's
+       built-in shimmer-color animation). */
     [data-persona-tool-group] {
+      position: relative;
       background: #ffffff !important;
       border: 1px solid #eceef3 !important;
       border-radius: 10px !important;
+      overflow: hidden;
+    }
+    [data-persona-tool-group]::before {
+      content: "";
+      position: absolute;
+      left: 0;
+      right: 0;
+      top: 0;
+      height: 2px;
+      background: linear-gradient(90deg, #5e56e7, #b7adff, #7c6cf5, #5e56e7);
+      background-size: 220% 100%;
+      animation: otto-toolgrad 3.4s linear infinite;
+      opacity: 0.85;
+      pointer-events: none;
+    }
+    @keyframes otto-toolgrad {
+      to { background-position: 220% 0; }
+    }
+    @media (prefers-reduced-motion: reduce) {
+      [data-persona-tool-group]::before { animation: none; }
     }
 
     /* ============================ RESPONSIVE ============================ */

--- a/apps/web/docked-panel-demo.html
+++ b/apps/web/docked-panel-demo.html
@@ -4,55 +4,92 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <link rel="stylesheet" href="/src/demo-shared.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;450;500;550;600;650;700&display=swap" />
   <link rel="icon" href="/favicon.ico" sizes="any" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
   <title>Docked Panel Demo</title>
   <style>
+    /*
+      Docked-panel demo — a commerce admin ("Aster") with a WebMCP-driven
+      docked assistant ("Otto"). The chrome intentionally evokes a modern
+      merchant admin (near-black top bar, soft-gray canvas, white cards, Inter),
+      and Otto is themed to read like a first-party store copilot: flush-docked,
+      plain-text answers, a rounded composer with a soft violet halo. The look
+      is our own — nothing here reuses another product's marks or palette.
+    */
     * { box-sizing: border-box; }
-    html, body {
-      margin: 0;
-      height: 100%;
+    html, body { margin: 0; height: 100%; }
+
+    /* -- Page token overrides: replace the shared "editorial" theme with an
+       admin-console palette, scoped to this page. Later :root wins over the
+       demo-shared :root, so existing var(--*) references pick these up. -- */
+    :root {
+      --font-sans: "Inter", -apple-system, "system-ui", "Segoe UI", Roboto, "Helvetica Neue", sans-serif;
+      --font-mono: "SFMono-Regular", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+      --background: #f1f1f1;        /* app canvas */
+      --card: #ffffff;             /* surfaces */
+      --foreground: #1a1a1a;       /* headings / ink */
+      --muted: #616161;            /* secondary text */
+      --border: #e3e3e3;           /* hairlines */
+      --shadow-sm: 0 1px 0 rgba(0, 0, 0, 0.04), 0 1px 2px rgba(0, 0, 0, 0.05);
+      --radius: 8px;
+      --radius-lg: 12px;
+
+      /* Admin-specific tokens */
+      --ink: #1a1a1a;
+      --ink-2: #303030;
+      --text-subtle: #8a8a8a;
+      --border-strong: #d4d4d4;
+      --topbar: #1a1a1a;
+      --topbar-line: rgba(255, 255, 255, 0.10);
+      --nav-bg: #fbfbfb;
+      --nav-hover: #f1f1f1;
+      --nav-active: #ededed;
+      --canvas-inset: #f6f6f7;
+
+      /* Otto brand (violet — deliberately our own, not a borrowed accent) */
+      --brand: #5e56e7;
+      --brand-600: #4f47d6;
+      --brand-700: #4038c4;
+      --brand-soft: #efeefe;
+      --pos: #067a57;              /* positive delta green */
+      --pos-soft: #e3f5ec;
+      --warn: #b98900;             /* low-stock amber */
     }
+
     body {
       background: var(--background);
-      color: var(--foreground);
+      color: var(--ink-2);
+      font-family: var(--font-sans);
+      -webkit-font-smoothing: antialiased;
+      text-rendering: optimizeLegibility;
     }
-    /* Page-scoped tokens (align with demo-shared + admin chrome) */
-    :root {
-      --docked-canvas-bg: #f8fafc;
-      --docked-slate-900: #0f172a;
-      --docked-slate-800: #1e293b;
-      --docked-slate-700: #334155;
-      --docked-slate-600: #475569;
-      --docked-slate-200: #e2e8f0;
-      --docked-slate-100: #f1f5f9;
-      --docked-nav-active: #38bdf8;
-    }
+
     .app-root {
       height: 100%;
       display: flex;
       flex-direction: column;
       min-height: 0;
     }
+
+    /* ============================ TOP BAR ============================ */
     .admin-topbar {
       flex-shrink: 0;
-      display: flex;
+      height: 56px;
+      display: grid;
+      grid-template-columns: 232px minmax(0, 1fr) auto;
       align-items: center;
-      justify-content: space-between;
       gap: 16px;
-      padding: 12px 20px;
-      border-bottom: 1px solid rgba(255, 255, 255, 0.08);
-      background: var(--docked-slate-900);
-      color: #f8fafc;
-      font-family: var(--font-sans);
+      padding: 0 16px 0 20px;
+      background: var(--topbar);
+      color: #fff;
+      border-bottom: 1px solid var(--topbar-line);
     }
-    .admin-topbar__left {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    .admin-topbar__brand {
+    .topbar-brand {
       display: flex;
       align-items: center;
       gap: 10px;
@@ -60,1017 +97,833 @@
       color: inherit;
       user-select: none;
     }
-    .admin-topbar__logo {
-      flex-shrink: 0;
+    .brand-mark {
       width: 28px;
       height: 28px;
-      border-radius: var(--radius);
-      background: linear-gradient(145deg, #38bdf8 0%, #0ea5e9 100%);
-      color: var(--docked-slate-900);
+      border-radius: 8px;
+      background: linear-gradient(150deg, #7c6cf5 0%, #5e56e7 55%, #4038c4 100%);
       display: grid;
       place-items: center;
+      box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35), 0 1px 2px rgba(0, 0, 0, 0.4);
     }
-    .admin-topbar__logo svg {
-      width: 16px;
-      height: 16px;
-    }
-    .brand-mark {
-      width: 36px;
-      height: 36px;
-      border-radius: 12px;
-      background: var(--foreground);
-      color: white;
-      display: grid;
-      place-items: center;
-      font-weight: 700;
-    }
-    .brand-copy h1 {
-      margin: 0;
+    .brand-mark svg { width: 16px; height: 16px; color: #fff; }
+    .brand-wordmark {
       font-size: 17px;
-    }
-    .brand-copy p {
-      margin: 2px 0 0;
-      color: var(--muted);
-      font-size: 13px;
-    }
-    .metrics {
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-      justify-content: flex-end;
-    }
-    .metric {
-      min-width: 110px;
-      padding: 12px 14px;
-      border-radius: 16px;
-      background: var(--card);
-      box-shadow: var(--shadow-sm);
-    }
-    .metric-label {
-      display: block;
-      font-size: 11px;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--muted);
-    }
-    .metric-value {
-      display: block;
-      margin-top: 6px;
-      font-size: 20px;
-      font-weight: 700;
-      color: var(--foreground);
-    }
-    .controls {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 12px;
-      align-items: flex-end;
-      padding: 18px 28px;
-    }
-    .control {
-      display: flex;
-      flex-direction: column;
-      gap: 6px;
-    }
-    .control label {
-      font-size: 12px;
-      font-weight: 600;
-      color: var(--muted);
-    }
-    .control input,
-    .control select,
-    .control button {
-      border: 1px solid var(--border);
-      border-radius: 12px;
-      background: rgba(255, 255, 255, 0.9);
-      color: var(--foreground);
-      font: inherit;
-      padding: 10px 12px;
-    }
-    .control button {
-      cursor: pointer;
-      font-weight: 600;
-    }
-    .workspace-frame {
-      min-height: 0;
-      padding: 0 28px 28px;
-    }
-    /* Flush admin shell: no floating card chrome */
-    [data-persona-host-layout="docked"] {
-      flex: 1 1 auto;
-      min-height: 0;
-      height: 100%;
-      width: 100%;
-      border: none;
-      border-radius: 0;
-      background: #fff;
-      box-shadow: none;
-    }
-    [data-persona-dock-role="content"] {
-      overflow: hidden;
-      border-radius: 0;
-    }
-    .workspace-main {
-      min-width: 0;
-      min-height: 0;
-    }
-    .admin-topbar__wordmark {
-      font-size: 15px;
-      font-weight: 600;
+      font-weight: 650;
       letter-spacing: -0.02em;
-      color: rgba(255, 255, 255, 0.94);
-      font-family: var(--font-sans);
+      color: #fff;
     }
-    .admin-topbar__right {
+
+    .topbar-search {
+      justify-self: center;
+      width: 100%;
+      max-width: 560px;
+      height: 32px;
       display: flex;
       align-items: center;
       gap: 8px;
+      padding: 0 10px 0 12px;
+      border-radius: 8px;
+      background: rgba(255, 255, 255, 0.10);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      color: rgba(255, 255, 255, 0.62);
+      font-size: 13px;
+      cursor: text;
+      transition: background 0.15s ease, border-color 0.15s ease;
     }
-    .topbar-context {
+    .topbar-search:hover { background: rgba(255, 255, 255, 0.14); }
+    .topbar-search svg { width: 15px; height: 15px; flex-shrink: 0; opacity: 0.8; }
+    .topbar-search span { flex: 1; }
+    .topbar-search kbd {
+      font-family: var(--font-sans);
+      font-size: 11px;
+      font-weight: 500;
+      padding: 2px 6px;
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.12);
+      color: rgba(255, 255, 255, 0.7);
+    }
+
+    .topbar-right {
       display: flex;
       align-items: center;
-      gap: 10px;
-      margin-left: 6px;
-      padding-left: 14px;
-      border-left: 1px solid rgba(255, 255, 255, 0.12);
+      gap: 6px;
     }
-    .topbar-avatar {
-      position: relative;
-      flex-shrink: 0;
-      width: 36px;
-      height: 36px;
-      border-radius: 11px;
-      background: linear-gradient(145deg, #7dd3fc 0%, #38bdf8 100%);
-      color: #0f172a;
-      display: grid;
-      place-items: center;
-    }
-    .topbar-avatar__glyph {
-      font-size: 11px;
-      font-weight: 800;
-      letter-spacing: -0.05em;
-      line-height: 1;
-    }
-    /* Faux “logged in / online”: corner pip (sky palette, not commerce green). */
-    .topbar-avatar__status {
-      position: absolute;
-      right: -3px;
-      bottom: -3px;
-      width: 11px;
-      height: 11px;
-      border-radius: 50%;
-      background: #0ea5e9;
-      border: 2px solid #0f172a;
-      box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.35);
-    }
-    .topbar-context__name {
-      font-size: 14px;
-      font-weight: 500;
-      color: #fff;
-      letter-spacing: -0.01em;
-    }
-    .topbar-context__badge {
-      font-size: 11px;
-      font-weight: 500;
-      padding: 4px 10px;
-      border-radius: 999px;
-      background: rgba(255, 255, 255, 0.1);
-      color: rgba(248, 250, 252, 0.72);
-    }
+
+    /* Otto launcher (the docked assistant toggle) */
     #assistant-toggle {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 40px;
-      height: 40px;
+      width: 34px;
+      height: 34px;
       padding: 0;
-      /* Same border width as .is-active so toggling doesn’t animate 0 → 1px (reads as a flash). */
       border: 1px solid transparent;
-      border-radius: 14px;
+      border-radius: 9px;
       background: transparent;
-      box-shadow: none;
-      color: rgba(255, 255, 255, 0.88);
+      color: rgba(255, 255, 255, 0.86);
       cursor: pointer;
-      /* Don’t transition box-shadow/border: active state inset shadow would tween and flash. */
-      transition: background 0.15s ease, color 0.15s ease;
+      transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease, box-shadow 0.15s ease;
       -webkit-tap-highlight-color: transparent;
-      -webkit-appearance: none;
       appearance: none;
     }
-    #assistant-toggle:focus {
-      outline: none;
+    #assistant-toggle svg { width: 19px; height: 19px; }
+    #assistant-toggle:hover { background: rgba(255, 255, 255, 0.12); color: #fff; }
+    #assistant-toggle:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
+    /* Selected: a soft violet "well" — a quiet, tasteful on-state (no neon). */
+    #assistant-toggle.is-active {
+      background: rgba(124, 108, 245, 0.22);
+      border-color: rgba(124, 108, 245, 0.45);
+      color: #e7e3ff;
+      box-shadow: inset 0 0 0 1px rgba(124, 108, 245, 0.2);
     }
-    #assistant-toggle:focus-visible {
-      outline: 2px solid #38bdf8;
-      outline-offset: 2px;
+    /* Pre-open nudge: one gentle breathing ring so a first-time viewer notices
+       Otto without a loud banner. Stops the moment the panel is opened. */
+    #assistant-toggle.assistant-toggle--hint {
+      animation: otto-hint 2.6s ease-in-out 1.2s 3 both;
     }
-    #assistant-toggle:active {
-      outline: none;
-    }
-    #assistant-toggle:hover {
-      background: rgba(255, 255, 255, 0.08);
-      color: #fff;
-    }
-    /*
-     * Selected: clearly darker “well” vs bar (#0f172a), soft sky rim + brighter icon = obvious “on”.
-     * Still inset (dark top, lighter floor), not a flat raised chip.
-     */
-    #assistant-toggle.is-active,
-    #assistant-toggle.assistant-toggle--persist-highlight {
-      background: linear-gradient(
-        180deg,
-        #010409 0%,
-        #0a1629 38%,
-        #0f2137 72%,
-        #132a45 100%
-      );
-      border-color: rgba(56, 189, 248, 0.5);
-      color: #e0f2fe;
-      box-shadow:
-        0 0 14px rgba(56, 189, 248, 0.22),
-        inset 0 12px 26px rgba(0, 0, 0, 0.88),
-        inset 0 5px 14px rgba(0, 0, 0, 0.72),
-        inset 0 -12px 22px rgba(125, 211, 252, 0.14),
-        inset 0 -2px 0 rgba(255, 255, 255, 0.22);
-    }
-    #assistant-toggle.is-active:hover,
-    #assistant-toggle.assistant-toggle--persist-highlight:hover {
-      border-color: rgba(56, 189, 248, 0.6);
-      color: #f0f9ff;
-      box-shadow:
-        0 0 16px rgba(56, 189, 248, 0.28),
-        inset 0 12px 26px rgba(0, 0, 0, 0.84),
-        inset 0 5px 14px rgba(0, 0, 0, 0.68),
-        inset 0 -12px 22px rgba(125, 211, 252, 0.17),
-        inset 0 -2px 0 rgba(255, 255, 255, 0.26);
-    }
-    #assistant-toggle.assistant-toggle--persist-highlight {
-      animation:
-        assistant-toggle-arrive 0.7s cubic-bezier(0.22, 1, 0.36, 1) both,
-        assistant-toggle-pulse 2.8s ease-in-out infinite;
-      animation-delay: var(--arrive-delay, 1.0s), var(--pulse-delay, 1.8s);
-    }
-    @keyframes assistant-toggle-arrive {
-      0% {
-        box-shadow:
-          0 0 14px rgba(56, 189, 248, 0.22),
-          inset 0 12px 26px rgba(0, 0, 0, 0.88),
-          inset 0 5px 14px rgba(0, 0, 0, 0.72),
-          inset 0 -12px 22px rgba(125, 211, 252, 0.14),
-          inset 0 -2px 0 rgba(255, 255, 255, 0.22);
-        border-color: rgba(56, 189, 248, 0.5);
-      }
-      22% {
-        box-shadow:
-          0 0 28px rgba(56, 189, 248, 0.6),
-          0 0 48px rgba(125, 211, 252, 0.3),
-          inset 0 12px 26px rgba(0, 0, 0, 0.76),
-          inset 0 5px 14px rgba(0, 0, 0, 0.6),
-          inset 0 -12px 22px rgba(125, 211, 252, 0.24),
-          inset 0 -2px 0 rgba(255, 255, 255, 0.3);
-        border-color: rgba(56, 189, 248, 0.85);
-      }
-      100% {
-        box-shadow:
-          0 0 14px rgba(56, 189, 248, 0.22),
-          inset 0 12px 26px rgba(0, 0, 0, 0.88),
-          inset 0 5px 14px rgba(0, 0, 0, 0.72),
-          inset 0 -12px 22px rgba(125, 211, 252, 0.14),
-          inset 0 -2px 0 rgba(255, 255, 255, 0.22);
-        border-color: rgba(56, 189, 248, 0.5);
-      }
-    }
-    @keyframes assistant-toggle-pulse {
-      0%, 100% {
-        box-shadow:
-          0 0 14px rgba(56, 189, 248, 0.22),
-          inset 0 12px 26px rgba(0, 0, 0, 0.88),
-          inset 0 5px 14px rgba(0, 0, 0, 0.72),
-          inset 0 -12px 22px rgba(125, 211, 252, 0.14),
-          inset 0 -2px 0 rgba(255, 255, 255, 0.22);
-        border-color: rgba(56, 189, 248, 0.5);
-      }
-      50% {
-        box-shadow:
-          0 0 22px rgba(56, 189, 248, 0.38),
-          0 0 36px rgba(125, 211, 252, 0.12),
-          inset 0 12px 26px rgba(0, 0, 0, 0.84),
-          inset 0 5px 14px rgba(0, 0, 0, 0.68),
-          inset 0 -12px 22px rgba(125, 211, 252, 0.19),
-          inset 0 -2px 0 rgba(255, 255, 255, 0.26);
-        border-color: rgba(56, 189, 248, 0.68);
-      }
+    @keyframes otto-hint {
+      0%, 100% { box-shadow: 0 0 0 0 rgba(124, 108, 245, 0); }
+      50% { box-shadow: 0 0 0 5px rgba(124, 108, 245, 0.16); background: rgba(255, 255, 255, 0.10); }
     }
     @media (prefers-reduced-motion: reduce) {
-      #assistant-toggle.assistant-toggle--persist-highlight {
-        animation: none;
-      }
+      #assistant-toggle.assistant-toggle--hint { animation: none; }
     }
-    #assistant-toggle svg {
-      width: 22px;
-      height: 22px;
-    }
+
     .icon-btn--ghost {
       display: inline-flex;
       align-items: center;
       justify-content: center;
-      width: 40px;
-      height: 40px;
+      width: 34px;
+      height: 34px;
       border: none;
-      border-radius: 10px;
+      border-radius: 9px;
       background: transparent;
-      color: rgba(255, 255, 255, 0.88);
+      color: rgba(255, 255, 255, 0.86);
       cursor: pointer;
+      transition: background 0.15s ease;
     }
-    .icon-btn--ghost:hover {
-      background: rgba(255, 255, 255, 0.08);
-    }
-    /* Coachmark: label + arrow pointing at the assistant control (demo-only). */
-    .assistant-coachmark {
+    .icon-btn--ghost svg { width: 18px; height: 18px; }
+    .icon-btn--ghost:hover { background: rgba(255, 255, 255, 0.12); }
+
+    .topbar-store {
       display: flex;
       align-items: center;
       gap: 8px;
-      margin-right: 10px;
-      padding: 8px 14px 8px 16px;
-      border-radius: 999px;
-      background: linear-gradient(
-        145deg,
-        rgba(14, 165, 233, 0.42) 0%,
-        rgba(56, 189, 248, 0.28) 48%,
-        rgba(125, 211, 252, 0.2) 100%
-      );
-      border: 2px solid rgba(186, 230, 253, 0.85);
-      box-shadow:
-        0 0 0 1px rgba(0, 0, 0, 0.25),
-        0 4px 18px rgba(56, 189, 248, 0.45),
-        inset 0 1px 0 rgba(255, 255, 255, 0.35);
-      font-size: 13px;
+      margin-left: 6px;
+      padding: 3px 10px 3px 4px;
+      border-radius: 9px;
+      cursor: pointer;
+      transition: background 0.15s ease;
+    }
+    .topbar-store:hover { background: rgba(255, 255, 255, 0.10); }
+    .store-avatar {
+      width: 26px;
+      height: 26px;
+      border-radius: 7px;
+      background: linear-gradient(150deg, #4f9d7d 0%, #2f7d63 100%);
+      color: #fff;
+      display: grid;
+      place-items: center;
+      font-size: 10px;
       font-weight: 700;
-      letter-spacing: 0.02em;
-      color: #f8fafc;
-      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.45);
+      letter-spacing: -0.03em;
+    }
+    .store-name { font-size: 13px; font-weight: 500; color: #fff; }
+    .store-plan {
+      font-size: 11px;
+      font-weight: 550;
+      padding: 2px 7px;
+      border-radius: 6px;
+      background: rgba(255, 255, 255, 0.14);
+      color: rgba(255, 255, 255, 0.82);
+    }
+
+    /* Coachmark: quiet one-line label that points at Otto, then fades. */
+    .assistant-coachmark {
+      display: inline-flex;
+      align-items: center;
+      gap: 7px;
+      margin-right: 4px;
+      padding: 5px 11px;
+      border-radius: 999px;
+      background: rgba(124, 108, 245, 0.16);
+      border: 1px solid rgba(124, 108, 245, 0.32);
+      font-size: 12.5px;
+      font-weight: 550;
+      color: #e7e3ff;
       white-space: nowrap;
-      flex-shrink: 0;
       pointer-events: none;
-      position: relative;
-      overflow: hidden;
       opacity: 0;
-      transform: translateX(-12px);
+      transform: translateX(6px);
       animation:
-        assistant-coachmark-enter 0.5s cubic-bezier(0.22, 1, 0.36, 1) 2s forwards,
-        assistant-coachmark-settle 1.1s cubic-bezier(0.33, 1, 0.68, 1) 3.6s forwards;
+        coachmark-in 0.5s cubic-bezier(0.22, 1, 0.36, 1) 1.1s forwards,
+        coachmark-out 0.6s ease 6.5s forwards;
     }
-    .assistant-coachmark::before {
-      content: '';
-      position: absolute;
-      inset: 0;
-      background: linear-gradient(
-        90deg,
-        transparent 0%,
-        rgba(255, 255, 255, 0.2) 35%,
-        rgba(186, 230, 253, 0.45) 50%,
-        rgba(255, 255, 255, 0.2) 65%,
-        transparent 100%
-      );
-      transform: translateX(-110%);
-      animation: assistant-coachmark-sweep 1.4s cubic-bezier(0.76, 0, 0.24, 1) 2.7s forwards;
-      pointer-events: none;
-      border-radius: inherit;
-    }
-    @keyframes assistant-coachmark-enter {
-      0% {
-        opacity: 0;
-        transform: translateX(-12px) scale(0.97);
-      }
-      100% {
-        opacity: 1;
-        transform: translateX(0) scale(1);
-      }
-    }
-    @keyframes assistant-coachmark-sweep {
-      0%   { transform: translateX(-110%); }
-      100% { transform: translateX(110%); }
-    }
-    @keyframes assistant-coachmark-settle {
-      0% {
-        box-shadow:
-          0 0 0 1px rgba(0, 0, 0, 0.25),
-          0 4px 18px rgba(56, 189, 248, 0.45),
-          inset 0 1px 0 rgba(255, 255, 255, 0.35);
-        border-color: rgba(186, 230, 253, 0.85);
-        opacity: 1;
-      }
-      100% {
-        box-shadow:
-          0 0 0 1px rgba(0, 0, 0, 0.1),
-          0 2px 6px rgba(56, 189, 248, 0.1),
-          inset 0 1px 0 rgba(255, 255, 255, 0.1);
-        border-color: rgba(186, 230, 253, 0.3);
-        opacity: 0.6;
-      }
-    }
+    .assistant-coachmark svg { width: 15px; height: 15px; }
+    @keyframes coachmark-in { to { opacity: 1; transform: translateX(0); } }
+    @keyframes coachmark-out { to { opacity: 0; transform: translateX(6px); } }
     @media (prefers-reduced-motion: reduce) {
-      .assistant-coachmark {
-        animation: none;
-        opacity: 0.6;
-        transform: none;
-        border-color: rgba(186, 230, 253, 0.3);
-      }
-      .assistant-coachmark::before {
-        animation: none;
-        display: none;
-      }
+      .assistant-coachmark { animation: coachmark-in 0.01s forwards; }
     }
-    .assistant-coachmark__arrow {
-      display: block;
-      flex-shrink: 0;
-      color: #e0f2fe;
-      filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.4));
-      animation: assistant-coachmark-nudge 0.5s cubic-bezier(0.22, 1.4, 0.36, 1) 3.2s 2 both;
-    }
-    @keyframes assistant-coachmark-nudge {
-      0%, 100% { transform: translateX(0); }
-      50%      { transform: translateX(6px); }
-    }
-    @media (prefers-reduced-motion: reduce) {
-      .assistant-coachmark__arrow {
-        animation: none;
-      }
-    }
+
+    /* ============================ BODY / NAV ============================ */
     .workspace-shell {
       flex: 1;
       min-height: 0;
       min-width: 0;
       display: flex;
-      flex-direction: column;
-      background: var(--docked-canvas-bg);
+      background: var(--background);
     }
-    .workspace-panel {
-      flex: 1 1 auto;
-      min-height: 0;
-      min-width: 0;
-      overflow: hidden;
-      display: flex;
-      flex-direction: column;
-    }
+    .workspace-panel { flex: 1 1 auto; min-height: 0; min-width: 0; display: flex; }
+
     .workspace-main {
-      --workspace-nav-w: 240px;
+      --workspace-nav-w: 232px;
+      flex: 1 1 auto;
       min-width: 0;
       min-height: 0;
       height: 100%;
     }
-    /*
-      Layout follows data-dock-side (set from the demo script to match dock.side):
-      - right: full-bleed stage + absolute nav on top: push/overlay can move the canvas behind the rail.
-      - left: flex row [nav | stage]: dock opens beside the rail (nothing under the sidebar).
-    */
-    .workspace-main[data-dock-side="right"] {
-      position: relative;
-      display: block;
-      width: 100%;
-      min-width: 0;
-      overflow-x: hidden;
-    }
+    /* Right dock: full-bleed stage with the nav rail layered on top so the dock
+       can slide in beside the canvas. Left dock: a flex row [nav | stage]. */
+    .workspace-main[data-dock-side="right"] { position: relative; display: block; width: 100%; overflow-x: hidden; }
     .workspace-main[data-dock-side="right"] .workspace-stage {
-      position: relative;
-      width: 100%;
-      height: 100%;
-      min-width: 0;
-      min-height: 0;
-      overflow-x: hidden;
-      display: flex;
-      flex-direction: column;
+      position: relative; width: 100%; height: 100%; min-width: 0; min-height: 0;
+      overflow-x: hidden; display: flex; flex-direction: column;
     }
     .workspace-main[data-dock-side="right"] .workspace-nav {
-      position: absolute;
-      left: 0;
-      top: 0;
-      bottom: 0;
-      z-index: 3;
+      position: absolute; left: 0; top: 0; bottom: 0; z-index: 3;
       width: var(--workspace-nav-w);
+    }
+    .workspace-main[data-dock-side="left"] { display: flex; flex-direction: row; align-items: stretch; width: 100%; overflow-x: hidden; }
+    .workspace-main[data-dock-side="left"] .workspace-nav { flex: 0 0 var(--workspace-nav-w); }
+    .workspace-main[data-dock-side="left"] .workspace-stage { flex: 1 1 auto; min-width: 0; min-height: 0; display: flex; flex-direction: column; }
+
+    .workspace-nav {
       box-sizing: border-box;
-      padding: 20px 14px;
-      background: linear-gradient(180deg, var(--docked-slate-900) 0%, var(--docked-slate-800) 100%);
-      color: #cbd5e1;
-      border-right: 1px solid rgba(255, 255, 255, 0.06);
-    }
-    .workspace-main[data-dock-side="left"] {
-      display: flex;
-      flex-direction: row;
-      align-items: stretch;
-      width: 100%;
-      min-width: 0;
-      overflow-x: hidden;
-    }
-    .workspace-main[data-dock-side="left"] .workspace-nav {
-      flex: 0 0 var(--workspace-nav-w);
-      box-sizing: border-box;
-      padding: 20px 14px;
-      background: linear-gradient(180deg, var(--docked-slate-900) 0%, var(--docked-slate-800) 100%);
-      color: #cbd5e1;
-      border-right: 1px solid rgba(255, 255, 255, 0.06);
-    }
-    .workspace-main[data-dock-side="left"] .workspace-stage {
-      flex: 1 1 auto;
-      min-width: 0;
-      min-height: 0;
+      padding: 12px 12px 14px;
+      background: var(--nav-bg);
+      border-right: 1px solid var(--border);
+      overflow-y: auto;
       display: flex;
       flex-direction: column;
     }
-    .workspace-nav h2 {
-      margin: 0 0 16px;
-      font-size: 11px;
-      font-family: var(--font-sans);
-      font-weight: 600;
-      text-transform: uppercase;
-      letter-spacing: 0.1em;
-      color: rgba(148, 163, 184, 0.9);
-    }
-    .workspace-nav ul {
-      list-style: none;
-      padding: 0;
-      margin: 0;
+    .workspace-nav ul { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 2px; }
+    .nav-item {
       display: flex;
-      flex-direction: column;
-      gap: 4px;
-    }
-    .workspace-nav .nav-item {
-      display: block;
-      padding: 10px 12px;
-      border-radius: var(--radius);
-      font-family: var(--font-sans);
-      font-size: 14px;
+      align-items: center;
+      gap: 10px;
+      padding: 7px 10px;
+      border-radius: 8px;
+      font-size: 13.5px;
       font-weight: 500;
-      color: rgba(226, 232, 240, 0.88);
+      color: var(--ink-2);
       background: transparent;
-      border: 1px solid transparent;
       cursor: default;
-      transition: background 0.15s ease, color 0.15s ease, border-color 0.15s ease;
+      transition: background 0.12s ease, color 0.12s ease;
     }
-    .workspace-nav .nav-item:hover {
-      background: rgba(255, 255, 255, 0.06);
-      color: #f8fafc;
+    .nav-item svg { width: 18px; height: 18px; flex-shrink: 0; color: #4a4a4a; }
+    .nav-item:hover { background: var(--nav-hover); }
+    .nav-item.is-active { background: var(--nav-active); font-weight: 600; color: var(--ink); }
+    .nav-item.is-active svg { color: var(--ink); }
+    .nav-section {
+      margin: 16px 0 6px;
+      padding: 0 10px;
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: none;
+      color: var(--text-subtle);
     }
-    .workspace-nav .nav-item.is-active {
-      background: rgba(56, 189, 248, 0.12);
-      border-color: rgba(56, 189, 248, 0.35);
-      color: #f0f9ff;
-    }
-    [data-persona-dock-role="host"] .persona-rounded-button {
-      border-radius: 0 !important;
-    }
+    .nav-spacer { flex: 1 1 auto; min-height: 12px; }
+    .nav-item--settings { margin-top: 4px; }
+
+    /* ============================ CANVAS ============================ */
     .workspace-canvas {
       min-width: 0;
       min-height: 0;
       overflow: auto;
-      display: grid;
-      grid-template-rows: auto auto auto 1fr;
-      gap: 20px;
-      padding: 24px;
-      background: var(--docked-canvas-bg);
-    }
-    .workspace-main[data-dock-side="right"] .workspace-canvas {
-      padding-left: calc(var(--workspace-nav-w) + 24px);
-    }
-    .dock-settings__row {
-      display: flex;
-      flex-wrap: wrap;
-      align-items: flex-end;
-      gap: 14px 20px;
-    }
-    .dock-settings__field {
       display: flex;
       flex-direction: column;
-      gap: 6px;
+      gap: 16px;
+      padding: 24px 28px 40px;
+      background: var(--background);
     }
-    .dock-settings__field label {
-      font-size: 12px;
-      font-weight: 600;
-      color: var(--docked-slate-600);
-      font-family: var(--font-sans);
+    .workspace-main[data-dock-side="right"] .workspace-canvas { padding-left: calc(var(--workspace-nav-w) + 28px); }
+    /* Center content in a comfortable column so wide screens don't sprawl. */
+    .canvas-inner { width: 100%; max-width: 940px; margin: 0 auto; display: flex; flex-direction: column; gap: 16px; }
+
+    .page-head { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 2px; }
+    .page-title { margin: 0; font-size: 20px; font-weight: 650; letter-spacing: -0.02em; color: var(--ink); }
+    .page-pill {
+      display: inline-flex; align-items: center; gap: 7px;
+      height: 30px; padding: 0 11px;
+      border-radius: 8px; border: 1px solid var(--border-strong);
+      background: var(--card); color: var(--ink-2);
+      font-size: 13px; font-weight: 500; cursor: default;
+      box-shadow: var(--shadow-sm);
     }
-    .dock-settings__field input,
-    .dock-settings__field select {
-      border: 1px solid rgba(148, 163, 184, 0.45);
+    .page-pill svg { width: 15px; height: 15px; opacity: 0.7; }
+
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
       border-radius: var(--radius-lg);
-      background: #fff;
-      color: #0f172a;
-      font: inherit;
-      padding: 9px 12px;
-      min-width: 120px;
+      box-shadow: var(--shadow-sm);
     }
-    .dock-settings__field input#dock-width {
-      min-width: 100px;
-      width: 8rem;
-    }
-    .dock-settings__field-label {
-      font-size: 12px;
-      font-weight: 600;
-      color: var(--docked-slate-600);
-      font-family: var(--font-sans);
-    }
-    .dock-settings__check {
-      display: inline-flex;
+    .card__head { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 16px 18px 0; }
+    .card__title { margin: 0; font-size: 14px; font-weight: 600; color: var(--ink); }
+    .card__link { font-size: 13px; font-weight: 500; color: var(--brand); text-decoration: none; cursor: default; }
+
+    /* Metrics */
+    .metrics { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); }
+    .metric { padding: 16px 18px; border-right: 1px solid var(--border); }
+    .metric:last-child { border-right: none; }
+    .metric__label { font-size: 12.5px; font-weight: 500; color: var(--muted); }
+    .metric__value { margin-top: 8px; font-size: 22px; font-weight: 650; letter-spacing: -0.02em; color: var(--ink); }
+    .metric__delta { margin-top: 5px; display: inline-flex; align-items: center; gap: 4px; font-size: 12px; font-weight: 550; }
+    .metric__delta svg { width: 13px; height: 13px; }
+    .metric__delta.is-up { color: var(--pos); }
+    .metric__delta.is-flat { color: var(--text-subtle); }
+
+    /* Product / inventory list */
+    .prod-list { padding: 4px 0 6px; }
+    .prod {
+      display: grid;
+      grid-template-columns: 40px 1fr auto auto;
       align-items: center;
-      gap: 8px;
-      margin: 0;
-      margin-top: -30px;
+      gap: 14px;
+      padding: 11px 18px;
+      border-top: 1px solid var(--border);
+    }
+    .prod:first-child { border-top: none; }
+    .prod__thumb { width: 40px; height: 40px; border-radius: 9px; display: grid; place-items: center; font-size: 19px; }
+    .prod__name { font-size: 13.5px; font-weight: 550; color: var(--ink); }
+    .prod__sku { margin-top: 2px; font-size: 12px; color: var(--text-subtle); }
+    .prod__price { font-size: 13.5px; font-weight: 550; color: var(--ink-2); text-align: right; }
+    .prod__stock { display: inline-flex; align-items: center; gap: 7px; min-width: 128px; justify-content: flex-end; }
+    .stock-badge {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 3px 9px; border-radius: 999px;
+      font-size: 12px; font-weight: 550; white-space: nowrap;
+    }
+    .stock-badge::before { content: ""; width: 6px; height: 6px; border-radius: 50%; }
+    .stock-badge--in { background: var(--pos-soft); color: var(--pos); }
+    .stock-badge--in::before { background: var(--pos); }
+    .stock-badge--low { background: #fbf1d9; color: var(--warn); }
+    .stock-badge--low::before { background: var(--warn); }
+    .stock-badge--out { background: #fbe4e2; color: #b3261e; }
+    .stock-badge--out::before { background: #b3261e; }
+    .prod__count { font-size: 12.5px; color: var(--muted); min-width: 54px; text-align: right; }
+
+    /* Activity feed */
+    .feed { padding: 4px 0 8px; }
+    .feed-item { display: grid; gap: 3px; padding: 12px 18px; border-top: 1px solid var(--border); }
+    .feed-item:first-child { border-top: none; }
+    .feed-meta { font-size: 11.5px; font-weight: 600; letter-spacing: 0.01em; color: var(--text-subtle); }
+    .feed-title { font-size: 13.5px; font-weight: 550; color: var(--ink); }
+    .feed-item > span:last-child { font-size: 13px; color: var(--muted); line-height: 1.5; }
+
+    /* Dock settings card */
+    .dock-settings-card__inner { padding: 16px 18px 4px; }
+    .dock-settings-card__title { margin: 0 0 14px; font-size: 14px; font-weight: 600; color: var(--ink); }
+    .dock-settings__row { display: flex; flex-wrap: wrap; align-items: flex-end; gap: 14px 18px; }
+    .dock-settings__field { display: flex; flex-direction: column; gap: 6px; }
+    .dock-settings__field label { font-size: 12.5px; font-weight: 550; color: var(--ink-2); }
+    .dock-settings__field select,
+    .dock-settings__field input {
+      height: 34px;
+      border: 1px solid var(--border-strong);
+      border-radius: 8px;
+      background: var(--card);
+      color: var(--ink);
+      font: inherit;
       font-size: 13px;
-      font-weight: 500;
-      color: var(--docked-slate-700);
-      font-family: var(--font-sans);
-      cursor: pointer;
-      user-select: none;
+      padding: 0 11px;
+      min-width: 130px;
     }
-    .dock-settings__check input {
-      width: 1.05rem;
-      height: 1.05rem;
-      min-width: unset;
-      margin: 0;
-      padding: 0;
-      accent-color: var(--docked-slate-900);
-    }
-    #dock-reveal {
-      min-width: 11rem;
-    }
+    .dock-settings__field select:focus,
+    .dock-settings__field input:focus { outline: none; border-color: var(--brand); box-shadow: 0 0 0 3px rgba(94, 86, 231, 0.15); }
+    .dock-settings__field input#dock-width { min-width: 110px; width: 8rem; }
+    .dock-settings__check { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 500; color: var(--ink-2); cursor: pointer; user-select: none; padding-bottom: 8px; }
+    .dock-settings__check input { width: 1rem; height: 1rem; accent-color: var(--brand); margin: 0; }
     #apply-dock-settings {
+      height: 34px;
       border: none;
-      border-radius: var(--radius);
-      background: var(--docked-slate-900);
+      border-radius: 8px;
+      background: var(--ink);
       color: #fff;
       font-family: var(--font-sans);
-      font-weight: 600;
+      font-weight: 550;
       font-size: 13px;
-      padding: 9px 16px;
+      padding: 0 16px;
       cursor: pointer;
       transition: background 0.15s ease;
     }
-    #apply-dock-settings:hover {
-      background: var(--docked-slate-800);
-    }
-    .dock-settings-card {
-      padding: 0;
-      border-radius: var(--radius-lg);
-      background: var(--card);
-      border: 1px solid var(--border);
-      box-shadow: var(--shadow-sm);
-      overflow: hidden;
-    }
-    /* Inner padding matches .workspace-banner (22px 24px) so the form aligns with other cards */
-    .dock-settings-card__inner {
-      padding: 22px 24px 20px;
-    }
-    .dock-settings-card__title {
-      margin: 0 0 16px;
-      font-size: 11px;
-      font-family: var(--font-sans);
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--docked-slate-600);
-    }
+    #apply-dock-settings:hover { background: #000; }
     .dock-settings__status {
-      margin: 0;
-      padding: 12px 24px 14px;
-      box-sizing: border-box;
+      margin: 14px 0 0;
+      padding: 11px 18px;
       font-family: var(--font-mono);
-      font-size: 12px;
+      font-size: 11.5px;
       line-height: 1.5;
-      color: var(--docked-slate-600);
-      background: var(--docked-slate-100);
+      color: var(--muted);
+      background: var(--canvas-inset);
       border-top: 1px solid var(--border);
+      border-radius: 0 0 var(--radius-lg) var(--radius-lg);
     }
-    .workspace-banner {
-      padding: 22px 24px;
-      border-radius: var(--radius-lg);
-      background: var(--card);
-      border: 1px solid var(--border);
-      box-shadow: var(--shadow-sm);
+
+    /* -- Docked host: flush admin shell, no floating card chrome. -- */
+    [data-persona-host-layout="docked"] {
+      flex: 1 1 auto; min-height: 0; height: 100%; width: 100%;
+      border: none; border-radius: 0; background: #fff; box-shadow: none;
     }
-    .workspace-banner h3 {
-      margin: 0 0 10px;
-      font-size: 1.25rem;
-      font-family: var(--font-sans);
-      font-weight: 600;
-      letter-spacing: -0.02em;
-      color: var(--foreground);
+    [data-persona-dock-role="content"] { overflow: hidden; border-radius: 0; }
+    [data-persona-dock-role="host"] .persona-rounded-button { border-radius: 0 !important; }
+
+    /* ==========================================================================
+       OTTO — Persona widget theming (first-party store-copilot look, our own palette).
+       Persona writes theme tokens inline via style.setProperty, so the consumed
+       --persona-* seams need !important to win. Layout/rounding is done on the
+       real data-persona-* / .persona-* seams (verified against the widget's
+       component markup). useShadowDom stays false so this page CSS reaches in.
+       ========================================================================== */
+    [data-persona-root],
+    [data-persona-theme-zone] {
+      --persona-primary: #5e56e7 !important;
+      --persona-secondary: #7c6cf5 !important;
+      --persona-accent: #5e56e7 !important;
+      --persona-call-to-action: #5e56e7 !important;
+      --persona-surface: #ffffff !important;
+      --persona-container: #ffffff !important;
+      --persona-input-background: #ffffff !important;
+      --persona-button-primary-bg: #5e56e7 !important;
+      --persona-button-primary-fg: #ffffff !important;
+      --persona-text: #303030 !important;
+      --persona-text-inverse: #ffffff !important;
+      --persona-muted: #616161 !important;
+      --persona-text-muted: #616161 !important;
+      --persona-border: #e3e3e3 !important;
+      --persona-divider: #ececec !important;
+      --persona-message-border: #eceef3 !important;
+      --persona-md-link-color: #5e56e7 !important;
     }
-    .workspace-banner > p {
-      margin: 0;
-      color: var(--muted);
-      font-family: var(--font-sans);
-      font-size: 14px;
-      max-width: 72ch;
-      line-height: 1.55;
+
+    /* Header — flush white bar with an Otto identity, matching a first-party
+       store copilot (not a dark chat toolbar). */
+    [data-persona-theme-zone="header"],
+    .persona-widget-header {
+      background: #ffffff !important;
+      color: var(--ink) !important;
+      border-bottom: 1px solid #ececec !important;
     }
-    .workspace-grid {
-      display: grid;
-      grid-template-columns: repeat(3, minmax(0, 1fr));
-      gap: 16px;
+    .persona-widget-header * { color: var(--ink) !important; }
+    /* Header media tile → Otto's violet mark (the default is an empty square). */
+    .persona-widget-header > div:first-child {
+      background: linear-gradient(150deg, #7c6cf5 0%, #5e56e7 55%, #4038c4 100%) !important;
+      border-radius: 11px !important;
+      box-shadow: 0 2px 6px rgba(94, 86, 231, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
     }
-    .workspace-card {
-      padding: 18px 24px;
-      border-radius: var(--radius-lg);
-      background: var(--card);
-      border: 1px solid var(--border);
-      box-shadow: var(--shadow-sm);
+    .persona-widget-header > div:first-child svg,
+    .persona-widget-header > div:first-child svg * { color: #ffffff !important; stroke: #ffffff !important; }
+
+    /* Body + composer surfaces: clean white. */
+    .persona-widget-body,
+    [data-persona-theme-zone="messages"] { background: #ffffff !important; }
+    .persona-widget-footer,
+    [data-persona-theme-zone="composer"] { background: #ffffff !important; border-top-color: #f0f0f0 !important; }
+
+    /* Zero-state hero: center it, drop the card chrome, and prepend Otto's
+       gradient avatar. Persona renders welcomeTitle/welcomeSubtitle here. */
+    [data-persona-intro-card] {
+      background: transparent !important;
+      box-shadow: none !important;
+      border: none !important;
+      display: flex !important;
+      flex-direction: column;
+      align-items: center;
+      text-align: center;
+      gap: 0;
+      padding: 20px 22px 8px !important;
+      margin: auto 0;
     }
-    .workspace-card h4 {
-      margin: 0 0 10px;
-      font-family: var(--font-sans);
+    [data-persona-intro-card]::before {
+      content: "";
+      display: block;
+      width: 46px; height: 46px;
+      margin: 0 auto 16px;
+      border-radius: 13px;
+      background:
+        radial-gradient(circle at 32% 28%, #a89bff 0%, #7c6cf5 42%, #5e56e7 72%, #4038c4 100%);
+      box-shadow:
+        0 6px 16px rgba(94, 86, 231, 0.34),
+        inset 0 1px 0 rgba(255, 255, 255, 0.45);
+    }
+    [data-persona-intro-card] h2 {
+      font-size: 19px !important;
+      font-weight: 650 !important;
+      color: var(--ink) !important;
+      line-height: 1.3 !important;
+      letter-spacing: -0.01em;
+    }
+    [data-persona-intro-card] p {
+      font-size: 13.5px !important;
+      color: var(--muted) !important;
+      line-height: 1.55 !important;
+      max-width: 300px;
+      margin: 8px auto 0 !important;
+    }
+
+    /* Suggestion chips — soft bordered rows with a leading spark. */
+    [data-persona-composer-suggestions] {
+      flex-direction: column !important;
+      align-items: stretch !important;
+      gap: 7px !important;
+      margin-bottom: 12px !important;
+    }
+    [data-persona-composer-suggestions] button {
+      display: flex !important;
+      align-items: center;
+      justify-content: flex-start;
+      gap: 9px;
+      width: 100%;
+      text-align: left;
+      background: #ffffff !important;
+      border: 1px solid #e3e3e3 !important;
+      border-radius: 10px !important;
+      color: var(--ink-2) !important;
+      padding: 9px 13px !important;
+      font-size: 13px !important;
+      font-weight: 500 !important;
+      box-shadow: 0 1px 1px rgba(0, 0, 0, 0.02) !important;
+      transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+    }
+    [data-persona-composer-suggestions] button:hover {
+      background: #faf9ff !important;
+      border-color: #d8d4f7 !important;
+      opacity: 1 !important;
+      box-shadow: 0 2px 8px rgba(94, 86, 231, 0.10) !important;
+    }
+    [data-persona-composer-suggestions] button::before {
+      content: "\2726"; /* ✦ */
+      color: var(--brand);
+      font-size: 12px;
+      line-height: 1;
+      flex: none;
+    }
+    [data-persona-composer-suggestions] button::after {
+      content: "\2192"; /* → */
+      margin-left: auto;
+      color: #b9b4e8;
       font-size: 15px;
-      font-weight: 600;
-      color: var(--foreground);
+      line-height: 1;
+      flex: none;
     }
-    .workspace-card p {
-      margin: 0;
-      color: var(--muted);
-      font-family: var(--font-sans);
-      font-size: 14px;
-      line-height: 1.5;
+
+    /* Composer — a single rounded field with a soft violet halo above it (the
+       glow reads as "the assistant is listening"). */
+    [data-persona-composer-form] {
+      border: 1px solid #e3e3e3 !important;
+      border-radius: 14px !important;
+      background: #ffffff !important;
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04) !important;
+      transition: border-color 0.15s ease, box-shadow 0.15s ease;
     }
-    .workspace-feed {
-      min-height: 0;
-      padding: 18px 24px;
-      border-radius: var(--radius-lg);
-      background: var(--card);
-      border: 1px solid var(--border);
-      box-shadow: var(--shadow-sm);
+    [data-persona-composer-form]:focus-within {
+      border-color: #c4bdf5 !important;
+      box-shadow: 0 0 0 3px rgba(94, 86, 231, 0.12), 0 1px 2px rgba(0, 0, 0, 0.04) !important;
     }
-    .workspace-feed__heading {
-      margin: 0 0 12px;
-      font-size: 11px;
-      font-family: var(--font-sans);
-      font-weight: 700;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      color: var(--docked-slate-600);
+    [data-persona-theme-zone="composer"] { position: relative; }
+    [data-persona-theme-zone="composer"]::before {
+      content: "";
+      position: absolute;
+      left: 0; right: 0; top: -26px;
+      height: 26px;
+      pointer-events: none;
+      background: linear-gradient(180deg, rgba(124, 108, 245, 0) 0%, rgba(124, 108, 245, 0.07) 100%);
     }
-    .feed-item {
-      display: grid;
-      gap: 4px;
-      padding: 12px 0 12px 14px;
-      border-bottom: 1px solid var(--border);
-      border-left: 3px solid transparent;
-      margin-left: 0;
+    /* Circular violet submit with the paper-plane it already renders. */
+    [data-persona-composer-submit] {
+      border-radius: 50% !important;
+      background: #5e56e7 !important;
+      color: #ffffff !important;
     }
-    .feed-item:last-child {
-      border-bottom: none;
+    [data-persona-composer-submit]:hover { background: #4f47d6 !important; }
+
+    /* Messages — right-aligned gray user pill, plain-text assistant. */
+    .persona-message-user-bubble {
+      background: #f1f1f1 !important;
+      color: #303030 !important;
+      border: none !important;
+      border-radius: 14px !important;
+      box-shadow: none !important;
     }
-    .feed-item:hover {
-      border-left-color: var(--docked-nav-active);
+    .persona-message-user-bubble * { color: #303030 !important; }
+    .persona-message-assistant-bubble {
+      background: transparent !important;
+      border: none !important;
+      box-shadow: none !important;
+      padding-left: 2px !important;
     }
-    .feed-meta {
-      font-size: 11px;
-      font-family: var(--font-sans);
-      font-weight: 600;
-      color: var(--docked-slate-600);
-      text-transform: uppercase;
-      letter-spacing: 0.06em;
+
+    /* Tool group — a quiet "steps" strip, not a loud debug console. */
+    [data-persona-tool-group] {
+      background: #ffffff !important;
+      border: 1px solid #eceef3 !important;
+      border-radius: 10px !important;
     }
-    .feed-title {
-      font-family: var(--font-sans);
-      font-weight: 600;
-      font-size: 14px;
-      color: var(--foreground);
-    }
-    .feed-item > span:last-child {
-      font-family: var(--font-sans);
-      font-size: 13px;
-      color: var(--muted);
-      line-height: 1.45;
-    }
-    .status-row {
-      padding: 0 28px 18px;
-      color: var(--muted);
-      font-size: 13px;
-    }
+
+    /* ============================ RESPONSIVE ============================ */
     @media (max-width: 1120px) {
-      .workspace-main {
-        --workspace-nav-w: 0px;
-      }
-
+      .workspace-main { --workspace-nav-w: 0px; }
       .workspace-main[data-dock-side="right"],
-      .workspace-main[data-dock-side="left"] {
-        display: flex !important;
-        flex-direction: column !important;
-      }
-
+      .workspace-main[data-dock-side="left"] { display: flex !important; flex-direction: column !important; }
       .workspace-main[data-dock-side="right"] .workspace-nav,
       .workspace-main[data-dock-side="left"] .workspace-nav {
-        position: relative;
-        inset: auto;
-        z-index: auto;
-        width: 100%;
-        flex: 0 0 auto;
-        height: auto;
-        border-right: none;
-        border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-        padding: 12px 16px 14px;
+        position: relative; inset: auto; z-index: auto; width: 100%; flex: 0 0 auto; height: auto;
+        border-right: none; border-bottom: 1px solid var(--border); padding: 10px 14px;
       }
-
-      .workspace-nav h2 {
-        margin: 0 0 10px;
-      }
-
-      .workspace-nav ul {
-        flex-direction: row !important;
-        flex-wrap: wrap;
-        gap: 6px !important;
-      }
-
-      .workspace-nav .nav-item {
-        font-size: 12px;
-        min-height: unset;
-        padding: 8px 12px;
-        white-space: nowrap;
-      }
-
-      .workspace-main[data-dock-side="right"] .workspace-stage,
-      .workspace-main[data-dock-side="left"] .workspace-stage {
-        flex: 1 1 auto;
-        min-height: 0;
-        width: 100%;
-      }
-
-      .workspace-main[data-dock-side="right"] .workspace-canvas {
-        padding-left: 24px;
-      }
+      .workspace-nav .nav-section, .workspace-nav .nav-spacer { display: none; }
+      .workspace-nav ul { flex-direction: row !important; flex-wrap: wrap; gap: 4px !important; }
+      .nav-item { padding: 6px 10px; }
+      .nav-item span { white-space: nowrap; }
+      .workspace-main[data-dock-side="right"] .workspace-canvas,
+      .workspace-main[data-dock-side="left"] .workspace-canvas { padding-left: 20px; padding-right: 20px; }
     }
-    @media (max-width: 860px) {
-      .workspace-grid {
-        grid-template-columns: 1fr;
-      }
-      .topbar-context__name {
-        display: none;
-      }
-      .topbar-context {
-        padding-left: 10px;
-        margin-left: 4px;
-      }
+    @media (max-width: 720px) {
+      .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      .metric:nth-child(2) { border-right: none; }
+      .metric:nth-child(1), .metric:nth-child(2) { border-bottom: 1px solid var(--border); }
+      .topbar-search { display: none; }
+      .store-name { display: none; }
+      .admin-topbar { grid-template-columns: auto 1fr auto; }
     }
   </style>
 </head>
 <body>
   <div class="app-root">
+    <!-- ============================ TOP BAR ============================ -->
     <header class="admin-topbar">
-      <div class="admin-topbar__left">
-        <span class="admin-topbar__brand">
-          <span class="admin-topbar__logo" aria-hidden="true">
-            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" />
-              <path d="M5 3v4" />
-              <path d="M19 17v4" />
-              <path d="M3 5h4" />
-              <path d="M17 19h4" />
-            </svg>
-          </span>
-          <span class="admin-topbar__wordmark">Persona <em>Docked</em></span>
-        </span>
-      </div>
-      <div class="admin-topbar__right">
-        <div id="assistant-coachmark" class="assistant-coachmark" role="note">
-          <span class="assistant-coachmark__label">Click the sparkles: open Copilot</span>
-          <svg
-            class="assistant-coachmark__arrow"
-            width="20"
-            height="20"
-            viewBox="0 0 24 24"
-            fill="none"
-            aria-hidden="true"
-            stroke="currentColor"
-            stroke-width="2.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M5 12h14" />
-            <path d="m12 5 7 7-7 7" />
+      <a class="topbar-brand" href="#" onclick="return false">
+        <span class="brand-mark" aria-hidden="true">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 3v18M3 12h18M5.6 5.6l12.8 12.8M18.4 5.6 5.6 18.4" />
           </svg>
+        </span>
+        <span class="brand-wordmark">Aster</span>
+      </a>
+
+      <div class="topbar-search" role="search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" /></svg>
+        <span>Search</span>
+        <kbd>⌘K</kbd>
+      </div>
+
+      <div class="topbar-right">
+        <div id="assistant-coachmark" class="assistant-coachmark" role="note">
+          <span class="assistant-coachmark__label">Meet Otto, your store copilot</span>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14" /><path d="m12 5 7 7-7 7" /></svg>
         </div>
         <button
           type="button"
           id="assistant-toggle"
-          class="assistant-toggle--persist-highlight"
+          class="assistant-toggle--hint"
           aria-expanded="false"
           aria-describedby="assistant-coachmark"
-          aria-label="Open assistant"
-          title="Open assistant"
+          aria-label="Open Otto"
+          title="Open Otto"
         >
-          <!-- Lucide-style sparkles -->
-          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <!-- sparkles -->
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
             <path d="m12 3-1.912 5.813a2 2 0 0 1-1.275 1.275L3 12l5.813 1.912a2 2 0 0 1 1.275 1.275L12 21l1.912-5.813a2 2 0 0 1 1.275-1.275L21 12l-5.813-1.912a2 2 0 0 1-1.275-1.275L12 3Z" />
-            <path d="M5 3v4" />
-            <path d="M19 17v4" />
-            <path d="M3 5h4" />
-            <path d="M17 19h4" />
+            <path d="M5 3v4M19 17v4M3 5h4M17 19h4" />
           </svg>
         </button>
         <button type="button" class="icon-btn--ghost" aria-label="Notifications (decorative)">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.75" aria-hidden="true">
-            <path d="M18 8A6 6 0 1 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" stroke-linecap="round" stroke-linejoin="round" />
-            <path d="M13.73 21a2 2 0 0 1-3.46 0" stroke-linecap="round" />
-          </svg>
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M18 8A6 6 0 1 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" /><path d="M13.73 21a2 2 0 0 1-3.46 0" /></svg>
         </button>
-        <div class="topbar-context">
-          <div class="topbar-avatar" aria-hidden="true">
-            <span class="topbar-avatar__glyph">AC</span>
-            <span class="topbar-avatar__status" title="Signed in"></span>
-          </div>
-          <span class="topbar-context__name">Acme Corp</span>
-          <span class="topbar-context__badge">staging</span>
+        <div class="topbar-store" title="Kestrel &amp; Co.">
+          <span class="store-avatar" aria-hidden="true">KC</span>
+          <span class="store-name">Kestrel &amp; Co.</span>
+          <span class="store-plan">Pro</span>
         </div>
       </div>
     </header>
 
+    <!-- ============================ BODY ============================ -->
     <div class="workspace-shell">
       <div class="workspace-panel">
         <section class="workspace-main" id="workspace-main" data-dock-side="right">
+          <!-- Left nav (sections drivable by Otto's switch_section tool) -->
           <aside class="workspace-nav">
-            <h2>Workspace</h2>
             <ul>
-              <li><span class="nav-item is-active" aria-current="page">Overview</span></li>
-              <li><span class="nav-item">Automation</span></li>
-              <li><span class="nav-item">Audience</span></li>
-              <li><span class="nav-item">Catalog</span></li>
-              <li><span class="nav-item">Publishing</span></li>
+              <li><span class="nav-item is-active" aria-current="page">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="m3 10 9-7 9 7v9a2 2 0 0 1-2 2h-4v-6H9v6H5a2 2 0 0 1-2-2z" /></svg>
+                <span>Home</span></span></li>
+              <li><span class="nav-item">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" /><path d="M3 6h18M16 10a4 4 0 0 1-8 0" /></svg>
+                <span>Orders</span></span></li>
+              <li><span class="nav-item">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="m7.5 4.27 9 5.15M21 8.5 12 13 3 8.5m9 4.5v9" /><path d="M20 16.5v-9a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 2 7.5v9a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 20 16.5" /></svg>
+                <span>Products</span></span></li>
+              <li><span class="nav-item">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" /></svg>
+                <span>Customers</span></span></li>
+              <li><span class="nav-item">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><line x1="19" x2="5" y1="5" y2="19" /><circle cx="6.5" cy="6.5" r="2.5" /><circle cx="17.5" cy="17.5" r="2.5" /></svg>
+                <span>Discounts</span></span></li>
+              <li><span class="nav-item">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v16a2 2 0 0 0 2 2h16" /><path d="M7 15l3-3 3 2 4-5" /></svg>
+                <span>Analytics</span></span></li>
+            </ul>
+            <div class="nav-section">Sales channels</div>
+            <ul>
+              <li><span class="nav-item">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10" /><path d="M2 12h20M12 2a15.3 15.3 0 0 1 0 20 15.3 15.3 0 0 1 0-20" /></svg>
+                <span>Online Store</span></span></li>
+              <li><span class="nav-item">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><rect x="5" y="2" width="14" height="20" rx="2" /><path d="M12 18h.01" /></svg>
+                <span>Point of Sale</span></span></li>
+            </ul>
+            <div class="nav-spacer"></div>
+            <ul>
+              <li><span class="nav-item nav-item--settings">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.85" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></svg>
+                <span>Settings</span></span></li>
             </ul>
           </aside>
+
           <div class="workspace-stage">
             <div id="workspace-dock-target">
               <div class="workspace-canvas">
-            <div class="workspace-banner">
-              <h3>Operations overview</h3>
-              <p>
-                Track launches, team activity, and performance in one place. Open Copilot from the header when you need answers or drafting help: it stays docked beside this view instead of covering your work.
-              </p>
-            </div>
-            <section class="dock-settings-card" aria-labelledby="dock-settings-heading">
-              <div class="dock-settings-card__inner">
-                <h4 class="dock-settings-card__title" id="dock-settings-heading">Assistant dock</h4>
-                <div class="dock-settings__row">
-                  <div class="dock-settings__field">
-                    <label for="dock-side">Side</label>
-                    <select id="dock-side" autocomplete="off">
-                      <option value="right" selected>Right</option>
-                      <option value="left">Left</option>
-                    </select>
+                <div class="canvas-inner">
+
+                  <div class="page-head">
+                    <h1 class="page-title">Home</h1>
+                    <span class="page-pill">
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" /><path d="M16 2v4M8 2v4M3 10h18" /></svg>
+                      Last 30 days
+                    </span>
                   </div>
-                  <div class="dock-settings__field">
-                    <label for="dock-width">Width when open</label>
-                    <input id="dock-width" type="text" value="420px" inputmode="numeric" autocomplete="off" />
-                  </div>
-                  <div class="dock-settings__field">
-                    <label for="dock-reveal">Reveal</label>
-                    <select id="dock-reveal" autocomplete="off" title="How the dock opens: resize column, overlay transform, or push track">
-                      <option value="resize">resize (flex width)</option>
-                      <option value="emerge" selected>emerge (resize + fixed panel)</option>
-                      <option value="overlay">overlay (transform)</option>
-                      <option value="push">push (translate)</option>
-                    </select>
-                  </div>
-                  <div class="dock-settings__field">
-                    <label class="dock-settings__check">
-                      <input id="dock-animate" type="checkbox" checked autocomplete="off" />
-                      <span>Animate</span>
-                    </label>
-                  </div>
-                  <button id="apply-dock-settings" type="button">Apply</button>
+
+                  <!-- Metrics -->
+                  <section class="card" aria-label="Store metrics">
+                    <div class="metrics">
+                      <div class="metric" data-metric="Sessions">
+                        <div class="metric__label">Sessions</div>
+                        <div class="metric__value">2,412</div>
+                        <div class="metric__delta is-up"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8" /></svg>12.4%</div>
+                      </div>
+                      <div class="metric" data-metric="Total sales">
+                        <div class="metric__label">Total sales</div>
+                        <div class="metric__value">$18,240</div>
+                        <div class="metric__delta is-up"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8" /></svg>8.4%</div>
+                      </div>
+                      <div class="metric" data-metric="Orders">
+                        <div class="metric__label">Orders</div>
+                        <div class="metric__value">143</div>
+                        <div class="metric__delta is-up"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17 17 7M9 7h8v8" /></svg>5.1%</div>
+                      </div>
+                      <div class="metric" data-metric="Conversion rate">
+                        <div class="metric__label">Conversion rate</div>
+                        <div class="metric__value">3.8%</div>
+                        <div class="metric__delta is-flat"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14" /></svg>0.2%</div>
+                      </div>
+                    </div>
+                  </section>
+
+                  <!-- Products / inventory -->
+                  <section class="card" id="product-card" aria-label="Products">
+                    <div class="card__head">
+                      <h3 class="card__title">Inventory</h3>
+                      <a class="card__link" href="#" onclick="return false">View all</a>
+                    </div>
+                    <div class="prod-list" id="product-list">
+                      <div class="prod" data-product="Aurora Table Lamp" data-inventory="54" data-status="in">
+                        <span class="prod__thumb" style="background:#fdeede">💡</span>
+                        <div><div class="prod__name">Aurora Table Lamp</div><div class="prod__sku">SKU · AUR-114</div></div>
+                        <div class="prod__price">$128.00</div>
+                        <div class="prod__stock"><span class="stock-badge stock-badge--in">In stock</span><span class="prod__count">54</span></div>
+                      </div>
+                      <div class="prod" data-product="Linen Throw Blanket" data-inventory="7" data-status="low">
+                        <span class="prod__thumb" style="background:#eef1fb">🧺</span>
+                        <div><div class="prod__name">Linen Throw Blanket</div><div class="prod__sku">SKU · LIN-042</div></div>
+                        <div class="prod__price">$64.00</div>
+                        <div class="prod__stock"><span class="stock-badge stock-badge--low">Low stock</span><span class="prod__count">7</span></div>
+                      </div>
+                      <div class="prod" data-product="Ceramic Pour-Over" data-inventory="0" data-status="out">
+                        <span class="prod__thumb" style="background:#eef6f1">☕️</span>
+                        <div><div class="prod__name">Ceramic Pour-Over</div><div class="prod__sku">SKU · CER-088</div></div>
+                        <div class="prod__price">$42.00</div>
+                        <div class="prod__stock"><span class="stock-badge stock-badge--out">Sold out</span><span class="prod__count">0</span></div>
+                      </div>
+                      <div class="prod" data-product="Walnut Desk Shelf" data-inventory="31" data-status="in">
+                        <span class="prod__thumb" style="background:#f4efe7">🗄️</span>
+                        <div><div class="prod__name">Walnut Desk Shelf</div><div class="prod__sku">SKU · WAL-205</div></div>
+                        <div class="prod__price">$96.00</div>
+                        <div class="prod__stock"><span class="stock-badge stock-badge--in">In stock</span><span class="prod__count">31</span></div>
+                      </div>
+                    </div>
+                  </section>
+
+                  <!-- Recent activity -->
+                  <section class="card" aria-label="Recent activity">
+                    <div class="card__head"><h3 class="card__title">Recent activity</h3></div>
+                    <div class="feed" id="activity-feed">
+                      <div class="feed-item">
+                        <span class="feed-meta">Today · 2:14 PM</span>
+                        <span class="feed-title">Order #1043 fulfilled</span>
+                        <span>Two items shipped to Portland, OR via standard delivery.</span>
+                      </div>
+                      <div class="feed-item">
+                        <span class="feed-meta">Today · 11:02 AM</span>
+                        <span class="feed-title">Price updated on Aurora Table Lamp</span>
+                        <span>Raised to $128.00 after the summer-collection refresh.</span>
+                      </div>
+                      <div class="feed-item">
+                        <span class="feed-meta">Yesterday</span>
+                        <span class="feed-title">New 5★ review on Linen Throw Blanket</span>
+                        <span>“Softer than expected and ships fast.” — verified buyer.</span>
+                      </div>
+                    </div>
+                  </section>
+
+                  <!-- Assistant dock settings (demo control; Otto can drive this too) -->
+                  <section class="card dock-settings-card" aria-labelledby="dock-settings-heading">
+                    <div class="dock-settings-card__inner">
+                      <h4 class="dock-settings-card__title" id="dock-settings-heading">Assistant dock</h4>
+                      <div class="dock-settings__row">
+                        <div class="dock-settings__field">
+                          <label for="dock-side">Side</label>
+                          <select id="dock-side" autocomplete="off">
+                            <option value="right" selected>Right</option>
+                            <option value="left">Left</option>
+                          </select>
+                        </div>
+                        <div class="dock-settings__field">
+                          <label for="dock-width">Width when open</label>
+                          <input id="dock-width" type="text" value="420px" inputmode="numeric" autocomplete="off" />
+                        </div>
+                        <div class="dock-settings__field">
+                          <label for="dock-reveal">Reveal</label>
+                          <select id="dock-reveal" autocomplete="off" title="How the dock opens: resize column, overlay transform, or push track">
+                            <option value="resize">resize (flex width)</option>
+                            <option value="emerge" selected>emerge (resize + fixed panel)</option>
+                            <option value="overlay">overlay (transform)</option>
+                            <option value="push">push (translate)</option>
+                          </select>
+                        </div>
+                        <label class="dock-settings__check">
+                          <input id="dock-animate" type="checkbox" checked autocomplete="off" />
+                          <span>Animate</span>
+                        </label>
+                        <button id="apply-dock-settings" type="button">Apply</button>
+                      </div>
+                    </div>
+                    <p class="dock-settings__status" id="dock-status"></p>
+                  </section>
+
                 </div>
-              </div>
-              <p class="dock-settings__status" id="dock-status"></p>
-            </section>
-            <div class="workspace-grid">
-              <article class="workspace-card">
-                <h4>Launch checklist</h4>
-                <p>Review assets, update pricing, and confirm event tracking before publication.</p>
-              </article>
-              <article class="workspace-card">
-                <h4>Team updates</h4>
-                <p>Two new comments need responses in the shared brand workspace.</p>
-              </article>
-              <article class="workspace-card">
-                <h4>Performance</h4>
-                <p>Conversion is up 8.4% this week after the latest merchandising changes.</p>
-              </article>
-            </div>
-            <div class="workspace-feed">
-              <h4 class="workspace-feed__heading">Recent activity</h4>
-              <div class="feed-item">
-                <span class="feed-meta">Today</span>
-                <span class="feed-title">Campaign brief approved</span>
-                <span>AI assistant suggested a shorter launch checklist for the team review.</span>
-              </div>
-              <div class="feed-item">
-                <span class="feed-meta">Yesterday</span>
-                <span class="feed-title">Homepage hero refreshed</span>
-                <span>Variant B is performing best on desktop traffic and retained its mobile score.</span>
-              </div>
-              <div class="feed-item">
-                <span class="feed-meta">This week</span>
-                <span class="feed-title">Partner onboarding queue</span>
-                <span>Three new partner submissions are awaiting audit and copy review.</span>
-              </div>
-            </div>
               </div>
             </div>
           </div>

--- a/apps/web/src/docked-panel-charts.ts
+++ b/apps/web/src/docked-panel-charts.ts
@@ -1,0 +1,220 @@
+// Inline data-viz for the docked "Otto" demo.
+//
+// Two registered Persona components that Otto renders straight into the
+// transcript (via controller.injectComponentDirective) when its WebMCP tools
+// run: an area "sales trend" chart and a ranked "top products" bar chart. The
+// look matches the admin's card system (white surface, hairline border, Inter,
+// a single violet brand hue) so a chart reads as first-party output, not a
+// bolted-on widget. Renderers take plain props and return DOM — no state.
+
+import type { ComponentRenderer } from "@runtypelabs/persona";
+
+const SVG_NS = "http://www.w3.org/2000/svg";
+const BRAND = "#5e56e7";
+const BRAND_SOFT = "rgba(94, 86, 231, 0.16)";
+const INK = "#1a1a1a";
+const MUTED = "#616161";
+const POS = "#067a57";
+
+type Point = { label: string; value: number };
+
+function coercePoints(raw: unknown): Point[] {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((p): Point | null => {
+      if (typeof p === "number") return { label: "", value: p };
+      if (p && typeof p === "object") {
+        const o = p as Record<string, unknown>;
+        const value = Number(o.value ?? o.revenue ?? o.y ?? 0);
+        if (!Number.isFinite(value)) return null;
+        return { label: String(o.label ?? o.date ?? o.x ?? ""), value };
+      }
+      return null;
+    })
+    .filter((p): p is Point => p !== null);
+}
+
+/** Shared card shell so both charts share the exact admin card aesthetic. */
+function chartCard(): HTMLElement {
+  const card = document.createElement("div");
+  card.style.cssText = [
+    "font-family: inherit",
+    "background: #ffffff",
+    "border: 1px solid #ececf2",
+    "border-radius: 12px",
+    "box-shadow: 0 1px 2px rgba(0,0,0,0.05)",
+    "padding: 16px 16px 14px",
+    "margin: 6px 0 2px",
+    "max-width: 520px",
+  ].join(";");
+  return card;
+}
+
+function el(
+  tag: string,
+  style: string,
+  text?: string,
+): HTMLElement {
+  const node = document.createElement(tag);
+  node.style.cssText = style;
+  if (text !== undefined) node.textContent = text;
+  return node;
+}
+
+function svgEl(tag: string, attrs: Record<string, string | number>): SVGElement {
+  const node = document.createElementNS(SVG_NS, tag);
+  for (const [k, v] of Object.entries(attrs)) node.setAttribute(k, String(v));
+  return node;
+}
+
+// ---------------------------------------------------------------------------
+// otto_sales_chart — area/line trend
+// props: { title?, subtitle?, points: (number | {label,value})[], total?, delta? }
+// ---------------------------------------------------------------------------
+export const OttoSalesChart: ComponentRenderer = (props) => {
+  const card = chartCard();
+  const points = coercePoints(props.points);
+
+  // Header: title + subtitle on the left, total + delta on the right.
+  const head = el("div", "display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:14px");
+  const headL = el("div", "min-width:0");
+  headL.appendChild(el("div", `font-size:13.5px;font-weight:600;color:${INK};letter-spacing:-0.01em`, String(props.title ?? "Sales trend")));
+  if (props.subtitle) headL.appendChild(el("div", `font-size:12px;color:${MUTED};margin-top:2px`, String(props.subtitle)));
+  head.appendChild(headL);
+
+  if (props.total !== undefined) {
+    const headR = el("div", "text-align:right;flex:none");
+    headR.appendChild(el("div", `font-size:18px;font-weight:650;color:${INK};letter-spacing:-0.02em`, String(props.total)));
+    if (props.delta !== undefined) {
+      const up = !String(props.delta).trim().startsWith("-");
+      const delta = el(
+        "div",
+        `display:inline-flex;align-items:center;gap:3px;font-size:12px;font-weight:550;margin-top:2px;color:${up ? POS : "#b3261e"}`,
+        `${up ? "▲" : "▼"} ${String(props.delta).replace(/^[-+]/, "")}`,
+      );
+      headR.appendChild(delta);
+    }
+    head.appendChild(headR);
+  }
+  card.appendChild(head);
+
+  // Chart
+  const W = 488;
+  const H = 132;
+  const padY = 10;
+  const vals = points.map((p) => p.value);
+  const max = vals.length ? Math.max(...vals) : 1;
+  const min = vals.length ? Math.min(...vals) : 0;
+  const span = max - min || 1;
+  const x = (i: number) => (points.length <= 1 ? 0 : (i / (points.length - 1)) * W);
+  const y = (v: number) => H - padY - ((v - min) / span) * (H - padY * 2);
+
+  const svg = svgEl("svg", { viewBox: `0 0 ${W} ${H}`, width: "100%", height: H, preserveAspectRatio: "none" });
+  (svg as SVGElement).style.cssText = "display:block;overflow:visible";
+
+  // gradient def
+  const defs = svgEl("defs", {});
+  const grad = svgEl("linearGradient", { id: "otto-area-grad", x1: "0", y1: "0", x2: "0", y2: "1" });
+  grad.appendChild(svgEl("stop", { offset: "0%", "stop-color": BRAND, "stop-opacity": "0.22" }));
+  grad.appendChild(svgEl("stop", { offset: "100%", "stop-color": BRAND, "stop-opacity": "0" }));
+  defs.appendChild(grad);
+  svg.appendChild(defs);
+
+  if (points.length >= 2) {
+    // baseline
+    svg.appendChild(svgEl("line", { x1: 0, y1: H - padY, x2: W, y2: H - padY, stroke: "#eceef3", "stroke-width": 1 }));
+
+    const linePts = points.map((p, i) => `${x(i)},${y(p.value)}`).join(" ");
+    const areaPts = `0,${H - padY} ${linePts} ${W},${H - padY}`;
+    svg.appendChild(svgEl("polygon", { points: areaPts, fill: "url(#otto-area-grad)" }));
+    svg.appendChild(
+      svgEl("polyline", {
+        points: linePts,
+        fill: "none",
+        stroke: BRAND,
+        "stroke-width": 2.25,
+        "stroke-linejoin": "round",
+        "stroke-linecap": "round",
+      }),
+    );
+    // end dot
+    const last = points.length - 1;
+    svg.appendChild(svgEl("circle", { cx: x(last), cy: y(points[last].value), r: 4, fill: "#fff", stroke: BRAND, "stroke-width": 2.25 }));
+  }
+  card.appendChild(svg);
+
+  // x-axis labels (first / mid / last)
+  if (points.length >= 2) {
+    const axis = el("div", `display:flex;justify-content:space-between;margin-top:8px;font-size:11px;color:${MUTED}`);
+    const mid = Math.floor((points.length - 1) / 2);
+    [points[0], points[mid], points[points.length - 1]].forEach((p, i) => {
+      axis.appendChild(el("span", i === 1 ? "opacity:0.75" : "", p.label));
+    });
+    card.appendChild(axis);
+  }
+
+  if (props.footnote) {
+    card.appendChild(el("div", `margin-top:10px;padding-top:10px;border-top:1px solid #f0f0f4;font-size:11px;color:#9a9a9a`, String(props.footnote)));
+  }
+  return card;
+};
+
+// ---------------------------------------------------------------------------
+// otto_bar_chart — ranked horizontal bars
+// props: { title?, subtitle?, bars: {label, value, sub?, display?}[] }
+// ---------------------------------------------------------------------------
+export const OttoBarChart: ComponentRenderer = (props) => {
+  const card = chartCard();
+  const bars = Array.isArray(props.bars)
+    ? (props.bars as Record<string, unknown>[]).map((b) => ({
+        label: String(b.label ?? ""),
+        value: Number(b.value ?? 0) || 0,
+        sub: b.sub !== undefined ? String(b.sub) : "",
+        display: b.display !== undefined ? String(b.display) : undefined,
+      }))
+    : [];
+
+  const head = el("div", "margin-bottom:14px");
+  head.appendChild(el("div", `font-size:13.5px;font-weight:600;color:${INK};letter-spacing:-0.01em`, String(props.title ?? "Top products")));
+  if (props.subtitle) head.appendChild(el("div", `font-size:12px;color:${MUTED};margin-top:2px`, String(props.subtitle)));
+  card.appendChild(head);
+
+  const max = bars.reduce((m, b) => Math.max(m, b.value), 0) || 1;
+  const list = el("div", "display:flex;flex-direction:column;gap:12px");
+  bars.forEach((b, i) => {
+    const row = el("div", "");
+    const top = el("div", "display:flex;align-items:baseline;justify-content:space-between;gap:10px;margin-bottom:5px");
+    const left = el("div", "display:flex;align-items:baseline;gap:7px;min-width:0");
+    left.appendChild(el("span", `font-size:13px;font-weight:550;color:${INK};white-space:nowrap;overflow:hidden;text-overflow:ellipsis`, b.label));
+    if (b.sub) left.appendChild(el("span", `font-size:11.5px;color:${MUTED};flex:none`, b.sub));
+    top.appendChild(left);
+    top.appendChild(el("span", `font-size:12.5px;font-weight:600;color:${INK};flex:none`, b.display ?? String(b.value)));
+    row.appendChild(top);
+
+    const track = el("div", "position:relative;height:8px;border-radius:999px;background:#f1f1f4;overflow:hidden");
+    const pct = Math.max(3, Math.round((b.value / max) * 100));
+    // Lead bar full-strength, the rest slightly stepped down for a ranked feel.
+    const alpha = 1 - Math.min(i, 3) * 0.14;
+    const fill = el(
+      "div",
+      `position:absolute;left:0;top:0;bottom:0;width:${pct}%;border-radius:999px;background:${BRAND};opacity:${alpha.toFixed(2)}`,
+    );
+    track.appendChild(fill);
+    row.appendChild(track);
+    list.appendChild(row);
+  });
+  card.appendChild(list);
+
+  if (props.footnote) {
+    card.appendChild(el("div", `margin-top:12px;padding-top:10px;border-top:1px solid #f0f0f4;font-size:11px;color:#9a9a9a`, String(props.footnote)));
+  }
+  return card;
+};
+
+/** Register both inline charts on the given registry. */
+export function registerOttoCharts(registry: {
+  register: (name: string, renderer: ComponentRenderer) => void;
+}): void {
+  registry.register("otto_sales_chart", OttoSalesChart);
+  registry.register("otto_bar_chart", OttoBarChart);
+}

--- a/apps/web/src/docked-panel-demo.ts
+++ b/apps/web/src/docked-panel-demo.ts
@@ -2,6 +2,7 @@ import "@runtypelabs/persona/widget.css";
 
 import {
   DEFAULT_WIDGET_CONFIG,
+  componentRegistry,
   createLocalStorageAdapter,
   initAgentWidget,
   markdownPostprocessor,
@@ -9,11 +10,18 @@ import {
   type WebMcpConfirmInfo,
 } from "@runtypelabs/persona";
 import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+import { registerOttoCharts } from "./docked-panel-charts";
 
-// The docked Copilot is WebMCP-powered: this page registers four workspace
-// tools on document.modelContext (see "WebMCP page tools" at the bottom) and
-// the dispatch-docked flow drives them: read the dashboard, switch sections,
-// log activity, and even move the assistant's own dock.
+// Otto renders charts inline (right in the transcript) via
+// injectComponentDirective, so its two viz components must be in the registry
+// before the widget mounts.
+registerOttoCharts(componentRegistry);
+
+// Otto — the docked store copilot — is WebMCP-powered: this page registers
+// storefront tools on document.modelContext (see the bottom of the file) and the
+// dispatch-docked flow drives them: read the store's KPIs and inventory, chart
+// the sales trend and top products inline, switch admin sections, restock a
+// product (visible on the page), log activity, and even reposition its own dock.
 const proxyPort = import.meta.env.VITE_PROXY_PORT ?? 43111;
 const apiUrl =
   import.meta.env.VITE_PROXY_URL
@@ -35,8 +43,13 @@ interface RegisterableModelContext {
   ): void;
 }
 
-/** Read-only tools run without confirmation; mutations get Persona's approval bubble. */
-const READ_ONLY_TOOLS = new Set(["get_workspace_overview", "switch_section"]);
+/** Read-only tools run without confirmation; mutations get Otto's approval bubble. */
+const READ_ONLY_TOOLS = new Set([
+  "get_store_overview",
+  "switch_section",
+  "show_sales_trend",
+  "show_top_products",
+]);
 
 const dockSideSelect = document.getElementById("dock-side") as HTMLSelectElement | null;
 const dockWidthInput = document.getElementById("dock-width") as HTMLInputElement | null;
@@ -84,8 +97,8 @@ function getDemoLauncher() {
     autoExpand: false,
     fullHeight: true,
     mobileBreakpoint: 1120,
-    title: "Copilot",
-    subtitle: "Dashboard Assistant",
+    title: "Otto",
+    subtitle: "Store copilot",
   };
 }
 
@@ -110,19 +123,15 @@ function formatDockOptionsLine(dock: ReturnType<typeof getDockConfig>): string {
 function syncToggleUi(): void {
   const open = controller.getState().open;
   assistantToggle.setAttribute("aria-expanded", open ? "true" : "false");
-  assistantToggle.setAttribute("aria-label", open ? "Hide assistant" : "Open assistant");
+  assistantToggle.setAttribute("aria-label", open ? "Hide Otto" : "Open Otto");
   assistantToggle.classList.toggle("is-active", open);
-  assistantToggle.title = open ? "Hide assistant" : "Open assistant";
+  assistantToggle.title = open ? "Hide Otto" : "Open Otto";
+  if (open) assistantToggle.classList.remove("assistant-toggle--hint");
 
   const coachEl = document.getElementById("assistant-coachmark");
-  if (coachEl) {
-    coachEl.toggleAttribute("hidden", open);
-  }
-  if (open) {
-    assistantToggle.removeAttribute("aria-describedby");
-  } else {
-    assistantToggle.setAttribute("aria-describedby", "assistant-coachmark");
-  }
+  if (coachEl) coachEl.toggleAttribute("hidden", open);
+  if (open) assistantToggle.removeAttribute("aria-describedby");
+  else assistantToggle.setAttribute("aria-describedby", "assistant-coachmark");
 }
 
 function updateStatus(label: string): void {
@@ -135,70 +144,54 @@ function updateStatus(label: string): void {
 function createController(): AgentWidgetInitHandle {
   return initAgentWidget({
     target: "#workspace-dock-target",
+    windowKey: "ottoDocked",
     config: {
       ...DEFAULT_WIDGET_CONFIG,
       apiUrl,
       storageAdapter: createLocalStorageAdapter("persona-state-docked-panel-demo"),
       launcher: getDemoLauncher(),
+      // Violet brand for Otto. Rounding/surface details are refined on the CSS
+      // seams in docked-panel-demo.html; the panel + header stay flush (radius 0)
+      // so the dock sits cleanly against the admin edge like a first-party panel.
       theme: {
         semantic: {
           colors: {
-            primary: "#0f172a",
-            accent: "#0f172a",
+            primary: "#5e56e7",
+            accent: "#5e56e7",
             surface: "#ffffff",
             background: "#ffffff",
-            textMuted: "#64748b",
+            textMuted: "#616161",
             interactive: {
-              default: "#0f172a",
-              hover: "#1e293b",
-              focus: "#334155",
-              active: "#020617",
+              default: "#5e56e7",
+              hover: "#4f47d6",
+              focus: "#4f47d6",
+              active: "#4038c4",
             },
             feedback: {
-              info: "#0f172a",
+              info: "#5e56e7",
             },
-          },
-        },
-        palette: {
-          radius: {
-            full: "0",
           },
         },
         components: {
-          panel: {
-            borderRadius: "0",
-          },
-          header: {
-            borderRadius: "0",
-          },
-          input: {
-            borderRadius: "0",
-          },
-          message: {
-            user: {
-              borderRadius: "0",
-            },
-            assistant: {
-              borderRadius: "0",
-            },
-          },
+          panel: { borderRadius: "0" },
+          header: { borderRadius: "0" },
         },
       },
       copy: {
         ...DEFAULT_WIDGET_CONFIG.copy,
-        welcomeTitle: "Ask Copilot",
+        welcomeTitle: "How can I help?",
         welcomeSubtitle:
-          "I can read this dashboard, switch sections, log activity, and even move my own panel: using the page's own tools.",
-        inputPlaceholder: "Ask a question or describe what you need…",
+          "I can read your store, draft copy, and take action right here — restock a product, log activity, or reorganize this workspace.",
+        inputPlaceholder: "Ask anything about your store…",
       },
-      // Ordered to walk the tool surface: read-only overview (auto-approved),
-      // read-only-ish navigation, then two mutations that raise approval bubbles
-      // (one of which moves the assistant's own dock).
+      // Ordered to walk the tool surface: an inline chart (auto-approved),
+      // a ranked bar chart, then two mutations that raise Otto's approval
+      // bubble — one restocks a product on the page, one moves Otto's own dock.
       suggestionChips: [
-        "What needs my attention on this dashboard?",
-        "Switch to the Catalog section",
-        "Log a note that the launch checklist is done",
-        "Move your panel to the left side, 360px wide",
+        "How are sales trending this month?",
+        "Show my top products by revenue",
+        "Restock the Ceramic Pour-Over",
+        "Dock yourself on the left at 380px",
       ],
       webmcp: {
         enabled: true,
@@ -226,45 +219,7 @@ function applyDockSettings(): void {
   updateStatus("Layout updated.");
 }
 
-/**
- * Compute when the coachmark shimmer would physically arrive at the button,
- * accounting for the gap between the two elements and the shimmer's exit velocity.
- *
- * Sweep: translateX(-110%) → +110% over SWEEP_DUR with cubic-bezier(0.76,0,0.24,1).
- * The shimmer center exits the coachmark right edge at ~56.5% of the sweep time
- * (inverse of the easing curve at 72.7% linear progress).  At that point the
- * instantaneous velocity is ~2.49× the average sweep speed.  We project that
- * velocity across the measured gap to get the button-arrive delay.
- */
-function syncCoachmarkTiming(): void {
-  const coachmark = document.getElementById("assistant-coachmark");
-  if (!coachmark) return;
-
-  const coachRect = coachmark.getBoundingClientRect();
-  const btnRect = assistantToggle.getBoundingClientRect();
-
-  const ENTRANCE_TOTAL = 2.5;
-  const SWEEP_START = ENTRANCE_TOTAL + 0.2;
-  const SWEEP_DUR = 1.4;
-  const EXIT_FRAC = 0.565;
-  const exitTime = SWEEP_START + SWEEP_DUR * EXIT_FRAC;
-
-  const totalDist = 2.2 * coachRect.width;
-  const exitVelocity = 2.493 * totalDist / SWEEP_DUR;
-
-  const gap = btnRect.left + btnRect.width / 2 - coachRect.right;
-  const transit = Math.max(0, gap / exitVelocity);
-
-  const ARRIVE_DUR = 0.7;
-  const arriveDelay = exitTime + transit;
-  const pulseDelay = arriveDelay + ARRIVE_DUR;
-
-  assistantToggle.style.setProperty("--arrive-delay", `${arriveDelay.toFixed(3)}s`);
-  assistantToggle.style.setProperty("--pulse-delay", `${pulseDelay.toFixed(3)}s`);
-}
-
 syncWorkspaceMainDockSide();
-syncCoachmarkTiming();
 controller = createController();
 bindControllerEvents();
 syncToggleUi();
@@ -277,15 +232,13 @@ sideSelect.addEventListener("change", () => {
   syncWorkspaceMainDockSide();
 });
 
-/** Keeps the button from taking focus on mouse click (avoids OS / UA focus ring flash); keyboard still tabs in. */
+/** Keeps the button from taking focus on mouse click (avoids OS focus-ring flash); keyboard still tabs in. */
 assistantToggle.addEventListener("mousedown", (e) => {
-  if (e.button === 0) {
-    e.preventDefault();
-  }
+  if (e.button === 0) e.preventDefault();
 });
 
 assistantToggle.addEventListener("click", () => {
-  assistantToggle.classList.remove("assistant-toggle--persist-highlight");
+  assistantToggle.classList.remove("assistant-toggle--hint");
   document.getElementById("assistant-coachmark")?.remove();
   controller.toggle();
 });
@@ -293,10 +246,10 @@ assistantToggle.addEventListener("click", () => {
 // ---------------------------------------------------------------------------
 // WebMCP page tools
 //
-// Mocked workspace actions in the same spirit as webmcp-demo.ts: the page
-// owns the tools, Persona drives them, and every result is visible on the
-// dashboard. Read-only tools auto-approve (see READ_ONLY_TOOLS); mutations
-// raise Persona's in-panel approval bubble.
+// Mocked storefront actions in the same spirit as webmcp-demo.ts: the page owns
+// the tools, Otto drives them, and every result is visible on the dashboard.
+// Read-only tools auto-approve (see READ_ONLY_TOOLS); mutations raise Otto's
+// in-panel approval bubble.
 // ---------------------------------------------------------------------------
 
 initializeWebMCPPolyfill();
@@ -306,25 +259,49 @@ const modelContext = (
 ).modelContext;
 
 if (modelContext) {
+  // Only the primary admin sections are drivable navigation targets (the first
+  // nav group); sales channels + settings are chrome, not sections.
   const navItems = (): HTMLElement[] =>
-    Array.from(document.querySelectorAll<HTMLElement>(".workspace-nav .nav-item"));
+    Array.from(
+      document.querySelectorAll<HTMLElement>(".workspace-nav > ul:first-of-type .nav-item"),
+    );
   const sectionName = (el: HTMLElement): string => el.textContent?.trim() ?? "";
 
-  // -- get_workspace_overview (read-only) --
+  type StockStatus = "in" | "low" | "out";
+  const stockFor = (count: number): { status: StockStatus; label: string; cls: string } => {
+    if (count <= 0) return { status: "out", label: "Sold out", cls: "stock-badge--out" };
+    if (count <= 10) return { status: "low", label: "Low stock", cls: "stock-badge--low" };
+    return { status: "in", label: "In stock", cls: "stock-badge--in" };
+  };
+  const productEls = (): HTMLElement[] =>
+    Array.from(document.querySelectorAll<HTMLElement>("#product-list .prod"));
+  const productName = (el: HTMLElement): string =>
+    el.getAttribute("data-product") ?? el.querySelector(".prod__name")?.textContent?.trim() ?? "";
+
+  // -- get_store_overview (read-only) --
   modelContext.registerTool({
-    name: "get_workspace_overview",
-    title: "Read the dashboard",
+    name: "get_store_overview",
+    title: "Read the store dashboard",
     description:
-      "Read the current workspace: available sections and which is active, the overview banner, the highlight cards, the recent-activity feed, and the assistant's current dock layout.",
+      "Read the current admin dashboard: the KPI metrics (with 30-day change), the available admin sections and which is active, the product inventory (name, price, on-hand count and stock status), the recent-activity feed, and Otto's current dock layout.",
     inputSchema: { type: "object", properties: {} },
     annotations: { readOnlyHint: true },
     execute() {
-      const banner = document.querySelector(".workspace-banner");
-      const cards = Array.from(document.querySelectorAll(".workspace-card")).map((card) => ({
-        title: card.querySelector("h4")?.textContent?.trim() ?? "",
-        summary: card.querySelector("p")?.textContent?.trim() ?? "",
+      const metrics = Array.from(document.querySelectorAll<HTMLElement>(".metric")).map((m) => ({
+        label: m.querySelector(".metric__label")?.textContent?.trim() ?? "",
+        value: m.querySelector(".metric__value")?.textContent?.trim() ?? "",
+        change: m.querySelector(".metric__delta")?.textContent?.trim() ?? "",
       }));
-      const activity = Array.from(document.querySelectorAll(".workspace-feed .feed-item")).map(
+      const products = productEls().map((el) => {
+        const count = Number(el.getAttribute("data-inventory") ?? "0");
+        return {
+          name: productName(el),
+          price: el.querySelector(".prod__price")?.textContent?.trim() ?? "",
+          inventory: count,
+          status: stockFor(count).label,
+        };
+      });
+      const activity = Array.from(document.querySelectorAll("#activity-feed .feed-item")).map(
         (item) => {
           const spans = item.querySelectorAll("span");
           return {
@@ -339,23 +316,112 @@ if (modelContext) {
           name: sectionName(el),
           active: el.classList.contains("is-active"),
         })),
-        banner: {
-          title: banner?.querySelector("h3")?.textContent?.trim() ?? "",
-          text: banner?.querySelector("p")?.textContent?.trim() ?? "",
-        },
-        cards,
+        metrics,
+        products,
         activity,
         dock: getDockConfig(),
       };
     },
   });
 
+  // Mock 30-day sales series (trending up) that show_sales_trend visualizes.
+  const SALES_SERIES: Array<{ label: string; value: number }> = [
+    { label: "Jun 9", value: 410 }, { label: "Jun 12", value: 480 },
+    { label: "Jun 15", value: 455 }, { label: "Jun 18", value: 560 },
+    { label: "Jun 21", value: 540 }, { label: "Jun 24", value: 690 },
+    { label: "Jun 27", value: 720 }, { label: "Jun 30", value: 660 },
+    { label: "Jul 3", value: 815 }, { label: "Jul 6", value: 890 },
+  ];
+  const usd = (n: number): string =>
+    "$" + Math.round(n).toLocaleString("en-US");
+
+  // -- show_sales_trend (read-only; renders an inline chart) --
+  modelContext.registerTool({
+    name: "show_sales_trend",
+    title: "Chart the sales trend",
+    description:
+      "Render an inline area chart of total sales over the last 30 days directly in the conversation, and return the series so you can comment on it. Use this whenever the merchant asks how sales are trending.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute() {
+      const total = SALES_SERIES.reduce((s, d) => s + d.value, 0);
+      controller.injectComponentDirective({
+        component: "otto_sales_chart",
+        props: {
+          title: "Total sales",
+          subtitle: "Last 30 days",
+          points: SALES_SERIES,
+          total: usd(total),
+          delta: "8.4%",
+          footnote: "Computed from 143 orders · Jun 9 – Jul 6 · excludes refunds.",
+        },
+        text: "",
+        llmContent: "[Rendered the 30-day sales trend chart inline]",
+      });
+      return {
+        ok: true,
+        rendered: "otto_sales_chart",
+        total_sales: usd(total),
+        change_vs_prev_period: "+8.4%",
+        peak_day: "Jul 6",
+        series: SALES_SERIES,
+      };
+    },
+  });
+
+  // -- show_top_products (read-only; renders an inline bar chart) --
+  modelContext.registerTool({
+    name: "show_top_products",
+    title: "Chart top products",
+    description:
+      "Render an inline ranked bar chart of the best-selling products by revenue directly in the conversation, and return the rows so you can comment on them. Use this when the merchant asks for top / best-selling products.",
+    inputSchema: { type: "object", properties: {} },
+    annotations: { readOnlyHint: true },
+    execute() {
+      // Revenue = price × mock units sold, so the bars track the visible catalog.
+      const units: Record<string, number> = {
+        "Aurora Table Lamp": 41,
+        "Walnut Desk Shelf": 33,
+        "Linen Throw Blanket": 58,
+        "Ceramic Pour-Over": 72,
+      };
+      const rows = productEls()
+        .map((p) => {
+          const name = productName(p);
+          const price = Number(
+            (p.querySelector(".prod__price")?.textContent ?? "0").replace(/[^0-9.]/g, ""),
+          );
+          const sold = units[name] ?? 20;
+          return { name, revenue: Math.round(price * sold), units: sold };
+        })
+        .sort((a, b) => b.revenue - a.revenue);
+
+      controller.injectComponentDirective({
+        component: "otto_bar_chart",
+        props: {
+          title: "Top products by revenue",
+          subtitle: "Last 30 days",
+          bars: rows.map((r) => ({
+            label: r.name,
+            value: r.revenue,
+            sub: `${r.units} sold`,
+            display: usd(r.revenue),
+          })),
+          footnote: "Revenue = unit price × units sold in the period.",
+        },
+        text: "",
+        llmContent: "[Rendered the top-products bar chart inline]",
+      });
+      return { ok: true, rendered: "otto_bar_chart", products: rows };
+    },
+  });
+
   // -- switch_section (read-only-ish navigation) --
   modelContext.registerTool({
     name: "switch_section",
-    title: "Switch workspace section",
+    title: "Switch admin section",
     description:
-      "Highlight a section in the workspace navigation. Valid section names come from get_workspace_overview (e.g. Overview, Automation, Audience, Catalog, Publishing).",
+      "Highlight a section in the admin navigation. Valid section names come from get_store_overview (e.g. Home, Orders, Products, Customers, Discounts, Analytics).",
     inputSchema: {
       type: "object",
       properties: {
@@ -363,8 +429,6 @@ if (modelContext) {
       },
       required: ["section"],
     },
-    // Mutates UI state (active nav item), so no readOnlyHint, but it stays in
-    // READ_ONLY_TOOLS above: pure navigation auto-approves at the gate.
     annotations: { readOnlyHint: false },
     execute(args) {
       const requested = String(args.section ?? "").trim().toLowerCase();
@@ -385,48 +449,51 @@ if (modelContext) {
     },
   });
 
-  // -- set_dock_layout (mutating: the assistant repositions itself) --
+  // -- restock_product (mutating: on-page inventory change) --
   modelContext.registerTool({
-    name: "set_dock_layout",
-    title: "Move the assistant dock",
+    name: "restock_product",
+    title: "Restock a product",
     description:
-      "Reposition or resize the assistant's own docked panel. All fields optional; omitted ones keep their current value. side: 'left' | 'right'. width: CSS width like '360px'. reveal: 'resize' | 'emerge' | 'overlay' | 'push'. animate: boolean.",
+      "Set a product's on-hand inventory. Pass the exact product name (from get_store_overview) and either `quantity` to ADD to the current count, or `set_to` to set an absolute count. The product's stock badge updates immediately (Sold out → Low stock → In stock).",
     inputSchema: {
       type: "object",
       properties: {
-        side: { type: "string", enum: ["left", "right"] },
-        width: { type: "string", description: "CSS width for the open dock, e.g. '360px'." },
-        reveal: { type: "string", enum: ["resize", "emerge", "overlay", "push"] },
-        animate: { type: "boolean" },
+        product: { type: "string", description: "Exact product name to restock." },
+        quantity: { type: "number", description: "Units to ADD to the current on-hand count." },
+        set_to: { type: "number", description: "Absolute on-hand count to set (overrides quantity)." },
       },
+      required: ["product"],
     },
+    annotations: { readOnlyHint: false },
     execute(args) {
-      if (args.side !== undefined) {
-        if (args.side !== "left" && args.side !== "right") {
-          throw new Error(`Invalid side "${args.side}": use "left" or "right".`);
-        }
-        sideSelect.value = args.side;
+      const requested = String(args.product ?? "").trim().toLowerCase();
+      const el = productEls().find((p) => productName(p).toLowerCase() === requested);
+      if (!el) {
+        throw new Error(
+          `Unknown product "${args.product}". Available: ${productEls().map(productName).join(", ")}.`,
+        );
       }
-      if (args.width !== undefined) {
-        const raw = String(args.width).trim();
-        const width = /^\d+(\.\d+)?$/.test(raw) ? `${raw}px` : raw;
-        if (!/^\d+(\.\d+)?(px|rem|em|vw|%)$/.test(width)) {
-          throw new Error(`Invalid width "${args.width}": use a CSS length like "360px".`);
-        }
-        widthInput.value = width;
+      const current = Number(el.getAttribute("data-inventory") ?? "0");
+      let next: number;
+      if (args.set_to !== undefined && Number.isFinite(Number(args.set_to))) {
+        next = Math.max(0, Math.round(Number(args.set_to)));
+      } else if (args.quantity !== undefined && Number.isFinite(Number(args.quantity))) {
+        next = Math.max(0, current + Math.round(Number(args.quantity)));
+      } else {
+        next = current + 40; // sensible default restock
       }
-      if (args.reveal !== undefined) {
-        const reveal = String(args.reveal);
-        if (!["resize", "emerge", "overlay", "push"].includes(reveal)) {
-          throw new Error(`Invalid reveal "${args.reveal}": use resize, emerge, overlay, or push.`);
-        }
-        revealSelect.value = reveal;
+      const s = stockFor(next);
+      el.setAttribute("data-inventory", String(next));
+      el.setAttribute("data-status", s.status);
+      const countEl = el.querySelector(".prod__count");
+      if (countEl) countEl.textContent = String(next);
+      const badge = el.querySelector(".stock-badge");
+      if (badge) {
+        badge.className = `stock-badge ${s.cls}`;
+        badge.textContent = s.label;
       }
-      if (args.animate !== undefined) {
-        animateCheck.checked = Boolean(args.animate);
-      }
-      applyDockSettings();
-      return { ok: true, dock: getDockConfig() };
+      updateStatus(`Restocked ${productName(el)} to ${next}.`);
+      return { ok: true, product: productName(el), inventory: next, status: s.label };
     },
   });
 
@@ -444,8 +511,9 @@ if (modelContext) {
       },
       required: ["title"],
     },
+    annotations: { readOnlyHint: false },
     execute(args) {
-      const feed = document.querySelector(".workspace-feed");
+      const feed = document.getElementById("activity-feed");
       if (!feed) throw new Error("Activity feed not found on the page.");
 
       // Built with textContent: agent-supplied strings never touch innerHTML.
@@ -463,9 +531,55 @@ if (modelContext) {
         detail.textContent = String(args.detail).trim();
         item.append(detail);
       }
-      feed.querySelector(".workspace-feed__heading")?.after(item);
+      feed.prepend(item);
       updateStatus("Activity logged.");
       return { ok: true, logged: title.textContent };
+    },
+  });
+
+  // -- set_dock_layout (mutating: Otto repositions itself) --
+  modelContext.registerTool({
+    name: "set_dock_layout",
+    title: "Move Otto's dock",
+    description:
+      "Reposition or resize Otto's own docked panel. All fields optional; omitted ones keep their current value. side: 'left' | 'right'. width: CSS width like '380px'. reveal: 'resize' | 'emerge' | 'overlay' | 'push'. animate: boolean.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        side: { type: "string", enum: ["left", "right"] },
+        width: { type: "string", description: "CSS width for the open dock, e.g. '380px'." },
+        reveal: { type: "string", enum: ["resize", "emerge", "overlay", "push"] },
+        animate: { type: "boolean" },
+      },
+    },
+    annotations: { readOnlyHint: false },
+    execute(args) {
+      if (args.side !== undefined) {
+        if (args.side !== "left" && args.side !== "right") {
+          throw new Error(`Invalid side "${args.side}": use "left" or "right".`);
+        }
+        sideSelect.value = args.side;
+      }
+      if (args.width !== undefined) {
+        const raw = String(args.width).trim();
+        const width = /^\d+(\.\d+)?$/.test(raw) ? `${raw}px` : raw;
+        if (!/^\d+(\.\d+)?(px|rem|em|vw|%)$/.test(width)) {
+          throw new Error(`Invalid width "${args.width}": use a CSS length like "380px".`);
+        }
+        widthInput.value = width;
+      }
+      if (args.reveal !== undefined) {
+        const reveal = String(args.reveal);
+        if (!["resize", "emerge", "overlay", "push"].includes(reveal)) {
+          throw new Error(`Invalid reveal "${args.reveal}": use resize, emerge, overlay, or push.`);
+        }
+        revealSelect.value = reveal;
+      }
+      if (args.animate !== undefined) {
+        animateCheck.checked = Boolean(args.animate);
+      }
+      applyDockSettings();
+      return { ok: true, dock: getDockConfig() };
     },
   });
 }

--- a/apps/web/src/docked-panel-demo.ts
+++ b/apps/web/src/docked-panel-demo.ts
@@ -51,6 +51,17 @@ const READ_ONLY_TOOLS = new Set([
   "show_top_products",
 ]);
 
+/** Plain-language [active, done] labels for Otto's grouped tool-call strip. */
+const TOOL_LABELS: Record<string, [string, string]> = {
+  get_store_overview: ["Reading your store", "Read your store"],
+  show_sales_trend: ["Charting sales", "Charted your sales trend"],
+  show_top_products: ["Ranking products", "Ranked your top products"],
+  switch_section: ["Opening a section", "Opened a section"],
+  restock_product: ["Updating inventory", "Updated inventory"],
+  log_activity: ["Logging activity", "Logged activity"],
+  set_dock_layout: ["Repositioning", "Repositioned my panel"],
+};
+
 const dockSideSelect = document.getElementById("dock-side") as HTMLSelectElement | null;
 const dockWidthInput = document.getElementById("dock-width") as HTMLInputElement | null;
 const dockRevealSelect = document.getElementById("dock-reveal") as HTMLSelectElement | null;
@@ -196,6 +207,33 @@ function createController(): AgentWidgetInitHandle {
       webmcp: {
         enabled: true,
         autoApprove: (info: WebMcpConfirmInfo): boolean => READ_ONLY_TOOLS.has(info.toolName),
+      },
+      // Group Otto's steps into one compact strip with plain-language labels,
+      // and give the running step a violet gradient shimmer.
+      features: {
+        ...DEFAULT_WIDGET_CONFIG.features,
+        showReasoning: false,
+        toolCallDisplay: {
+          ...DEFAULT_WIDGET_CONFIG.features?.toolCallDisplay,
+          collapsedMode: "tool-name",
+          grouped: true,
+          expandable: false,
+          loadingAnimation: "shimmer-color",
+        },
+      },
+      toolCall: {
+        loadingAnimationColor: "#5e56e7",
+        loadingAnimationSecondaryColor: "#b7adff",
+        loadingAnimationDuration: 1500,
+        renderCollapsedSummary: ({ toolCall, isActive }) => {
+          const label = toolCall.name ? TOOL_LABELS[toolCall.name] : undefined;
+          return label ? (isActive ? `${label[0]}…` : label[1]) : null;
+        },
+        renderGroupedSummary: ({ toolCalls }) => {
+          const active = toolCalls.some((t) => t.status !== "complete");
+          const n = toolCalls.length;
+          return active ? "Working on your store…" : `Completed ${n} ${n === 1 ? "step" : "steps"}`;
+        },
       },
       postprocessMessage: ({ text }) => markdownPostprocessor(text),
     },


### PR DESCRIPTION
Restyles the docked-panel example as a polished commerce admin console with a WebMCP-driven store copilot.

- **Admin chrome**: KPI dashboard, inventory table with live stock badges, activity feed
- **Copilot**: flush-docked panel, plain-text answers, rounded composer, refined suggestion chips
- **Inline charts**: sales-trend (area) and top-products (bar) rendered right in the transcript via `injectComponentDirective`
- **WebMCP tools**: read the page, chart data, restock a product, switch section, log activity, reposition its own dock

Touches only `apps/web` (no package changes, no changeset).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes the docked-panel demo as a commerce admin experience. The main changes are:

- New admin chrome with KPIs, inventory, navigation, and activity feed.
- Otto-themed docked assistant styling and widget configuration.
- Inline Persona chart renderers for sales trends and top products.
- Store-focused WebMCP tools for charting, restocking, logging activity, navigation, and dock layout.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small chart-rendering cleanup.

- The main demo flow and WebMCP tool wiring look consistent with the updated markup.
- Repeated sales charts can reuse the same SVG gradient id, which can make later chart fills depend on earlier chart DOM.

apps/web/src/docked-panel-charts.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/docked-panel-demo.html | Replaces the old demo layout with commerce admin markup, styling, navigation, product inventory, and activity feed sections. |
| apps/web/src/docked-panel-charts.ts | Adds two inline chart renderers; the sales chart should avoid reusing the same SVG gradient id across instances. |
| apps/web/src/docked-panel-demo.ts | Registers the chart components, updates Otto widget configuration, and adds store-focused WebMCP tools. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fdocked-panel-charts.ts%3A117-129%0A**Static%20SVG%20Gradient%20Id**%0A%0AWhen%20Otto%20renders%20more%20than%20one%20sales%20chart%20in%20the%20same%20transcript%2C%20each%20chart%20adds%20%60id%3D%22otto-area-grad%22%60%20to%20the%20page.%20SVG%20fragment%20references%20are%20document-scoped%2C%20so%20later%20charts%20can%20resolve%20their%20fill%20to%20an%20earlier%20chart's%20gradient%3B%20if%20that%20earlier%20message%20is%20removed%20or%20re-rendered%2C%20the%20later%20chart%20can%20lose%20its%20area%20fill.%0A%0A&repo=runtypelabs%2Fpersona&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22demo%2Fdocked-panel-refresh%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22demo%2Fdocked-panel-refresh%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fdocked-panel-charts.ts%3A117-129%0A**Static%20SVG%20Gradient%20Id**%0A%0AWhen%20Otto%20renders%20more%20than%20one%20sales%20chart%20in%20the%20same%20transcript%2C%20each%20chart%20adds%20%60id%3D%22otto-area-grad%22%60%20to%20the%20page.%20SVG%20fragment%20references%20are%20document-scoped%2C%20so%20later%20charts%20can%20resolve%20their%20fill%20to%20an%20earlier%20chart's%20gradient%3B%20if%20that%20earlier%20message%20is%20removed%20or%20re-rendered%2C%20the%20later%20chart%20can%20lose%20its%20area%20fill.%0A%0A&repo=runtypelabs%2Fpersona&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Fdocked-panel-charts.ts%3A117-129%0A**Static%20SVG%20Gradient%20Id**%0A%0AWhen%20Otto%20renders%20more%20than%20one%20sales%20chart%20in%20the%20same%20transcript%2C%20each%20chart%20adds%20%60id%3D%22otto-area-grad%22%60%20to%20the%20page.%20SVG%20fragment%20references%20are%20document-scoped%2C%20so%20later%20charts%20can%20resolve%20their%20fill%20to%20an%20earlier%20chart's%20gradient%3B%20if%20that%20earlier%20message%20is%20removed%20or%20re-rendered%2C%20the%20later%20chart%20can%20lose%20its%20area%20fill.%0A%0A&pr=365&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(web): group the copilot&#39;s tool call..."](https://github.com/runtypelabs/persona/commit/717f64e3b1486634aa6e8138b088efa202b2234b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43040025)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->