### PR TITLE
Add Northstar Analytics to the home page carousel

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -183,6 +183,14 @@
                   <span class="carousel-3d-card-title">Theme Editor</span>
                 </a>
               </div>
+              <div class="carousel-3d-card">
+                <a href="/analytics-agent-demo.html" class="carousel-3d-card-link">
+                  <div class="carousel-3d-iframe-wrap">
+                    <iframe data-src="/analytics-agent-demo.html" tabindex="-1" title="Northstar Analytics"></iframe>
+                  </div>
+                  <span class="carousel-3d-card-title">Northstar Analytics</span>
+                </a>
+              </div>
             </div>
             <div class="carousel-3d-controls">
               <button type="button" class="carousel-3d-nav" data-carousel-prev aria-label="Previous demo">&larr;</button>


### PR DESCRIPTION
## Summary
- Add a carousel card for the Northstar Analytics demo (added in #373) to the home page's showcase carousel in `apps/web/index.html`
- Follows the existing card pattern: lazy-loaded iframe preview (`data-src`), title matching the demo page's own `<title>`

## Test plan
- [x] Verified in a live dev server (`pnpm dev:widget`) that the new card renders correctly, previews the demo via iframe, and carousel nav/dots work (dots/cards are derived from the DOM in `main.ts`, no JS changes needed)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Northstar Analytics to the home-page showcase carousel. The main changes are:

- Adds a card linking to `/analytics-agent-demo.html`.
- Adds a lazy-loaded iframe preview.
- Uses the demo title for the card and iframe.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/index.html | Adds a carousel card that follows the existing markup, lazy-loading, navigation, and title conventions. |

<sub>Reviews (1): Last reviewed commit: ["Add Northstar Analytics to the home page..."](https://github.com/runtypelabs/persona/commit/ccf91bb9be78bb58ea69f141347fba4301ddd540) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45334772)</sub>

<!-- /greptile_comment -->