### PR TITLE
Regenerate OpenAPI contract types; live appearance knobs for the docked-panel demo

### DIFF
--- a/.changeset/regen-runtype-openapi-contract.md
+++ b/.changeset/regen-runtype-openapi-contract.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Regenerate the Runtype OpenAPI contract types from the latest published spec (adds `blockReason`, `approvalId`, and subagent `parentToolCallId` fields to stream event types). Fixes the `check:runtype-types` CI gate.

--- a/apps/web/docked-panel-demo.html
+++ b/apps/web/docked-panel-demo.html
@@ -51,11 +51,19 @@
       --nav-active: #ededed;
       --canvas-inset: #f6f6f7;
 
-      /* Otto brand (violet — deliberately our own, not a borrowed accent) */
+      /* Otto brand (violet — deliberately our own, not a borrowed accent).
+         These are LIVE tokens: the Copilot-settings swatches (and Otto's own
+         restyle_copilot tool) swap them at runtime, so every Otto-owned
+         surface below references them instead of hardcoding a hue. */
       --brand: #5e56e7;
       --brand-600: #4f47d6;
       --brand-700: #4038c4;
+      --brand-2: #7c6cf5;         /* gradient mid tone */
+      --brand-bright: #b7adff;    /* gradient highlight */
       --brand-soft: #efeefe;
+      /* Corner-rounding knobs (Copilot settings → Corners) */
+      --otto-radius: 14px;        /* composer, user bubble */
+      --otto-radius-sm: 10px;     /* chips, tool strip */
       --pos: #067a57;              /* positive delta green */
       --pos-soft: #e3f5ec;
       --warn: #b98900;             /* low-stock amber */
@@ -170,12 +178,12 @@
     #assistant-toggle svg { width: 19px; height: 19px; }
     #assistant-toggle:hover { background: rgba(255, 255, 255, 0.12); color: #fff; }
     #assistant-toggle:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
-    /* Selected: a soft violet "well" — a quiet, tasteful on-state (no neon). */
+    /* Selected: a soft accent "well" — a quiet, tasteful on-state (no neon). */
     #assistant-toggle.is-active {
-      background: rgba(124, 108, 245, 0.22);
-      border-color: rgba(124, 108, 245, 0.45);
-      color: #e7e3ff;
-      box-shadow: inset 0 0 0 1px rgba(124, 108, 245, 0.2);
+      background: color-mix(in srgb, var(--brand-2) 22%, transparent);
+      border-color: color-mix(in srgb, var(--brand-2) 45%, transparent);
+      color: color-mix(in srgb, var(--brand-bright) 35%, #fff);
+      box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--brand-2) 20%, transparent);
     }
     /* Pre-open nudge: one gentle breathing ring so a first-time viewer notices
        Otto without a loud banner. Stops the moment the panel is opened. */
@@ -183,8 +191,8 @@
       animation: otto-hint 2.6s ease-in-out 1.2s 3 both;
     }
     @keyframes otto-hint {
-      0%, 100% { box-shadow: 0 0 0 0 rgba(124, 108, 245, 0); }
-      50% { box-shadow: 0 0 0 5px rgba(124, 108, 245, 0.16); background: rgba(255, 255, 255, 0.10); }
+      0%, 100% { box-shadow: 0 0 0 0 transparent; }
+      50% { box-shadow: 0 0 0 5px color-mix(in srgb, var(--brand-2) 16%, transparent); background: rgba(255, 255, 255, 0.10); }
     }
     @media (prefers-reduced-motion: reduce) {
       #assistant-toggle.assistant-toggle--hint { animation: none; }
@@ -247,11 +255,11 @@
       margin-right: 4px;
       padding: 5px 11px;
       border-radius: 999px;
-      background: rgba(124, 108, 245, 0.16);
-      border: 1px solid rgba(124, 108, 245, 0.32);
+      background: color-mix(in srgb, var(--brand-2) 16%, transparent);
+      border: 1px solid color-mix(in srgb, var(--brand-2) 32%, transparent);
       font-size: 12.5px;
       font-weight: 550;
-      color: #e7e3ff;
+      color: color-mix(in srgb, var(--brand-bright) 35%, #fff);
       white-space: nowrap;
       pointer-events: none;
       opacity: 0;
@@ -424,9 +432,73 @@
     .feed-title { font-size: 13.5px; font-weight: 550; color: var(--ink); }
     .feed-item > span:last-child { font-size: 13px; color: var(--muted); line-height: 1.5; }
 
-    /* Dock settings card */
+    /* Copilot settings card (placement + appearance knobs) */
     .dock-settings-card__inner { padding: 16px 18px 4px; }
-    .dock-settings-card__title { margin: 0 0 14px; font-size: 14px; font-weight: 600; color: var(--ink); }
+    .dock-settings-card__title { margin: 0; font-size: 14px; font-weight: 600; color: var(--ink); }
+    .dock-settings-card__sub { margin: 3px 0 16px; font-size: 12.5px; color: var(--muted); }
+    .settings-group-label {
+      margin: 0 0 10px;
+      font-size: 11px;
+      font-weight: 650;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--text-subtle);
+    }
+    .settings-divider { height: 1px; background: var(--border); margin: 16px 0 14px; }
+    /* Accent swatches */
+    .swatches { display: flex; align-items: center; gap: 9px; padding-bottom: 5px; }
+    .swatch {
+      width: 26px;
+      height: 26px;
+      padding: 0;
+      border: none;
+      border-radius: 50%;
+      background: var(--sw);
+      cursor: pointer;
+      transition: transform 0.12s ease, box-shadow 0.12s ease;
+    }
+    .swatch:hover { transform: scale(1.1); }
+    .swatch:focus-visible { outline: 2px solid var(--brand); outline-offset: 2px; }
+    .swatch[aria-checked="true"] {
+      box-shadow: 0 0 0 2px #fff, 0 0 0 4px var(--sw);
+      transform: scale(1.05);
+    }
+    /* Corner-radius slider */
+    .knob-range { display: flex; align-items: center; gap: 10px; height: 34px; }
+    .knob-range input[type="range"] {
+      width: 150px;
+      min-width: 0;
+      height: auto;
+      padding: 0;
+      border: none;
+      accent-color: var(--brand);
+    }
+    .knob-readout {
+      font-family: var(--font-mono);
+      font-size: 11.5px;
+      color: var(--muted);
+      min-width: 34px;
+    }
+    /* Segmented control (working-animation style) */
+    .segmented { display: inline-flex; gap: 2px; padding: 3px; background: #f0f0f0; border-radius: 9px; }
+    .segmented button {
+      border: none;
+      background: transparent;
+      font: inherit;
+      font-size: 12.5px;
+      font-weight: 550;
+      color: var(--muted);
+      padding: 5px 12px;
+      border-radius: 7px;
+      cursor: pointer;
+      transition: background 0.12s ease, color 0.12s ease;
+    }
+    .segmented button:hover { color: var(--ink); }
+    .segmented button[aria-checked="true"] {
+      background: #fff;
+      color: var(--ink);
+      box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    }
     .dock-settings__row { display: flex; flex-wrap: wrap; align-items: flex-end; gap: 14px 18px; }
     .dock-settings__field { display: flex; flex-direction: column; gap: 6px; }
     .dock-settings__field label { font-size: 12.5px; font-weight: 550; color: var(--ink-2); }
@@ -443,7 +515,7 @@
       min-width: 130px;
     }
     .dock-settings__field select:focus,
-    .dock-settings__field input:focus { outline: none; border-color: var(--brand); box-shadow: 0 0 0 3px rgba(94, 86, 231, 0.15); }
+    .dock-settings__field input:focus { outline: none; border-color: var(--brand); box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 15%, transparent); }
     .dock-settings__field input#dock-width { min-width: 110px; width: 8rem; }
     .dock-settings__check { display: inline-flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 500; color: var(--ink-2); cursor: pointer; user-select: none; padding-bottom: 8px; }
     .dock-settings__check input { width: 1rem; height: 1rem; accent-color: var(--brand); margin: 0; }
