### PR TITLE
Fix live config update() merge and related UI stability

### DIFF
--- a/.changeset/attachment-button-live-update.md
+++ b/.changeset/attachment-button-live-update.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix the attachment button ignoring live `update()` changes: `buttonIconName` and `buttonTooltipText` were rendered once when the button was created and never re-applied, so updating them at runtime had no effect until a re-mount. The icon, tooltip, and aria-label are now re-rendered from the merged config on every update.

--- a/.changeset/composer-icon-update-drift.md
+++ b/.changeset/composer-icon-update-drift.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix three more cases where any live `update()` visibly restyled composer and header chrome: the mic icon boldened (updater rendered stroke 2 while the builder uses 1.5), the mic button color flipped from the text token to `currentColor` (updater had an extra fallback the builder does not), and the close and clear-chat icons lost the builder's `display:block`, shifting them off-center. The update path now mirrors the mount-time builders exactly.

--- a/.changeset/config-update-merge.md
+++ b/.changeset/config-update-merge.md
@@ -1,0 +1,9 @@
+---
+"@runtypelabs/persona": minor
+---
+
+update() now applies one consistent recursive patch policy across the live controller and the init handle. A key merges recursively only when both the previous value and the patch value are plain objects; otherwise the patch value replaces (arrays, functions, class instances, and boolean/string vs object unions all replace wholesale). A small replace-leaf list also replaces wholesale to avoid corrupt hybrids or stranded keys: headers, agent, storageAdapter, components, targetProviders, voiceRecognition.provider.custom, and features.streamAnimation.plugins. A key passed explicitly with value undefined clears the previous value and resets to its default (or stays unset when no default exists); an omitted key is preserved.
+
+The merge is exposed as a new AgentWidgetConfigPatch type accepted by update() (a loosening from the full config type, so existing calls keep working). This also fixes the init handle passing the raw patch to the controller (a double-merge) and an inconsistent tool-call diff baseline.
+
+Compatibility note: consumers who relied on omitting a nested field to erase sibling values will now see those values preserved. To disable or reset a nested field, set it explicitly (for example to false or to undefined) rather than omitting it.

--- a/.changeset/contain-artifact-content.md
+++ b/.changeset/contain-artifact-content.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Contain component artifacts to the pane width and reset stale horizontal scroll when selecting or expanding artifacts.

--- a/.changeset/drop-overlay-live-update.md
+++ b/.changeset/drop-overlay-live-update.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix the attachment drop overlay ignoring live `update()` changes: the overlay was built once at mount and never rebuilt, so `attachments.dropOverlay` values (background, icon, label, border, blur, inset) applied through `update()` had no effect until a re-mount. The overlay is now rebuilt from the merged config on every update.

--- a/.changeset/header-update-stability.md
+++ b/.changeset/header-update-stability.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix two header regressions triggered by any live `update()` call: the close button was revealed on non-closeable panels (an unset `layout.header.showCloseButton` was treated as "show" instead of deferring to panel toggleability), and the clear-chat icon boldened because the update path re-rendered it with stroke width 2 while the mount-time builder uses 1.

--- a/.changeset/send-button-midstream-update.md
+++ b/.changeset/send-button-midstream-update.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix the send button reverting from the stop icon to the send icon when a live `update()` lands during an active stream. The button showed the send arrow mid-stream while its aria-label still read "stop"; the icon content is now left untouched while streaming, so the stop glyph set by the composer survives an update and heals to the send icon on completion.

