### PR TITLE
feat: send refreshed WebMCP clientTools on client-token resume

### DIFF
--- a/.changeset/clienttools-resume-refresh.md
+++ b/.changeset/clienttools-resume-refresh.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Send a refreshed WebMCP `clientTools[]` snapshot on client-token resume (`POST /v1/client/resume`), using the same diff-only / send-once protocol as the chat path: fingerprint-only when the page's tool registry is unchanged, full array + fingerprint on change or after a `409 client_tools_resend_required` (retried exactly once). Tools registered by a mid-run page navigation now become callable on the next model turn instead of staying frozen at dispatch time. When the registry vanished after a non-empty send, the widget ships an explicit `clientTools: []` so the server replaces the persisted set. Fully backward compatible: older servers strip the unknown fields and keep the frozen-at-dispatch behavior.

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -3925,6 +3925,218 @@ describe('AgentWidgetClient - diff-only clientTools (client-token)', () => {
   });
 });
 
+// ============================================================================
+// Mid-run clientTools refresh on resume (client-token mode, core#5361)
+// ============================================================================
+
+describe('AgentWidgetClient - resumeFlow clientTools refresh (client-token)', () => {
+  const TOOLS = [
+    { name: 'add_to_cart', description: 'Add to cart', origin: 'webmcp' as const },
+  ];
+
+  function sse(): Response {
+    const encoder = new TextEncoder();
+    const stream = new ReadableStream({
+      start(c) {
+        c.enqueue(encoder.encode('data: {"type":"done"}\n\n'));
+        c.close();
+      },
+    });
+    return new Response(stream, { headers: { 'Content-Type': 'text/event-stream' } });
+  }
+
+  // A client-token client with a live session (so initSession short-circuits)
+  // and a stubbed bridge whose snapshot is read lazily via `tools()`.
+  function makeClient(tools: () => unknown[]) {
+    const client = new AgentWidgetClient({
+      clientToken: 'ct_live_demo',
+      apiUrl: 'https://api.runtype.com',
+    });
+    (client as unknown as { clientSession: { sessionId: string; expiresAt: Date } }).clientSession = {
+      sessionId: 'cs_resume_1',
+      expiresAt: new Date(Date.now() + 600_000),
+    };
+    (client as unknown as { webMcpBridge: { snapshotForDispatch: () => unknown[] } | null }).webMcpBridge = {
+      snapshotForDispatch: () => tools(),
+    };
+    return client;
+  }
+
+  const userMsg = () => ({
+    messages: [{ id: 'u1', role: 'user' as const, content: 'hi', createdAt: new Date().toISOString() }],
+    assistantMessageId: 'a1',
+  });
+
+  let chatBodies: Array<Record<string, unknown>>;
+  let resumeBodies: Array<Record<string, unknown>>;
+  beforeEach(() => {
+    chatBodies = [];
+    resumeBodies = [];
+  });
+
+  // Records chat/resume bodies; `onResume` (keyed by 1-based resume call
+  // index) can override the response for a given resume call.
+  function captureFetch(onResume?: Record<number, () => Response>) {
+    let resumeCall = 0;
+    return vi.fn().mockImplementation(async (url: string, init: { body: string }) => {
+      if (url.includes('/client/chat')) chatBodies.push(JSON.parse(init.body));
+      if (url.includes('/client/resume')) {
+        resumeBodies.push(JSON.parse(init.body));
+        resumeCall += 1;
+        const override = onResume?.[resumeCall];
+        if (override) return override();
+      }
+      return sse();
+    });
+  }
+
+  it('first send of a session ships the full tool list AND a fingerprint on resume', async () => {
+    global.fetch = captureFetch();
+    const client = makeClient(() => TOOLS);
+
+    const response = await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(response.ok).toBe(true);
+    expect(resumeBodies).toHaveLength(1);
+    expect(resumeBodies[0]!.executionId).toBe('exec_1');
+    expect(resumeBodies[0]!.toolOutputs).toEqual({ call_1: 'ok' });
+    expect(resumeBodies[0]!.clientTools).toEqual(TOOLS);
+    expect(typeof resumeBodies[0]!.clientToolsFingerprint).toBe('string');
+  });
+
+  it('resume after an unchanged chat send is fingerprint-only', async () => {
+    global.fetch = captureFetch();
+    const client = makeClient(() => TOOLS);
+
+    await client.dispatch(userMsg(), () => undefined);
+    await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(resumeBodies).toHaveLength(1);
+    expect(resumeBodies[0]!.clientTools).toBeUndefined();
+    expect(resumeBodies[0]!.clientToolsFingerprint).toBe(chatBodies[0]!.clientToolsFingerprint);
+  });
+
+  it('a successful resume full-send commits the shared cache: the next chat turn is fingerprint-only', async () => {
+    global.fetch = captureFetch();
+    const client = makeClient(() => TOOLS);
+
+    await client.resumeFlow('exec_1', { call_1: 'ok' });
+    await client.dispatch(userMsg(), () => undefined);
+
+    expect(resumeBodies[0]!.clientTools).toEqual(TOOLS);
+    expect(chatBodies).toHaveLength(1);
+    expect(chatBodies[0]!.clientTools).toBeUndefined();
+    expect(chatBodies[0]!.clientToolsFingerprint).toBe(resumeBodies[0]!.clientToolsFingerprint);
+  });
+
+  it('a changed registry (mid-run navigation) resends the full list on resume', async () => {
+    global.fetch = captureFetch();
+    let live = [...TOOLS];
+    const client = makeClient(() => live);
+
+    await client.dispatch(userMsg(), () => undefined);
+    live = [...TOOLS, { name: 'checkout', description: 'Checkout', origin: 'webmcp' as const }];
+    await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(resumeBodies[0]!.clientTools).toEqual(live);
+    expect(resumeBodies[0]!.clientToolsFingerprint).not.toBe(chatBodies[0]!.clientToolsFingerprint);
+  });
+
+  it('a 409 client_tools_resend_required on resume retries exactly once with the full list', async () => {
+    global.fetch = captureFetch({
+      1: () =>
+        new Response(JSON.stringify({ error: 'client_tools_resend_required' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    });
+    const client = makeClient(() => TOOLS);
+
+    await client.dispatch(userMsg(), () => undefined); // commits the fingerprint
+    const response = await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(response.ok).toBe(true);
+    expect(resumeBodies).toHaveLength(2);
+    expect(resumeBodies[0]!.clientTools).toBeUndefined(); // fingerprint-only first
+    expect(resumeBodies[1]!.clientTools).toEqual(TOOLS); // retry carries the full list
+    // ...with the SAME executionId + toolOutputs (no double resume).
+    expect(resumeBodies[1]!.executionId).toBe(resumeBodies[0]!.executionId);
+    expect(resumeBodies[1]!.toolOutputs).toEqual(resumeBodies[0]!.toolOutputs);
+  });
+
+  it('any other 409 is returned once, body still readable (no retry, no consumed stream)', async () => {
+    global.fetch = captureFetch({
+      1: () =>
+        new Response(JSON.stringify({ error: 'execution_conflict' }), {
+          status: 409,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+    });
+    const client = makeClient(() => TOOLS);
+
+    const response = await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(response.status).toBe(409);
+    expect(resumeBodies).toHaveLength(1);
+    // The 409 probe used a clone, so callers can still parse the error body.
+    await expect(response.json()).resolves.toEqual({ error: 'execution_conflict' });
+  });
+
+  it('a failed resume does not commit the cache: the next chat turn resends full', async () => {
+    global.fetch = captureFetch({
+      1: () => new Response(JSON.stringify({ error: 'boom' }), { status: 500 }),
+    });
+    const client = makeClient(() => TOOLS);
+
+    const response = await client.resumeFlow('exec_1', { call_1: 'ok' });
+    expect(response.status).toBe(500);
+    await client.dispatch(userMsg(), () => undefined);
+
+    expect(chatBodies[0]!.clientTools).toEqual(TOOLS); // full, not fingerprint-only
+  });
+
+  it('registry vanished after a non-empty send: resume ships an explicit clientTools: []', async () => {
+    global.fetch = captureFetch();
+    let live: unknown[] = [...TOOLS];
+    const client = makeClient(() => live);
+
+    await client.dispatch(userMsg(), () => undefined); // non-empty send committed
+    live = []; // navigation landed on a page with no registry
+    await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(resumeBodies[0]!.clientTools).toEqual([]);
+    expect(resumeBodies[0]!.clientToolsFingerprint).toBeUndefined();
+  });
+
+  it('empty registry with no prior send omits both fields', async () => {
+    global.fetch = captureFetch();
+    const client = makeClient(() => []);
+
+    await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(resumeBodies[0]!.clientTools).toBeUndefined();
+    expect(resumeBodies[0]!.clientToolsFingerprint).toBeUndefined();
+  });
+
+  it('proxy-mode resume never adds clientTools fields (route does not accept them)', async () => {
+    const bodies: Array<Record<string, unknown>> = [];
+    global.fetch = vi.fn().mockImplementation(async (_url: string, init: { body: string }) => {
+      bodies.push(JSON.parse(init.body));
+      return sse();
+    });
+    const client = new AgentWidgetClient({ apiUrl: 'http://localhost:8000/api/chat/dispatch' });
+    (client as unknown as { webMcpBridge: { snapshotForDispatch: () => unknown[] } | null }).webMcpBridge = {
+      snapshotForDispatch: () => TOOLS,
+    };
+
+    await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(bodies).toHaveLength(1);
+    expect(bodies[0]!.clientTools).toBeUndefined();
+    expect(bodies[0]!.clientToolsFingerprint).toBeUndefined();
+  });
+});
+
 describe('AgentWidgetClient - non-client-token paths always send full clientTools', () => {
   function sse(): Response {
     const encoder = new TextEncoder();

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -4108,6 +4108,28 @@ describe('AgentWidgetClient - resumeFlow clientTools refresh (client-token)', ()
     expect(resumeBodies[0]!.clientToolsFingerprint).toBeUndefined();
   });
 
+  it('an interleaved empty-tool chat turn does not lose the pending clear (Greptile P1)', async () => {
+    // Chat with tools (persisted server-side) → chat with an empty registry
+    // (omits both fields, so the paused execution's persisted tools survive)
+    // → resume must STILL send the explicit [] replace.
+    global.fetch = captureFetch();
+    let live: unknown[] = [...TOOLS];
+    const client = makeClient(() => live);
+
+    await client.dispatch(userMsg(), () => undefined); // non-empty send committed
+    live = [];
+    await client.dispatch(userMsg(), () => undefined); // empty chat: omits fields
+    expect(chatBodies[1]!.clientTools).toBeUndefined();
+    await client.resumeFlow('exec_1', { call_1: 'ok' });
+
+    expect(resumeBodies[0]!.clientTools).toEqual([]);
+    expect(resumeBodies[0]!.clientToolsFingerprint).toBeUndefined();
+
+    // The confirmed [] replace clears the flag: a second empty resume omits.
+    await client.resumeFlow('exec_1', { call_2: 'ok' });
+    expect(resumeBodies[1]!.clientTools).toBeUndefined();
+  });
+
   it('empty registry with no prior send omits both fields', async () => {
     global.fetch = captureFetch();
     const client = makeClient(() => []);

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -17,6 +17,7 @@ import {
   ClientSession,
   ClientInitResponse,
   ClientChatRequest,
+  ClientToolDefinition,
   ClientFeedbackRequest,
   ClientFeedbackType,
   PersonaArtifactKind,
@@ -674,71 +675,32 @@ export class AgentWidgetClient {
       };
 
       // Diff-only / send-once WebMCP tool dispatch. `buildPayload()` already
-      // snapshotted the full set; decide whether to ship it again or just its
-      // fingerprint. First turn of a session, or a changed set, sends the full
-      // array; an unchanged set sends only the fingerprint and the server
-      // reuses its stored copy. The cache is committed only after a successful
-      // stream start (below), so a 409/failure leaves it untouched.
-      const fullClientTools = basePayload.clientTools;
-      const hasClientTools = !!(fullClientTools && fullClientTools.length > 0);
-      const clientToolsFingerprint = hasClientTools
-        ? computeClientToolsFingerprint(fullClientTools!)
-        : undefined;
-      const sameSession = this.clientToolsFingerprintSessionId === session.sessionId;
-      const unchanged =
-        hasClientTools && sameSession && this.lastSentClientToolsFingerprint === clientToolsFingerprint;
+      // snapshotted the full set; `sendWithClientToolsDiff` decides whether to
+      // ship it again or just its fingerprint (retrying once on a 409 registry
+      // miss). The cache is committed only after a successful stream start
+      // (below), so a 409/failure leaves it untouched.
+      const { response, commit: commitClientToolsFingerprint } =
+        await this.sendWithClientToolsDiff(session.sessionId, basePayload.clientTools, (toolFields) => {
+          const chatRequest: ClientChatRequest = { ...baseChatRequest, ...toolFields };
 
-      // `forceFull` flips to true after a 409 cache-miss so the single retry
-      // resends the full list. Capture any error body read inside the loop so
-      // the `!response.ok` handler below doesn't re-consume the stream.
-      let forceFull = false;
-      let errorData: { error?: string; hint?: string } | null = null;
-      let response: Response;
-      for (let attempt = 0; ; attempt++) {
-        const sendFull = hasClientTools && (forceFull || !unchanged);
-        const chatRequest: ClientChatRequest = {
-          ...baseChatRequest,
-          ...(sendFull && fullClientTools ? { clientTools: fullClientTools } : {}),
-          ...(clientToolsFingerprint ? { clientToolsFingerprint } : {}),
-        };
+          if (this.debug) {
+            // eslint-disable-next-line no-console
+            console.debug("[AgentWidgetClient] client token dispatch", chatRequest);
+          }
 
-        if (this.debug) {
-          // eslint-disable-next-line no-console
-          console.debug("[AgentWidgetClient] client token dispatch", chatRequest);
-        }
-
-        response = await fetch(this.getClientApiUrl('chat'), {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            'X-Persona-Version': VERSION,
-          },
-          body: JSON.stringify(chatRequest),
-          signal: options.signal,
+          return fetch(this.getClientApiUrl('chat'), {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'X-Persona-Version': VERSION,
+            },
+            body: JSON.stringify(chatRequest),
+            signal: options.signal,
+          });
         });
 
-        // Diff-only cache miss: the server has no stored tool set matching our
-        // fingerprint. Retry exactly once with the full list. A second miss
-        // falls through to the normal error handling below (no infinite loop).
-        if (response.status === 409 && attempt === 0 && hasClientTools) {
-          const body = (await response.json().catch(() => null)) as
-            | { error?: string; hint?: string }
-            | null;
-          if (body?.error === 'client_tools_resend_required') {
-            forceFull = true;
-            // Invalidate so future turns also resend until a clean success
-            // commits a fresh fingerprint.
-            this.lastSentClientToolsFingerprint = null;
-            continue;
-          }
-          // Some other 409: keep the parsed body for the handler below.
-          errorData = body ?? { error: 'Chat request failed' };
-        }
-        break;
-      }
-
       if (!response.ok) {
-        const data = errorData ?? (await response.json().catch(() => ({ error: 'Chat request failed' })));
+        const data = await response.json().catch(() => ({ error: 'Chat request failed' }));
 
         if (response.status === 401) {
           // Session expired
@@ -769,8 +731,7 @@ export class AgentWidgetClient {
       // Stream is good: the server now holds this tool set under this
       // fingerprint for the session. Commit the cache so unchanged follow-up
       // turns can send fingerprint-only.
-      this.lastSentClientToolsFingerprint = clientToolsFingerprint ?? null;
-      this.clientToolsFingerprintSessionId = session.sessionId;
+      commitClientToolsFingerprint();
 
       onEvent({ type: "status", status: "connected" });
       
@@ -993,8 +954,13 @@ export class AgentWidgetClient {
    *  - **client-token mode**: POST `${apiBase}/v1/client/resume` (the
    *    session-authenticated sibling of `/v1/client/chat`; runtypelabs/core#3889),
    *    with the active `sessionId` in the body and no Bearer key: a browser
-   *    client-token page holds no secret. `clientTools` are already persisted
-   *    server-side from the dispatch turn, so only `toolOutputs` is re-sent.
+   *    client-token page holds no secret. The page's tool registry is
+   *    re-snapshotted and sent alongside `toolOutputs` via the same diff-only
+   *    `clientTools` / `clientToolsFingerprint` protocol as `/v1/client/chat`
+   *    (runtypelabs/core#5361), so tools registered by a mid-run page
+   *    navigation replace the run's dispatch-time set and become callable on
+   *    the next model turn. Old servers strip the unknown fields and keep the
+   *    frozen-at-dispatch behavior.
    *  - **dispatch / proxy mode**: POST `${apiUrl}/resume`: Runtype mounts
    *    resume as a child of `/v1/dispatch`, so the URL is `${apiUrl}/resume`,
    *    and proxies follow the same shape (`/api/chat/dispatch/resume`).
@@ -1006,6 +972,102 @@ export class AgentWidgetClient {
    * @param toolOutputs - Map keyed by per-call `toolCallId` (core#3878),
    *   falling back to tool name for legacy servers → the tool's result value.
    */
+  /**
+   * Diff-only / send-once WebMCP clientTools transport, shared by the
+   * client-token chat (`/v1/client/chat`) and resume (`/v1/client/resume`)
+   * paths — both routes speak the same protocol (runtypelabs/core#5361).
+   *
+   * Decides, against the shared fingerprint cache, whether this request ships
+   * the full `clientTools[]` + fingerprint (first send under this session, or
+   * a changed set) or the fingerprint alone (unchanged set; the server reuses
+   * its stored copy). Runs `doFetch` with the chosen fields and retries
+   * EXACTLY once with the full array on a
+   * `409 { error: 'client_tools_resend_required' }` registry miss — the retry
+   * is 409-*triggered*, never 409-*expected*, so servers predating the
+   * protocol (which strip the unknown fields and never 409) work unchanged.
+   * The 409 body is probed on a `clone()` so the original response body stays
+   * readable by the caller's error handling.
+   *
+   * The cache is NOT committed here: callers invoke the returned `commit()`
+   * only after the server has accepted the request (response OK / stream
+   * started), so a failed request can never record a fingerprint the server
+   * never stored. A resend-required miss invalidates the cached fingerprint
+   * immediately so later turns keep resending in full until a clean success
+   * commits a fresh one.
+   *
+   * `emptyMeansReplace` (resume only): when the live snapshot is empty but the
+   * last committed send under this session was non-empty (the paused tool
+   * navigated to a page with no tool registry), ship an explicit
+   * `clientTools: []` so the server REPLACES the persisted dispatch-time set
+   * with nothing and clears its stored registry. Chat keeps its
+   * omit-when-empty behavior: on `/chat`, absent fields already mean "no tools
+   * this turn", whereas on `/resume` absence means "keep the frozen
+   * dispatch-time set".
+   */
+  private async sendWithClientToolsDiff(
+    sessionId: string,
+    fullClientTools: ClientToolDefinition[] | undefined,
+    doFetch: (
+      toolFields: Pick<ClientChatRequest, 'clientTools' | 'clientToolsFingerprint'>
+    ) => Promise<Response>,
+    opts?: { emptyMeansReplace?: boolean }
+  ): Promise<{ response: Response; commit: () => void }> {
+    const hasClientTools = !!(fullClientTools && fullClientTools.length > 0);
+    const clientToolsFingerprint = hasClientTools
+      ? computeClientToolsFingerprint(fullClientTools!)
+      : undefined;
+    const sameSession = this.clientToolsFingerprintSessionId === sessionId;
+    const unchanged =
+      hasClientTools && sameSession && this.lastSentClientToolsFingerprint === clientToolsFingerprint;
+    // A committed non-null fingerprint under this session means the previous
+    // successful send was non-empty (zero-tool turns commit null), so an empty
+    // snapshot now is a real "registry vanished" transition worth replacing.
+    const sendEmptyReplace =
+      !hasClientTools &&
+      opts?.emptyMeansReplace === true &&
+      sameSession &&
+      this.lastSentClientToolsFingerprint !== null;
+
+    // `forceFull` flips to true after a 409 cache-miss so the single retry
+    // resends the full list.
+    let forceFull = false;
+    let response: Response;
+    for (let attempt = 0; ; attempt++) {
+      const sendFull = hasClientTools && (forceFull || !unchanged);
+      response = await doFetch({
+        ...(sendFull && fullClientTools ? { clientTools: fullClientTools } : {}),
+        ...(sendEmptyReplace ? { clientTools: [] } : {}),
+        ...(clientToolsFingerprint ? { clientToolsFingerprint } : {}),
+      });
+
+      // Diff-only cache miss: the server has no stored tool set matching our
+      // fingerprint. Retry exactly once with the full list. A second miss
+      // falls through to the caller's normal error handling (no infinite loop).
+      if (response.status === 409 && attempt === 0 && hasClientTools) {
+        const body = (await response
+          .clone()
+          .json()
+          .catch(() => null)) as { error?: string } | null;
+        if (body?.error === 'client_tools_resend_required') {
+          forceFull = true;
+          // Invalidate so future turns also resend until a clean success
+          // commits a fresh fingerprint.
+          this.lastSentClientToolsFingerprint = null;
+          continue;
+        }
+      }
+      break;
+    }
+
+    return {
+      response,
+      commit: () => {
+        this.lastSentClientToolsFingerprint = clientToolsFingerprint ?? null;
+        this.clientToolsFingerprintSessionId = sessionId;
+      },
+    };
+  }
+
   public async resumeFlow(
     executionId: string,
     toolOutputs: Record<string, unknown>,
@@ -1044,6 +1106,47 @@ export class AgentWidgetClient {
     // Thread the (refreshed) sessionId through like `/v1/client/chat` does.
     if (resumeSessionId) {
       body.sessionId = resumeSessionId;
+    }
+
+    if (isClientToken && resumeSessionId) {
+      // Mid-run WebMCP tool refresh (runtypelabs/core#5361): the paused tool
+      // may have navigated the page, so the dispatch-time snapshot the server
+      // persisted can be stale. Re-snapshot the registry — the same built-in +
+      // bridge composition as the payload builders, so fingerprints computed
+      // here and on chat turns describe the same tool space — and ship it via
+      // the shared diff-only protocol. `emptyMeansReplace` sends an explicit
+      // `clientTools: []` when the registry vanished after a non-empty send,
+      // so the server replaces the persisted set instead of keeping it frozen.
+      const fullClientTools = [
+        ...builtInClientToolsForDispatch(this.config),
+        ...((await this.webMcpBridge?.snapshotForDispatch()) ?? []),
+      ];
+      const { response, commit } = await this.sendWithClientToolsDiff(
+        resumeSessionId,
+        fullClientTools,
+        (toolFields) => {
+          const resumeRequest = { ...body, ...toolFields };
+          if (this.debug) {
+            // eslint-disable-next-line no-console
+            console.debug("[AgentWidgetClient] client token resume", resumeRequest);
+          }
+          return fetch(url, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify(resumeRequest),
+            signal: options?.signal,
+          });
+        },
+        { emptyMeansReplace: true }
+      );
+      // The server stores the refreshed registry before running the
+      // continuation pipeline, so an OK response means it holds this set under
+      // this fingerprint. Mirror chat's commit-on-success discipline: a failed
+      // resume must not record a fingerprint the server never stored.
+      if (response.ok) {
+        commit();
+      }
+      return response;
     }
 
     return fetch(url, {

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -181,6 +181,14 @@ export class AgentWidgetClient {
   // (silent re-init / expiry) forces a fresh full send.
   private lastSentClientToolsFingerprint: string | null = null;
   private clientToolsFingerprintSessionId: string | null = null;
+  // Session under which a non-empty clientTools[] was last committed and not
+  // yet confirmed cleared server-side. Distinct from the fingerprint above:
+  // an empty-tool chat turn commits a null fingerprint, but OMITTING the
+  // fields on chat doesn't clear the tools persisted for a still-paused
+  // execution — so a later resume with an empty registry must still send the
+  // explicit `clientTools: []` replace. Reset only by an explicit [] replace,
+  // a session change, or a conversation reset.
+  private sentNonEmptyClientToolsSessionId: string | null = null;
 
   // WebMCP: page-discovered tool consumption (see ./webmcp-bridge).
   // Constructed lazily: null when `config.webmcp?.enabled !== true`.
@@ -439,6 +447,7 @@ export class AgentWidgetClient {
   public resetClientToolsFingerprint(): void {
     this.lastSentClientToolsFingerprint = null;
     this.clientToolsFingerprintSessionId = null;
+    this.sentNonEmptyClientToolsSessionId = null;
   }
 
   /**
@@ -995,13 +1004,13 @@ export class AgentWidgetClient {
    * immediately so later turns keep resending in full until a clean success
    * commits a fresh one.
    *
-   * `emptyMeansReplace` (resume only): when the live snapshot is empty but the
-   * last committed send under this session was non-empty (the paused tool
-   * navigated to a page with no tool registry), ship an explicit
-   * `clientTools: []` so the server REPLACES the persisted dispatch-time set
-   * with nothing and clears its stored registry. Chat keeps its
-   * omit-when-empty behavior: on `/chat`, absent fields already mean "no tools
-   * this turn", whereas on `/resume` absence means "keep the frozen
+   * `emptyMeansReplace` (resume only): when the live snapshot is empty but a
+   * non-empty set was committed under this session and never explicitly
+   * cleared (the paused tool navigated to a page with no tool registry), ship
+   * an explicit `clientTools: []` so the server REPLACES the persisted
+   * dispatch-time set with nothing and clears its stored registry. Chat keeps
+   * its omit-when-empty behavior: on `/chat`, absent fields already mean "no
+   * tools this turn", whereas on `/resume` absence means "keep the frozen
    * dispatch-time set".
    */
   private async sendWithClientToolsDiff(
@@ -1019,14 +1028,16 @@ export class AgentWidgetClient {
     const sameSession = this.clientToolsFingerprintSessionId === sessionId;
     const unchanged =
       hasClientTools && sameSession && this.lastSentClientToolsFingerprint === clientToolsFingerprint;
-    // A committed non-null fingerprint under this session means the previous
-    // successful send was non-empty (zero-tool turns commit null), so an empty
-    // snapshot now is a real "registry vanished" transition worth replacing.
+    // Keyed on `sentNonEmptyClientToolsSessionId`, NOT the fingerprint: an
+    // interleaved empty-tool chat turn commits a null fingerprint without
+    // clearing the tools persisted for a still-paused execution, so the
+    // fingerprint alone would lose the pending clear. The dedicated flag
+    // survives omitted-empty commits and is reset only once an explicit []
+    // replace is confirmed.
     const sendEmptyReplace =
       !hasClientTools &&
       opts?.emptyMeansReplace === true &&
-      sameSession &&
-      this.lastSentClientToolsFingerprint !== null;
+      this.sentNonEmptyClientToolsSessionId === sessionId;
 
     // `forceFull` flips to true after a 409 cache-miss so the single retry
     // resends the full list.
@@ -1064,6 +1075,15 @@ export class AgentWidgetClient {
       commit: () => {
         this.lastSentClientToolsFingerprint = clientToolsFingerprint ?? null;
         this.clientToolsFingerprintSessionId = sessionId;
+        if (hasClientTools) {
+          this.sentNonEmptyClientToolsSessionId = sessionId;
+        } else if (sendEmptyReplace) {
+          // The explicit [] replaced the persisted set server-side; the
+          // pending clear is done.
+          this.sentNonEmptyClientToolsSessionId = null;
+        }
+        // Omitted-empty commits (chat with zero tools) leave the flag set:
+        // they don't touch tools persisted for a paused execution.
       },
     };
   }


### PR DESCRIPTION
## Problem

The WebMCP tool set for a run is frozen at dispatch time. When a paused page tool navigates (e.g. a storefront's goto tool), the destination page registers new tools on `document.modelContext` — the widget's bridge can execute them, but the run only knows the original snapshot, forcing a "navigate, stop, wait for the next user message" dance to pick them up.

## Change

The Runtype API now accepts an optional `clientTools[]` + `clientToolsFingerprint` refresh on `POST /v1/client/resume`. `resumeFlow()` (client-token mode only) now:

- Re-snapshots the page registry on every resume, using the same built-in (`sdk`) + WebMCP-bridge composition as the chat payload builders, so fingerprints computed on chat and resume turns describe the same tool space.
- Applies the chat path's diff-only / send-once decision against the **same shared fingerprint cache**: unchanged set → fingerprint-only; first send / changed set → full `clientTools[]` + fingerprint.
- Retries exactly once with the full array on `409 { "error": "client_tools_resend_required" }`, invalidating the cache on the miss. The retry is 409-*triggered*, never 409-*expected*, so servers without this capability (which strip the unknown fields and never 409) work unchanged.
- Commits the fingerprint cache only after an OK response — a failed resume never records a fingerprint the server didn't store.
- **Empty-registry transition**: when the snapshot is empty but the last committed send under this session was non-empty (navigation landed on a tool-less page), sends an explicit `clientTools: []` so the server replaces the persisted set with nothing and clears its stored registry. With no prior send, both fields are omitted (keeps the dispatch-time set, matching chat's omit-when-empty behavior).

The decision/retry loop is extracted into a private `sendWithClientToolsDiff()` helper shared by `dispatchClientToken` and `resumeFlow` (the 409 probe now reads a `clone()`, so the caller's error handling keeps a readable body). Dispatch/proxy-mode resume is untouched — that route doesn't accept the fields.

## Tests

New `resumeFlow clientTools refresh` suite in `client.test.ts`: first-send full + fingerprint; unchanged-after-chat fingerprint-only; resume full-send commits the shared cache (next chat turn is fingerprint-only); changed registry resends full; 409 resend-required retries exactly once with same `executionId`/`toolOutputs`; other 409 returned once with readable body; failed resume doesn't commit; vanished registry sends explicit `[]`; empty-with-no-prior-send omits both; proxy-mode resume never adds the fields. Full suite: 1377 tests green; build/lint/typecheck green.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refreshes WebMCP client tools during client-token resume. The main changes are:

- Shared diff-only client tool sending for chat and resume.
- Resume-time re-snapshot of built-in and WebMCP bridge tools.
- One retry with the full tool list after a resend-required response.
- Explicit empty tool replacement after a previously sent non-empty registry.
- Tests for resume refresh, retry behavior, failed commits, empty registries, and proxy-mode omission.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/widget/src/client.ts | Adds the shared client tool diff helper, resume refresh path, retry handling, and empty-registry clear tracking. |
| packages/widget/src/client.test.ts | Adds coverage for client-token resume tool refresh, cache commits, retry behavior, empty registries, and proxy-mode behavior. |
| .changeset/clienttools-resume-refresh.md | Documents the client-token resume tool refresh behavior for the release. |

<sub>Reviews (2): Last reviewed commit: ["fix: don&#39;t lose the pending empty-regist..."](https://github.com/runtypelabs/persona/commit/a362683cd677de5b5b7d9f6eacac4dd39ee368d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43594799)</sub>

<!-- /greptile_comment -->