@@ -480,6 +552,12 @@
     }
     [data-persona-dock-role="content"] { overflow: hidden; border-radius: 0; }
     [data-persona-dock-role="host"] .persona-rounded-button { border-radius: 0 !important; }
+    /* Height chain through the widget's dock wrapper: the content wrapper above
+       is viewport-sized with overflow hidden, so the dock target and canvas
+       must inherit that bound — otherwise the canvas grows to fit and its own
+       overflow:auto never engages (the dashboard couldn't scroll). */
+    #workspace-dock-target { height: 100%; min-height: 0; }
+    .workspace-canvas { height: 100%; }
 
     /* ==========================================================================
        OTTO — Persona widget theming (first-party store-copilot look, our own palette).
@@ -490,14 +568,14 @@
        ========================================================================== */
     [data-persona-root],
     [data-persona-theme-zone] {
-      --persona-primary: #5e56e7 !important;
-      --persona-secondary: #7c6cf5 !important;
-      --persona-accent: #5e56e7 !important;
-      --persona-call-to-action: #5e56e7 !important;
+      --persona-primary: var(--brand) !important;
+      --persona-secondary: var(--brand-2) !important;
+      --persona-accent: var(--brand) !important;
+      --persona-call-to-action: var(--brand) !important;
       --persona-surface: #ffffff !important;
       --persona-container: #ffffff !important;
       --persona-input-background: #ffffff !important;
-      --persona-button-primary-bg: #5e56e7 !important;
+      --persona-button-primary-bg: var(--brand) !important;
       --persona-button-primary-fg: #ffffff !important;
       --persona-text: #303030 !important;
       --persona-text-inverse: #ffffff !important;
@@ -506,7 +584,7 @@
       --persona-border: #e3e3e3 !important;
       --persona-divider: #ececec !important;
       --persona-message-border: #eceef3 !important;
-      --persona-md-link-color: #5e56e7 !important;
+      --persona-md-link-color: var(--brand) !important;
     }
 
     /* Header — flush white bar with an Otto identity, matching a first-party
@@ -518,11 +596,11 @@
       border-bottom: 1px solid #ececec !important;
     }
     .persona-widget-header * { color: var(--ink) !important; }
-    /* Header media tile → Otto's violet mark (the default is an empty square). */
+    /* Header media tile → Otto's accent mark (the default is an empty square). */
     .persona-widget-header > div:first-child {
-      background: linear-gradient(150deg, #7c6cf5 0%, #5e56e7 55%, #4038c4 100%) !important;
+      background: linear-gradient(150deg, var(--brand-2) 0%, var(--brand) 55%, var(--brand-700) 100%) !important;
       border-radius: 11px !important;
-      box-shadow: 0 2px 6px rgba(94, 86, 231, 0.28), inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
+      box-shadow: 0 2px 6px color-mix(in srgb, var(--brand) 28%, transparent), inset 0 1px 0 rgba(255, 255, 255, 0.4) !important;
     }
     .persona-widget-header > div:first-child svg,
     .persona-widget-header > div:first-child svg * { color: #ffffff !important; stroke: #ffffff !important; }
@@ -554,9 +632,9 @@
       margin: 0 auto 16px;
       border-radius: 13px;
       background:
-        radial-gradient(circle at 32% 28%, #a89bff 0%, #7c6cf5 42%, #5e56e7 72%, #4038c4 100%);
+        radial-gradient(circle at 32% 28%, var(--brand-bright) 0%, var(--brand-2) 42%, var(--brand) 72%, var(--brand-700) 100%);
       box-shadow:
-        0 6px 16px rgba(94, 86, 231, 0.34),
+        0 6px 16px color-mix(in srgb, var(--brand) 34%, transparent),
         inset 0 1px 0 rgba(255, 255, 255, 0.45);
     }
     [data-persona-intro-card] h2 {
@@ -590,7 +668,7 @@
       text-align: left;
       background: #ffffff !important;
       border: 1px solid #e3e3e3 !important;
-      border-radius: 10px !important;
+      border-radius: var(--otto-radius-sm) !important;
       color: var(--ink-2) !important;
       padding: 9px 13px !important;
       font-size: 13px !important;
@@ -599,10 +677,10 @@
       transition: background 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
     }
     [data-persona-composer-suggestions] button:hover {
-      background: #faf9ff !important;
-      border-color: #d8d4f7 !important;
+      background: color-mix(in srgb, var(--brand) 3%, #fff) !important;
+      border-color: color-mix(in srgb, var(--brand) 24%, #fff) !important;
       opacity: 1 !important;
-      box-shadow: 0 2px 8px rgba(94, 86, 231, 0.10) !important;
+      box-shadow: 0 2px 8px color-mix(in srgb, var(--brand) 10%, transparent) !important;
     }
     [data-persona-composer-suggestions] button::before {
       content: "\2726"; /* ✦ */
@@ -614,24 +692,26 @@
     [data-persona-composer-suggestions] button::after {
       content: "\2192"; /* → */
       margin-left: auto;
-      color: #b9b4e8;
+      color: color-mix(in srgb, var(--brand) 40%, #fff);
       font-size: 15px;
       line-height: 1;
       flex: none;
     }
 
-    /* Composer — a single rounded field with a soft violet halo above it (the
+    /* Composer — a single rounded field with a soft accent halo above it (the
        glow reads as "the assistant is listening"). */
     [data-persona-composer-form] {
       border: 1px solid #e3e3e3 !important;
-      border-radius: 14px !important;
+      border-radius: var(--otto-radius) !important;
       background: #ffffff !important;
       box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04) !important;
+      /* No border-radius transition: a mid-flight CSS transition outranks even
+         !important declarations, so a stuck one froze the corner knob. */
       transition: border-color 0.15s ease, box-shadow 0.15s ease;
     }
     [data-persona-composer-form]:focus-within {
-      border-color: #c4bdf5 !important;
-      box-shadow: 0 0 0 3px rgba(94, 86, 231, 0.12), 0 1px 2px rgba(0, 0, 0, 0.04) !important;
+      border-color: color-mix(in srgb, var(--brand) 32%, #fff) !important;
+      box-shadow: 0 0 0 3px color-mix(in srgb, var(--brand) 12%, transparent), 0 1px 2px rgba(0, 0, 0, 0.04) !important;
     }
     [data-persona-theme-zone="composer"] { position: relative; }
     [data-persona-theme-zone="composer"]::before {
@@ -640,22 +720,22 @@
       left: 0; right: 0; top: -26px;
       height: 26px;
       pointer-events: none;
-      background: linear-gradient(180deg, rgba(124, 108, 245, 0) 0%, rgba(124, 108, 245, 0.07) 100%);
+      background: linear-gradient(180deg, transparent 0%, color-mix(in srgb, var(--brand-2) 7%, transparent) 100%);
     }
-    /* Circular violet submit with the paper-plane it already renders. */
+    /* Circular accent submit with the paper-plane it already renders. */
     [data-persona-composer-submit] {
       border-radius: 50% !important;
-      background: #5e56e7 !important;
+      background: var(--brand) !important;
       color: #ffffff !important;
     }
-    [data-persona-composer-submit]:hover { background: #4f47d6 !important; }
+    [data-persona-composer-submit]:hover { background: var(--brand-600) !important; }
 
     /* Messages — right-aligned gray user pill, plain-text assistant. */
     .persona-message-user-bubble {
       background: #f1f1f1 !important;
       color: #303030 !important;
       border: none !important;
-      border-radius: 14px !important;
+      border-radius: var(--otto-radius) !important;
       box-shadow: none !important;
     }
     .persona-message-user-bubble * { color: #303030 !important; }
@@ -666,14 +746,14 @@
       padding-left: 2px !important;
     }
 
-    /* Tool group — a quiet "steps" strip with a slow violet gradient accent
-       flowing along the top edge (the running step itself gets the widget's
-       built-in shimmer-color animation). */
+    /* Tool group — a quiet "steps" strip with a slow accent gradient flowing
+       along the top edge (the running step itself gets the widget's built-in
+       shimmer-color animation). */
     [data-persona-tool-group] {
       position: relative;
       background: #ffffff !important;
       border: 1px solid #eceef3 !important;
-      border-radius: 10px !important;
+      border-radius: var(--otto-radius-sm) !important;
       overflow: hidden;
     }
     [data-persona-tool-group]::before {
@@ -683,7 +763,7 @@
       right: 0;
       top: 0;
       height: 2px;
-      background: linear-gradient(90deg, #5e56e7, #b7adff, #7c6cf5, #5e56e7);
+      background: linear-gradient(90deg, var(--brand), var(--brand-bright), var(--brand-2), var(--brand));
       background-size: 220% 100%;
       animation: otto-toolgrad 3.4s linear infinite;
       opacity: 0.85;
@@ -911,10 +991,47 @@
                     </div>
                   </section>
 
-                  <!-- Assistant dock settings (demo control; Otto can drive this too) -->
+                  <!-- Copilot settings: placement + appearance knobs. Everything
+                       here is also drivable by Otto itself (set_dock_layout /
+                       restyle_copilot), so the card doubles as the demo's
+                       "look what the page exposes" surface. -->
                   <section class="card dock-settings-card" aria-labelledby="dock-settings-heading">
                     <div class="dock-settings-card__inner">
-                      <h4 class="dock-settings-card__title" id="dock-settings-heading">Assistant dock</h4>
+                      <h4 class="dock-settings-card__title" id="dock-settings-heading">Copilot</h4>
+                      <p class="dock-settings-card__sub">Appearance updates live as you play — or ask Otto to restyle itself. Placement applies on Apply.</p>
+
+                      <p class="settings-group-label">Appearance</p>
+                      <div class="dock-settings__row">
+                        <div class="dock-settings__field">
+                          <label id="accent-label">Accent</label>
+                          <div class="swatches" id="accent-swatches" role="radiogroup" aria-labelledby="accent-label">
+                            <button type="button" class="swatch" role="radio" aria-checked="true" data-accent="violet" style="--sw:#5e56e7" aria-label="Violet" title="Violet"></button>
+                            <button type="button" class="swatch" role="radio" aria-checked="false" data-accent="ocean" style="--sw:#0f7ac4" aria-label="Ocean" title="Ocean"></button>
+                            <button type="button" class="swatch" role="radio" aria-checked="false" data-accent="forest" style="--sw:#177a53" aria-label="Forest" title="Forest"></button>
+                            <button type="button" class="swatch" role="radio" aria-checked="false" data-accent="ember" style="--sw:#c2410c" aria-label="Ember" title="Ember"></button>
+                          </div>
+                        </div>
+                        <div class="dock-settings__field">
+                          <label for="otto-radius">Corners</label>
+                          <div class="knob-range">
+                            <input id="otto-radius" type="range" min="4" max="22" step="1" value="14" autocomplete="off" />
+                            <span class="knob-readout" id="otto-radius-readout">14px</span>
+                          </div>
+                        </div>
+                        <div class="dock-settings__field">
+                          <label id="anim-label">Working animation</label>
+                          <div class="segmented" id="otto-anim" role="radiogroup" aria-labelledby="anim-label">
+                            <button type="button" role="radio" aria-checked="true" data-anim="shimmer-color">Shimmer</button>
+                            <button type="button" role="radio" aria-checked="false" data-anim="rainbow">Rainbow</button>
+                            <button type="button" role="radio" aria-checked="false" data-anim="pulse">Pulse</button>
+                            <button type="button" role="radio" aria-checked="false" data-anim="none">Off</button>
+                          </div>
+                        </div>
+                      </div>
+
+                      <div class="settings-divider" role="presentation"></div>
+
+                      <p class="settings-group-label">Placement</p>
                       <div class="dock-settings__row">
                         <div class="dock-settings__field">
                           <label for="dock-side">Side</label>

--- a/apps/web/src/docked-panel-charts.ts
+++ b/apps/web/src/docked-panel-charts.ts
@@ -4,17 +4,26 @@
 // transcript (via controller.injectComponentDirective) when its WebMCP tools
 // run: an area "sales trend" chart and a ranked "top products" bar chart. The
 // look matches the admin's card system (white surface, hairline border, Inter,
-// a single violet brand hue) so a chart reads as first-party output, not a
+// a single accent hue) so a chart reads as first-party output, not a
 // bolted-on widget. Renderers take plain props and return DOM — no state.
 
 import type { ComponentRenderer } from "@runtypelabs/persona";
 
 const SVG_NS = "http://www.w3.org/2000/svg";
-const BRAND = "#5e56e7";
-const BRAND_SOFT = "rgba(94, 86, 231, 0.16)";
 const INK = "#1a1a1a";
 const MUTED = "#616161";
 const POS = "#067a57";
+
+/** Read the live accent from the page tokens (the appearance knobs rewrite
+ *  --brand at runtime), so charts rendered after a restyle match the copilot. */
+function brandColor(): string {
+  const v = getComputedStyle(document.documentElement).getPropertyValue("--brand").trim();
+  return v || "#5e56e7";
+}
+
+/** Unique gradient id per render: charts rendered under different accents each
+ *  keep their own <defs> (a shared id would repaint old charts' fills). */
+let gradSeq = 0;
 
 type Point = { label: string; value: number };
 
@@ -112,11 +121,13 @@ export const OttoSalesChart: ComponentRenderer = (props) => {
   const svg = svgEl("svg", { viewBox: `0 0 ${W} ${H}`, width: "100%", height: H, preserveAspectRatio: "none" });
   (svg as SVGElement).style.cssText = "display:block;overflow:visible";
 
-  // gradient def
+  // gradient def (accent sampled at render time, id unique per chart)
+  const accent = brandColor();
+  const gradId = `otto-area-grad-${++gradSeq}`;
   const defs = svgEl("defs", {});
-  const grad = svgEl("linearGradient", { id: "otto-area-grad", x1: "0", y1: "0", x2: "0", y2: "1" });
-  grad.appendChild(svgEl("stop", { offset: "0%", "stop-color": BRAND, "stop-opacity": "0.22" }));
-  grad.appendChild(svgEl("stop", { offset: "100%", "stop-color": BRAND, "stop-opacity": "0" }));
+  const grad = svgEl("linearGradient", { id: gradId, x1: "0", y1: "0", x2: "0", y2: "1" });
+  grad.appendChild(svgEl("stop", { offset: "0%", "stop-color": accent, "stop-opacity": "0.22" }));
+  grad.appendChild(svgEl("stop", { offset: "100%", "stop-color": accent, "stop-opacity": "0" }));
   defs.appendChild(grad);
   svg.appendChild(defs);
 
@@ -126,12 +137,12 @@ export const OttoSalesChart: ComponentRenderer = (props) => {
 
     const linePts = points.map((p, i) => `${x(i)},${y(p.value)}`).join(" ");
     const areaPts = `0,${H - padY} ${linePts} ${W},${H - padY}`;
-    svg.appendChild(svgEl("polygon", { points: areaPts, fill: "url(#otto-area-grad)" }));
+    svg.appendChild(svgEl("polygon", { points: areaPts, fill: `url(#${gradId})` }));
     svg.appendChild(
       svgEl("polyline", {
         points: linePts,
         fill: "none",
-        stroke: BRAND,
+        stroke: accent,
         "stroke-width": 2.25,
         "stroke-linejoin": "round",
         "stroke-linecap": "round",
@@ -139,7 +150,7 @@ export const OttoSalesChart: ComponentRenderer = (props) => {
     );
     // end dot
     const last = points.length - 1;
-    svg.appendChild(svgEl("circle", { cx: x(last), cy: y(points[last].value), r: 4, fill: "#fff", stroke: BRAND, "stroke-width": 2.25 }));
+    svg.appendChild(svgEl("circle", { cx: x(last), cy: y(points[last].value), r: 4, fill: "#fff", stroke: accent, "stroke-width": 2.25 }));
   }
   card.appendChild(svg);
 
@@ -180,6 +191,7 @@ export const OttoBarChart: ComponentRenderer = (props) => {
   card.appendChild(head);
 
   const max = bars.reduce((m, b) => Math.max(m, b.value), 0) || 1;
+  const accent = brandColor();
   const list = el("div", "display:flex;flex-direction:column;gap:12px");
   bars.forEach((b, i) => {
     const row = el("div", "");
@@ -197,7 +209,7 @@ export const OttoBarChart: ComponentRenderer = (props) => {
     const alpha = 1 - Math.min(i, 3) * 0.14;
     const fill = el(
       "div",
-      `position:absolute;left:0;top:0;bottom:0;width:${pct}%;border-radius:999px;background:${BRAND};opacity:${alpha.toFixed(2)}`,
+      `position:absolute;left:0;top:0;bottom:0;width:${pct}%;border-radius:999px;background:${accent};opacity:${alpha.toFixed(2)}`,
     );
     track.appendChild(fill);
     row.appendChild(track);

--- a/apps/web/src/docked-panel-demo.ts
+++ b/apps/web/src/docked-panel-demo.ts
@@ -60,7 +60,101 @@ const TOOL_LABELS: Record<string, [string, string]> = {
   restock_product: ["Updating inventory", "Updated inventory"],
   log_activity: ["Logging activity", "Logged activity"],
   set_dock_layout: ["Repositioning", "Repositioned my panel"],
+  restyle_copilot: ["Restyling", "Gave myself a new look"],
 };
+
+// ---------------------------------------------------------------------------
+// Appearance knobs (Copilot settings card + the restyle_copilot tool).
+//
+// The accent presets rewrite the page's --brand* custom properties, which every
+// Otto-owned surface (widget seams, launcher on-state, inline charts, gradient
+// tool strip) reads live — so one swatch click (or one tool call from Otto)
+// recolors the whole copilot without a re-mount.
+// ---------------------------------------------------------------------------
+
+const ACCENT_PRESETS = {
+  violet: { base: "#5e56e7", hover: "#4f47d6", deep: "#4038c4", mid: "#7c6cf5", bright: "#b7adff", soft: "#efeefe" },
+  ocean: { base: "#0f7ac4", hover: "#0d6cae", deep: "#0b5a94", mid: "#2f96dd", bright: "#9fd2f4", soft: "#e9f4fc" },
+  forest: { base: "#177a53", hover: "#136a48", deep: "#0f5c3e", mid: "#2f9a6f", bright: "#9fdcc0", soft: "#e8f6ef" },
+  ember: { base: "#c2410c", hover: "#ad3a0b", deep: "#993108", mid: "#e05e26", bright: "#f6b795", soft: "#fdeee5" },
+} as const;
+type AccentName = keyof typeof ACCENT_PRESETS;
+type OttoAnimation = "shimmer-color" | "rainbow" | "pulse" | "none";
+
+const appearance: { accent: AccentName; radius: number; animation: OttoAnimation } = {
+  accent: "violet",
+  radius: 14,
+  animation: "shimmer-color",
+};
+
+/** Widget theme derived from the active accent (full object: `update` merges shallowly). */
+function buildOttoTheme() {
+  const p = ACCENT_PRESETS[appearance.accent];
+  return {
+    semantic: {
+      colors: {
+        primary: p.base,
+        accent: p.base,
+        surface: "#ffffff",
+        background: "#ffffff",
+        textMuted: "#616161",
+        interactive: {
+          default: p.base,
+          hover: p.hover,
+          focus: p.hover,
+          active: p.deep,
+        },
+        feedback: {
+          info: p.base,
+        },
+      },
+    },
+    components: {
+      panel: { borderRadius: "0" },
+      header: { borderRadius: "0" },
+    },
+  };
+}
+
+/** Features block derived from the animation knob (grouped steps stay fixed). */
+function buildOttoFeatures() {
+  return {
+    ...DEFAULT_WIDGET_CONFIG.features,
+    showReasoning: false,
+    toolCallDisplay: {
+      ...DEFAULT_WIDGET_CONFIG.features?.toolCallDisplay,
+      collapsedMode: "tool-name" as const,
+      grouped: true,
+      expandable: false,
+      loadingAnimation: appearance.animation,
+    },
+  };
+}
+
+/** Tool-call presentation: friendly labels + accent-matched gradient shimmer. */
+function buildOttoToolCall() {
+  const p = ACCENT_PRESETS[appearance.accent];
+  return {
+    loadingAnimationColor: p.base,
+    loadingAnimationSecondaryColor: p.bright,
+    loadingAnimationDuration: 1500,
+    renderCollapsedSummary: ({
+      toolCall,
+      isActive,
+    }: {
+      toolCall: { name?: string };
+      isActive: boolean;
+    }) => {
+      const label = toolCall.name ? TOOL_LABELS[toolCall.name] : undefined;
+      return label ? (isActive ? `${label[0]}…` : label[1]) : null;
+    },
+    renderGroupedSummary: ({ toolCalls }: { toolCalls: Array<{ status: string }> }) => {
+      const active = toolCalls.some((t) => t.status !== "complete");
+      const n = toolCalls.length;
+      return active ? "Working on your store…" : `Completed ${n} ${n === 1 ? "step" : "steps"}`;
+    },
+  };
+}
 
 const dockSideSelect = document.getElementById("dock-side") as HTMLSelectElement | null;
 const dockWidthInput = document.getElementById("dock-width") as HTMLInputElement | null;
@@ -161,33 +255,11 @@ function createController(): AgentWidgetInitHandle {
       apiUrl,
       storageAdapter: createLocalStorageAdapter("persona-state-docked-panel-demo"),
       launcher: getDemoLauncher(),
-      // Violet brand for Otto. Rounding/surface details are refined on the CSS
-      // seams in docked-panel-demo.html; the panel + header stay flush (radius 0)
-      // so the dock sits cleanly against the admin edge like a first-party panel.
-      theme: {
-        semantic: {
-          colors: {
-            primary: "#5e56e7",
-            accent: "#5e56e7",
-            surface: "#ffffff",
-            background: "#ffffff",
-            textMuted: "#616161",
-            interactive: {
-              default: "#5e56e7",
-              hover: "#4f47d6",
-              focus: "#4f47d6",
-              active: "#4038c4",
-            },
-            feedback: {
-              info: "#5e56e7",
-            },
-          },
-        },
-        components: {
-          panel: { borderRadius: "0" },
-          header: { borderRadius: "0" },
-        },
-      },
+      // Accent-preset theme for Otto (violet by default; the Copilot-settings
+      // swatches and restyle_copilot swap it live). Rounding/surface details are
+      // refined on the CSS seams in docked-panel-demo.html; the panel + header
+      // stay flush (radius 0) so the dock sits cleanly against the admin edge.
+      theme: buildOttoTheme(),
       copy: {
         ...DEFAULT_WIDGET_CONFIG.copy,
         welcomeTitle: "How can I help?",
@@ -197,44 +269,22 @@ function createController(): AgentWidgetInitHandle {
       },
       // Ordered to walk the tool surface: an inline chart (auto-approved),
       // a ranked bar chart, then two mutations that raise Otto's approval
-      // bubble — one restocks a product on the page, one moves Otto's own dock.
+      // bubble — one restocks a product on the page, one restyles + re-docks
+      // Otto itself (two grouped tool calls from one ask).
       suggestionChips: [
         "How are sales trending this month?",
         "Show my top products by revenue",
         "Restock the Ceramic Pour-Over",
-        "Dock yourself on the left at 380px",
+        "Go ocean blue and dock on the left",
       ],
       webmcp: {
         enabled: true,
         autoApprove: (info: WebMcpConfirmInfo): boolean => READ_ONLY_TOOLS.has(info.toolName),
       },
       // Group Otto's steps into one compact strip with plain-language labels,
-      // and give the running step a violet gradient shimmer.
-      features: {
-        ...DEFAULT_WIDGET_CONFIG.features,
-        showReasoning: false,
-        toolCallDisplay: {
-          ...DEFAULT_WIDGET_CONFIG.features?.toolCallDisplay,
-          collapsedMode: "tool-name",
-          grouped: true,
-          expandable: false,
-          loadingAnimation: "shimmer-color",
-        },
-      },
-      toolCall: {
-        loadingAnimationColor: "#5e56e7",
-        loadingAnimationSecondaryColor: "#b7adff",
-        loadingAnimationDuration: 1500,
-        renderCollapsedSummary: ({ toolCall, isActive }) => {
-          const label = toolCall.name ? TOOL_LABELS[toolCall.name] : undefined;
-          return label ? (isActive ? `${label[0]}…` : label[1]) : null;
-        },
-        renderGroupedSummary: ({ toolCalls }) => {
-          const active = toolCalls.some((t) => t.status !== "complete");
-          const n = toolCalls.length;
-          return active ? "Working on your store…" : `Completed ${n} ${n === 1 ? "step" : "steps"}`;
-        },
-      },
+      // and give the running step an accent-matched gradient shimmer.
+      features: buildOttoFeatures(),
+      toolCall: buildOttoToolCall(),
       postprocessMessage: ({ text }) => markdownPostprocessor(text),
     },
   });
@@ -280,6 +330,77 @@ assistantToggle.addEventListener("click", () => {
   document.getElementById("assistant-coachmark")?.remove();
   controller.toggle();
 });
+
+// ---------------------------------------------------------------------------
+// Appearance knobs: swatches, corner slider, animation segmented control.
+// Live-apply (no button): the page tokens restyle CSS-driven surfaces instantly
+// and `controller.update` re-themes the widget's own token-driven bits.
+// ---------------------------------------------------------------------------
+
+const swatchButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>("#accent-swatches .swatch"),
+);
+const radiusInput = document.getElementById("otto-radius") as HTMLInputElement | null;
+const radiusReadout = document.getElementById("otto-radius-readout");
+const animButtons = Array.from(
+  document.querySelectorAll<HTMLButtonElement>("#otto-anim button"),
+);
+
+function syncAppearanceUi(): void {
+  swatchButtons.forEach((btn) => {
+    btn.setAttribute("aria-checked", btn.dataset.accent === appearance.accent ? "true" : "false");
+  });
+  if (radiusInput) radiusInput.value = String(appearance.radius);
+  if (radiusReadout) radiusReadout.textContent = `${appearance.radius}px`;
+  animButtons.forEach((btn) => {
+    btn.setAttribute("aria-checked", btn.dataset.anim === appearance.animation ? "true" : "false");
+  });
+}
+
+function applyAppearance(statusLabel = "Appearance updated."): void {
+  const p = ACCENT_PRESETS[appearance.accent];
+  const rootStyle = document.documentElement.style;
+  rootStyle.setProperty("--brand", p.base);
+  rootStyle.setProperty("--brand-600", p.hover);
+  rootStyle.setProperty("--brand-700", p.deep);
+  rootStyle.setProperty("--brand-2", p.mid);
+  rootStyle.setProperty("--brand-bright", p.bright);
+  rootStyle.setProperty("--brand-soft", p.soft);
+  rootStyle.setProperty("--otto-radius", `${appearance.radius}px`);
+  rootStyle.setProperty("--otto-radius-sm", `${Math.max(6, appearance.radius - 4)}px`);
+  controller.update({
+    theme: buildOttoTheme(),
+    features: buildOttoFeatures(),
+    toolCall: buildOttoToolCall(),
+  });
+  syncAppearanceUi();
+  updateStatus(statusLabel);
+}
+
+swatchButtons.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const name = btn.dataset.accent as AccentName | undefined;
+    if (!name || !(name in ACCENT_PRESETS)) return;
+    appearance.accent = name;
+    applyAppearance(`Accent set to ${name}.`);
+  });
+});
+
+radiusInput?.addEventListener("input", () => {
+  appearance.radius = Number(radiusInput.value) || 14;
+  applyAppearance(`Corners set to ${appearance.radius}px.`);
+});
+
+animButtons.forEach((btn) => {
+  btn.addEventListener("click", () => {
+    const anim = btn.dataset.anim as OttoAnimation | undefined;
+    if (!anim || !["shimmer-color", "rainbow", "pulse", "none"].includes(anim)) return;
+    appearance.animation = anim;
+    applyAppearance(`Working animation: ${anim}.`);
+  });
+});
+
+syncAppearanceUi();
 
 // ---------------------------------------------------------------------------
 // WebMCP page tools
@@ -358,6 +479,7 @@ if (modelContext) {
         products,
         activity,
         dock: getDockConfig(),
+        appearance: { ...appearance },
       };
     },
   });
@@ -618,6 +740,52 @@ if (modelContext) {
       }
       applyDockSettings();
       return { ok: true, dock: getDockConfig() };
+    },
+  });
+
+  // -- restyle_copilot (mutating: Otto restyles itself) --
+  modelContext.registerTool({
+    name: "restyle_copilot",
+    title: "Restyle Otto",
+    description:
+      "Change Otto's own appearance — the same knobs as the Copilot settings card. All fields optional; omitted ones keep their current value. accent: 'violet' | 'ocean' | 'forest' | 'ember' (ocean is the blue one). radius: corner rounding in px, 4–22. animation: 'shimmer-color' | 'rainbow' | 'pulse' | 'none' (the working-step header animation).",
+    inputSchema: {
+      type: "object",
+      properties: {
+        accent: { type: "string", enum: ["violet", "ocean", "forest", "ember"] },
+        radius: { type: "number", description: "Corner rounding in px (4–22)." },
+        animation: { type: "string", enum: ["shimmer-color", "rainbow", "pulse", "none"] },
+      },
+    },
+    annotations: { readOnlyHint: false },
+    execute(args) {
+      if (args.accent !== undefined) {
+        const accent = String(args.accent);
+        if (!(accent in ACCENT_PRESETS)) {
+          throw new Error(
+            `Unknown accent "${args.accent}". Available: ${Object.keys(ACCENT_PRESETS).join(", ")}.`,
+          );
+        }
+        appearance.accent = accent as AccentName;
+      }
+      if (args.radius !== undefined) {
+        const radius = Number(args.radius);
+        if (!Number.isFinite(radius)) {
+          throw new Error(`Invalid radius "${args.radius}": use a number of pixels (4–22).`);
+        }
+        appearance.radius = Math.min(22, Math.max(4, Math.round(radius)));
+      }
+      if (args.animation !== undefined) {
+        const animation = String(args.animation);
+        if (!["shimmer-color", "rainbow", "pulse", "none"].includes(animation)) {
+          throw new Error(
+            `Invalid animation "${args.animation}": use shimmer-color, rainbow, pulse, or none.`,
+          );
+        }
+        appearance.animation = animation as OttoAnimation;
+      }
+      applyAppearance("Otto restyled itself.");
+      return { ok: true, appearance: { ...appearance } };
     },
   });
 }

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -41,6 +41,7 @@ export type RuntypeExecutionStreamEvent = ({
 };
   type: "execution_complete";
 }) | ({
+  blockReason?: string;
   code?: string;
   completedAt?: string;
   error: string | {
@@ -295,6 +296,7 @@ export type RuntypeExecutionStreamEvent = ({
   startedAt?: string;
   subagent?: {
   agentName?: string;
+  parentToolCallId?: string;
   toolName: string;
 };
   timeout?: number;
@@ -389,6 +391,7 @@ export type RuntypeFlowSSEEvent = {
   totalTokensUsed?: number;
   type: "flow_complete";
 } | ({
+  blockReason?: string;
   code?: string;
   error: string | {
   code: string;
@@ -409,6 +412,7 @@ export type RuntypeFlowSSEEvent = {
   type: "flow_error";
   upgradeUrl?: string;
 }) | ({
+  approvalId?: string;
   awaitReason?: string;
   awaitedAt: string;
   crawlId?: string;
@@ -419,6 +423,7 @@ export type RuntypeFlowSSEEvent = {
   parameters?: Record<string, unknown>;
   seq?: number;
   stepId?: string;
+  timeout?: number;
   toolCallId?: string;
   toolId?: string;
   toolName?: string;
@@ -673,7 +678,7 @@ export type RuntypeClientInitResponse = {
   welcomeMessage?: string | null;
 };
   expiresAt: string;
-  flow: {
+  flow?: {
   description?: string | null;
   id: string;
   name?: string | null;
@@ -695,6 +700,10 @@ export type RuntypeClientChatRequest = {
   untrustedContentHint?: boolean;
 }>;
   clientToolsFingerprint?: string;
+  identityProof?: {
+  provider: string;
+  token: string;
+};
   inputs?: Record<string, unknown>;
   messages: Array<{
   content: string | (Array<{


### PR DESCRIPTION
Two things:

**Contract regen (unblocks CI)** — the published API spec drifted (new `blockReason` / `approvalId` / subagent `parentToolCallId` fields), so `check:runtype-types` failed on every PR. Regenerated the committed contract; changeset included (patch).

**Docked-panel demo: appearance knobs** — the settings card is now a full Copilot section: accent swatches, corner-radius slider, and working-animation picker, live-applied next to the existing placement controls. The same knobs are exposed to the assistant as a `restyle_copilot` tool, so it can restyle itself on request; inline charts sample the accent at render time and follow along.

Also fixes two demo bugs found along the way: the dashboard couldn't scroll (canvas was unconstrained inside the dock wrapper), and the corner knob could freeze (a stuck border-radius transition outranks `!important`).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes generated contract types and adds live styling controls to the docked-panel demo. The main changes are:

- Regenerated OpenAPI-derived runtime contract types.
- Added Copilot accent, corner, and animation controls.
- Added a `restyle_copilot` tool for changing the demo appearance.
- Updated inline charts to sample the live accent color.
- Fixed dock canvas sizing and radius-transition behavior.

<h3>Confidence Score: 4/5</h3>

The generated init contract can now produce a session shape that current clients do not handle.

- `flow` is optional in the regenerated public type.
- The runtime client and demos still read `session.flow` as required.
- The demo appearance changes are validated and contained to the browser demo path.

packages/widget/src/generated/runtype-openapi-contract.ts and the matching client session response types

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/widget/src/generated/runtype-openapi-contract.ts | Adds optional stream/request fields and makes `RuntypeClientInitResponse.flow` optional, which conflicts with current session consumers. |
| apps/web/src/docked-panel-demo.ts | Adds appearance state, live widget updates, settings handlers, and the `restyle_copilot` tool with validation. |
| apps/web/src/docked-panel-charts.ts | Updates chart renderers to read the active accent at render time and use unique SVG gradient ids. |
| apps/web/docked-panel-demo.html | Adds appearance controls and rewires demo styles to use live Copilot tokens. |
| .changeset/regen-runtype-openapi-contract.md | Adds a patch changeset for the regenerated contract. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fgenerated%2Fruntype-openapi-contract.ts%3A681%0A**Optional%20Flow%20Breaks%20Sessions**%0A%0AThis%20regenerated%20response%20type%20now%20allows%20init%20responses%20without%20%60flow%60%2C%20but%20the%20client%20session%20path%20still%20passes%20%60data.flow%60%20through%20as%20required%20and%20demos%20dereference%20%60session.flow.name%60%20%2F%20%60session.flow.id%60.%20When%20the%20server%20omits%20%60flow%60%20under%20this%20contract%2C%20callers%20can%20receive%20a%20session%20with%20%60flow%3A%20undefined%60%20and%20then%20crash%20on%20the%20first%20flow%20read.%0A%0A&repo=runtypelabs%2Fpersona&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22fix%2Fruntype-openapi-contract-and-demo-knobs%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fruntype-openapi-contract-and-demo-knobs%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fgenerated%2Fruntype-openapi-contract.ts%3A681%0A**Optional%20Flow%20Breaks%20Sessions**%0A%0AThis%20regenerated%20response%20type%20now%20allows%20init%20responses%20without%20%60flow%60%2C%20but%20the%20client%20session%20path%20still%20passes%20%60data.flow%60%20through%20as%20required%20and%20demos%20dereference%20%60session.flow.name%60%20%2F%20%60session.flow.id%60.%20When%20the%20server%20omits%20%60flow%60%20under%20this%20contract%2C%20callers%20can%20receive%20a%20session%20with%20%60flow%3A%20undefined%60%20and%20then%20crash%20on%20the%20first%20flow%20read.%0A%0A&repo=runtypelabs%2Fpersona&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Apackages%2Fwidget%2Fsrc%2Fgenerated%2Fruntype-openapi-contract.ts%3A681%0A**Optional%20Flow%20Breaks%20Sessions**%0A%0AThis%20regenerated%20response%20type%20now%20allows%20init%20responses%20without%20%60flow%60%2C%20but%20the%20client%20session%20path%20still%20passes%20%60data.flow%60%20through%20as%20required%20and%20demos%20dereference%20%60session.flow.name%60%20%2F%20%60session.flow.id%60.%20When%20the%20server%20omits%20%60flow%60%20under%20this%20contract%2C%20callers%20can%20receive%20a%20session%20with%20%60flow%3A%20undefined%60%20and%20then%20crash%20on%20the%20first%20flow%20read.%0A%0A&pr=366&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["feat(web): live appearance knobs in the ..."](https://github.com/runtypelabs/persona/commit/138c7b140f1649bdf6cd38e02697aedd8846c5c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43077833)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->