--- a/apps/web/src/artifact-demo.ts
+++ b/apps/web/src/artifact-demo.ts
@@ -827,25 +827,25 @@ const readAnimationControls = () => {
 // for shimmer-color.
 const buildArtifactsFeature = () => {
   const { mode, duration, primary, secondary } = readAnimationControls();
-  // Only send statusLabel when a non-default mode is picked; Default leaves the
-  // key unset so the widget keeps its built-in "Generating <type>..." label.
+  // Default mode returns undefined; sent explicitly so it clears a prior label.
   const statusLabel = buildStatusLabel();
-  // Custom tab bar for Buttons/Menu; undefined in Scroll mode leaves the
-  // built-in strip in place.
+  // Buttons/Menu return a renderer; Scroll returns undefined to clear it.
   const tabBar = buildTabBar();
+  // Read once; the pane-appearance recipe sends every key explicitly below so a
+  // control toggled back clears the previous recipe under patch-merge update().
+  const appearance = readPaneAppearance();
+  const chatFlush = appearance === "detached" && readChatFlush();
   return {
     ...artifactDemoConfigBase.features?.artifacts,
     display: readDisplayMode(),
-    ...(statusLabel !== undefined ? { statusLabel } : {}),
-    ...(tabBar ? { renderTabBar: tabBar } : {}),
+    statusLabel,
+    renderTabBar: tabBar,
     loadingAnimation: mode,
     loadingAnimationDuration: duration,
-    ...(mode === "shimmer-color"
-      ? {
-          loadingAnimationColor: primary,
-          loadingAnimationSecondaryColor: secondary,
-        }
-      : {}),
+    // Colors only apply to shimmer-color; cleared otherwise so they round-trip.
+    loadingAnimationColor: mode === "shimmer-color" ? primary : undefined,
+    loadingAnimationSecondaryColor:
+      mode === "shimmer-color" ? secondary : undefined,
     // Copy is always on in the demo so the default pane toolbar shows it;
     // the expand toggle stays behind its control pill. White pane surface so
     // the source view reads like a document sheet against this page's warm
@@ -853,38 +853,38 @@ const buildArtifactsFeature = () => {
     layout: {
       showCopyButton: true,
       paneBackground: "#ffffff",
-      ...(readExpandToggle() ? { showExpandToggle: true } : {}),
-      ...(readResizable() ? { resizable: true } : {}),
-      // Edge fade for the built-in Scroll strip; send only when turned Off.
-      // The custom Buttons/Menu bars (renderTabBar) own their own affordances.
-      ...(readTabFade() ? {} : { tabFade: false }),
-      ...(readPaneAppearance() === "seamless"
-        ? {
-            paneAppearance: "seamless" as const,
-            splitGap: "0",
-            paneShadow: "none",
-          }
-        : readPaneAppearance() === "detached"
-          ? // Detached: the widget widens the split gap to the panel inset
-            // token and adds all-side radius, border, and elevation. This
-            // page's warm background shows through the gap by default. Flush
-            // chat surface drops the chat card entirely so only the pane floats.
-            {
-              paneAppearance: "detached" as const,
-              // Flush squares the outer panel, so round the floating pane on its
-              // own token instead of inheriting the squared panel radius.
-              ...(readChatFlush()
-                ? { chatSurface: "flush" as const, paneBorderRadius: "0.75rem" }
-                : {}),
-            }
-          : // Panel: send it explicitly only under Always inset, so
-            // launcher.detachedPanel does not flip it to detached via the
-            // coordinated default; otherwise omit it (minimal default config).
-            readAlwaysInset()
-            ? { paneAppearance: "panel" as const }
-            : {}),
+      showExpandToggle: readExpandToggle(),
+      resizable: readResizable(),
+      // Edge fade for the built-in Scroll strip; the custom Buttons/Menu bars
+      // (renderTabBar) own their own affordances.
+      tabFade: readTabFade(),
+      // Panel sends undefined so launcher.detachedPanel can still flip the
+      // coordinated default to detached; "panel" pins it only under Always inset.
+      // Seamless/detached each set their own value.
+      paneAppearance:
+        appearance === "seamless"
+          ? ("seamless" as const)
+          : appearance === "detached"
+            ? ("detached" as const)
+            : readAlwaysInset()
+              ? ("panel" as const)
+              : undefined,
+      // Seamless flush recipe; cleared to undefined for panel/detached.
+      splitGap: appearance === "seamless" ? "0" : undefined,
+      paneShadow: appearance === "seamless" ? "none" : undefined,
+      // Detached + flush: square the outer panel, round the floating pane on its
+      // own token. Cleared to undefined otherwise.
+      chatSurface: chatFlush ? ("flush" as const) : undefined,
+      paneBorderRadius: chatFlush ? "0.75rem" : undefined,
     },
-    ...(readCustomActions() ? buildCustomActions() : {}),
+    // Off clears the sample actions (arrays replace wholesale under patch merge).
+    ...(readCustomActions()
+      ? buildCustomActions()
+      : {
+          toolbarActions: undefined,
+          cardActions: undefined,
+          inlineActions: undefined,
+        }),
     // Inline chrome On sends the object form so showViewToggle can ride along;
     // showCopy/showExpand default to true when unspecified in the object form.
     // Off sends inlineChrome: false for a bare inline body. showViewToggle is a
@@ -939,22 +939,20 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
             autoExpand: true,
             width: "100%",
             fullHeight: true,
-            // Always keeps the inline widget inset even when no artifact is open.
-            ...(readAlwaysInset() ? { detachedPanel: true } : {}),
+            // Always keeps the inline widget inset even when no artifact is open;
+            // sent explicitly so toggling Always off clears it.
+            detachedPanel: readAlwaysInset() ? true : undefined,
           },
     theme: {
       ...artifactDemoConfigBase.theme,
-      ...(insetLook
-        ? {
-            components: {
-              ...artifactDemoConfigBase.theme?.components,
-              panel: {
-                ...artifactDemoConfigBase.theme?.components?.panel,
-                borderRadius: "0.75rem",
-              },
-            },
-          }
-        : {}),
+      components: {
+        ...artifactDemoConfigBase.theme?.components,
+        panel: {
+          ...artifactDemoConfigBase.theme?.components?.panel,
+          // Rounded only under the inset look; cleared otherwise so it round-trips.
+          borderRadius: insetLook ? "0.75rem" : undefined,
+        },
+      },
     },
     layout: { showHeader: false },
   } as AgentWidgetConfig;

--- a/apps/web/src/attachments-demo.ts
+++ b/apps/web/src/attachments-demo.ts
@@ -61,14 +61,16 @@ function readAttachmentsConfig(): AgentWidgetAttachmentsConfig {
   const dropBlur = (document.getElementById("cfg-drop-blur") as HTMLSelectElement).value;
   const dropInset = (document.getElementById("cfg-drop-inset") as HTMLSelectElement).value;
 
+  // Every key is sent explicitly (undefined when its control is empty) so
+  // clearing a control clears the value under patch-merge update().
   const dropOverlay: AgentWidgetAttachmentsConfig["dropOverlay"] = {
-    ...(dropBg ? { background: dropBg } : {}),
-    ...(dropIcon ? { iconName: dropIcon } : {}),
-    ...(dropStroke ? { iconStrokeWidth: Number(dropStroke) } : {}),
-    ...(dropLabel ? { label: dropLabel } : {}),
-    ...(dropBorder ? { border: dropBorder } : {}),
-    ...(dropBlur ? { backdropBlur: dropBlur } : {}),
-    ...(dropInset ? { inset: dropInset } : {}),
+    background: dropBg || undefined,
+    iconName: dropIcon || undefined,
+    iconStrokeWidth: dropStroke ? Number(dropStroke) : undefined,
+    label: dropLabel || undefined,
+    border: dropBorder || undefined,
+    backdropBlur: dropBlur || undefined,
+    inset: dropInset || undefined,
   };
 
   return {
@@ -77,7 +79,7 @@ function readAttachmentsConfig(): AgentWidgetAttachmentsConfig {
     maxFileSize,
     allowedTypes,
     buttonIconName,
-    ...(Object.keys(dropOverlay).length > 0 ? { dropOverlay } : {}),
+    dropOverlay,
   };
 }
 

--- a/apps/web/src/docked-panel-demo.ts
+++ b/apps/web/src/docked-panel-demo.ts
@@ -109,10 +109,12 @@ function buildOttoTheme() {
         },
       },
     },
+    // panel.borderRadius is always sent so toggling detached clears the flush
+    // override under patch-merge update() and the rounded default returns.
     components: detachedCheck.checked
-      ? // Detached card: keep the theme's rounded defaults so the inset card
-        // reads as elevated; header still squares against the container clip.
-        { header: { borderRadius: "0" } }
+      ? // Detached card: clear the panel override so the theme's rounded default
+        // makes the inset card read as elevated; header still squares.
+        { panel: { borderRadius: undefined }, header: { borderRadius: "0" } }
       : // Flush dock: zero radius so the panel sits cleanly against the admin edge.
         {
           panel: { borderRadius: "0" },

--- a/apps/web/src/dynamic-form-demo.ts
+++ b/apps/web/src/dynamic-form-demo.ts
@@ -112,6 +112,15 @@ const VARIANTS: Array<{
   },
 ];
 
+// Every formStyle key any variant sets, mapped to undefined. Spread first in the
+// config so switching to a variant that omits a key clears it under patch-merge
+// update() (absent keys are preserved, so an omitted key would otherwise persist).
+const FORM_STYLE_RESET = Object.fromEntries(
+  Array.from(
+    new Set(VARIANTS.flatMap((v) => Object.keys(v.formStyles))),
+  ).map((key) => [key, undefined]),
+) as DynamicFormStyles;
+
 let selectedVariant = VARIANTS[0];
 
 function buildFormProps(variant = selectedVariant) {
@@ -172,6 +181,7 @@ const buildConfig = (mode: Mode): AgentWidgetConfig => {
       "Create a status badge",
     ],
     formStyles: {
+      ...FORM_STYLE_RESET,
       ...selectedVariant.formStyles,
       ...(isLauncher
         ? {

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -26,7 +26,7 @@
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "158 kB",
+    "limit": "159 kB",
     "gzip": true
   },
   {
@@ -44,7 +44,7 @@
   {
     "name": "Opt-in · theme-editor preview subpath (theme-editor-preview.js)",
     "path": "dist/theme-editor-preview.js",
-    "limit": "136 kB",
+    "limit": "137 kB",
     "gzip": true
   },
   {

--- a/packages/widget/README.md
+++ b/packages/widget/README.md
@@ -86,7 +86,19 @@ const docked = initAgentWidget({
 });
 ```
 
-### Initialization options
+### Update merge policy
+
+`update()` applies a recursive patch, not a shallow replace. A key merges into the
+live config only when both the previous value and the patch value are plain
+objects, so a partial patch (for example `launcher.title`) preserves defaulted and
+earlier-set sibling values instead of dropping them. Arrays, functions, class
+instances, and scalar values replace wholesale, and so do a small set of
+replace-leaf fields whose plain-object values must not be spliced together:
+`headers`, `agent`, `storageAdapter`, `components`, `targetProviders`,
+`voiceRecognition.provider.custom`, and `features.streamAnimation.plugins`.
+Omitting a key preserves its current value: to reset a field, pass it explicitly
+with `undefined`, which falls back to the field's default, or leaves it unset
+when no default exists.
 
 `initAgentWidget` accepts the following options:
 

--- a/packages/widget/src/components/artifact-pane.test.ts
+++ b/packages/widget/src/components/artifact-pane.test.ts
@@ -436,6 +436,37 @@ describe("artifact-pane expand toggle", () => {
     expect(btn.title).toBe("Expand artifacts panel");
     expect(btn.querySelector("svg")).toBeTruthy();
   });
+
+  it("resets content scroll after expanded-state transitions only", () => {
+    const frames: Array<(time: number) => void> = [];
+    vi.stubGlobal("requestAnimationFrame", (callback: (time: number) => void) => {
+      frames.push(callback);
+      return frames.length;
+    });
+    try {
+      const pane = createArtifactPane(makeExpandConfig(), { onSelect: () => {} });
+      pane.update({ artifacts: [fileRecord()], selectedId: "a1" });
+      const content = contentEl(pane);
+
+      content.scrollLeft = 80;
+      pane.setExpanded(true);
+      expect(frames).toHaveLength(1);
+      frames.shift()?.(0);
+      expect(content.scrollLeft).toBe(0);
+
+      content.scrollLeft = 80;
+      pane.setExpanded(true);
+      expect(frames).toHaveLength(0);
+      expect(content.scrollLeft).toBe(80);
+
+      pane.setExpanded(false);
+      expect(frames).toHaveLength(1);
+      frames.shift()?.(0);
+      expect(content.scrollLeft).toBe(0);
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
 });
 
 const makeCopyButtonConfig = (): AgentWidgetConfig =>
@@ -697,6 +728,22 @@ describe("artifact-pane tabs", () => {
     } finally {
       Element.prototype.scrollIntoView = orig;
     }
+  });
+
+  it("resets content scroll only when the selected artifact changes", () => {
+    const pane = createArtifactPane(makeConfig(), { onSelect: () => {} });
+    const [a1, a2] = twoFileRecords();
+
+    pane.update({ artifacts: [a1], selectedId: "a1" });
+    const content = contentEl(pane);
+    content.scrollLeft = 80;
+
+    pane.update({ artifacts: [a1, a2], selectedId: "a2" });
+    expect(content.scrollLeft).toBe(0);
+
+    content.scrollLeft = 80;
+    pane.update({ artifacts: [a1, a2], selectedId: "a2" });
+    expect(content.scrollLeft).toBe(80);
   });
 });
 

--- a/packages/widget/src/components/artifact-pane.ts
+++ b/packages/widget/src/components/artifact-pane.ts
@@ -421,6 +421,21 @@ export function createArtifactPane(
     "div",
     "persona-artifact-content persona-flex-1 persona-min-h-0 persona-overflow-y-auto persona-p-3"
   );
+  const resetContentInlineScroll = () => {
+    // The shared body survives artifact and layout changes. Always return it to
+    // inline start at those lifecycle boundaries so a wide previous preview
+    // cannot leave the next one clipped by a stale horizontal offset.
+    content.scrollLeft = 0;
+  };
+  const scheduleContentInlineScrollReset = () => {
+    // ui.ts applies the expanded root class immediately before setExpanded().
+    // Wait one frame so the new pane width has taken effect before resetting.
+    if (typeof requestAnimationFrame === "function") {
+      requestAnimationFrame(resetContentInlineScroll);
+    } else {
+      setTimeout(resetContentInlineScroll, 0);
+    }
+  };
   if (panePadding) {
     for (const el of [list, customBarMount]) {
       el.style.paddingLeft = panePadding;
@@ -437,6 +452,7 @@ export function createArtifactPane(
   let records: PersonaArtifactRecord[] = [];
   let selectedId: string | null = null;
   let mobileOpen = false;
+  let expandedState = false;
   // Lazy-render gate. `visible` reflects the host's explicit setVisible() signal
   // (never inferred from layout/offsetParent, so class-hiding + jsdom behave the
   // same). It defaults to true so the pane renders eagerly when constructed
@@ -682,11 +698,13 @@ export function createArtifactPane(
     element: shell,
     backdrop,
     update(state: { artifacts: PersonaArtifactRecord[]; selectedId: string | null }) {
-      records = state.artifacts;
-      selectedId =
+      const nextSelectedId =
         state.selectedId ??
         state.artifacts[state.artifacts.length - 1]?.id ??
         null;
+      const selectionChanged = nextSelectedId !== selectedId;
+      records = state.artifacts;
+      selectedId = nextSelectedId;
       if (records.length > 0) {
         mobileOpen = true;
       }
@@ -696,6 +714,7 @@ export function createArtifactPane(
       // executing artifact scripts twice. Defer the whole render() to reveal.
       dirty = true;
       if (visible) flush();
+      if (selectionChanged) resetContentInlineScroll();
     },
     setMobileOpen(open: boolean) {
       mobileOpen = open;
@@ -707,6 +726,10 @@ export function createArtifactPane(
       }
     },
     setExpanded(expanded: boolean) {
+      if (expanded !== expandedState) {
+        expandedState = expanded;
+        scheduleContentInlineScrollReset();
+      }
       // Swap the icon (the state signal) and update the accessible label. We
       // deliberately avoid aria-pressed here: the icon-btn [aria-pressed] CSS
       // would add unwanted active styling.

--- a/packages/widget/src/index-core.ts
+++ b/packages/widget/src/index-core.ts
@@ -5,6 +5,7 @@ import {
 
 export type {
   AgentWidgetConfig,
+  AgentWidgetConfigPatch,
   TargetResolver,
   ResolvedTarget,
   AgentWidgetFeatureFlags,

--- a/packages/widget/src/runtime/init-update-reset.test.ts
+++ b/packages/widget/src/runtime/init-update-reset.test.ts
@@ -1,0 +1,81 @@
+// @vitest-environment jsdom
+
+// End-to-end handle.update() through the REAL ui module (init.test.ts mocks it,
+// so it cannot see the controller's own patch merge). Regression: explicit
+// undefined resets must reach the controller, not be materialized as absent
+// keys by the handle's pre-merge.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { initAgentWidget } from "./init";
+
+describe("handle.update explicit-undefined reset reaches the controller", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("round-trips artifact pane appearance seamless -> panel via explicit undefined", () => {
+    window.scrollTo = vi.fn();
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const handle = initAgentWidget({
+      target: "#target",
+      config: {
+        apiUrl: "https://api.example.com/chat",
+        launcher: { enabled: false },
+        features: { artifacts: { enabled: true } },
+      },
+    });
+
+    const root = () => document.querySelector<HTMLElement>("[data-persona-root]")!;
+    expect(root().classList.contains("persona-artifact-appearance-panel")).toBe(true);
+
+    handle.update({
+      features: {
+        artifacts: {
+          layout: { paneAppearance: "seamless", splitGap: "0", paneShadow: "none" },
+        },
+      },
+    });
+    expect(root().classList.contains("persona-artifact-appearance-seamless")).toBe(true);
+
+    handle.update({
+      features: {
+        artifacts: {
+          layout: { paneAppearance: undefined, splitGap: undefined, paneShadow: undefined },
+        },
+      },
+    });
+    expect(root().classList.contains("persona-artifact-appearance-panel")).toBe(true);
+    expect(root().classList.contains("persona-artifact-appearance-seamless")).toBe(false);
+    expect(root().style.getPropertyValue("--persona-artifact-pane-shadow")).toBe("");
+
+    handle.destroy();
+  });
+
+  it("handle and controller stored configs converge on the same merged result", () => {
+    window.scrollTo = vi.fn();
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    const handle = initAgentWidget({
+      target: "#target",
+      config: {
+        apiUrl: "https://api.example.com/chat",
+        launcher: { enabled: false, clearChat: { backgroundColor: "#123456" } },
+      },
+    });
+
+    // Sibling override must survive an unrelated patch in BOTH layers: the
+    // controller renders it now, and the handle's stored config must carry it
+    // into a mount-mode rebuild. tooltipText also renames the aria-label.
+    handle.update({ launcher: { clearChat: { tooltipText: "Wipe" } } });
+    const clear = () => document.querySelector<HTMLButtonElement>('button[aria-label="Wipe"]')!;
+    expect(clear().style.backgroundColor).toBe("rgb(18, 52, 86)");
+
+    handle.update({ launcher: { mountMode: "docked" } });
+    expect(clear().style.backgroundColor).toBe("rgb(18, 52, 86)");
+
+    handle.destroy();
+  });
+});

--- a/packages/widget/src/runtime/init.test.ts
+++ b/packages/widget/src/runtime/init.test.ts
@@ -483,3 +483,63 @@ describe("initAgentWidget docked mode", () => {
     handleB.destroy();
   });
 });
+
+describe("initAgentWidget update merge policy", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    createAgentExperienceMock.mockReset();
+  });
+
+  it("passes an equivalent merged config to the controller (no double-merge, siblings preserved)", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    let controllerRef: ReturnType<typeof createMockController> | undefined;
+    createAgentExperienceMock.mockImplementation((_mount, config) => {
+      controllerRef = createMockController(config);
+      return controllerRef;
+    });
+
+    const handle = initAgentWidget({
+      target: "#target",
+      config: {
+        apiUrl: "https://api.example.com/chat",
+        launcher: { enabled: false, clearChat: { backgroundColor: "#123456" } },
+      },
+    });
+
+    handle.update({ launcher: { clearChat: { tooltipText: "Clear" } } });
+
+    const passed = controllerRef!.update.mock.calls.at(-1)?.[0] as any;
+    expect(passed.launcher.clearChat.backgroundColor).toBe("#123456");
+    expect(passed.launcher.clearChat.tooltipText).toBe("Clear");
+
+    handle.destroy();
+  });
+
+  it("retains prior nested overrides when a mount-mode change rebuilds the controller", async () => {
+    const { initAgentWidget } = await import("./init");
+    document.body.innerHTML = `<div id="target"></div>`;
+
+    createAgentExperienceMock.mockImplementation((_mount, config) => createMockController(config));
+
+    const handle = initAgentWidget({
+      target: "#target",
+      config: {
+        apiUrl: "https://api.example.com/chat",
+        launcher: { enabled: false, clearChat: { backgroundColor: "#123456" } },
+      },
+    });
+
+    // Patch a sibling, then flip the mount mode to force a rebuild.
+    handle.update({ launcher: { clearChat: { tooltipText: "Clear" } } });
+    handle.update({ launcher: { mountMode: "docked" } });
+
+    const rebuildConfig = createAgentExperienceMock.mock.calls.at(-1)?.[1] as any;
+    expect(rebuildConfig.launcher.clearChat.backgroundColor).toBe("#123456");
+    expect(rebuildConfig.launcher.clearChat.tooltipText).toBe("Clear");
+    expect(rebuildConfig.launcher.mountMode).toBe("docked");
+
+    handle.destroy();
+  });
+});

--- a/packages/widget/src/runtime/init.test.ts
+++ b/packages/widget/src/runtime/init.test.ts
@@ -490,7 +490,7 @@ describe("initAgentWidget update merge policy", () => {
     createAgentExperienceMock.mockReset();
   });
 
-  it("passes an equivalent merged config to the controller (no double-merge, siblings preserved)", async () => {
+  it("passes the raw patch to the controller so explicit-undefined resets survive", async () => {
     const { initAgentWidget } = await import("./init");
     document.body.innerHTML = `<div id="target"></div>`;
 
@@ -508,11 +508,13 @@ describe("initAgentWidget update merge policy", () => {
       },
     });
 
-    handle.update({ launcher: { clearChat: { tooltipText: "Clear" } } });
+    // The merged config materializes explicit-undefined as absence, which the
+    // controller's patch merge would preserve; only the raw patch carries resets.
+    const patch = { launcher: { clearChat: { tooltipText: "Clear" } } };
+    handle.update(patch);
 
     const passed = controllerRef!.update.mock.calls.at(-1)?.[0] as any;
-    expect(passed.launcher.clearChat.backgroundColor).toBe("#123456");
-    expect(passed.launcher.clearChat.tooltipText).toBe("Clear");
+    expect(passed).toBe(patch);
 
     handle.destroy();
   });

--- a/packages/widget/src/runtime/init.ts
+++ b/packages/widget/src/runtime/init.ts
@@ -1,6 +1,7 @@
 import { createAgentExperience, AgentWidgetController } from "../ui";
-import { AgentWidgetConfig as _AgentWidgetConfig, AgentWidgetInitOptions, AgentWidgetEvent as _AgentWidgetEvent } from "../types";
+import { AgentWidgetConfig as _AgentWidgetConfig, AgentWidgetConfigPatch, AgentWidgetInitOptions, AgentWidgetEvent as _AgentWidgetEvent } from "../types";
 import { isComposerBarMountMode, isDockedMountMode } from "../utils/dock";
+import { mergeConfigUpdate } from "../utils/config-merge";
 import { createWidgetHostLayout } from "./host-layout";
 
 const ensureTarget = (target: string | HTMLElement): HTMLElement => {
@@ -126,19 +127,8 @@ export const initAgentWidget = (
   };
 
   const handleBase = {
-    update(nextConfig: _AgentWidgetConfig) {
-      const mergedConfig = {
-        ...config,
-        ...nextConfig,
-        launcher: {
-          ...(config?.launcher ?? {}),
-          ...(nextConfig?.launcher ?? {}),
-          dock: {
-            ...(config?.launcher?.dock ?? {}),
-            ...(nextConfig?.launcher?.dock ?? {}),
-          },
-        },
-      } as _AgentWidgetConfig;
+    update(nextConfig: AgentWidgetConfigPatch) {
+      const mergedConfig = mergeConfigUpdate(config ?? ({} as _AgentWidgetConfig), nextConfig);
       const previousDocked = isDockedMountMode(config);
       const nextDocked = isDockedMountMode(mergedConfig);
       const previousComposerBar = isComposerBarMountMode(config);
@@ -151,7 +141,9 @@ export const initAgentWidget = (
 
       config = mergedConfig;
       hostLayout.updateConfig(config);
-      controller.update(nextConfig);
+      // Pass the merged config (not the raw patch): both layers share one
+      // idempotent policy, so controller.update over an equal base is a no-op.
+      controller.update(mergedConfig);
       syncHostState();
     },
     destroy() {

--- a/packages/widget/src/runtime/init.ts
+++ b/packages/widget/src/runtime/init.ts
@@ -141,9 +141,10 @@ export const initAgentWidget = (
 
       config = mergedConfig;
       hostLayout.updateConfig(config);
-      // Pass the merged config (not the raw patch): both layers share one
-      // idempotent policy, so controller.update over an equal base is a no-op.
-      controller.update(mergedConfig);
+      // Pass the raw patch: mergedConfig materializes explicit-undefined resets
+      // as absent keys, which the controller's patch merge would preserve
+      // instead of clearing. Both layers share mergeConfigUpdate, so they converge.
+      controller.update(nextConfig);
       syncHostState();
     },
     destroy() {

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -3206,6 +3206,20 @@
 /* Shared artifact preview body wrapper (artifact-preview.ts): generates no box
    so children (e.g. the iframe's height: 100%) lay out against the host
    container exactly as if they were its direct children. */
+[data-persona-root] .persona-artifact-content {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+}
+
+[data-persona-root]
+  .persona-artifact-content
+  > .persona-artifact-preview-body
+  > * {
+  min-width: 0;
+  max-width: 100%;
+}
+
 [data-persona-root] .persona-artifact-preview-body {
   display: contents;
 }

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -5431,6 +5431,23 @@ export type AgentWidgetConfig = {
   loadingIndicator?: AgentWidgetLoadingIndicatorConfig;
 };
 
+/**
+ * Patch-aware deep-partial of {@link AgentWidgetConfig} accepted by `update()`.
+ * Function types and arrays are preserved whole (not mapped over); plain-object
+ * leaves recurse so a partial patch merges into the live config. See the merge
+ * policy in utils/config-merge.ts (some plain-object fields still replace
+ * wholesale at runtime; that is not encoded at the type level).
+ */
+export type AgentWidgetConfigPatch = ConfigPatch<AgentWidgetConfig>;
+
+type ConfigPatch<T> = T extends (...args: never[]) => unknown
+  ? T
+  : T extends readonly unknown[]
+    ? T
+    : T extends object
+      ? { [K in keyof T]?: ConfigPatch<T[K]> }
+      : T;
+
 export type AgentWidgetMessageRole = "user" | "assistant" | "system";
 
 export type AgentWidgetReasoning = {

--- a/packages/widget/src/ui.artifact-pane-gating.test.ts
+++ b/packages/widget/src/ui.artifact-pane-gating.test.ts
@@ -402,7 +402,17 @@ describe("artifact pane expand toggle (full widget)", () => {
     expect(mountEl.classList.contains("persona-artifact-expanded")).toBe(true);
 
     // Turning the toggle back off hides the button and collapses the pane.
-    controller.update(base);
+    // update() patches recursively now, so omission preserves the prior
+    // showExpandToggle: the flag must be set false explicitly to disable it.
+    controller.update({
+      features: {
+        artifacts: {
+          enabled: true,
+          allowedTypes: ["markdown", "component"],
+          layout: { showExpandToggle: false },
+        },
+      },
+    });
     expect(mountEl.classList.contains("persona-artifact-expanded")).toBe(false);
     expect(expandBtn(mountEl).classList.contains("persona-hidden")).toBe(true);
     controller.destroy();

--- a/packages/widget/src/ui.attachments-drop.test.ts
+++ b/packages/widget/src/ui.attachments-drop.test.ts
@@ -186,3 +186,93 @@ describe("createAgentExperience attachment file drop", () => {
     controller.destroy();
   });
 });
+
+describe("drop overlay live config updates", () => {
+  beforeEach(() => {
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("rebuilds the overlay with new dropOverlay values on update() (regression: built once, live updates ignored)", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: true, dropOverlay: { label: "Drop it", background: "#111111" } },
+    });
+
+    const overlay = () => mount.querySelector<HTMLElement>(".persona-attachment-drop-overlay")!;
+    expect(overlay()).not.toBeNull();
+    expect(overlay().querySelector(".persona-drop-overlay-label")!.textContent).toBe("Drop it");
+    expect(overlay().style.getPropertyValue("--persona-drop-overlay-bg")).toBe("#111111");
+
+    controller.update({
+      attachments: { dropOverlay: { label: "New label", background: "#222222" } },
+    });
+
+    expect(overlay().querySelector(".persona-drop-overlay-label")!.textContent).toBe("New label");
+    expect(overlay().style.getPropertyValue("--persona-drop-overlay-bg")).toBe("#222222");
+    // Only one overlay after the rebuild.
+    expect(mount.querySelectorAll(".persona-attachment-drop-overlay").length).toBe(1);
+
+    controller.destroy();
+  });
+
+  it("clears overlay styling when dropOverlay is reset via explicit undefined", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: true, dropOverlay: { label: "Drop it", background: "#111111" } },
+    });
+
+    controller.update({ attachments: { dropOverlay: undefined } });
+
+    const overlay = mount.querySelector<HTMLElement>(".persona-attachment-drop-overlay")!;
+    expect(overlay).not.toBeNull();
+    expect(overlay.querySelector(".persona-drop-overlay-label")).toBeNull();
+    expect(overlay.style.getPropertyValue("--persona-drop-overlay-bg")).toBe("");
+
+    controller.destroy();
+  });
+});
+
+describe("attachment button live config updates", () => {
+  beforeEach(() => {
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("re-renders the button icon and tooltip on update() (regression: set once at creation)", () => {
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      attachments: { enabled: true, buttonIconName: "paperclip", buttonTooltipText: "Attach file" },
+    });
+
+    const button = () => mount.querySelector<HTMLButtonElement>(".persona-attachment-button")!;
+    expect(button()).not.toBeNull();
+    const initialSvg = button().querySelector("svg")!.outerHTML;
+
+    controller.update({
+      attachments: { buttonIconName: "camera", buttonTooltipText: "Add a photo" },
+    });
+
+    expect(button().getAttribute("aria-label")).toBe("Add a photo");
+    const updatedSvg = button().querySelector("svg")!.outerHTML;
+    expect(updatedSvg).not.toBe(initialSvg);
+    const tooltip = button().parentElement!.querySelector(".persona-send-button-tooltip");
+    expect(tooltip?.textContent).toBe("Add a photo");
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.header-update-stability.test.ts
+++ b/packages/widget/src/ui.header-update-stability.test.ts
@@ -95,3 +95,55 @@ describe("header stability across unrelated updates", () => {
     controller.destroy();
   });
 });
+
+describe("composer and header icon stability across unrelated updates", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the mic icon stroke and button color stable", () => {
+    window.scrollTo = vi.fn();
+    // The mic button only renders when speech recognition is available.
+    vi.stubGlobal("SpeechRecognition", class {});
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      voiceRecognition: { enabled: true },
+    });
+
+    const mic = () => mount.querySelector<HTMLElement>("[data-persona-composer-mic]")!;
+    expect(mic()).not.toBeNull();
+    expect(mic().querySelector("svg")!.getAttribute("stroke-width")).toBe("1.5");
+    expect(mic().style.color).toBe("var(--persona-text, #111827)");
+
+    controller.update({ attachments: { enabled: true } });
+
+    expect(mic().querySelector("svg")!.getAttribute("stroke-width")).toBe("1.5");
+    expect(mic().style.color).toBe("var(--persona-text, #111827)");
+
+    controller.destroy();
+  });
+
+  it("keeps display:block on close and clear-chat icons", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: true, autoExpand: true },
+    });
+
+    const iconDisplay = (label: string) =>
+      mount.querySelector<SVGElement>(`button[aria-label="${label}"] svg`)!.style.display;
+    expect(iconDisplay("Close chat")).toBe("block");
+    expect(iconDisplay("Clear chat")).toBe("block");
+
+    controller.update({ attachments: { enabled: true } });
+
+    expect(iconDisplay("Close chat")).toBe("block");
+    expect(iconDisplay("Clear chat")).toBe("block");
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.header-update-stability.test.ts
+++ b/packages/widget/src/ui.header-update-stability.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+
+// An update must not restyle or reveal header chrome the mount deliberately
+// set: the close button hidden on non-closeable panels, and the clear-chat
+// icon's stroke weight (builder and updater drifted to different constants).
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentExperience } from "./ui";
+
+const createMount = () => {
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  return mount;
+};
+
+const inlineConfig = () => ({
+  apiUrl: "https://api.example.com/chat",
+  launcher: { enabled: false },
+  attachments: { enabled: true },
+});
+
+describe("header stability across unrelated updates", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the close button hidden on a non-closeable panel after an unrelated update", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, inlineConfig());
+
+    const closeBtn = () =>
+      mount.querySelector<HTMLElement>('button[aria-label="Close chat"]')!;
+    expect(closeBtn().style.display).toBe("none");
+
+    controller.update({ attachments: { enabled: true, maxFiles: 2 } });
+    expect(closeBtn().style.display).toBe("none");
+
+    controller.destroy();
+  });
+
+  it("showCloseButton filters on top of toggleability, it cannot force-show", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, inlineConfig());
+
+    const closeBtn = () =>
+      mount.querySelector<HTMLElement>('button[aria-label="Close chat"]')!;
+
+    // Non-closeable panel stays hidden even with an explicit true (which is
+    // also the default, so it cannot mean force-show).
+    controller.update({ layout: { header: { showCloseButton: true } } });
+    expect(closeBtn().style.display).toBe("none");
+
+    controller.destroy();
+  });
+
+  it("still honors showCloseButton on a toggleable (launcher) panel", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: true, autoExpand: true },
+    });
+
+    const closeBtn = () =>
+      mount.querySelector<HTMLElement>('button[aria-label="Close chat"]')!;
+    expect(closeBtn().style.display).toBe("");
+
+    controller.update({ layout: { header: { showCloseButton: false } } });
+    expect(closeBtn().style.display).toBe("none");
+
+    controller.update({ layout: { header: { showCloseButton: true } } });
+    expect(closeBtn().style.display).toBe("");
+
+    controller.destroy();
+  });
+
+  it("keeps the clear-chat icon stroke weight stable across updates", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, inlineConfig());
+
+    const stroke = () =>
+      mount
+        .querySelector('button[aria-label="Clear chat"] svg')!
+        .getAttribute("stroke-width");
+    expect(stroke()).toBe("1");
+
+    controller.update({ attachments: { enabled: true, maxFiles: 2 } });
+    expect(stroke()).toBe("1");
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.launcher-update-merge.test.ts
+++ b/packages/widget/src/ui.launcher-update-merge.test.ts
@@ -1,0 +1,83 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentExperience } from "./ui";
+
+const createMount = () => {
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  return mount;
+};
+
+describe("createAgentExperience partial launcher update", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("preserves defaulted launcher styling when update() carries a partial launcher (regression: header buttons fell back to UA buttonface chrome)", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false, title: "Before" },
+    });
+
+    const closeBefore = mount.querySelector<HTMLButtonElement>('button[aria-label="Close chat"]');
+    const clearBefore = mount.querySelector<HTMLButtonElement>('button[aria-label="Clear chat"]');
+    expect(closeBefore).not.toBeNull();
+    expect(clearBefore).not.toBeNull();
+    // mergeWithDefaults supplies transparent button chrome at mount time.
+    expect(closeBefore!.style.backgroundColor).toBe("transparent");
+    expect(clearBefore!.style.backgroundColor).toBe("transparent");
+
+    // A partial launcher update (e.g. a live settings preview changing only
+    // the title) must not wholesale-replace the defaulted launcher config.
+    controller.update({ launcher: { enabled: false, title: "After" } });
+
+    const closeAfter = mount.querySelector<HTMLButtonElement>('button[aria-label="Close chat"]');
+    const clearAfter = mount.querySelector<HTMLButtonElement>('button[aria-label="Clear chat"]');
+    expect(closeAfter).not.toBeNull();
+    expect(clearAfter).not.toBeNull();
+    expect(closeAfter!.style.backgroundColor).toBe("transparent");
+    expect(clearAfter!.style.backgroundColor).toBe("transparent");
+  });
+
+  it("keeps nested clearChat overrides across unrelated launcher updates", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: {
+        enabled: false,
+        clearChat: { backgroundColor: "#123456" },
+      },
+    });
+
+    controller.update({ launcher: { enabled: false, title: "After" } });
+
+    const clear = mount.querySelector<HTMLButtonElement>('button[aria-label="Clear chat"]');
+    expect(clear).not.toBeNull();
+    expect(clear!.style.backgroundColor).toBe("rgb(18, 52, 86)");
+  });
+
+  it("keeps a clearChat override when a later update patches only launcher.dock", () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: {
+        enabled: false,
+        clearChat: { backgroundColor: "#123456" },
+      },
+    });
+
+    // A partial dock patch must not wholesale-replace the launcher group.
+    controller.update({ launcher: { dock: { side: "left" } } });
+
+    const clear = mount.querySelector<HTMLButtonElement>('button[aria-label="Clear chat"]');
+    expect(clear).not.toBeNull();
+    expect(clear!.style.backgroundColor).toBe("rgb(18, 52, 86)");
+  });
+});

--- a/packages/widget/src/ui.send-button-stream-update.test.ts
+++ b/packages/widget/src/ui.send-button-stream-update.test.ts
@@ -1,0 +1,69 @@
+// @vitest-environment jsdom
+
+// An update() that lands during an active stream must not clobber the stop
+// icon back to the send icon: the button holds the stop glyph (owned by
+// setSendButtonMode) and the aria-label still reads "stop", so re-rendering
+// the send icon here produced a mid-stream icon/label mismatch.
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { createAgentExperience } from "./ui";
+import { buildAssistantTurnFrames, createMockSSEStream } from "./testing/mock-stream";
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+const createMount = () => {
+  const m = document.createElement("div");
+  document.body.appendChild(m);
+  return m;
+};
+
+describe("send button icon stability across a mid-stream update", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the stop icon after update() while streaming, and heals to send on completion", async () => {
+    window.scrollTo = vi.fn();
+    const mount = createMount();
+    const controller = createAgentExperience(mount, {
+      apiUrl: "https://api.example.com/chat",
+      launcher: { enabled: false },
+      sendButton: { useIcon: true, iconName: "arrow-up", stopIconName: "square" },
+    });
+
+    // The send button element is mutated in place by update(); hold the ref.
+    const btn = Array.from(mount.querySelectorAll("button")).find(
+      (b) => b.getAttribute("aria-label") === "Send message"
+    )!;
+    const glyph = () => btn.querySelector("svg")?.querySelector("rect, path")?.tagName.toLowerCase() ?? null;
+
+    // Send icon (arrow-up) is a <path>; stop icon (square) is a <rect>.
+    expect(glyph()).toBe("path");
+
+    const frames = buildAssistantTurnFrames({
+      executionId: "e1",
+      text: "a reasonably long streamed reply to keep the stream open",
+      chunkSize: 4,
+    });
+    const done = controller.connectStream(createMockSSEStream(frames, { delayMs: 40 }));
+
+    await sleep(80); // stop mode engages
+    expect(btn.getAttribute("aria-label")).toBe("Stop generating");
+    expect(glyph()).toBe("rect");
+
+    // Unrelated update mid-stream must not revert the stop icon.
+    controller.update({ attachments: { enabled: true } });
+    expect(btn.getAttribute("aria-label")).toBe("Stop generating");
+    expect(glyph()).toBe("rect");
+
+    await done;
+    await sleep(20);
+    // Completion returns the button to send mode.
+    expect(btn.getAttribute("aria-label")).toBe("Send message");
+    expect(glyph()).toBe("path");
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8842,9 +8842,6 @@ export const createAgentExperience = (
         sendButton.style.fontSize = "18px";
         sendButton.style.lineHeight = "1";
         
-        // Clear existing content
-        sendButton.innerHTML = "";
-        
         // Set foreground color from config or theme token
         if (textColor) {
           sendButton.style.color = textColor;
@@ -8852,20 +8849,25 @@ export const createAgentExperience = (
           sendButton.style.color = "var(--persona-button-primary-fg, #ffffff)";
         }
 
-        // Use Lucide icon if iconName is provided, otherwise fall back to iconText
-        if (iconName) {
-          const iconSize = parseFloat(buttonSize) || 24;
-          const iconColor = textColor?.trim() || "currentColor";
-          const iconSvg = renderLucideIcon(iconName, iconSize, iconColor, 2);
-          if (iconSvg) {
-            sendButton.appendChild(iconSvg);
+        // Skip the icon-content re-render while streaming: the button holds the
+        // stop icon (owned by setSendButtonMode), and clobbering it here would
+        // show the send arrow mid-stream while the aria-label still says stop.
+        if (!session.isStreaming()) {
+          sendButton.innerHTML = "";
+          if (iconName) {
+            const iconSize = parseFloat(buttonSize) || 24;
+            const iconColor = textColor?.trim() || "currentColor";
+            const iconSvg = renderLucideIcon(iconName, iconSize, iconColor, 2);
+            if (iconSvg) {
+              sendButton.appendChild(iconSvg);
+            } else {
+              sendButton.textContent = iconText;
+            }
           } else {
             sendButton.textContent = iconText;
           }
-        } else {
-          sendButton.textContent = iconText;
         }
-        
+
         // Update classes
         sendButton.className = "persona-rounded-button persona-flex persona-items-center persona-justify-center disabled:persona-opacity-50 persona-cursor-pointer";
         

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -5,6 +5,7 @@ import { onMarkdownParsersReady, getMarkdownParsersSync } from "./markdown-parse
 import { AgentWidgetSession, AgentWidgetSessionStatus } from "./session";
 import {
   AgentWidgetConfig,
+  AgentWidgetConfigPatch,
   AgentWidgetApprovalDecisionOptions,
   AgentWidgetMessage,
   AgentWidgetEvent,
@@ -133,6 +134,7 @@ import { readFlexGapPx, resolveArtifactPaneWidthPx } from "./utils/artifact-resi
 import { enhanceWithForms } from "./components/forms";
 import { pluginRegistry } from "./plugins/registry";
 import { mergeWithDefaults, DEFAULT_FLOATING_LAUNCHER_WIDTH } from "./defaults";
+import { mergeConfigUpdate } from "./utils/config-merge";
 import { createEventBus } from "./utils/events";
 import {
   createActionManager,
@@ -305,7 +307,7 @@ const stripStreamingFromMessages = (messages: AgentWidgetMessage[]) =>
   }));
 
 type Controller = {
-  update: (config: AgentWidgetConfig) => void;
+  update: (config: AgentWidgetConfigPatch) => void;
   destroy: () => void;
   open: () => void;
   close: () => void;
@@ -7683,7 +7685,7 @@ export const createAgentExperience = (
   }
 
   const controller: Controller = {
-    update(nextConfig: AgentWidgetConfig) {
+    update(nextConfig: AgentWidgetConfigPatch) {
       const previousToolCallConfig = config.toolCall;
       const previousMessageActions = config.messageActions;
       const previousLayoutMessages = config.layout?.messages;
@@ -7695,7 +7697,10 @@ export const createAgentExperience = (
       const previousToolCallDisplay = config.features?.toolCallDisplay;
       const previousReasoningDisplay = config.features?.reasoningDisplay;
       const previousStreamAnimationType = config.features?.streamAnimation?.type;
-      config = { ...config, ...nextConfig };
+      // One consistent recursive patch policy across the live controller and the
+      // init handle. See utils/config-merge.ts for the replace-leaf list and
+      // explicit-undefined reset semantics.
+      config = mergeConfigUpdate(config, nextConfig);
       // applyFullHeightStyles resets mount.style.cssText, so call it before applyThemeVariables
       applyFullHeightStyles();
       applyThemeVariables(mount, config);
@@ -7926,7 +7931,7 @@ export const createAgentExperience = (
       refreshCloseButton();
 
       // Re-render messages if config affecting message rendering changed
-      const toolCallConfigChanged = JSON.stringify(nextConfig.toolCall) !== JSON.stringify(previousToolCallConfig);
+      const toolCallConfigChanged = JSON.stringify(config.toolCall) !== JSON.stringify(previousToolCallConfig);
       const messageActionsChanged = JSON.stringify(config.messageActions) !== JSON.stringify(previousMessageActions);
       const layoutMessagesChanged = JSON.stringify(config.layout?.messages) !== JSON.stringify(previousLayoutMessages);
       const loadingIndicatorChanged = config.loadingIndicator?.render !== previousLoadingIndicator?.render

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8746,10 +8746,6 @@ export const createAgentExperience = (
             });
           }
 
-          // Create drop overlay if missing
-          if (!container.querySelector(".persona-attachment-drop-overlay")) {
-            container.appendChild(buildDropOverlay(attachmentsConfig.dropOverlay));
-          }
         } else {
           // Show existing attachment button and update config
           attachmentButtonWrapper.style.display = "";
@@ -8769,6 +8765,33 @@ export const createAgentExperience = (
               maxFiles: attachmentsConfig.maxFiles
             });
           }
+        }
+
+        // Rebuild the overlay so live dropOverlay updates restyle it; visibility
+        // is owned by the container's drop-active class, so this is drag-safe.
+        container.querySelector(".persona-attachment-drop-overlay")?.remove();
+        container.appendChild(buildDropOverlay(config.attachments?.dropOverlay));
+
+        // Re-render icon/tooltip so live buttonIconName/buttonTooltipText
+        // updates apply; the button element itself is created once and kept.
+        if (attachmentButton) {
+          const attCfg = config.attachments ?? {};
+          const tooltipText = attCfg.buttonTooltipText ?? "Attach file";
+          attachmentButton.setAttribute("aria-label", tooltipText);
+          attachmentButton.textContent = "";
+          const btnSize = parseFloat(config.sendButton?.size ?? "40px") || 40;
+          const iconSvg = renderLucideIcon(
+            attCfg.buttonIconName ?? "paperclip",
+            Math.round(btnSize * 0.6),
+            "currentColor",
+            1.5
+          );
+          if (iconSvg) attachmentButton.appendChild(iconSvg);
+          else attachmentButton.textContent = "📎";
+          const attachTooltip = attachmentButtonWrapper?.querySelector(
+            ".persona-send-button-tooltip"
+          );
+          if (attachTooltip) attachTooltip.textContent = tooltipText;
         }
       } else {
         // Hide attachment button if disabled

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8170,6 +8170,9 @@ export const createAgentExperience = (
         closeButton.innerHTML = "";
         const iconSvg = renderLucideIcon(closeButtonIconName, "28px", "currentColor", 1);
         if (iconSvg) {
+          // display:block matches the builder; inline SVG baseline spacing
+          // shifts the icon off-center.
+          iconSvg.style.display = "block";
           closeButton.appendChild(iconSvg);
         } else {
           closeButton.textContent = closeButtonIconText;
@@ -8360,6 +8363,9 @@ export const createAgentExperience = (
           // different weight here makes the icon visibly bolden on update.
           const iconSvg = renderLucideIcon(clearChatIconName, clearChatIconSize, "currentColor", 1);
           if (iconSvg) {
+            // display:block matches the builder; inline SVG baseline spacing
+            // shifts the icon off-center.
+            iconSvg.style.display = "block";
             clearChatButton.appendChild(iconSvg);
           }
 
@@ -8562,10 +8568,16 @@ export const createAgentExperience = (
           micButton.style.minWidth = micIconSize;
           micButton.style.minHeight = micIconSize;
           
-          // Update icon
-          const iconColor = voiceConfig.iconColor ?? sendButtonConfig.textColor ?? "currentColor";
+          // Update icon; color chain and stroke 1.5 match the mount-time
+          // builder (composer-parts.ts) so an unrelated update cannot restyle.
+          const iconColor = voiceConfig.iconColor ?? sendButtonConfig.textColor;
           micButton.innerHTML = "";
-          const micIconSvg = renderLucideIcon(micIconName, micIconSizeNum, iconColor, 2);
+          const micIconSvg = renderLucideIcon(
+            micIconName,
+            micIconSizeNum,
+            iconColor || "currentColor",
+            1.5
+          );
           if (micIconSvg) {
             micButton.appendChild(micIconSvg);
           } else {

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -7870,7 +7870,10 @@ export const createAgentExperience = (
           headerSubtitle.style.display = headerLayoutConfig.showSubtitle === false ? "none" : "";
         }
         if (closeButton) {
-          closeButton.style.display = headerLayoutConfig.showCloseButton === false ? "none" : "";
+          // showCloseButton (defaulted true) filters on top of toggleability;
+          // it must not reveal the close button on non-closeable panels.
+          const showClose = isPanelToggleable() && headerLayoutConfig.showCloseButton !== false;
+          closeButton.style.display = showClose ? "" : "none";
         }
         if (panelElements.clearChatButtonWrapper) {
           // showClearChat explicitly controls visibility when set
@@ -8072,13 +8075,11 @@ export const createAgentExperience = (
       }
 
       if (closeButton) {
-        // Handle close button visibility from layout config
-        const layoutShowCloseButton = config.layout?.header?.showCloseButton;
-        if (layoutShowCloseButton === false) {
-          closeButton.style.display = "none";
-        } else {
-          closeButton.style.display = "";
-        }
+        // showCloseButton (defaulted true) filters on top of toggleability;
+        // it must not reveal the close button on non-closeable panels.
+        const layoutShowCloseButton =
+          isPanelToggleable() && config.layout?.header?.showCloseButton !== false;
+        closeButton.style.display = layoutShowCloseButton ? "" : "none";
 
         const closeButtonSize = launcher.closeButtonSize ?? "32px";
         const closeButtonPlacement = launcher.closeButtonPlacement ?? "inline";
@@ -8355,7 +8356,9 @@ export const createAgentExperience = (
           // the icon to match its 16px button.
           clearChatButton.innerHTML = "";
           const clearChatIconSize = isComposerBar() ? "14px" : "20px";
-          const iconSvg = renderLucideIcon(clearChatIconName, clearChatIconSize, "currentColor", 2);
+          // Stroke 1 matches the mount-time builder (header-parts.ts); a
+          // different weight here makes the icon visibly bolden on update.
+          const iconSvg = renderLucideIcon(clearChatIconName, clearChatIconSize, "currentColor", 1);
           if (iconSvg) {
             clearChatButton.appendChild(iconSvg);
           }

--- a/packages/widget/src/utils/config-merge.test.ts
+++ b/packages/widget/src/utils/config-merge.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { mergeConfigUpdate } from "./config-merge";
+import { mergeWithDefaults } from "../defaults";
+import type { AgentWidgetConfig, StreamAnimationPlugin } from "../types";
+
+// Stored controller config is post-mergeWithDefaults; simulate that here.
+const base = (overrides: Partial<AgentWidgetConfig> = {}): AgentWidgetConfig =>
+  mergeWithDefaults({ apiUrl: "https://api.example.com/chat", ...overrides }) as AgentWidgetConfig;
+
+describe("mergeConfigUpdate", () => {
+  it("recursively merges nested plain objects, preserving sibling overrides", () => {
+    const prev = base({ launcher: { enabled: false, clearChat: { backgroundColor: "#123456" } } });
+    const next = mergeConfigUpdate(prev, { launcher: { title: "After" } });
+    expect(next.launcher?.clearChat?.backgroundColor).toBe("#123456");
+    expect(next.launcher?.title).toBe("After");
+    // Launcher defaults survive a partial patch.
+    expect(next.launcher?.mountMode).toBe("floating");
+  });
+
+  it("patches composerBar without replacing sibling launcher fields", () => {
+    const prev = base({ launcher: { title: "Keep", composerBar: { collapsedMaxWidth: "700px" } } });
+    const next = mergeConfigUpdate(prev, { launcher: { composerBar: { bottomOffset: "8px" } } });
+    expect(next.launcher?.title).toBe("Keep");
+    expect(next.launcher?.composerBar?.collapsedMaxWidth).toBe("700px");
+    expect(next.launcher?.composerBar?.bottomOffset).toBe("8px");
+  });
+
+  it("replaces arrays wholesale (suggestionChips)", () => {
+    const prev = base({ suggestionChips: ["a", "b", "c"] });
+    const next = mergeConfigUpdate(prev, { suggestionChips: ["x"] });
+    expect(next.suggestionChips).toEqual(["x"]);
+  });
+
+  it("replaces callbacks wholesale", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const prev = base({ onSessionInit: first });
+    const next = mergeConfigUpdate(prev, { onSessionInit: second });
+    expect(next.onSessionInit).toBe(second);
+  });
+
+  it("guards boolean|object unions in both directions", () => {
+    const objFirst = base({ approval: { backgroundColor: "#ffffff" } });
+    const toScalar = mergeConfigUpdate(objFirst, { approval: false });
+    expect(toScalar.approval).toBe(false);
+
+    const scalarFirst = base({ persistState: true });
+    const toObject = mergeConfigUpdate(scalarFirst, { persistState: { storage: "local" } });
+    expect(toObject.persistState).toEqual({ storage: "local" });
+  });
+
+  it("replaces the headers map wholesale (stale keys do not survive)", () => {
+    const prev = base({ headers: { "X-A": "1", "X-B": "2" } });
+    const next = mergeConfigUpdate(prev, { headers: { "X-B": "3" } });
+    expect(next.headers).toEqual({ "X-B": "3" });
+    expect(next.headers?.["X-A"]).toBeUndefined();
+  });
+
+  it("replaces features.streamAnimation.plugins wholesale", () => {
+    const p1 = { name: "p1" } as StreamAnimationPlugin;
+    const p2 = { name: "p2" } as StreamAnimationPlugin;
+    const prev = base({ features: { streamAnimation: { plugins: { p1 } } } });
+    const next = mergeConfigUpdate(prev, { features: { streamAnimation: { plugins: { p2 } } } });
+    expect(next.features?.streamAnimation?.plugins).toEqual({ p2 });
+    expect(next.features?.streamAnimation?.plugins?.p1).toBeUndefined();
+  });
+
+  it("replaces storageAdapter wholesale (no hybrid: new adapter's absent save is not inherited)", () => {
+    const oldSave = vi.fn();
+    const oldLoad = vi.fn();
+    const newLoad = vi.fn();
+    const prev = base({ storageAdapter: { save: oldSave, load: oldLoad } });
+    const next = mergeConfigUpdate(prev, { storageAdapter: { load: newLoad } });
+    expect(next.storageAdapter?.load).toBe(newLoad);
+    expect(next.storageAdapter?.save).toBeUndefined();
+  });
+
+  it("resets a cleared key to its default value (launcher.title)", () => {
+    const prev = base({ launcher: { title: "Custom" } });
+    expect(prev.launcher?.title).toBe("Custom");
+    const next = mergeConfigUpdate(prev, { launcher: { title: undefined } });
+    expect(next.launcher?.title).toBe("Chat Assistant");
+    // Other launcher fields are untouched by the clear.
+    expect(next.launcher?.mountMode).toBe("floating");
+  });
+
+  it("leaves a cleared key unset when no default exists (launcher.closeButtonColor)", () => {
+    const prev = base({ launcher: { closeButtonColor: "#ff0000" } });
+    expect(prev.launcher?.closeButtonColor).toBe("#ff0000");
+    const next = mergeConfigUpdate(prev, { launcher: { closeButtonColor: undefined } });
+    // closeButtonColor is intentionally omitted from the launcher defaults.
+    expect(next.launcher?.closeButtonColor).toBeUndefined();
+  });
+
+  it("resets a cleared key with a truthy default (messageActions.showCopy resets to true)", () => {
+    const prev = base({ messageActions: { showCopy: false } });
+    expect(prev.messageActions?.showCopy).toBe(false);
+    const next = mergeConfigUpdate(prev, { messageActions: { showCopy: undefined } });
+    // The key must be absent (not own-undefined) so the default spread repopulates it.
+    expect(next.messageActions?.showCopy).toBe(true);
+  });
+
+  it("resets a cleared nested key with a truthy default (layout.header.showTitle resets to true)", () => {
+    const prev = base({ layout: { header: { showTitle: false } } });
+    expect(prev.layout?.header?.showTitle).toBe(false);
+    const next = mergeConfigUpdate(prev, { layout: { header: { showTitle: undefined } } });
+    expect(next.layout?.header?.showTitle).toBe(true);
+  });
+
+  it("preserves keys absent from the patch", () => {
+    const prev = base({ launcher: { title: "Keep", subtitle: "Sub" } });
+    const next = mergeConfigUpdate(prev, { launcher: { title: "New" } });
+    expect(next.launcher?.title).toBe("New");
+    expect(next.launcher?.subtitle).toBe("Sub");
+  });
+
+  it("deep-merges theme partials through update, preserving earlier theme overrides", () => {
+    const prev = base({ theme: { semantic: { colors: { primary: "#111111" } } } });
+    const next = mergeConfigUpdate(prev, { theme: { semantic: { colors: { secondary: "#222222" } } } });
+    expect(next.theme?.semantic?.colors?.primary).toBe("#111111");
+    expect(next.theme?.semantic?.colors?.secondary).toBe("#222222");
+  });
+
+  it("is idempotent: merging a config over its equal self is a no-op", () => {
+    const prev = base({ launcher: { clearChat: { backgroundColor: "#123456" } } });
+    const merged = mergeConfigUpdate(prev, { launcher: { title: "T" } });
+    const again = mergeConfigUpdate(merged, merged);
+    expect(again).toEqual(merged);
+  });
+});

--- a/packages/widget/src/utils/config-merge.ts
+++ b/packages/widget/src/utils/config-merge.ts
@@ -1,0 +1,61 @@
+import { mergeWithDefaults } from "../defaults";
+import type { AgentWidgetConfig, AgentWidgetConfigPatch } from "../types";
+
+// Same predicate as utils/deep-merge.ts: plain object, non-null, non-array.
+// Class instances and DOM nodes also pass here, so replace-leaf paths guard the
+// ones that must not be recursed into.
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value);
+
+// Dotted paths whose plain-object value replaces wholesale instead of recursing.
+// - user-defined key maps: recursive merge would strand stale keys from the old value
+//   (headers, targetProviders, components, features.streamAnimation.plugins).
+// - implementation objects: partial merge splices two impls into a broken hybrid
+//   (agent, storageAdapter, voiceRecognition.provider.custom).
+const REPLACE_LEAF_PATHS = new Set<string>([
+  "headers",
+  "agent",
+  "storageAdapter",
+  "components",
+  "targetProviders",
+  "voiceRecognition.provider.custom",
+  "features.streamAnimation.plugins",
+]);
+
+// Recursive patch merge. A key merges recursively iff both previous and patch
+// values are plain objects and the path is not a replace-leaf; otherwise the
+// patch value replaces. A key present in the patch with value undefined is
+// deleted from the result (an own undefined property would shadow defaults in
+// mergeWithDefaults' spreads); absent keys are never visited, so they are
+// preserved. theme/darkTheme need no special case: the both-sides-plain-object
+// rule already reproduces mergeThemePartials/deepMerge (defaults.ts:225-236).
+const mergePatch = (previous: unknown, patch: unknown, path: string): unknown => {
+  if (!isPlainObject(previous) || !isPlainObject(patch)) return patch;
+  if (REPLACE_LEAF_PATHS.has(path)) return patch;
+
+  const result: Record<string, unknown> = { ...previous };
+  for (const key of Object.keys(patch)) {
+    if (patch[key] === undefined) {
+      delete result[key];
+      continue;
+    }
+    const childPath = path ? `${path}.${key}` : key;
+    result[key] = mergePatch(previous[key], patch[key], childPath);
+  }
+  return result;
+};
+
+/**
+ * Merge a config patch over the previous widget config with one consistent
+ * recursive policy, then re-apply mergeWithDefaults so a cleared
+ * (explicit-undefined) key resets to its default. The stored controller config
+ * is already post-mergeWithDefaults, so re-applying it is idempotent and keeps
+ * initial mount, live update, and rebuild on the same merge policy.
+ */
+export function mergeConfigUpdate(
+  previousConfig: AgentWidgetConfig,
+  patch: AgentWidgetConfigPatch
+): AgentWidgetConfig {
+  const merged = mergePatch(previousConfig, patch, "") as Partial<AgentWidgetConfig>;
+  return mergeWithDefaults(merged) as AgentWidgetConfig;
+}

--- a/packages/widget/src/utils/theme.test.ts
+++ b/packages/widget/src/utils/theme.test.ts
@@ -60,6 +60,32 @@ describe('theme utils', () => {
     expect(cssVars['--persona-palette-colors-primary-500']).toBe('#22c55e');
   });
 
+  it('preserves user radius and typography palette overrides in dark mode', () => {
+    // Regression: createDarkTheme() used to spread a pre-built default palette
+    // over the merged user config, which kept only `colors` and silently
+    // dropped radius/typography overrides that light mode honored.
+    const themeConfig = {
+      colorScheme: 'dark' as const,
+      theme: {
+        palette: {
+          radius: { xl: '4px' },
+          typography: { fontFamily: { sans: 'Georgia, serif' } },
+        },
+      },
+    };
+
+    const activeTheme = getActiveTheme(themeConfig);
+    const cssVars = themeToCssVariables(activeTheme);
+
+    // User non-color palette overrides survive the dark rebuild…
+    expect(cssVars['--persona-palette-radius-xl']).toBe('4px');
+    expect(cssVars['--persona-palette-typography-fontFamily-sans']).toBe('Georgia, serif');
+    // …untouched radius steps still resolve from the defaults…
+    expect(cssVars['--persona-palette-radius-full']).toBe('9999px');
+    // …and the dark color palette still applies underneath.
+    expect(cssVars['--persona-palette-colors-primary-500']).toBe('#171717');
+  });
+
   it('maps radius tokens into the legacy widget radius aliases', () => {
     const theme = createTheme({
       palette: {

--- a/packages/widget/src/utils/theme.ts
+++ b/packages/widget/src/utils/theme.ts
@@ -146,13 +146,16 @@ export const createLightTheme = (userConfig?: DeepPartial<PersonaTheme>): Person
 };
 
 export const createDarkTheme = (userConfig?: DeepPartial<PersonaTheme>): PersonaTheme => {
-  const baseTheme = createTheme(undefined, { validate: false });
-  
+  // createTheme() already merges every palette sub-object (radius, typography,
+  // shadows, …) over the defaults, so only the dark color scales need to be
+  // layered UNDER the user's colors here. Spreading a pre-built default
+  // palette instead would clobber the user's non-color palette overrides
+  // (radius/typography) in dark mode while light mode honored them.
   return createTheme(
     {
       ...userConfig,
       palette: {
-        ...baseTheme.palette,
+        ...userConfig?.palette,
         colors: {
           ...DARK_PALETTE.colors,
           ...userConfig?.palette?.colors,


### PR DESCRIPTION
## What does this PR do?

Makes `update()` apply a consistent recursive patch-merge for `AgentWidgetConfig`, and fixes live-update regressions so chrome (header, composer, attachments, drop overlay, send/stop) stays correct without remounting. Also resets artifact pane scroll on selection/expand and updates demos/docs for explicit `undefined` resets.

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Tooling / CI

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run`) and I added tests for new behavior
- [x] **Changeset added if I touched `packages/widget` or `packages/proxy`** (`pnpm changeset`). _Not required for changes only under `examples/`, `docs/`, CI, or tooling_
- [x] Docs updated if I changed public API or behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates runtime configuration merging to apply recursive patches and explicit resets consistently, while stabilizing live-updated widget chrome, attachment controls, artifact-pane behavior, demos, tests, and documentation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failures remain within the follow-up review scope.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/widget/src/utils/config-merge.ts | Introduces the shared recursive configuration patch merger, explicit-reset handling, and replacement paths for implementation objects and keyed maps. |
| packages/widget/src/runtime/init.ts | Aligns init-handle updates with the shared merge policy while forwarding raw patches for explicit resets. |
| packages/widget/src/ui.ts | Applies merged live configuration across header, composer, attachment, overlay, and streaming-button UI state. |
| packages/widget/src/components/artifact-pane.ts | Resets artifact-pane scroll state when selection or expansion changes. |
| packages/widget/src/types.ts | Adds and exposes the recursive configuration patch type used by update APIs. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[update patch] --> B[Recursive patch merge]
  B --> C{Explicit undefined?}
  C -->|Yes| D[Remove current value]
  C -->|No| E[Preserve omitted siblings]
  D --> F[Reapply defaults]
  E --> F
  F --> G[Refresh live widget UI]
```

<sub>Reviews (2): Last reviewed commit: ["Update size limits for CJS bundle and th..."](https://github.com/runtypelabs/persona/commit/60be7418f19cb57692ea3db669b6736b3ec18def) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46602748)</sub>

<!-- /greptile_comment -->