### PR TITLE
Avoid the in-operator shape that breaks Vite 8 bundling; add dist regression gate

### DIFF
--- a/.changeset/fix-vite8-no-in-for-init.md
+++ b/.changeset/fix-vite8-no-in-for-init.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix Vite 8 (Rolldown/Oxc) consumers: the minified dist contained an `in` expression inside a `for(init;;)` head (via an arrow body), a shape Oxc mis-parses ("Expected a semicolon") and Rolldown can silently emit as an empty chunk. The two `"message" in e` error guards are now `Reflect.has(e, "message")` (identical `[[HasProperty]]` semantics), and the build gains a dist-scan gate (`check:dist-vite8`) that fails if the toxic shape ever reappears in `dist/`.

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -69,7 +69,8 @@
     "src"
   ],
   "scripts": {
-    "build": "rimraf dist && pnpm run build:styles && pnpm run build:markdown-parsers && pnpm run build:client && pnpm run build:installer && pnpm run build:launcher && pnpm run build:webmcp-polyfill && pnpm run build:runtype-tts && pnpm run build:theme-ref && pnpm run build:codegen && pnpm run build:theme-editor && pnpm run build:theme-editor-preview && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:voice-worklet-player && pnpm run build:plugin-kit && pnpm run build:animations",
+    "build": "rimraf dist && pnpm run build:styles && pnpm run build:markdown-parsers && pnpm run build:client && pnpm run build:installer && pnpm run build:launcher && pnpm run build:webmcp-polyfill && pnpm run build:runtype-tts && pnpm run build:theme-ref && pnpm run build:codegen && pnpm run build:theme-editor && pnpm run build:theme-editor-preview && pnpm run build:testing && pnpm run build:smart-dom-reader && pnpm run build:voice-worklet-player && pnpm run build:plugin-kit && pnpm run build:animations && pnpm run check:dist-vite8",
+    "check:dist-vite8": "node scripts/check-dist-no-in-for-init.mjs",
     "build:markdown-parsers": "tsup --config tsup.markdown-parsers.config.ts",
     "build:plugin-kit": "tsup src/plugin-kit.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
     "build:theme-editor": "tsup src/theme-editor.ts --format esm,cjs --minify --dts --out-dir dist --no-splitting",
@@ -107,6 +108,7 @@
   },
   "devDependencies": {
     "@size-limit/file": "^12.1.0",
+    "acorn": "^8.15.0",
     "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",

--- a/packages/widget/scripts/check-dist-no-in-for-init.mjs
+++ b/packages/widget/scripts/check-dist-no-in-for-init.mjs
@@ -1,4 +1,4 @@
-// Regression gate: fail the build if any dist/**/*.js contains an `in`
+// Regression gate: fail the build if any dist JS bundle (.js/.cjs/.mjs) contains an `in`
 // expression inside a `for(init;;)` head — including inside ARROW function
 // bodies nested in that head, which is where the minifier actually puts them.
 //
@@ -38,13 +38,16 @@ function collectJsFiles(dir) {
   for (const entry of readdirSync(dir)) {
     const full = join(dir, entry);
     if (statSync(full).isDirectory()) out.push(...collectJsFiles(full));
-    else if (entry.endsWith(".js")) out.push(full);
+    else if (entry.endsWith(".js") || entry.endsWith(".cjs") || entry.endsWith(".mjs"))
+      out.push(full);
   }
   return out;
 }
 
-function findInExprsInForInit(code) {
-  const ast = acorn.parse(code, { ecmaVersion: "latest", sourceType: "module" });
+function findInExprsInForInit(code, file) {
+  // .cjs bundles are scripts (top-level `require`/`module`), not ESM.
+  const sourceType = file.endsWith(".cjs") ? "script" : "module";
+  const ast = acorn.parse(code, { ecmaVersion: "latest", sourceType });
   const hits = [];
   const walk = (node, inForInit) => {
     if (node == null || typeof node !== "object") return;
@@ -57,10 +60,14 @@ function findInExprsInForInit(code) {
       hits.push(node.start);
     }
     if (node.type === "ForStatement") {
+      // Only the init clause carries the no-in restriction. A nested for's
+      // test/update/body reset it even inside an outer for-init's arrow body
+      // (verified empirically against Vite 8.1.4 / Rolldown 1.1.5: `in` in a
+      // nested loop's test clause builds correctly, parenthesized or not).
       walk(node.init, true);
-      walk(node.test, inForInit);
-      walk(node.update, inForInit);
-      walk(node.body, inForInit);
+      walk(node.test, false);
+      walk(node.update, false);
+      walk(node.body, false);
       return;
     }
     if (
@@ -92,7 +99,7 @@ for (const file of collectJsFiles(DIST)) {
   scanned++;
   let hits;
   try {
-    hits = findInExprsInForInit(code);
+    hits = findInExprsInForInit(code, file);
   } catch (err) {
     console.error(`check-dist-no-in-for-init: acorn failed to parse ${file}: ${err.message}`);
     failed = true;

--- a/packages/widget/scripts/check-dist-no-in-for-init.mjs
+++ b/packages/widget/scripts/check-dist-no-in-for-init.mjs
@@ -1,0 +1,121 @@
+// Regression gate: fail the build if any dist/**/*.js contains an `in`
+// expression inside a `for(init;;)` head — including inside ARROW function
+// bodies nested in that head, which is where the minifier actually puts them.
+//
+// Why this matters (do NOT delete this gate to "fix" a failure here):
+// Oxc/Rolldown (Vite 8) has two bugs with this exact trigger:
+//   1. Oxc's parser leaks the spec's "no-in" restriction into arrow bodies,
+//      rejecting valid JS like `for(x=()=>{"message" in G};;)` with
+//      "Expected a semicolon" (acorn and V8 both accept it).
+//   2. With the `in` parenthesized (also valid), the parse succeeds but
+//      Rolldown SILENTLY emits the entire containing module as an EMPTY
+//      (0-byte) chunk — the consumer's build exits 0 and they get
+//      "does not provide an export named ..." at runtime. This broke 13
+//      routes on the Runtype dashboard's Vite 8 upgrade (runtypelabs/core
+//      PR #5309) and hits any customer bundling this package with Vite 8.
+//
+// esbuild's minifier mints the shape on its own: it merges a preceding
+// assignment like `const probe = (e) => "message" in e` into a following
+// loop's `for(init;;)` head. So fixing today's source occurrences is not
+// enough — any future source change can re-introduce it, and only this
+// build-output scan catches that before it ships. The source-level fix is to
+// write `Reflect.has(obj, key)` instead of `key in obj` (same [[HasProperty]]
+// semantics; note the flipped operand order) in any code that could be
+// hoisted into a loop head.
+//
+// Regular (non-arrow) function bodies reset the restriction and Oxc handles
+// them correctly, so the walker stops at FunctionExpression /
+// FunctionDeclaration boundaries — mirroring the detection logic of the
+// consumer-side `personaOxcNoInWorkaround()` plugin this gate lets core delete.
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import * as acorn from "acorn";
+
+const DIST = "dist";
+
+function collectJsFiles(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) out.push(...collectJsFiles(full));
+    else if (entry.endsWith(".js")) out.push(full);
+  }
+  return out;
+}
+
+function findInExprsInForInit(code) {
+  const ast = acorn.parse(code, { ecmaVersion: "latest", sourceType: "module" });
+  const hits = [];
+  const walk = (node, inForInit) => {
+    if (node == null || typeof node !== "object") return;
+    if (Array.isArray(node)) {
+      for (const child of node) walk(child, inForInit);
+      return;
+    }
+    if (typeof node.type !== "string") return;
+    if (node.type === "BinaryExpression" && node.operator === "in" && inForInit) {
+      hits.push(node.start);
+    }
+    if (node.type === "ForStatement") {
+      walk(node.init, true);
+      walk(node.test, inForInit);
+      walk(node.update, inForInit);
+      walk(node.body, inForInit);
+      return;
+    }
+    if (
+      inForInit &&
+      (node.type === "FunctionExpression" || node.type === "FunctionDeclaration")
+    ) {
+      // Regular function bodies reset the no-in restriction and Oxc parses
+      // them correctly — only arrow bodies carry the bug, so keep recursing
+      // through arrows but reset at real function boundaries.
+      for (const key of Object.keys(node)) {
+        if (key === "type" || key === "start" || key === "end") continue;
+        walk(node[key], false);
+      }
+      return;
+    }
+    for (const key of Object.keys(node)) {
+      if (key === "type" || key === "start" || key === "end") continue;
+      walk(node[key], inForInit);
+    }
+  };
+  walk(ast, false);
+  return hits;
+}
+
+let failed = false;
+let scanned = 0;
+for (const file of collectJsFiles(DIST)) {
+  const code = readFileSync(file, "utf8");
+  scanned++;
+  let hits;
+  try {
+    hits = findInExprsInForInit(code);
+  } catch (err) {
+    console.error(`check-dist-no-in-for-init: acorn failed to parse ${file}: ${err.message}`);
+    failed = true;
+    continue;
+  }
+  for (const start of hits) {
+    const { line, column } = acorn.getLineInfo(code, start);
+    console.error(
+      `check-dist-no-in-for-init: ${file}:${line}:${column} — \`in\` expression inside a ` +
+        `for(init;;) head. Vite 8 (Rolldown) silently emits the whole module as an empty ` +
+        `chunk for this shape (and Oxc rejects the unparenthesized form). Rewrite the ` +
+        `source-level \`key in obj\` as \`Reflect.has(obj, key)\`. See the header of ` +
+        `scripts/check-dist-no-in-for-init.mjs — do not delete this gate.`,
+    );
+    failed = true;
+  }
+}
+
+if (scanned === 0) {
+  console.error("check-dist-no-in-for-init: no .js files found under dist/ — run the build first");
+  process.exit(1);
+}
+if (failed) process.exit(1);
+console.log(
+  `check-dist-no-in-for-init: ${scanned} dist .js files clean (no \`in\` inside for(init;;) heads)`,
+);

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -2562,7 +2562,11 @@ export class AgentWidgetClient {
             const message =
               typeof e === "string" && e !== ""
                 ? e
-                : e != null && typeof e === "object" && "message" in e
+                : // Reflect.has, not `in`: the `in` operator inside an arrow body can
+                  // be minified into a `for(init;;)` head, which Oxc mis-parses and
+                  // Rolldown (Vite 8) silently emits as an empty chunk. Same
+                  // [[HasProperty]] semantics. Enforced by scripts/check-dist-no-in-for-init.mjs.
+                  e != null && typeof e === "object" && Reflect.has(e, "message")
                   ? String((e as { message?: unknown }).message ?? "Step failed")
                   : "Step failed";
             onEvent({ type: "error", error: new Error(message) });
@@ -3145,7 +3149,8 @@ export class AgentWidgetClient {
             const e = payload.error;
             if (typeof e === "string" && e !== "") {
               resolvedError = new Error(e);
-            } else if (e != null && typeof e === "object" && "message" in e) {
+            } else if (e != null && typeof e === "object" && Reflect.has(e, "message")) {
+              // Reflect.has, not `in` — see the note on the equivalent guard above.
               resolvedError = new Error(String((e as { message?: unknown }).message ?? e));
             }
           }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.0.9
         version: 4.0.18(vitest@4.0.18)
+      acorn:
+        specifier: ^8.15.0
+        version: 8.16.0
       esbuild:
         specifier: ^0.21.5
         version: 0.21.5
@@ -2174,6 +2177,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@vercel/cli-config@0.2.0':
     resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
@@ -6233,7 +6237,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.22.4)
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jsdom@28.1.0)(lightningcss@1.32.0)(tsx@4.22.4)
 
   '@vitest/utils@4.0.18':
     dependencies:


### PR DESCRIPTION
## Problem

Oxc/Rolldown (Vite 8.1.4 / Rolldown 1.1.5) has two bugs with one trigger — an `in` expression inside an **arrow** function body nested in a `for(init;;)` head:

1. Oxc's parser rejects the shape outright ("Expected a semicolon") even though it's valid JS (acorn/V8 accept it; only arrow bodies leak the no-in restriction).
2. With the `in` parenthesized (also valid), the parse succeeds but Rolldown **silently emits the entire containing module as an empty chunk** — the consumer's build exits 0 and they get `does not provide an export named ...` at runtime.

Persona's esbuild-minified `dist/index.js` / `dist/theme-editor-preview.js` contained exactly this shape: esbuild's minifier merges a preceding `const probe = (e) => "message" in e`-style assignment into a following loop's `for(init;;)` head. This broke 13 routes on the Runtype dashboard's Vite 8 upgrade (runtypelabs/core#5309) and hits any customer bundling `@runtypelabs/persona` with Vite 8.

## Fix

- Rewrite the two `"message" in e` error-narrowing guards in `packages/widget/src/client.ts` as `Reflect.has(e, "message")` — same `[[HasProperty]]` internal method, so exact semantic equivalence (not `Object.hasOwn`, which skips the prototype chain). Operand evaluation order flips, which is irrelevant here (both operands side-effect-free).
- **Regression gate** (`packages/widget/scripts/check-dist-no-in-for-init.mjs`, run as the last step of the widget `build` script, so CI's `pnpm build` enforces it): an acorn walker over every `dist/**/*.js` that fails the build on any `in` expression inside a for-init subtree, recursing into arrow bodies and resetting at real function boundaries. This is the long-term deliverable — the source fix cures today's instance, but any future source change can re-mint the shape through the minifier; only the build-output scan prevents shipping it again.

## Verification

- `check:dist-vite8` reports all 21 dist `.js` files clean after rebuild; a negative test with the toxic shape correctly fails the gate.
- Both guards survive minification as `Reflect.has(...)` in `dist/index.js` and `dist/theme-editor-preview.js` (2 each, matching the previous `in` hit counts).
- **Vite 8.1.4 fixture** (throwaway app, `file:` dep on the rebuilt package, no config workarounds): build succeeds, persona chunk is fully populated (530 KB, all `persona-` markers present), no empty chunks. **Control with published 4.6.0 on the same fixture: `vite build` fails with the Rolldown/Oxc error**, confirming the fixture reproduces the bug and this package fixes it.
- Widget test suite (1354 tests), lint, and typecheck all pass.

## Follow-up (runtypelabs/core, after the patch release)

Bump `@runtypelabs/persona` in `apps/dashboard-spa`, delete the consumer-side `personaOxcNoInWorkaround()` from `apps/dashboard-spa/vite.config.ts` (both registrations: `plugins` and `optimizeDeps.rolldownOptions.plugins`), and drop the `acorn` + `magic-string` devDeps if nothing else uses them.

Out of scope: filing the upstream oxc/rolldown issues (repro lives in core#5309), and moving persona's dist off minified monoliths.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents the widget package from shipping the Vite/Rolldown `in`-operator bundle shape. The main changes are:

- Replaces two error guards with `Reflect.has` in the widget client.
- Adds a dist scanner that checks `.js`, `.cjs`, and `.mjs` bundles.
- Runs the scanner at the end of the widget build.
- Adds the `acorn` build dependency and a patch changeset.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/widget/scripts/check-dist-no-in-for-init.mjs | Adds the dist scanner and covers the relevant bundle extensions. |
| packages/widget/package.json | Runs the scanner after the widget build and adds the parser dependency. |
| packages/widget/src/client.ts | Replaces the two `in` checks with `Reflect.has`. |
| pnpm-lock.yaml | Updates the lockfile for the new parser dependency. |
| .changeset/fix-vite8-no-in-for-init.md | Adds a patch release note for the Vite compatibility fix. |

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile findings (scan .cj..."](https://github.com/runtypelabs/persona/commit/4542e2dc1160a6ebb6a20690b453164a8c5294c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43408337)</sub>

<!-- /greptile_comment -->