### PR TITLE
fix: await getHistory() — @litert-lm/core 0.14.0 made it async

### DIFF
--- a/apps/web/src/litert-shared/litert-engine.ts
+++ b/apps/web/src/litert-shared/litert-engine.ts
@@ -94,7 +94,10 @@ interface LiteRtConversation {
     message: LiteRtMessageLike | LiteRtMessageLike[],
   ): ReadableStream<LiteRtMessage>;
   cancel(): void;
-  getHistory(): LiteRtMessage[];
+  // Sync in ≤0.13.x, Promise in 0.14.0 — always `await` the call so the engine
+  // works against either. (Spreading the 0.14.0 Promise threw "history is not
+  // iterable" and killed every text-only final turn as an execution_error.)
+  getHistory(): LiteRtMessage[] | Promise<LiteRtMessage[]>;
   delete(): Promise<void>;
 }
 interface LiteRtEngine {
@@ -765,7 +768,7 @@ export function createLiteRtPersonaEngine(options: {
     // call inline (some runtime builds only attach tool_calls to the committed
     // message).
     if (toolCalls.length === 0) {
-      const history = conversation.getHistory();
+      const history = await conversation.getHistory();
       const lastAssistant = [...history]
         .reverse()
         .find((m) => m.role !== "user" && m.tool_calls?.length);


### PR DESCRIPTION
Follow-up to #376, which merged before this fix landed on the branch.

0.14.0 changed `Conversation.getHistory()` to return a Promise; un-awaited, every litert demo run ended in a silent `execution_error` after its first tool round (any model). One-line fix, verified live on E4B in litert-paint: 16 chained tool calls, clean `execution_complete`. Dark-launched pages, apps/web only, no changeset.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates LiteRT history handling for the asynchronous API in version 0.14.0. The main changes are:

- Expands the local `getHistory()` type to allow a Promise.
- Awaits history before searching committed assistant messages.

<h3>Confidence Score: 4/5</h3>

The asynchronous history read needs lifecycle coordination before merging.

- Awaiting the new Promise fixes the reported array-spread failure.
- Model changes and new dispatches can delete the conversation while the history read is pending.
- That race can end the turn with an error or omit committed tool calls.

apps/web/src/litert-shared/litert-engine.ts

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| apps/web/src/litert-shared/litert-engine.ts | Correctly awaits asynchronous history, but the new suspension point can race with conversation deletion. |

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flitert-shared%2Flitert-engine.ts%3A771%0A**History%20Read%20Races%20With%20Deletion**%0A%0AWhile%20this%20await%20is%20pending%2C%20a%20model%20change%20or%20new%20dispatch%20can%20delete%20the%20same%20live%20conversation.%20If%20%60getHistory%28%29%60%20rejects%20or%20reads%20cleared%20state%20after%20that%20deletion%2C%20the%20active%20turn%20reports%20%60execution_error%60%20or%20silently%20misses%20committed%20tool%20calls%3B%20conversation%20deletion%20must%20be%20coordinated%20with%20this%20read.%0A%0A&repo=runtypelabs%2Fpersona&pr=378&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22fix%2Flitert-gethistory-async%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Flitert-gethistory-async%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flitert-shared%2Flitert-engine.ts%3A771%0A**History%20Read%20Races%20With%20Deletion**%0A%0AWhile%20this%20await%20is%20pending%2C%20a%20model%20change%20or%20new%20dispatch%20can%20delete%20the%20same%20live%20conversation.%20If%20%60getHistory%28%29%60%20rejects%20or%20reads%20cleared%20state%20after%20that%20deletion%2C%20the%20active%20turn%20reports%20%60execution_error%60%20or%20silently%20misses%20committed%20tool%20calls%3B%20conversation%20deletion%20must%20be%20coordinated%20with%20this%20read.%0A%0A&repo=runtypelabs%2Fpersona&pr=378&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Aapps%2Fweb%2Fsrc%2Flitert-shared%2Flitert-engine.ts%3A771%0A**History%20Read%20Races%20With%20Deletion**%0A%0AWhile%20this%20await%20is%20pending%2C%20a%20model%20change%20or%20new%20dispatch%20can%20delete%20the%20same%20live%20conversation.%20If%20%60getHistory%28%29%60%20rejects%20or%20reads%20cleared%20state%20after%20that%20deletion%2C%20the%20active%20turn%20reports%20%60execution_error%60%20or%20silently%20misses%20committed%20tool%20calls%3B%20conversation%20deletion%20must%20be%20coordinated%20with%20this%20read.%0A%0A&pr=378&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["fix: await getHistory() — 0.14.0 made it..."](https://github.com/runtypelabs/persona/commit/b24e9ee65227c3f23ba171f10cd11409718dcfd9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46173683)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->