### PR TITLE
(WIP) UX/UI polish

### DIFF
--- a/.changeset/fix-clipped-control-tooltips.md
+++ b/.changeset/fix-clipped-control-tooltips.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Portal and viewport-clamp control tooltips so long labels remain visible in narrow and overflow-clipped panels.

--- a/.changeset/role-message-widths.md
+++ b/.changeset/role-message-widths.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add role-specific content or full-width message layouts with optional CSS max-width caps.

--- a/.changeset/role-message-widths.md
+++ b/.changeset/role-message-widths.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona": minor
 ---
 
-Add role-specific content or full-width message layouts with optional CSS max-width caps.
+Add role-specific content or full-width message layouts with optional CSS max-width caps and Theme Configurator controls.

--- a/.changeset/table-horizontal-scroll.md
+++ b/.changeset/table-horizontal-scroll.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona": patch
 ---
 
-Wide markdown tables now scroll horizontally inside their own container instead of pushing the whole chat column wide. Each table is wrapped in a scroll region with edge fades that appear only when there is more content to scroll toward, so tables stay contained and readable on narrow layouts.
+Wide markdown tables now scroll horizontally inside their own container instead of pushing the whole chat column wide. Each table is wrapped in a scroll region with edge fades that appear only when there is more content to scroll toward, so tables stay contained and readable on narrow layouts. While a table streams in, it now scrolls at its natural width with columns locked to the header row, instead of being squeezed to fit the column and only becoming scrollable once streaming finished.

--- a/.changeset/table-horizontal-scroll.md
+++ b/.changeset/table-horizontal-scroll.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona": patch
 ---
 
-Wide markdown tables now scroll horizontally inside their own container instead of pushing the whole chat column wide. Each table is wrapped in a scroll region with edge fades that appear only when there is more content to scroll toward, so tables stay contained and readable on narrow layouts. While a table streams in, it now scrolls at its natural width with columns locked to the header row, instead of being squeezed to fit the column and only becoming scrollable once streaming finished.
+Wide markdown tables now scroll horizontally inside their own container instead of pushing the whole chat column wide. Each table is wrapped in a scroll region with edge fades that appear only when there is more content to scroll toward, so tables stay contained and readable on narrow layouts. While a table streams in, it now scrolls at its natural width with columns locked to the header row, instead of being squeezed to fit the column and only becoming scrollable once streaming finished. The fade width is themeable via the `--persona-md-table-scroll-fade` CSS variable (set it to `0` to turn the fade off).

--- a/.changeset/table-horizontal-scroll.md
+++ b/.changeset/table-horizontal-scroll.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Wide markdown tables now scroll horizontally inside their own container instead of pushing the whole chat column wide. Each table is wrapped in a scroll region with edge fades that appear only when there is more content to scroll toward, so tables stay contained and readable on narrow layouts.

--- a/apps/web/src/streaming-table-demo.ts
+++ b/apps/web/src/streaming-table-demo.ts
@@ -21,6 +21,12 @@ import { createMarkdownProcessor, createDefaultSanitizer } from "@runtypelabs/pe
 // Internal modules, reachable via the apps/web "@runtypelabs/persona" → src alias.
 import { stabilizeStreamingTables } from "@runtypelabs/persona/utils/streaming-table";
 import { morphMessages } from "@runtypelabs/persona/utils/morph";
+// The same wrap-then-fade helpers the widget's transcript render path uses, so
+// this demo exercises the real overflow behavior (not a lookalike).
+import {
+  wrapScrollableTables,
+  refreshTableScrollFades,
+} from "@runtypelabs/persona/utils/table-scroll-fade";
 
 const md = createMarkdownProcessor();
 const sanitize = createDefaultSanitizer();
@@ -30,6 +36,19 @@ const render = (markdown: string): string => sanitize(md(markdown));
 type Sample = { id: string; label: string; text: string };
 
 const SAMPLES: Sample[] = [
+  {
+    id: "wide",
+    label: "Wide table (scrolls)",
+    text: `Here is the weekly production summary, actual vs target:
+
+| Site | Target (t) | Actual (t) | Variance (t) | % of Target | Trend | Site manager |
+| --- | --- | --- | --- | --- | --- | --- |
+| Cedar Ridge | 5,200 | 4,991 | -209 | 96% | down | Alex Johnson |
+| North Basin | 3,800 | 3,836 | +36 | 101% | up | Priya Chandrasekaran |
+| West Overlook | 7,100 | 7,540 | +440 | 106% | up | Bartholomew Fitzgerald |
+
+Cedar Ridge is the only site under target this week.`,
+  },
   {
     id: "pricing",
     label: "Pricing comparison",
@@ -84,7 +103,9 @@ const freshCancel = () => {
 };
 
 const content = document.getElementById("stream-content") as HTMLElement;
+const streamPanel = document.querySelector(".stream-panel") as HTMLElement;
 const sampleSelector = document.getElementById("sample-selector") as HTMLElement;
+const widthSelector = document.getElementById("width-selector") as HTMLElement;
 const speedSlider = document.getElementById("speed") as HTMLInputElement;
 const speedLabel = document.getElementById("speed-label") as HTMLElement;
 const playBtn = document.getElementById("btn-play") as HTMLButtonElement;
@@ -97,7 +118,11 @@ const paint = (acc: string, streaming: boolean) => {
   // paint) and stabilize the table-in-progress so it renders from the first row.
   content.classList.toggle("persona-content-streaming", streaming);
   scratch.innerHTML = render(streaming ? stabilizeStreamingTables(acc) : acc);
+  // Wrap tables before morphing (wrapper exists on both sides of the diff) and
+  // refresh the edge fades after — mirrors the widget's real render path.
+  wrapScrollableTables(scratch);
   morphMessages(content, scratch, { preserveTypingAnimation: false });
+  refreshTableScrollFades(content);
 };
 
 let activeSampleId = SAMPLES[0].id;
@@ -153,6 +178,18 @@ sampleSelector.addEventListener("click", (e) => {
   btn.classList.add("active");
   activeSampleId = btn.dataset.sample ?? SAMPLES[0].id;
   void replay();
+});
+
+// Width toggle: a "chat column" width makes wide tables overflow so the
+// horizontal scroll and edge fades are visible, the way they are in a docked or
+// floating panel. Recompute fades against the new width without a full replay.
+widthSelector.addEventListener("click", (e) => {
+  const btn = (e.target as HTMLElement).closest<HTMLElement>(".mode-btn");
+  if (!btn) return;
+  widthSelector.querySelectorAll(".mode-btn").forEach((b) => b.classList.remove("active"));
+  btn.classList.add("active");
+  streamPanel.classList.toggle("narrow", btn.dataset.width === "narrow");
+  refreshTableScrollFades(content);
 });
 
 speedSlider.addEventListener("input", () => {

--- a/apps/web/src/theme-configurator/sections/widget-config.test.ts
+++ b/apps/web/src/theme-configurator/sections/widget-config.test.ts
@@ -19,6 +19,10 @@ describe('widget config section parity', () => {
     // Layout sub-group
     expect(paths).toContain('layout.header.layout');
     expect(paths).toContain('layout.messages.layout');
+    expect(paths).toContain('layout.messages.user.width');
+    expect(paths).toContain('layout.messages.user.maxWidth');
+    expect(paths).toContain('layout.messages.assistant.width');
+    expect(paths).toContain('layout.messages.assistant.maxWidth');
     expect(paths).toContain('messageActions.enabled');
 
     // Widget sub-group: full launcher config is now in Configure tab

--- a/apps/web/streaming-table-demo.html
+++ b/apps/web/streaming-table-demo.html
@@ -32,7 +32,11 @@
         border-radius: 0.75rem;
         overflow: hidden;
         background: var(--surface, #fff);
+        transition: max-width 200ms ease;
       }
+      /* Chat-column width: wide tables overflow, so the in-place horizontal
+         scroll and edge fades become visible (as in a docked/floating panel). */
+      .stream-panel.narrow { max-width: 420px; }
       .stream-panel-head {
         padding: 0.75rem 1rem;
         border-bottom: 1px solid var(--border, #e5e7eb);
@@ -54,7 +58,10 @@
           reserves the column widths, so a real table appears immediately and
           rows fill in without the header flipping from a paragraph or the
           columns jiggling. Widths relax to their natural sizes once the stream
-          finishes. Pick a sample, slow the chunk delay down, and replay.
+          finishes. A table wider than the column scrolls horizontally in
+          place, with edge fades that show only on the side with more content,
+          so it never widens the chat. Try the wide sample in the chat-column
+          width, then scroll the table sideways.
         </p>
       </header>
 
@@ -62,6 +69,13 @@
         <div class="section">
           <label>Sample</label>
           <div class="mode-group" id="sample-selector"></div>
+        </div>
+        <div class="section">
+          <label>Panel width</label>
+          <div class="mode-group" id="width-selector">
+            <button class="mode-btn active" data-width="narrow">Chat column</button>
+            <button class="mode-btn" data-width="full">Full width</button>
+          </div>
         </div>
         <div class="section">
           <label>Chunk delay</label>
@@ -75,7 +89,7 @@
         </div>
       </div>
 
-      <div class="stream-panel">
+      <div class="stream-panel narrow">
         <div class="stream-panel-head">
           <h3>Assistant reply</h3>
         </div>

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -20,7 +20,7 @@
   {
     "name": "⛔ CRITICAL · ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "158 kB",
+    "limit": "160 kB",
     "gzip": true
   },
   {

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -14,7 +14,7 @@
   {
     "name": "⛔ CRITICAL · browser stylesheet (widget.css)",
     "path": "dist/widget.css",
-    "limit": "15 kB",
+    "limit": "15.5 kB",
     "gzip": true
   },
   {

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -1078,6 +1078,8 @@ Available: `header-left`, `header-center`, `header-right`, `body-top`, `messages
   --persona-md-table-border-color: #e5e7eb;
   --persona-md-table-header-bg: #f8fafc;
   --persona-md-table-cell-padding: 0.5rem 0.75rem;
+  /* Edge fade shown when a wide table scrolls horizontally; set to 0 to disable. */
+  --persona-md-table-scroll-fade: 24px;
 
   /* Blockquotes */
   --persona-md-blockquote-border-color: var(--persona-accent);
@@ -1183,6 +1185,7 @@ These merge into `PersonaTheme` and are exposed as CSS variables on the widget r
   --persona-md-table-header-weight: 600;
   --persona-md-table-cell-padding: 0.5rem 0.75rem;
   --persona-md-table-border-radius: 0.375rem;
+  --persona-md-table-scroll-fade: 24px;
 
   /* Horizontal Rule */
   --persona-md-hr-color: var(--persona-divider, #e5e7eb);

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -1013,7 +1013,7 @@ Templates support **inline formatting markers**: `~dim text~`, `*italic text*`, 
 ### Messages (`layout.messages.*`)
 | Property | Description |
 |----------|-------------|
-| `layout` | `"bubble" \| "flat" \| "minimal"` |
+| `layout` | `"bubble"` (bubbles for both), `"minimal"` (user bubble with an open assistant response), or `"flat"` (open messages for both) |
 | `groupConsecutive` | Group consecutive same-role messages |
 | `avatar.show` / `avatar.position` / `avatar.userAvatar` / `avatar.assistantAvatar` | Avatar config |
 | `timestamp.show` / `timestamp.position` / `timestamp.format` | Timestamp config |
@@ -1029,9 +1029,14 @@ full-width assistant response:
 layout: {
   contentMaxWidth: "72ch",
   messages: {
-    layout: "flat",
-    user: { width: "content", maxWidth: "80%" },
-    assistant: { width: "full" },
+    layout: "minimal",
+    user: {
+      width: "content",
+      maxWidth: "80%",
+    },
+    assistant: {
+      width: "full",
+    },
   },
 }
 ```

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -1017,7 +1017,28 @@ Templates support **inline formatting markers**: `~dim text~`, `*italic text*`, 
 | `groupConsecutive` | Group consecutive same-role messages |
 | `avatar.show` / `avatar.position` / `avatar.userAvatar` / `avatar.assistantAvatar` | Avatar config |
 | `timestamp.show` / `timestamp.position` / `timestamp.format` | Timestamp config |
+| `user.width` / `assistant.width` | `"content"` (shrink-wrap, default) or `"full"` (fill the available transcript track) |
+| `user.maxWidth` / `assistant.maxWidth` | Optional CSS max-width. Defaults to `"85%"` for content width and `"100%"` for full width |
 | `renderUserMessage` / `renderAssistantMessage` | Custom render functions |
+
+Role width is independent of the message chrome preset. For example, a modern
+AI-assistant layout can combine a content-sized user bubble with a flat,
+full-width assistant response:
+
+```ts
+layout: {
+  contentMaxWidth: "72ch",
+  messages: {
+    layout: "flat",
+    user: { width: "content", maxWidth: "80%" },
+    assistant: { width: "full" },
+  },
+}
+```
+
+`"full"` means the full track inside the transcript's padding and
+`layout.contentMaxWidth`; when an avatar is shown, the message fills the space
+remaining after the avatar and gap.
 
 ### Slots (`layout.slots.*`)
 Available: `header-left`, `header-center`, `header-right`, `body-top`, `messages`, `body-bottom`, `footer-top`, `composer`, `footer-bottom`

--- a/packages/widget/src/components/approval-bubble.ts
+++ b/packages/widget/src/components/approval-bubble.ts
@@ -161,7 +161,6 @@ export const createApprovalBubble = (
     [
       "persona-approval-bubble",
       "persona-w-full",
-      "persona-max-w-[85%]",
       "persona-rounded-2xl",
       "persona-border",
       "persona-shadow-sm",

--- a/packages/widget/src/components/composer-parts.ts
+++ b/packages/widget/src/components/composer-parts.ts
@@ -2,6 +2,7 @@ import { createElement, createNode, cx } from "../utils/dom";
 import { renderLucideIcon } from "../utils/icons";
 import { AgentWidgetConfig } from "../types";
 import { ALL_SUPPORTED_MIME_TYPES } from "../utils/content";
+import { attachTooltip } from "../utils/tooltip";
 
 /**
  * Low-level composer control factories. Both `buildComposer` (full,
@@ -172,15 +173,14 @@ export const createSendButton = (config?: AgentWidgetConfig): SendButtonParts =>
     button.textContent = sendLabel;
   }
 
-  let tooltip: HTMLElement | null = null;
-  if (showTooltip && tooltipText) {
-    tooltip = createElement("div", "persona-send-button-tooltip");
-    tooltip.textContent = tooltipText;
-    wrapper.appendChild(tooltip);
-  }
-
   button.setAttribute("aria-label", tooltipText);
   wrapper.appendChild(button);
+  attachTooltip({
+    anchor: button,
+    trigger: wrapper,
+    text: () => button.getAttribute("aria-label") ?? "",
+    enabled: showTooltip,
+  });
 
   let currentMode: "send" | "stop" = "send";
   const setMode = (mode: "send" | "stop") => {
@@ -188,9 +188,6 @@ export const createSendButton = (config?: AgentWidgetConfig): SendButtonParts =>
     currentMode = mode;
     const label = mode === "stop" ? stopTooltipText : tooltipText;
     button.setAttribute("aria-label", label);
-    if (tooltip) {
-      tooltip.textContent = label;
-    }
 
     if (useIcon) {
       if (sendIcon && stopIcon) {
@@ -250,7 +247,7 @@ export const createMicButton = (config?: AgentWidgetConfig): MicButtonParts | nu
     attrs: {
       type: "button",
       "data-persona-composer-mic": "",
-      "aria-label": "Start voice recognition",
+      "aria-label": voiceRecognitionConfig.tooltipText ?? "Start voice recognition",
     },
     style: {
       width: micIconSize,
@@ -283,11 +280,12 @@ export const createMicButton = (config?: AgentWidgetConfig): MicButtonParts | nu
 
   const micTooltipText = voiceRecognitionConfig.tooltipText ?? "Start voice recognition";
   const showMicTooltip = voiceRecognitionConfig.showTooltip ?? false;
-  if (showMicTooltip && micTooltipText) {
-    const tooltip = createElement("div", "persona-send-button-tooltip");
-    tooltip.textContent = micTooltipText;
-    wrapper.appendChild(tooltip);
-  }
+  attachTooltip({
+    anchor: button,
+    trigger: wrapper,
+    text: () => button.getAttribute("aria-label") ?? micTooltipText,
+    enabled: showMicTooltip,
+  });
 
   return { button, wrapper };
 };
@@ -368,9 +366,11 @@ export const createAttachmentControls = (config?: AgentWidgetConfig): Attachment
   wrapper.appendChild(button);
 
   const attachTooltipText = attachmentsConfig.buttonTooltipText ?? "Attach file";
-  const tooltip = createElement("div", "persona-send-button-tooltip");
-  tooltip.textContent = attachTooltipText;
-  wrapper.appendChild(tooltip);
+  attachTooltip({
+    anchor: button,
+    trigger: wrapper,
+    text: () => button.getAttribute("aria-label") ?? attachTooltipText,
+  });
 
   return { button, wrapper, input, previewsContainer };
 };

--- a/packages/widget/src/components/context-mention-button.test.ts
+++ b/packages/widget/src/components/context-mention-button.test.ts
@@ -22,13 +22,17 @@ describe("createMentionButton", () => {
       config: config({ buttonTooltipText: "Add context" }),
       onOpen,
     });
+    document.body.appendChild(wrapper);
     expect(button.getAttribute("aria-label")).toBe("Add context");
-    expect(wrapper.querySelector(".persona-send-button-tooltip")?.textContent).toBe(
+    wrapper.dispatchEvent(new MouseEvent("mouseenter"));
+    expect(document.body.querySelector(".persona-control-tooltip")?.textContent).toBe(
       "Add context"
     );
+    expect(wrapper.querySelector(".persona-control-tooltip")).toBeNull();
 
     button.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
     expect(onOpen).toHaveBeenCalledTimes(1);
+    wrapper.dispatchEvent(new MouseEvent("mouseleave"));
   });
 
   it("defaults to a '+' add-context icon, not an '@' glyph", () => {

--- a/packages/widget/src/components/context-mention-button.ts
+++ b/packages/widget/src/components/context-mention-button.ts
@@ -1,6 +1,7 @@
 import { createElement, createNode } from "../utils/dom";
 import { renderLucideIcon } from "../utils/icons";
 import type { AgentWidgetContextMentionConfig } from "../types";
+import { attachTooltip } from "../utils/tooltip";
 
 export interface MentionButtonParts {
   button: HTMLButtonElement;
@@ -73,10 +74,11 @@ export function createMentionButton(opts: {
   });
 
   wrapper.appendChild(button);
-
-  const tooltip = createElement("div", "persona-send-button-tooltip");
-  tooltip.textContent = tooltipText;
-  wrapper.appendChild(tooltip);
+  attachTooltip({
+    anchor: button,
+    trigger: wrapper,
+    text: () => button.getAttribute("aria-label") ?? tooltipText,
+  });
 
   return { button, wrapper };
 }

--- a/packages/widget/src/components/header-builder.test.ts
+++ b/packages/widget/src/components/header-builder.test.ts
@@ -22,11 +22,11 @@ describe("buildHeader tooltips", () => {
 
     closeButtonWrapper.dispatchEvent(new Event("mouseenter"));
 
-    expect(iframeDocument.body.querySelector(".persona-clear-chat-tooltip")).not.toBeNull();
-    expect(document.body.querySelector(".persona-clear-chat-tooltip")).toBeNull();
+    expect(iframeDocument.body.querySelector(".persona-control-tooltip")).not.toBeNull();
+    expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
 
     closeButtonWrapper.dispatchEvent(new Event("mouseleave"));
 
-    expect(iframeDocument.body.querySelector(".persona-clear-chat-tooltip")).toBeNull();
+    expect(iframeDocument.body.querySelector(".persona-control-tooltip")).toBeNull();
   });
 });

--- a/packages/widget/src/components/header-parts.ts
+++ b/packages/widget/src/components/header-parts.ts
@@ -1,7 +1,7 @@
-import { createElement, createElementInDocument, createNode, cx } from "../utils/dom";
+import { createElement, createNode, cx } from "../utils/dom";
 import { renderLucideIcon } from "../utils/icons";
 import { AgentWidgetConfig } from "../types";
-import { PORTALED_OVERLAY_Z_INDEX } from "../utils/constants";
+import { attachTooltip } from "../utils/tooltip";
 import { HEADER_THEME_CSS } from "./header-builder";
 
 export interface CloseButtonParts {
@@ -136,59 +136,12 @@ export const createCloseButton = (
   }
 
   wrapper.appendChild(button);
-
-  if (closeButtonShowTooltip && closeButtonTooltipText) {
-    let portaledTooltip: HTMLElement | null = null;
-
-    const showTooltip = () => {
-      if (portaledTooltip) return;
-
-      const tooltipDocument = button.ownerDocument;
-      const tooltipContainer = tooltipDocument.body;
-      if (!tooltipContainer) return;
-
-      portaledTooltip = createElementInDocument(
-        tooltipDocument,
-        "div",
-        "persona-clear-chat-tooltip"
-      );
-      portaledTooltip.textContent = closeButtonTooltipText;
-
-      const arrow = createElementInDocument(tooltipDocument, "div");
-      arrow.className = "persona-clear-chat-tooltip-arrow";
-      portaledTooltip.appendChild(arrow);
-
-      const buttonRect = button.getBoundingClientRect();
-
-      portaledTooltip.style.position = "fixed";
-      portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
-      portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
-      portaledTooltip.style.top = `${buttonRect.top - 8}px`;
-      portaledTooltip.style.transform = "translate(-50%, -100%)";
-
-      tooltipContainer.appendChild(portaledTooltip);
-    };
-
-    const hideTooltip = () => {
-      if (portaledTooltip && portaledTooltip.parentNode) {
-        portaledTooltip.parentNode.removeChild(portaledTooltip);
-        portaledTooltip = null;
-      }
-    };
-
-    wrapper.addEventListener("mouseenter", showTooltip);
-    wrapper.addEventListener("mouseleave", hideTooltip);
-    button.addEventListener("focus", showTooltip);
-    button.addEventListener("blur", hideTooltip);
-
-    (wrapper as any)._cleanupTooltip = () => {
-      hideTooltip();
-      wrapper.removeEventListener("mouseenter", showTooltip);
-      wrapper.removeEventListener("mouseleave", hideTooltip);
-      button.removeEventListener("focus", showTooltip);
-      button.removeEventListener("blur", hideTooltip);
-    };
-  }
+  attachTooltip({
+    anchor: button,
+    trigger: wrapper,
+    text: () => button.getAttribute("aria-label") ?? closeButtonTooltipText,
+    enabled: closeButtonShowTooltip,
+  });
 
   return { button, wrapper };
 };
@@ -271,59 +224,12 @@ export const createClearChatButton = (
   }
 
   wrapper.appendChild(button);
-
-  if (clearChatShowTooltip && clearChatTooltipText) {
-    let portaledTooltip: HTMLElement | null = null;
-
-    const showTooltip = () => {
-      if (portaledTooltip) return;
-
-      const tooltipDocument = button.ownerDocument;
-      const tooltipContainer = tooltipDocument.body;
-      if (!tooltipContainer) return;
-
-      portaledTooltip = createElementInDocument(
-        tooltipDocument,
-        "div",
-        "persona-clear-chat-tooltip"
-      );
-      portaledTooltip.textContent = clearChatTooltipText;
-
-      const arrow = createElementInDocument(tooltipDocument, "div");
-      arrow.className = "persona-clear-chat-tooltip-arrow";
-      portaledTooltip.appendChild(arrow);
-
-      const buttonRect = button.getBoundingClientRect();
-
-      portaledTooltip.style.position = "fixed";
-      portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
-      portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
-      portaledTooltip.style.top = `${buttonRect.top - 8}px`;
-      portaledTooltip.style.transform = "translate(-50%, -100%)";
-
-      tooltipContainer.appendChild(portaledTooltip);
-    };
-
-    const hideTooltip = () => {
-      if (portaledTooltip && portaledTooltip.parentNode) {
-        portaledTooltip.parentNode.removeChild(portaledTooltip);
-        portaledTooltip = null;
-      }
-    };
-
-    wrapper.addEventListener("mouseenter", showTooltip);
-    wrapper.addEventListener("mouseleave", hideTooltip);
-    button.addEventListener("focus", showTooltip);
-    button.addEventListener("blur", hideTooltip);
-
-    (wrapper as any)._cleanupTooltip = () => {
-      hideTooltip();
-      wrapper.removeEventListener("mouseenter", showTooltip);
-      wrapper.removeEventListener("mouseleave", hideTooltip);
-      button.removeEventListener("focus", showTooltip);
-      button.removeEventListener("blur", hideTooltip);
-    };
-  }
+  attachTooltip({
+    anchor: button,
+    trigger: wrapper,
+    text: () => button.getAttribute("aria-label") ?? clearChatTooltipText,
+    enabled: clearChatShowTooltip,
+  });
 
   return { button, wrapper };
 };

--- a/packages/widget/src/components/message-bubble.test.ts
+++ b/packages/widget/src/components/message-bubble.test.ts
@@ -257,6 +257,55 @@ describe("isSafeImageSrc", () => {
 });
 
 describe("createStandardBubble", () => {
+  it("uses a compact user bubble and borderless assistant response in minimal style", () => {
+    const userBubble = createStandardBubble(
+      makeMessage({ id: "minimal-user", role: "user", content: "Question" }),
+      ({ text }) => text,
+      { layout: "minimal" }
+    );
+    const assistantBubble = createStandardBubble(
+      makeMessage({
+        id: "minimal-assistant",
+        role: "assistant",
+        content: "Answer",
+      }),
+      ({ text }) => text,
+      { layout: "minimal" }
+    );
+
+    expect(userBubble.classList.contains("persona-bg-persona-accent")).toBe(true);
+    expect(userBubble.classList.contains("persona-rounded-lg")).toBe(true);
+    expect(userBubble.classList.contains("persona-px-3")).toBe(true);
+    expect(assistantBubble.classList.contains("persona-bg-persona-surface")).toBe(
+      true
+    );
+    expect(assistantBubble.classList.contains("persona-rounded-lg")).toBe(true);
+    expect(assistantBubble.classList.contains("persona-border")).toBe(false);
+    expect(assistantBubble.classList.contains("persona-shadow-sm")).toBe(false);
+  });
+
+  it("removes role background chrome from flat messages", () => {
+    const userMessage = createStandardBubble(
+      makeMessage({ id: "flat-user", role: "user", content: "Question" }),
+      ({ text }) => text,
+      { layout: "flat" }
+    );
+    const assistantMessage = createStandardBubble(
+      makeMessage({
+        id: "flat-assistant",
+        role: "assistant",
+        content: "Answer",
+      }),
+      ({ text }) => text,
+      { layout: "flat" }
+    );
+
+    expect(userMessage.style.backgroundColor).toBe("transparent");
+    expect(assistantMessage.style.backgroundColor).toBe("transparent");
+    expect(userMessage.classList.contains("persona-px-3")).toBe(false);
+    expect(assistantMessage.classList.contains("persona-px-3")).toBe(false);
+  });
+
   it("skips rendering blocked image previews while keeping safe ones", () => {
     const bubble = createStandardBubble(
       makeMessage({

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -653,7 +653,7 @@ const getBubbleClasses = (
   role: "user" | "assistant" | "system",
   layout: AgentWidgetMessageLayoutConfig["layout"] = "bubble"
 ): string[] => {
-  const baseClasses = ["persona-message-bubble", "persona-max-w-[85%]"];
+  const baseClasses = ["persona-message-bubble"];
 
   switch (layout) {
     case "flat":
@@ -1171,7 +1171,9 @@ export const createStandardBubble = (
   // Create wrapper with avatar
   const wrapper = createElement(
     "div",
-    `persona-flex persona-gap-2 ${message.role === "user" ? "persona-flex-row-reverse" : ""}`
+    `persona-message-with-avatar persona-flex persona-gap-2 ${
+      message.role === "user" ? "persona-flex-row-reverse" : ""
+    }`
   );
 
   const avatar = createAvatar(avatarConfig!, message.role);
@@ -1181,10 +1183,6 @@ export const createStandardBubble = (
   } else {
     wrapper.append(avatar, bubble);
   }
-
-  // Adjust bubble max-width when avatar is present
-  bubble.classList.remove("persona-max-w-[85%]");
-  bubble.classList.add("persona-max-w-[calc(85%-2.5rem)]");
 
   return wrapper;
 };

--- a/packages/widget/src/components/message-bubble.ts
+++ b/packages/widget/src/components/message-bubble.ts
@@ -877,7 +877,10 @@ export const createStandardBubble = (
   bubble.setAttribute("data-persona-theme-zone", message.role === "user" ? "user-message" : "assistant-message");
 
   // Apply component-level color overrides via CSS variables
-  if (message.role === "user") {
+  if (layout === "flat") {
+    bubble.style.backgroundColor = "transparent";
+    bubble.style.color = "var(--persona-primary, var(--persona-text))";
+  } else if (message.role === "user") {
     bubble.style.backgroundColor = 'var(--persona-message-user-bg, var(--persona-accent))';
     bubble.style.color = 'var(--persona-message-user-text, white)';
   } else if (message.role === "assistant") {

--- a/packages/widget/src/components/reasoning-bubble.ts
+++ b/packages/widget/src/components/reasoning-bubble.ts
@@ -72,7 +72,6 @@ export const createReasoningBubble = (message: AgentWidgetMessage, config?: Agen
       "persona-message-bubble",
       "persona-reasoning-bubble",
       "persona-w-full",
-      "persona-max-w-[85%]",
       "persona-rounded-2xl",
       "persona-bg-persona-surface",
       "persona-border",
@@ -350,6 +349,5 @@ export const createReasoningBubble = (message: AgentWidgetMessage, config?: Agen
   bubble.append(header, collapsedPreview, content);
   return bubble;
 };
-
 
 

--- a/packages/widget/src/components/tool-bubble.ts
+++ b/packages/widget/src/components/tool-bubble.ts
@@ -146,7 +146,6 @@ export const createToolBubble = (message: AgentWidgetMessage, config?: AgentWidg
       "persona-message-bubble",
       "persona-tool-bubble",
       "persona-w-full",
-      "persona-max-w-[85%]",
       "persona-rounded-2xl",
       "persona-bg-persona-surface",
       "persona-border",
@@ -542,6 +541,5 @@ export const createToolBubble = (message: AgentWidgetMessage, config?: AgentWidg
   bubble.append(header, collapsedPreview, content);
   return bubble;
 };
-
 
 

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -44,6 +44,7 @@ export type RuntypeExecutionStreamEvent = ({
   input: number;
   output: number;
 };
+  totalTokensUsed?: number;
   type: "execution_complete";
 }) | ({
   blockReason?: string;
@@ -303,6 +304,7 @@ export type RuntypeExecutionStreamEvent = ({
   stepId?: string;
   success: boolean;
   toolCallId: string;
+  toolCost?: number;
   toolName?: string;
   type: "tool_complete";
 } | {

--- a/packages/widget/src/index-core.ts
+++ b/packages/widget/src/index-core.ts
@@ -65,6 +65,7 @@ export type {
   AgentWidgetLayoutConfig,
   AgentWidgetHeaderLayoutConfig,
   AgentWidgetMessageLayoutConfig,
+  AgentWidgetMessageRoleLayout,
   AgentWidgetAvatarConfig,
   AgentWidgetTimestampConfig,
   WidgetLayoutSlot,

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -163,6 +163,8 @@
   --persona-md-table-header-weight: 600;
   --persona-md-table-cell-padding: 0.5rem 0.75rem;
   --persona-md-table-border-radius: 0.375rem;
+  /* Width of the horizontal-scroll edge fade on wide tables; set to 0 to disable. */
+  --persona-md-table-scroll-fade: 24px;
 
   /* Markdown Horizontal Rule Variables */
   --persona-md-hr-color: var(--persona-divider, #e5e7eb);

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -643,6 +643,47 @@
   max-width: 85%;
 }
 
+/* Message row geometry is role-configurable. The row always spans the
+   transcript; its direct content track either shrink-wraps or fills that row.
+   `--persona-message-row-max-width` is resolved per role in ui.ts. */
+.persona-message-row {
+  width: 100%;
+  min-width: 0;
+}
+
+.persona-message-row > * {
+  min-width: 0;
+  max-width: var(--persona-message-row-max-width, 85%);
+}
+
+.persona-message-row[data-message-width="content"] > * {
+  flex: 0 1 auto;
+}
+
+.persona-message-row[data-message-width="full"] > * {
+  flex: 1 1 auto;
+  width: 100%;
+}
+
+/* Avatars live inside the role-sized content track. The bubble flexes into
+   the space left after the fixed avatar + gap instead of making a full row
+   overflow by the avatar width. */
+.persona-message-with-avatar {
+  min-width: 0;
+}
+
+.persona-message-with-avatar > .persona-message-bubble {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.persona-message-row[data-message-width="full"]
+  > .persona-message-with-avatar
+  > .persona-message-bubble {
+  flex: 1 1 auto;
+  width: auto;
+}
+
 .persona-transition {
   transition: transform 160ms ease, background-color 160ms ease,
     box-shadow 160ms ease, opacity 160ms ease;
@@ -1501,12 +1542,58 @@
   flex-grow: 1;
 }
 
+/* Wide tables scroll inside this wrapper instead of widening the chat column.
+   The table keeps width:100% so it fills when it fits, but auto-grows past the
+   wrapper when its content is wider, and the wrapper scrolls. Injected by
+   wrapScrollableTables() before each morph. */
+.persona-table-scroll {
+  display: block;
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0.5rem 0;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Registered so the fade widths animate smoothly when they cross the edge
+   threshold; degrades to an instant toggle where @property is unsupported. */
+@property --persona-fade-l {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+@property --persona-fade-r {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+/* Edge fades (set by table-scroll-fade.ts) cue that the table scrolls; each
+   side shows only when there is more content that way. */
+.persona-table-scroll[data-persona-scroll-x] {
+  -webkit-mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 var(--persona-fade-l, 0px),
+    #000 calc(100% - var(--persona-fade-r, 0px)),
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to right,
+    transparent 0,
+    #000 var(--persona-fade-l, 0px),
+    #000 calc(100% - var(--persona-fade-r, 0px)),
+    transparent 100%
+  );
+  transition:
+    --persona-fade-l 150ms linear,
+    --persona-fade-r 150ms linear;
+}
+
 .persona-message-bubble table {
   width: 100%;
   border-collapse: collapse;
-  margin: 0.5rem 0;
+  margin: 0;
   font-size: 0.875rem;
-  overflow: hidden;
   border-radius: var(--persona-md-table-border-radius);
   border: 1px solid var(--persona-md-table-border-color);
 }

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -993,7 +993,8 @@
   cursor: pointer;
 }
 
-/* Send button tooltip */
+/* Shared icon-control tooltip. It is portaled to the document body (or the
+   widget ShadowRoot) and positioned in JS so panel overflow never clips it. */
 .persona-send-button-wrapper {
   position: relative;
   display: inline-flex;
@@ -1001,47 +1002,46 @@
   justify-content: center;
 }
 
-.persona-send-button-tooltip {
-  position: absolute;
-  bottom: calc(100% + 8px);
-  left: 50%;
-  transform: translateX(-50%);
+.persona-control-tooltip {
+  position: fixed;
+  box-sizing: border-box;
+  max-width: min(320px, calc(100vw - 16px));
   background-color: var(--persona-tooltip-background, #111827);
   color: var(--persona-tooltip-foreground, #ffffff);
   padding: 6px 12px;
   border-radius: var(--persona-radius-sm, 0.125rem);
   font-size: 12px;
-  white-space: nowrap;
-  opacity: 0;
-  pointer-events: none;
-  transition: opacity 0.2s;
-  z-index: 1000;
-}
-
-.persona-send-button-tooltip::after {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 4px solid transparent;
-  border-top-color: var(--persona-tooltip-background, #111827);
-}
-
-.persona-send-button-wrapper:hover .persona-send-button-tooltip,
-.persona-send-button-wrapper:focus-within .persona-send-button-tooltip {
+  line-height: 1.35;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  box-shadow: var(--persona-tooltip-shadow, 0 4px 12px rgba(15, 23, 42, 0.18));
   opacity: 1;
+  pointer-events: none;
+  transition: opacity 120ms ease;
 }
 
-/* Hide tooltips on touch devices: hover doesn't exist, and they cause clipping issues */
-@media (hover: none), (max-width: 500px) {
-  .persona-send-button-wrapper:hover .persona-send-button-tooltip,
-  .persona-send-button-wrapper:focus-within .persona-send-button-tooltip {
-    opacity: 0;
-  }
+.persona-control-tooltip[data-state="measuring"] {
+  visibility: hidden;
+  opacity: 0;
 }
 
-/* Clear chat button tooltip */
+.persona-control-tooltip__arrow {
+  position: absolute;
+  left: var(--persona-tooltip-arrow-x, 50%);
+  width: 8px;
+  height: 8px;
+  background: var(--persona-tooltip-background, #111827);
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.persona-control-tooltip[data-placement="top"] .persona-control-tooltip__arrow {
+  top: calc(100% - 4px);
+}
+
+.persona-control-tooltip[data-placement="bottom"] .persona-control-tooltip__arrow {
+  bottom: calc(100% - 4px);
+}
+
 .persona-clear-chat-button-wrapper {
   position: relative;
   display: inline-flex;
@@ -1049,30 +1049,9 @@
   justify-content: center;
 }
 
-.persona-clear-chat-tooltip {
-  background-color: var(--persona-tooltip-background, #111827);
-  color: var(--persona-tooltip-foreground, #ffffff);
-  padding: 6px 12px;
-  border-radius: var(--persona-radius-sm, 0.125rem);
-  font-size: 12px;
-  white-space: nowrap;
-  pointer-events: none;
-  z-index: 10000;
-}
-
-.persona-clear-chat-tooltip-arrow {
-  content: "";
-  position: absolute;
-  top: 100%;
-  left: 50%;
-  transform: translateX(-50%);
-  border: 4px solid transparent;
-  border-top-color: var(--persona-tooltip-background, #111827);
-}
-
-@media (hover: none), (max-width: 500px) {
-  .persona-clear-chat-tooltip {
-    display: none !important;
+@media (prefers-reduced-motion: reduce) {
+  .persona-control-tooltip {
+    transition: none;
   }
 }
 

--- a/packages/widget/src/styles/widget.css
+++ b/packages/widget/src/styles/widget.css
@@ -1530,24 +1530,14 @@
   max-width: 100%;
   overflow-x: auto;
   margin: 0.5rem 0;
-  -webkit-overflow-scrolling: touch;
-}
-
-/* Registered so the fade widths animate smoothly when they cross the edge
-   threshold; degrades to an instant toggle where @property is unsupported. */
-@property --persona-fade-l {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 0px;
-}
-@property --persona-fade-r {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 0px;
 }
 
 /* Edge fades (set by table-scroll-fade.ts) cue that the table scrolls; each
-   side shows only when there is more content that way. */
+   side shows only when there is more content that way. The fade is applied
+   instantly, not transitioned: each morph strips and re-applies the fade state,
+   so a transition would animate it from 0 on every streaming chunk (flicker) and
+   once more when the finished paint re-enables it (a single flash). Instant also
+   tracks the scroll position exactly instead of lagging behind the finger. */
 .persona-table-scroll[data-persona-scroll-x] {
   -webkit-mask-image: linear-gradient(
     to right,
@@ -1563,9 +1553,6 @@
     #000 calc(100% - var(--persona-fade-r, 0px)),
     transparent 100%
   );
-  transition:
-    --persona-fade-l 150ms linear,
-    --persona-fade-r 150ms linear;
 }
 
 .persona-message-bubble table {
@@ -1602,13 +1589,18 @@
   background-color: rgba(0, 0, 0, 0.02);
 }
 
-/* While a message is still streaming, lock table column widths so incoming rows
-   append without the per-chunk horizontal reflow (Telegram-style space
-   reservation). The class is removed on the final render, relaxing the finished
-   table to natural content-fit widths. overflow-wrap keeps long cell content
-   from spilling past the fixed columns mid-stream. */
+/* While a message is still streaming, lock column widths to the header row
+   (table-layout: fixed) so incoming rows append without per-chunk reflow. width
+   auto sizes columns from the header and lets cells wrap, so a table that fits
+   once wrapped fills the column (min-width: 100%) with no scroll, while one too
+   wide even wrapped scrolls: it only shows the scroll fade when it genuinely
+   needs it, matching the finished table rather than forcing every cell onto one
+   line. The class is removed on the final render, settling columns to
+   content-fit widths. overflow-wrap keeps long words from spilling the column. */
 .persona-content-streaming table {
   table-layout: fixed;
+  width: auto;
+  min-width: 100%;
 }
 
 .persona-content-streaming th,

--- a/packages/widget/src/theme-editor/sections.test.ts
+++ b/packages/widget/src/theme-editor/sections.test.ts
@@ -4,11 +4,19 @@ import { COMPONENTS_SECTIONS, CONFIGURE_SECTIONS, INTERFACE_ROLES_SECTION, STYLE
 import { ALL_ROLES } from "./role-mappings";
 
 describe("theme editor scroll-to-bottom controls", () => {
-  it("exposes independent user and assistant message width controls", () => {
+  it("exposes clear style semantics and independent role width controls", () => {
     const section = CONFIGURE_SECTIONS.find((entry) => entry.id === "messages-layout");
     const fieldsByPath = new Map(
       section?.fields.map((field) => [field.path, field]) ?? []
     );
+
+    expect(fieldsByPath.get("layout.messages.layout")?.options).toEqual([
+      { value: "bubble", label: "Bubble — bubbles for both" },
+      { value: "minimal", label: "Minimal — user bubble, open assistant" },
+      { value: "flat", label: "Flat — open messages for both" },
+    ]);
+    expect(fieldsByPath.has("layout.messages.user.style")).toBe(false);
+    expect(fieldsByPath.has("layout.messages.assistant.style")).toBe(false);
 
     expect(fieldsByPath.get("layout.messages.user.width")?.options).toEqual([
       { value: "content", label: "Content" },

--- a/packages/widget/src/theme-editor/sections.test.ts
+++ b/packages/widget/src/theme-editor/sections.test.ts
@@ -4,6 +4,31 @@ import { COMPONENTS_SECTIONS, CONFIGURE_SECTIONS, INTERFACE_ROLES_SECTION, STYLE
 import { ALL_ROLES } from "./role-mappings";
 
 describe("theme editor scroll-to-bottom controls", () => {
+  it("exposes independent user and assistant message width controls", () => {
+    const section = CONFIGURE_SECTIONS.find((entry) => entry.id === "messages-layout");
+    const fieldsByPath = new Map(
+      section?.fields.map((field) => [field.path, field]) ?? []
+    );
+
+    expect(fieldsByPath.get("layout.messages.user.width")?.options).toEqual([
+      { value: "content", label: "Content" },
+      { value: "full", label: "Full" },
+    ]);
+    expect(fieldsByPath.get("layout.messages.assistant.width")?.options).toEqual([
+      { value: "content", label: "Content" },
+      { value: "full", label: "Full" },
+    ]);
+
+    const userMaxWidth = fieldsByPath.get("layout.messages.user.maxWidth");
+    const assistantMaxWidth = fieldsByPath.get(
+      "layout.messages.assistant.maxWidth"
+    );
+    expect(userMaxWidth?.parseValue?.(" 72ch ")).toBe("72ch");
+    expect(userMaxWidth?.parseValue?.("  ")).toBeUndefined();
+    expect(assistantMaxWidth?.parseValue?.("80%")).toBe("80%");
+    expect(assistantMaxWidth?.parseValue?.("")).toBeUndefined();
+  });
+
   it("exposes scroll-to-bottom config controls", () => {
     const featureSection = CONFIGURE_SECTIONS.find((section) => section.id === "features");
 

--- a/packages/widget/src/theme-editor/sections.ts
+++ b/packages/widget/src/theme-editor/sections.ts
@@ -22,6 +22,11 @@ import {
   ROLE_BORDERS,
 } from './role-mappings';
 
+const parseOptionalCssValue = (value: unknown): string | undefined => {
+  const normalized = String(value ?? '').trim();
+  return normalized || undefined;
+};
+
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // STYLE TAB: brand colors, chat colors, typography, shape, etc.
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -602,6 +607,10 @@ const messagesLayoutSectionDef: SectionDef = {
   id: 'messages-layout', title: 'Messages', collapsed: true,
   fields: [
     { id: 'layout-messages', label: 'Messages Layout', type: 'select', path: 'layout.messages.layout', defaultValue: 'bubble', options: [{ value: 'bubble', label: 'Bubble' }, { value: 'flat', label: 'Flat' }, { value: 'minimal', label: 'Minimal' }] },
+    { id: 'layout-message-user-width', label: 'User Width', description: 'Content hugs the message; Full fills the transcript track', type: 'select', path: 'layout.messages.user.width', defaultValue: 'content', options: [{ value: 'content', label: 'Content' }, { value: 'full', label: 'Full' }] },
+    { id: 'layout-message-user-max-width', label: 'User Max Width', description: 'Optional CSS width such as 80%, 42rem, or 72ch; blank uses the width mode default', type: 'text', path: 'layout.messages.user.maxWidth', defaultValue: '', parseValue: parseOptionalCssValue },
+    { id: 'layout-message-assistant-width', label: 'Assistant Width', description: 'Content hugs the message; Full fills the transcript track', type: 'select', path: 'layout.messages.assistant.width', defaultValue: 'content', options: [{ value: 'content', label: 'Content' }, { value: 'full', label: 'Full' }] },
+    { id: 'layout-message-assistant-max-width', label: 'Assistant Max Width', description: 'Optional CSS width such as 80%, 42rem, or 72ch; blank uses the width mode default', type: 'text', path: 'layout.messages.assistant.maxWidth', defaultValue: '', parseValue: parseOptionalCssValue },
     { id: 'layout-group', label: 'Group Consecutive', type: 'toggle', path: 'layout.messages.groupConsecutive', defaultValue: false },
     { id: 'layout-avatar-show', label: 'Show Avatars', type: 'toggle', path: 'layout.messages.avatar.show', defaultValue: false },
     { id: 'layout-avatar-pos', label: 'Avatar Position', type: 'select', path: 'layout.messages.avatar.position', defaultValue: 'left', options: [{ value: 'left', label: 'Left' }, { value: 'right', label: 'Right' }] },

--- a/packages/widget/src/theme-editor/sections.ts
+++ b/packages/widget/src/theme-editor/sections.ts
@@ -606,7 +606,7 @@ const headerLayoutSectionDef: SectionDef = {
 const messagesLayoutSectionDef: SectionDef = {
   id: 'messages-layout', title: 'Messages', collapsed: true,
   fields: [
-    { id: 'layout-messages', label: 'Messages Layout', type: 'select', path: 'layout.messages.layout', defaultValue: 'bubble', options: [{ value: 'bubble', label: 'Bubble' }, { value: 'flat', label: 'Flat' }, { value: 'minimal', label: 'Minimal' }] },
+    { id: 'layout-messages', label: 'Message Style', description: 'Minimal uses a user bubble with an open assistant response', type: 'select', path: 'layout.messages.layout', defaultValue: 'bubble', options: [{ value: 'bubble', label: 'Bubble — bubbles for both' }, { value: 'minimal', label: 'Minimal — user bubble, open assistant' }, { value: 'flat', label: 'Flat — open messages for both' }] },
     { id: 'layout-message-user-width', label: 'User Width', description: 'Content hugs the message; Full fills the transcript track', type: 'select', path: 'layout.messages.user.width', defaultValue: 'content', options: [{ value: 'content', label: 'Content' }, { value: 'full', label: 'Full' }] },
     { id: 'layout-message-user-max-width', label: 'User Max Width', description: 'Optional CSS width such as 80%, 42rem, or 72ch; blank uses the width mode default', type: 'text', path: 'layout.messages.user.maxWidth', defaultValue: '', parseValue: parseOptionalCssValue },
     { id: 'layout-message-assistant-width', label: 'Assistant Width', description: 'Content hugs the message; Full fills the transcript track', type: 'select', path: 'layout.messages.assistant.width', defaultValue: 'content', options: [{ value: 'content', label: 'Content' }, { value: 'full', label: 'Full' }] },

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -3976,6 +3976,27 @@ export type AgentWidgetTimestampConfig = {
 };
 
 /**
+ * Width configuration for one message role.
+ *
+ * `content` shrink-wraps the rendered message up to `maxWidth`; `full` fills
+ * the available transcript track up to `maxWidth`. The track already accounts
+ * for transcript padding and, when present, the avatar and its gap.
+ */
+export type AgentWidgetMessageRoleLayout = {
+  /**
+   * Message width behavior.
+   * - content: size to the rendered content (the backward-compatible default)
+   * - full: fill the available transcript track
+   */
+  width?: "content" | "full";
+  /**
+   * Optional CSS max-width (for example "80%", "42rem", or "72ch").
+   * Defaults to "85%" for content width and "100%" for full width.
+   */
+  maxWidth?: string;
+};
+
+/**
  * Message layout configuration
  * Allows customization of how chat messages are displayed
  */
@@ -3993,6 +4014,10 @@ export type AgentWidgetMessageLayoutConfig = {
   timestamp?: AgentWidgetTimestampConfig;
   /** Group consecutive messages from the same role */
   groupConsecutive?: boolean;
+  /** Width behavior for user-authored message rows */
+  user?: AgentWidgetMessageRoleLayout;
+  /** Width behavior for assistant-authored message rows and assistant UI variants */
+  assistant?: AgentWidgetMessageRoleLayout;
   /**
    * Custom renderer for user messages
    * When provided, replaces the default user message rendering

--- a/packages/widget/src/ui.attachments-drop.test.ts
+++ b/packages/widget/src/ui.attachments-drop.test.ts
@@ -270,7 +270,8 @@ describe("attachment button live config updates", () => {
     expect(button().getAttribute("aria-label")).toBe("Add a photo");
     const updatedSvg = button().querySelector("svg")!.outerHTML;
     expect(updatedSvg).not.toBe(initialSvg);
-    const tooltip = button().parentElement!.querySelector(".persona-send-button-tooltip");
+    button().parentElement!.dispatchEvent(new MouseEvent("mouseenter"));
+    const tooltip = document.body.querySelector(".persona-control-tooltip");
     expect(tooltip?.textContent).toBe("Add a photo");
 
     controller.destroy();

--- a/packages/widget/src/ui.message-width.test.ts
+++ b/packages/widget/src/ui.message-width.test.ts
@@ -1,0 +1,407 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  createAgentExperience,
+  type AgentWidgetController,
+} from "./ui";
+import type {
+  AgentWidgetConfig,
+  AgentWidgetMessage,
+} from "./types";
+
+const CREATED_AT = "2026-07-24T00:00:00.000Z";
+
+const createMount = (): HTMLElement => {
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  return mount;
+};
+
+const createController = (
+  mount: HTMLElement,
+  config: Partial<AgentWidgetConfig> = {}
+): AgentWidgetController =>
+  createAgentExperience(mount, {
+    apiUrl: "https://api.example.com/chat",
+    launcher: { enabled: false },
+    ...config,
+  });
+
+const injectMessage = (
+  controller: AgentWidgetController,
+  message: Partial<AgentWidgetMessage> &
+    Pick<AgentWidgetMessage, "id" | "role">
+): void => {
+  controller.injectTestMessage({
+    type: "message",
+    message: {
+      content: "",
+      createdAt: CREATED_AT,
+      streaming: false,
+      ...message,
+    },
+  });
+};
+
+const getRow = (mount: HTMLElement, id: string): HTMLElement => {
+  const row = mount.querySelector<HTMLElement>(`#wrapper-${id}`);
+  expect(row).not.toBeNull();
+  return row!;
+};
+
+const expectRowLayout = (
+  row: HTMLElement,
+  expected: {
+    role: "user" | "assistant" | "system";
+    width: "content" | "full";
+    maxWidth: string;
+  }
+): void => {
+  expect(row.classList.contains("persona-message-row")).toBe(true);
+  expect(row.classList.contains(`persona-message-row-${expected.role}`)).toBe(
+    true
+  );
+  expect(row.classList.contains(`persona-message-width-${expected.width}`)).toBe(
+    true
+  );
+  expect(row.getAttribute("data-message-role")).toBe(expected.role);
+  expect(row.getAttribute("data-message-width")).toBe(expected.width);
+  expect(
+    row.style.getPropertyValue("--persona-message-row-max-width")
+  ).toBe(expected.maxWidth);
+};
+
+describe("createAgentExperience: role-specific message width", () => {
+  beforeEach(() => {
+    vi.stubGlobal("requestAnimationFrame", (callback: (time: number) => void) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    if (typeof localStorage !== "undefined") localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("preserves content-sized 85% rows by default", () => {
+    const mount = createMount();
+    const controller = createController(mount);
+
+    injectMessage(controller, {
+      id: "user-default",
+      role: "user",
+      content: "Hello",
+    });
+    injectMessage(controller, {
+      id: "assistant-default",
+      role: "assistant",
+      content: "Hi there",
+    });
+
+    expectRowLayout(getRow(mount, "user-default"), {
+      role: "user",
+      width: "content",
+      maxWidth: "85%",
+    });
+    expect(getRow(mount, "user-default").classList.contains("persona-justify-end")).toBe(
+      true
+    );
+    expectRowLayout(getRow(mount, "assistant-default"), {
+      role: "assistant",
+      width: "content",
+      maxWidth: "85%",
+    });
+
+    controller.destroy();
+  });
+
+  it("configures user and assistant geometry independently", () => {
+    const mount = createMount();
+    const controller = createController(mount, {
+      layout: {
+        messages: {
+          user: { width: "content", maxWidth: "70%" },
+          assistant: { width: "full" },
+        },
+      },
+    });
+
+    injectMessage(controller, {
+      id: "user-narrow",
+      role: "user",
+      content: "Question",
+    });
+    injectMessage(controller, {
+      id: "assistant-full",
+      role: "assistant",
+      content: "A longer response",
+    });
+
+    expectRowLayout(getRow(mount, "user-narrow"), {
+      role: "user",
+      width: "content",
+      maxWidth: "70%",
+    });
+    expectRowLayout(getRow(mount, "assistant-full"), {
+      role: "assistant",
+      width: "full",
+      maxWidth: "100%",
+    });
+
+    controller.destroy();
+  });
+
+  it("sizes the avatar and bubble together as one full-width content track", () => {
+    const mount = createMount();
+    const controller = createController(mount, {
+      layout: {
+        messages: {
+          assistant: { width: "full", maxWidth: "72ch" },
+          avatar: {
+            show: true,
+            position: "left",
+            assistantAvatar: "A",
+          },
+        },
+      },
+    });
+
+    injectMessage(controller, {
+      id: "assistant-avatar",
+      role: "assistant",
+      content: "Avatar-backed response",
+    });
+
+    const row = getRow(mount, "assistant-avatar");
+    expectRowLayout(row, {
+      role: "assistant",
+      width: "full",
+      maxWidth: "72ch",
+    });
+    const track = row.querySelector<HTMLElement>(
+      ":scope > .persona-message-with-avatar"
+    );
+    expect(track).not.toBeNull();
+    expect(
+      track?.querySelector(":scope > .persona-message-bubble")
+    ).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  it("applies assistant geometry to tools, reasoning, approvals, and idle UI", () => {
+    const mount = createMount();
+    const controller = createController(mount, {
+      layout: {
+        messages: {
+          assistant: { width: "full", maxWidth: "64rem" },
+        },
+      },
+      loadingIndicator: {
+        renderIdle: () => {
+          const idle = document.createElement("span");
+          idle.textContent = "Ready";
+          return idle;
+        },
+      },
+    });
+
+    injectMessage(controller, {
+      id: "tool-width",
+      role: "assistant",
+      variant: "tool",
+      toolCall: {
+        id: "tool-width",
+        name: "Read file",
+        status: "complete",
+        chunks: ["Done"],
+      },
+    });
+    injectMessage(controller, {
+      id: "reasoning-width",
+      role: "assistant",
+      variant: "reasoning",
+      reasoning: {
+        id: "reasoning-width",
+        status: "complete",
+        chunks: ["Considered the options"],
+      },
+    });
+    injectMessage(controller, {
+      id: "approval-width",
+      role: "assistant",
+      variant: "approval",
+      approval: {
+        id: "approval-1",
+        status: "pending",
+        agentId: "agent-1",
+        executionId: "execution-1",
+        toolName: "Write file",
+        description: "Write the generated file",
+        parameters: { path: "output.md" },
+      },
+    });
+
+    for (const id of ["tool-width", "reasoning-width", "approval-width"]) {
+      expectRowLayout(getRow(mount, id), {
+        role: "assistant",
+        width: "full",
+        maxWidth: "64rem",
+      });
+    }
+    expectRowLayout(getRow(mount, "idle-indicator"), {
+      role: "assistant",
+      width: "full",
+      maxWidth: "64rem",
+    });
+
+    controller.destroy();
+  });
+
+  it("wraps custom renderers in the resolved role row", () => {
+    const mount = createMount();
+    const controller = createController(mount, {
+      layout: {
+        messages: {
+          user: { width: "full" },
+          assistant: { width: "content", maxWidth: "42rem" },
+          renderUserMessage: ({ message }) => {
+            const element = document.createElement("article");
+            element.setAttribute("data-custom-user", "");
+            element.textContent = message.content;
+            return element;
+          },
+          renderAssistantMessage: ({ message }) => {
+            const element = document.createElement("article");
+            element.setAttribute("data-custom-assistant", "");
+            element.textContent = message.content;
+            return element;
+          },
+        },
+      },
+    });
+
+    injectMessage(controller, {
+      id: "custom-user",
+      role: "user",
+      content: "Custom question",
+    });
+    injectMessage(controller, {
+      id: "custom-assistant",
+      role: "assistant",
+      content: "Custom answer",
+    });
+
+    const userRow = getRow(mount, "custom-user");
+    expectRowLayout(userRow, {
+      role: "user",
+      width: "full",
+      maxWidth: "100%",
+    });
+    expect(userRow.querySelector(":scope > [data-custom-user]")).not.toBeNull();
+
+    const assistantRow = getRow(mount, "custom-assistant");
+    expectRowLayout(assistantRow, {
+      role: "assistant",
+      width: "content",
+      maxWidth: "42rem",
+    });
+    expect(
+      assistantRow.querySelector(":scope > [data-custom-assistant]")
+    ).not.toBeNull();
+
+    controller.destroy();
+  });
+
+  it("re-renders live rows when role width changes through update()", () => {
+    const mount = createMount();
+    const controller = createController(mount);
+
+    injectMessage(controller, {
+      id: "update-width",
+      role: "assistant",
+      content: "Update my row",
+    });
+    expectRowLayout(getRow(mount, "update-width"), {
+      role: "assistant",
+      width: "content",
+      maxWidth: "85%",
+    });
+
+    controller.update({
+      layout: {
+        messages: {
+          assistant: {
+            width: "full",
+            maxWidth: "68ch",
+          },
+        },
+      },
+    });
+
+    expectRowLayout(getRow(mount, "update-width"), {
+      role: "assistant",
+      width: "full",
+      maxWidth: "68ch",
+    });
+
+    controller.destroy();
+  });
+
+  it("lets a grouped tool row own the cap without applying it twice", () => {
+    const mount = createMount();
+    const controller = createController(mount, {
+      layout: {
+        messages: {
+          assistant: { width: "content", maxWidth: "80%" },
+        },
+      },
+      features: {
+        toolCallDisplay: {
+          grouped: true,
+        },
+      },
+    });
+
+    for (const id of ["group-tool-1", "group-tool-2"]) {
+      injectMessage(controller, {
+        id,
+        role: "assistant",
+        variant: "tool",
+        toolCall: {
+          id,
+          name: "Read file",
+          status: "complete",
+          chunks: ["Done"],
+        },
+      });
+    }
+
+    const groupRow = mount.querySelector<HTMLElement>(
+      "[data-persona-tool-group-row]"
+    );
+    expect(groupRow).not.toBeNull();
+    expectRowLayout(groupRow!, {
+      role: "assistant",
+      width: "content",
+      maxWidth: "80%",
+    });
+    const innerRows = groupRow!.querySelectorAll<HTMLElement>(
+      ".persona-message-row"
+    );
+    expect(innerRows.length).toBe(2);
+    innerRows.forEach((innerRow) => {
+      expect(
+        innerRow.style.getPropertyValue("--persona-message-row-max-width")
+      ).toBe("100%");
+    });
+
+    controller.destroy();
+  });
+});

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1,6 +1,7 @@
 import { escapeHtml, createMarkdownProcessorFromConfig } from "./postprocessors";
 import { resolveSanitizer } from "./utils/sanitize";
 import { stabilizeStreamingTables } from "./utils/streaming-table";
+import { wrapScrollableTables, refreshTableScrollFades } from "./utils/table-scroll-fade";
 import { onMarkdownParsersReady, getMarkdownParsersSync } from "./markdown-parsers-loader";
 import { AgentWidgetSession, AgentWidgetSessionStatus } from "./session";
 import {
@@ -4171,6 +4172,46 @@ export const createAgentExperience = (
 
 
   // Message rendering with plugin support (implementation)
+  const applyMessageRowLayout = (
+    wrapper: HTMLElement,
+    role: AgentWidgetMessage["role"]
+  ): void => {
+    const sizingRole = role === "user" ? "user" : "assistant";
+    const roleLayout = config.layout?.messages?.[sizingRole];
+    const width = roleLayout?.width ?? "content";
+    const maxWidth =
+      roleLayout?.maxWidth ?? (width === "full" ? "100%" : "85%");
+
+    wrapper.classList.add("persona-message-row");
+    wrapper.classList.remove(
+      "persona-message-row-user",
+      "persona-message-row-assistant",
+      "persona-message-row-system",
+      "persona-message-width-content",
+      "persona-message-width-full"
+    );
+    wrapper.classList.add(
+      `persona-message-row-${role}`,
+      `persona-message-width-${width}`
+    );
+    wrapper.classList.toggle("persona-justify-end", role === "user");
+    wrapper.setAttribute("data-message-role", role);
+    wrapper.setAttribute("data-message-width", width);
+    wrapper.style.setProperty("--persona-message-row-max-width", maxWidth);
+  };
+
+  const createMessageRow = (
+    id: string,
+    role: AgentWidgetMessage["role"]
+  ): HTMLElement => {
+    const wrapper = document.createElement("div");
+    wrapper.className = "persona-flex";
+    wrapper.id = `wrapper-${id}`;
+    wrapper.setAttribute("data-wrapper-id", id);
+    applyMessageRowLayout(wrapper, role);
+    return wrapper;
+  };
+
   const renderMessagesWithPluginsImpl = (
     container: HTMLElement,
     messages: AgentWidgetMessage[],
@@ -4212,6 +4253,7 @@ export const createAgentExperience = (
 
     // Track active message IDs for cache pruning
     const activeMessageIds = new Set<string>();
+    const messageRolesById = new Map<string, AgentWidgetMessage["role"]>();
     // Track ask_user_question tool-call ids whose bubbles were rendered this
     // pass: used to prune stale sheets from the composer overlay afterward.
     const liveAskToolIds = new Set<string>();
@@ -4265,6 +4307,7 @@ export const createAgentExperience = (
 
     messages.forEach((message) => {
       activeMessageIds.add(message.id);
+      messageRolesById.set(message.id, message.role);
 
       const askWithPlugin = hasAskPlugin && isAskUserQuestionMessage(message);
       const approvalWithPlugin =
@@ -4444,10 +4487,7 @@ export const createAgentExperience = (
 
           // Append a stub wrapper for the morph pass; hydrate the real bubble
           // into it post-morph so its event listeners survive.
-          const stub = document.createElement("div");
-          stub.className = "persona-flex";
-          stub.id = `wrapper-${message.id}`;
-          stub.setAttribute("data-wrapper-id", message.id);
+          const stub = createMessageRow(message.id, message.role);
           stub.setAttribute("data-ask-plugin-stub", "true");
           stub.setAttribute("data-preserve-runtime", "true");
           tempContainer.appendChild(stub);
@@ -4522,10 +4562,7 @@ export const createAgentExperience = (
         } else {
           // A fresh live bubble to hydrate (needsRebuild), or fingerprint
           // unchanged so we reuse the preserved live wrapper (`bubble: null`).
-          const stub = document.createElement("div");
-          stub.className = "persona-flex";
-          stub.id = `wrapper-${message.id}`;
-          stub.setAttribute("data-wrapper-id", message.id);
+          const stub = createMessageRow(message.id, message.role);
           stub.setAttribute("data-approval-plugin-stub", "true");
           stub.setAttribute("data-preserve-runtime", "true");
           tempContainer.appendChild(stub);
@@ -4642,7 +4679,6 @@ export const createAgentExperience = (
                 const componentWrapper = document.createElement("div");
                 componentWrapper.className = [
                   "persona-message-bubble",
-                  "persona-max-w-[85%]",
                   "persona-rounded-2xl",
                   "persona-bg-persona-surface",
                   "persona-border",
@@ -4698,15 +4734,9 @@ export const createAgentExperience = (
           // Otherwise fall through to the standard render path so the message
           // text is at least visible.
           if (liveBubble || lastFp != null) {
-            const stub = document.createElement("div");
-            stub.className = "persona-flex";
-            stub.id = `wrapper-${message.id}`;
-            stub.setAttribute("data-wrapper-id", message.id);
+            const stub = createMessageRow(message.id, message.role);
             stub.setAttribute("data-component-directive-stub", "true");
             stub.setAttribute("data-preserve-runtime", "true");
-            if (!wrapChrome) {
-              stub.classList.add("persona-w-full");
-            }
             tempContainer.appendChild(stub);
             componentDirectiveHydrate.push({
               messageId: message.id,
@@ -4763,17 +4793,7 @@ export const createAgentExperience = (
         }
       }
 
-      const wrapper = document.createElement("div");
-      wrapper.className = "persona-flex";
-      // Set id for idiomorph matching
-      wrapper.id = `wrapper-${message.id}`;
-      wrapper.setAttribute("data-wrapper-id", message.id);
-      if (message.role === "user") {
-        wrapper.classList.add("persona-justify-end");
-      }
-      if (bubble?.getAttribute("data-persona-component-directive") === "true") {
-        wrapper.classList.add("persona-w-full");
-      }
+      const wrapper = createMessageRow(message.id, message.role);
       wrapper.appendChild(bubble);
       setCachedWrapper(messageCache, message.id, fingerprint, wrapper);
       tempContainer.appendChild(wrapper);
@@ -4832,10 +4852,11 @@ export const createAgentExperience = (
           return;
         }
 
-        const groupWrapper = document.createElement("div");
-        groupWrapper.className = "persona-flex";
-        groupWrapper.id = `wrapper-tool-group-${groupIndex}-${group[0].id}`;
-        groupWrapper.setAttribute("data-wrapper-id", `tool-group-${groupIndex}-${group[0].id}`);
+        const groupWrapper = createMessageRow(
+          `tool-group-${groupIndex}-${group[0].id}`,
+          "assistant"
+        );
+        groupWrapper.setAttribute("data-persona-tool-group-row", "true");
 
         const groupContainer = document.createElement("div");
         groupContainer.className =
@@ -4875,6 +4896,10 @@ export const createAgentExperience = (
             wrapper.remove();
             return;
           }
+          // The outer group row owns role sizing. Inner message rows fill that
+          // resolved track instead of applying the role max-width a second
+          // time (which would turn an 85% cap into 72.25%).
+          wrapper.style.setProperty("--persona-message-row-max-width", "100%");
           const item = document.createElement("div");
           item.className = "persona-tool-group-item persona-relative";
           item.setAttribute("data-persona-tool-group-item", "true");
@@ -4938,7 +4963,6 @@ export const createAgentExperience = (
         const showBubble = config.loadingIndicator?.showBubble !== false; // default true
         typingBubble.className = showBubble
           ? [
-              "persona-max-w-[85%]",
               "persona-rounded-2xl",
               "persona-text-sm",
               "persona-leading-relaxed",
@@ -4950,7 +4974,6 @@ export const createAgentExperience = (
               "persona-py-3"
             ].join(" ")
           : [
-              "persona-max-w-[85%]",
               "persona-text-sm",
               "persona-leading-relaxed",
               "persona-text-persona-primary"
@@ -4960,11 +4983,10 @@ export const createAgentExperience = (
 
         typingBubble.appendChild(typingIndicator);
 
-        const typingWrapper = document.createElement("div");
-        typingWrapper.className = "persona-flex";
-        // Set id for idiomorph matching
-        typingWrapper.id = "wrapper-typing-indicator";
-        typingWrapper.setAttribute("data-wrapper-id", "typing-indicator");
+        const typingWrapper = createMessageRow(
+          "typing-indicator",
+          "assistant"
+        );
         typingWrapper.appendChild(typingBubble);
         tempContainer.appendChild(typingWrapper);
       }
@@ -5002,7 +5024,6 @@ export const createAgentExperience = (
         const showBubble = config.loadingIndicator?.showBubble !== false; // default true
         idleBubble.className = showBubble
           ? [
-              "persona-max-w-[85%]",
               "persona-rounded-2xl",
               "persona-text-sm",
               "persona-leading-relaxed",
@@ -5015,7 +5036,6 @@ export const createAgentExperience = (
               "persona-py-3"
             ].join(" ")
           : [
-              "persona-max-w-[85%]",
               "persona-text-sm",
               "persona-leading-relaxed",
               "persona-text-persona-primary"
@@ -5024,18 +5044,22 @@ export const createAgentExperience = (
 
         idleBubble.appendChild(idleIndicator);
 
-        const idleWrapper = document.createElement("div");
-        idleWrapper.className = "persona-flex";
-        // Set id for idiomorph matching
-        idleWrapper.id = "wrapper-idle-indicator";
-        idleWrapper.setAttribute("data-wrapper-id", "idle-indicator");
+        const idleWrapper = createMessageRow("idle-indicator", "assistant");
         idleWrapper.appendChild(idleBubble);
         tempContainer.appendChild(idleWrapper);
       }
     }
 
+    // Wrap wide tables in a horizontal-scroll container before morphing so the
+    // wrapper exists on both sides of the diff (survives streaming re-renders).
+    wrapScrollableTables(tempContainer);
+
     // Use idiomorph to morph the container contents
     morphMessages(container, tempContainer);
+
+    // Set initial edge-fade state on the live table wrappers and attach the
+    // delegated scroll listener (once) that keeps the fades in sync.
+    refreshTableScrollFades(container);
 
     // Hydrate plugin-rendered ask-question bubbles into their stub wrappers.
     // Idiomorph imports new nodes via `document.importNode`, which strips
@@ -5043,8 +5067,12 @@ export const createAgentExperience = (
     // the real, listener-bearing bubble directly into the live DOM.
     if (askPluginHydrate.length > 0) {
       for (const { messageId, fingerprint, bubble } of askPluginHydrate) {
-        const wrapper = container.querySelector(`#wrapper-${messageId}`);
+        const wrapper = container.querySelector<HTMLElement>(`#wrapper-${messageId}`);
         if (!wrapper) continue;
+        applyMessageRowLayout(
+          wrapper,
+          messageRolesById.get(messageId) ?? "assistant"
+        );
         if (bubble === null) {
           // No fresh bubble built this pass: either the plugin opted out
           // and a previously-mounted bubble already lives here (preserved by
@@ -5070,8 +5098,12 @@ export const createAgentExperience = (
     // the ask-question hydration above.
     if (componentDirectiveHydrate.length > 0) {
       for (const { messageId, fingerprint, bubble } of componentDirectiveHydrate) {
-        const wrapper = container.querySelector(`#wrapper-${messageId}`);
+        const wrapper = container.querySelector<HTMLElement>(`#wrapper-${messageId}`);
         if (!wrapper) continue;
+        applyMessageRowLayout(
+          wrapper,
+          messageRolesById.get(messageId) ?? "assistant"
+        );
         if (bubble === null) {
           // Fingerprint matched the previous pass: the live wrapper (kept
           // alive by `data-preserve-runtime`) still holds the listener-bearing
@@ -5094,8 +5126,12 @@ export const createAgentExperience = (
     // mirroring the ask-question / component-directive hydration above.
     if (approvalPluginHydrate.length > 0) {
       for (const { messageId, fingerprint, bubble } of approvalPluginHydrate) {
-        const wrapper = container.querySelector(`#wrapper-${messageId}`);
+        const wrapper = container.querySelector<HTMLElement>(`#wrapper-${messageId}`);
         if (!wrapper) continue;
+        applyMessageRowLayout(
+          wrapper,
+          messageRolesById.get(messageId) ?? "assistant"
+        );
         if (bubble === null) {
           // Fingerprint matched the previous pass (or the plugin opted out
           // after a prior render): the live wrapper, kept alive by

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -46,7 +46,8 @@ import { createTextPart, ALL_SUPPORTED_MIME_TYPES } from "./utils/content";
 import { applyThemeVariables, createThemeObserver, getActiveTheme } from "./utils/theme";
 import { resolveTokenValue } from "./utils/tokens";
 import { renderLucideIcon } from "./utils/icons";
-import { createElement, createElementInDocument } from "./utils/dom";
+import { createElement } from "./utils/dom";
+import { attachTooltip } from "./utils/tooltip";
 import { downloadInfoFor } from "./utils/artifact-file";
 import { artifactCopyText } from "./components/artifact-preview";
 import { morphMessages } from "./utils/morph";
@@ -67,7 +68,7 @@ import {
   resolveFollowStateFromScroll,
   resolveFollowStateFromWheel
 } from "./utils/auto-follow";
-import { statusCopy, DEFAULT_OVERLAY_Z_INDEX, PORTALED_OVERLAY_Z_INDEX } from "./utils/constants";
+import { statusCopy, DEFAULT_OVERLAY_Z_INDEX } from "./utils/constants";
 import {
   applyStreamBuffer,
   createSkeletonPlaceholder,
@@ -6825,7 +6826,8 @@ export const createAgentExperience = (
     ) as HTMLButtonElement;
     
     micButton.type = "button";
-    micButton.setAttribute("aria-label", "Start voice recognition");
+    const tooltipText = voiceConfig?.tooltipText ?? "Start voice recognition";
+    micButton.setAttribute("aria-label", tooltipText);
     
     const micIconName = voiceConfig?.iconName ?? "mic";
     const buttonSize = sendButtonConfig?.size ?? "40px";
@@ -6886,15 +6888,13 @@ export const createAgentExperience = (
     }
     
     micButtonWrapper.appendChild(micButton);
-    
-    // Add tooltip if enabled
-    const tooltipText = voiceConfig?.tooltipText ?? "Start voice recognition";
     const showTooltip = voiceConfig?.showTooltip ?? false;
-    if (showTooltip && tooltipText) {
-      const tooltip = createElement("div", "persona-send-button-tooltip");
-      tooltip.textContent = tooltipText;
-      micButtonWrapper.appendChild(tooltip);
-    }
+    attachTooltip({
+      anchor: micButton,
+      trigger: micButtonWrapper,
+      text: () => micButton.getAttribute("aria-label") ?? tooltipText,
+      enabled: showTooltip,
+    });
     
     return { micButton, micButtonWrapper };
   };
@@ -8234,76 +8234,13 @@ export const createAgentExperience = (
         closeButton.setAttribute("aria-label", closeButtonTooltipText);
 
         if (closeButtonWrapper) {
-          // Clean up old tooltip event listeners if they exist
-          if ((closeButtonWrapper as any)._cleanupTooltip) {
-            (closeButtonWrapper as any)._cleanupTooltip();
-            delete (closeButtonWrapper as any)._cleanupTooltip;
-          }
-
-          // Set up new portaled tooltip with event listeners
-          if (closeButtonShowTooltip && closeButtonTooltipText) {
-            let portaledTooltip: HTMLElement | null = null;
-
-            const showTooltip = () => {
-              if (portaledTooltip || !closeButton) return; // Already showing or button doesn't exist
-
-              const tooltipDocument = closeButton.ownerDocument;
-              const tooltipContainer = tooltipDocument.body;
-              if (!tooltipContainer) return;
-
-              // Create tooltip element
-              portaledTooltip = createElementInDocument(
-                tooltipDocument,
-                "div",
-                "persona-clear-chat-tooltip"
-              );
-              portaledTooltip.textContent = closeButtonTooltipText;
-
-              // Add arrow
-              const arrow = createElementInDocument(tooltipDocument, "div");
-              arrow.className = "persona-clear-chat-tooltip-arrow";
-              portaledTooltip.appendChild(arrow);
-
-              // Get button position
-              const buttonRect = closeButton.getBoundingClientRect();
-
-              // Position tooltip above button
-              portaledTooltip.style.position = "fixed";
-              portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
-              portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
-              portaledTooltip.style.top = `${buttonRect.top - 8}px`;
-              portaledTooltip.style.transform = "translate(-50%, -100%)";
-
-              // Append to body
-              tooltipContainer.appendChild(portaledTooltip);
-            };
-
-            const hideTooltip = () => {
-              if (portaledTooltip && portaledTooltip.parentNode) {
-                portaledTooltip.parentNode.removeChild(portaledTooltip);
-                portaledTooltip = null;
-              }
-            };
-
-            // Add event listeners
-            closeButtonWrapper.addEventListener("mouseenter", showTooltip);
-            closeButtonWrapper.addEventListener("mouseleave", hideTooltip);
-            closeButton.addEventListener("focus", showTooltip);
-            closeButton.addEventListener("blur", hideTooltip);
-
-            // Store cleanup function on the wrapper for later use
-            (closeButtonWrapper as any)._cleanupTooltip = () => {
-              hideTooltip();
-              if (closeButtonWrapper) {
-                closeButtonWrapper.removeEventListener("mouseenter", showTooltip);
-                closeButtonWrapper.removeEventListener("mouseleave", hideTooltip);
-              }
-              if (closeButton) {
-                closeButton.removeEventListener("focus", showTooltip);
-                closeButton.removeEventListener("blur", hideTooltip);
-              }
-            };
-          }
+          attachTooltip({
+            anchor: closeButton,
+            trigger: closeButtonWrapper,
+            text: () =>
+              closeButton?.getAttribute("aria-label") ?? closeButtonTooltipText,
+            enabled: closeButtonShowTooltip,
+          });
         }
       }
 
@@ -8469,76 +8406,14 @@ export const createAgentExperience = (
           clearChatButton.setAttribute("aria-label", clearChatTooltipText);
 
           if (clearChatButtonWrapper) {
-            // Clean up old tooltip event listeners if they exist
-            if ((clearChatButtonWrapper as any)._cleanupTooltip) {
-              (clearChatButtonWrapper as any)._cleanupTooltip();
-              delete (clearChatButtonWrapper as any)._cleanupTooltip;
-            }
-
-            // Set up new portaled tooltip with event listeners
-            if (clearChatShowTooltip && clearChatTooltipText) {
-              let portaledTooltip: HTMLElement | null = null;
-
-              const showTooltip = () => {
-                if (portaledTooltip || !clearChatButton) return; // Already showing or button doesn't exist
-
-                const tooltipDocument = clearChatButton.ownerDocument;
-                const tooltipContainer = tooltipDocument.body;
-                if (!tooltipContainer) return;
-
-                // Create tooltip element
-                portaledTooltip = createElementInDocument(
-                  tooltipDocument,
-                  "div",
-                  "persona-clear-chat-tooltip"
-                );
-                portaledTooltip.textContent = clearChatTooltipText;
-
-                // Add arrow
-                const arrow = createElementInDocument(tooltipDocument, "div");
-                arrow.className = "persona-clear-chat-tooltip-arrow";
-                portaledTooltip.appendChild(arrow);
-
-                // Get button position
-                const buttonRect = clearChatButton.getBoundingClientRect();
-
-                // Position tooltip above button
-                portaledTooltip.style.position = "fixed";
-                portaledTooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
-                portaledTooltip.style.left = `${buttonRect.left + buttonRect.width / 2}px`;
-                portaledTooltip.style.top = `${buttonRect.top - 8}px`;
-                portaledTooltip.style.transform = "translate(-50%, -100%)";
-
-                // Append to body
-                tooltipContainer.appendChild(portaledTooltip);
-              };
-
-              const hideTooltip = () => {
-                if (portaledTooltip && portaledTooltip.parentNode) {
-                  portaledTooltip.parentNode.removeChild(portaledTooltip);
-                  portaledTooltip = null;
-                }
-              };
-
-              // Add event listeners
-              clearChatButtonWrapper.addEventListener("mouseenter", showTooltip);
-              clearChatButtonWrapper.addEventListener("mouseleave", hideTooltip);
-              clearChatButton.addEventListener("focus", showTooltip);
-              clearChatButton.addEventListener("blur", hideTooltip);
-
-              // Store cleanup function on the button for later use
-              (clearChatButtonWrapper as any)._cleanupTooltip = () => {
-                hideTooltip();
-                if (clearChatButtonWrapper) {
-                  clearChatButtonWrapper.removeEventListener("mouseenter", showTooltip);
-                  clearChatButtonWrapper.removeEventListener("mouseleave", hideTooltip);
-                }
-                if (clearChatButton) {
-                  clearChatButton.removeEventListener("focus", showTooltip);
-                  clearChatButton.removeEventListener("blur", hideTooltip);
-                }
-              };
-            }
+            attachTooltip({
+              anchor: clearChatButton,
+              trigger: clearChatButtonWrapper,
+              text: () =>
+                clearChatButton?.getAttribute("aria-label") ??
+                clearChatTooltipText,
+              enabled: clearChatShowTooltip,
+            });
           }
         }
       }
@@ -8677,24 +8552,16 @@ export const createAgentExperience = (
             micButton.style.paddingBottom = "";
           }
           
-          // Update tooltip
-          const tooltip = micButtonWrapper?.querySelector(".persona-send-button-tooltip") as HTMLElement | null;
           const tooltipText = voiceConfig.tooltipText ?? "Start voice recognition";
           const showTooltip = voiceConfig.showTooltip ?? false;
-          if (showTooltip && tooltipText) {
-            if (!tooltip) {
-              // Create tooltip if it doesn't exist
-              const newTooltip = document.createElement("div");
-              newTooltip.className = "persona-send-button-tooltip";
-              newTooltip.textContent = tooltipText;
-              micButtonWrapper?.insertBefore(newTooltip, micButton);
-            } else {
-              tooltip.textContent = tooltipText;
-              tooltip.style.display = "";
-            }
-          } else if (tooltip) {
-            // Hide tooltip if disabled
-            tooltip.style.display = "none";
+          micButton.setAttribute("aria-label", tooltipText);
+          if (micButtonWrapper) {
+            attachTooltip({
+              anchor: micButton,
+              trigger: micButtonWrapper,
+              text: () => micButton?.getAttribute("aria-label") ?? tooltipText,
+              enabled: showTooltip,
+            });
           }
           
           // Show and update disabled state
@@ -8786,11 +8653,13 @@ export const createAgentExperience = (
 
           attachmentButtonWrapper.appendChild(attachmentButton);
 
-          // Add tooltip
           const attachTooltipText = attachmentsConfig.buttonTooltipText ?? "Attach file";
-          const tooltip = createElement("div", "persona-send-button-tooltip");
-          tooltip.textContent = attachTooltipText;
-          attachmentButtonWrapper.appendChild(tooltip);
+          attachTooltip({
+            anchor: attachmentButton,
+            trigger: attachmentButtonWrapper,
+            text: () =>
+              attachmentButton?.getAttribute("aria-label") ?? attachTooltipText,
+          });
 
           // Insert into left actions container (fall back to the form when a
           // custom composer has no left cluster).
@@ -8852,10 +8721,14 @@ export const createAgentExperience = (
           );
           if (iconSvg) attachmentButton.appendChild(iconSvg);
           else attachmentButton.textContent = "📎";
-          const attachTooltip = attachmentButtonWrapper?.querySelector(
-            ".persona-send-button-tooltip"
-          );
-          if (attachTooltip) attachTooltip.textContent = tooltipText;
+          if (attachmentButtonWrapper) {
+            attachTooltip({
+              anchor: attachmentButton,
+              trigger: attachmentButtonWrapper,
+              text: () =>
+                attachmentButton?.getAttribute("aria-label") ?? tooltipText,
+            });
+          }
         }
       } else {
         // Hide attachment button if disabled
@@ -8984,21 +8857,16 @@ export const createAgentExperience = (
         sendButton.style.paddingBottom = "";
       }
 
-      // Update tooltip
-      const tooltip = sendButtonWrapper?.querySelector(".persona-send-button-tooltip") as HTMLElement | null;
-      if (showTooltip && tooltipText) {
-        if (!tooltip) {
-          // Create tooltip if it doesn't exist
-          const newTooltip = document.createElement("div");
-          newTooltip.className = "persona-send-button-tooltip";
-          newTooltip.textContent = tooltipText;
-          sendButtonWrapper?.insertBefore(newTooltip, sendButton);
-        } else {
-          tooltip.textContent = tooltipText;
-          tooltip.style.display = "";
-        }
-      } else if (tooltip) {
-        tooltip.style.display = "none";
+      if (!session.isStreaming()) {
+        sendButton.setAttribute("aria-label", tooltipText);
+      }
+      if (sendButtonWrapper) {
+        attachTooltip({
+          anchor: sendButton,
+          trigger: sendButtonWrapper,
+          text: () => sendButton.getAttribute("aria-label") ?? tooltipText,
+          enabled: showTooltip,
+        });
       }
       
       // Update contentMaxWidth on messages wrapper and composer. Same

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -7409,6 +7409,9 @@ export const createAgentExperience = (
   if (typeof ResizeObserver !== "undefined") {
     const contentResizeObserver = new ResizeObserver(() => {
       handleContentResize();
+      // A resize can start or stop a table overflowing without a render or a
+      // scroll, which are the only other things that recompute the fades.
+      refreshTableScrollFades(messagesWrapper);
     });
     contentResizeObserver.observe(messagesWrapper);
     contentResizeObserver.observe(body);

--- a/packages/widget/src/utils/table-scroll-fade.test.ts
+++ b/packages/widget/src/utils/table-scroll-fade.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { wrapScrollableTables, refreshTableScrollFades } from "./table-scroll-fade";
+
+// jsdom has no layout, so scroll metrics are stubbed per element.
+function stubMetrics(
+  el: HTMLElement,
+  { scrollWidth, clientWidth, scrollLeft = 0 }: { scrollWidth: number; clientWidth: number; scrollLeft?: number }
+): void {
+  Object.defineProperty(el, "scrollWidth", { value: scrollWidth, configurable: true });
+  Object.defineProperty(el, "clientWidth", { value: clientWidth, configurable: true });
+  let sl = scrollLeft;
+  Object.defineProperty(el, "scrollLeft", {
+    get: () => sl,
+    set: (v: number) => {
+      sl = v;
+    },
+    configurable: true,
+  });
+}
+
+function makeContainerWithTable(): { container: HTMLElement; table: HTMLElement } {
+  const container = document.createElement("div");
+  const bubble = document.createElement("div");
+  bubble.className = "persona-message-content";
+  const table = document.createElement("table");
+  table.innerHTML = "<tbody><tr><td>a</td></tr></tbody>";
+  bubble.appendChild(table);
+  container.appendChild(bubble);
+  return { container, table };
+}
+
+describe("wrapScrollableTables", () => {
+  it("wraps a bare table in a .persona-table-scroll container", () => {
+    const { container, table } = makeContainerWithTable();
+    wrapScrollableTables(container);
+    const wrapper = table.parentElement!;
+    expect(wrapper.className).toBe("persona-table-scroll");
+    expect(wrapper.firstElementChild).toBe(table);
+  });
+
+  it("is idempotent: an already-wrapped table is not double-wrapped", () => {
+    const { container, table } = makeContainerWithTable();
+    wrapScrollableTables(container);
+    wrapScrollableTables(container);
+    expect(container.querySelectorAll(".persona-table-scroll").length).toBe(1);
+    expect(table.parentElement!.parentElement!.className).toBe("persona-message-content");
+  });
+});
+
+describe("refreshTableScrollFades", () => {
+  let container: HTMLElement;
+  let wrapper: HTMLElement;
+
+  beforeEach(() => {
+    const built = makeContainerWithTable();
+    container = built.container;
+    wrapScrollableTables(container);
+    wrapper = built.table.parentElement!;
+  });
+
+  it("marks an overflowing table scrollable and fades only the right edge at start", () => {
+    stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 0 });
+    refreshTableScrollFades(container);
+    expect(wrapper.hasAttribute("data-persona-scroll-x")).toBe(true);
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("0px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("24px");
+  });
+
+  it("fades only the left edge when scrolled to the end", () => {
+    stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 300 });
+    refreshTableScrollFades(container);
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("0px");
+  });
+
+  it("fades both edges mid-scroll", () => {
+    stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 120 });
+    refreshTableScrollFades(container);
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("24px");
+  });
+
+  it("leaves a table that fits unmarked (no fade)", () => {
+    stubMetrics(wrapper, { scrollWidth: 300, clientWidth: 300, scrollLeft: 0 });
+    refreshTableScrollFades(container);
+    expect(wrapper.hasAttribute("data-persona-scroll-x")).toBe(false);
+  });
+
+  it("updates fades when the table is scrolled (delegated capture listener)", () => {
+    stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 0 });
+    refreshTableScrollFades(container);
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("24px");
+    // Simulate a real scroll to the end: move position, fire the event the
+    // container's capture-phase listener is waiting for.
+    wrapper.scrollLeft = 300;
+    wrapper.dispatchEvent(new Event("scroll"));
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("0px");
+  });
+});

--- a/packages/widget/src/utils/table-scroll-fade.test.ts
+++ b/packages/widget/src/utils/table-scroll-fade.test.ts
@@ -3,6 +3,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { wrapScrollableTables, refreshTableScrollFades } from "./table-scroll-fade";
 
+// Off-edge fade value: a themeable token reference, not a resolved px length.
+const FADE_ON = "var(--persona-md-table-scroll-fade, 24px)";
+
 // jsdom has no layout, so scroll metrics are stubbed per element.
 function stubMetrics(
   el: HTMLElement,
@@ -65,21 +68,21 @@ describe("refreshTableScrollFades", () => {
     refreshTableScrollFades(container);
     expect(wrapper.hasAttribute("data-persona-scroll-x")).toBe(true);
     expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("0px");
-    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe(FADE_ON);
   });
 
   it("fades only the left edge when scrolled to the end", () => {
     stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 300 });
     refreshTableScrollFades(container);
-    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe(FADE_ON);
     expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("0px");
   });
 
   it("fades both edges mid-scroll", () => {
     stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 120 });
     refreshTableScrollFades(container);
-    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("24px");
-    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe(FADE_ON);
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe(FADE_ON);
   });
 
   it("leaves a table that fits unmarked (no fade)", () => {
@@ -91,12 +94,12 @@ describe("refreshTableScrollFades", () => {
   it("updates fades when the table is scrolled (delegated capture listener)", () => {
     stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 0 });
     refreshTableScrollFades(container);
-    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe(FADE_ON);
     // Simulate a real scroll to the end: move position, fire the event the
     // container's capture-phase listener is waiting for.
     wrapper.scrollLeft = 300;
     wrapper.dispatchEvent(new Event("scroll"));
-    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("24px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe(FADE_ON);
     expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("0px");
   });
 });

--- a/packages/widget/src/utils/table-scroll-fade.test.ts
+++ b/packages/widget/src/utils/table-scroll-fade.test.ts
@@ -85,6 +85,24 @@ describe("refreshTableScrollFades", () => {
     expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe(FADE_ON);
   });
 
+  // RTL scrolls on the negative model: scrollLeft runs [-overflow, 0], starting
+  // at 0 with the hidden content to the physical left (mirror of LTR).
+  it("fades the left edge at an RTL table's start position", () => {
+    wrapper.style.direction = "rtl";
+    stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: 0 });
+    refreshTableScrollFades(container);
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe(FADE_ON);
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe("0px");
+  });
+
+  it("fades the right edge when an RTL table is scrolled to its end", () => {
+    wrapper.style.direction = "rtl";
+    stubMetrics(wrapper, { scrollWidth: 600, clientWidth: 300, scrollLeft: -300 });
+    refreshTableScrollFades(container);
+    expect(wrapper.style.getPropertyValue("--persona-fade-l")).toBe("0px");
+    expect(wrapper.style.getPropertyValue("--persona-fade-r")).toBe(FADE_ON);
+  });
+
   it("leaves a table that fits unmarked (no fade)", () => {
     stubMetrics(wrapper, { scrollWidth: 300, clientWidth: 300, scrollLeft: 0 });
     refreshTableScrollFades(container);

--- a/packages/widget/src/utils/table-scroll-fade.ts
+++ b/packages/widget/src/utils/table-scroll-fade.ts
@@ -1,0 +1,70 @@
+// Wide markdown tables must scroll inside their own container, never widen the
+// chat column. Tables render from an HTML string with no wrapper, so we wrap
+// them in the freshly-built morph container before idiomorph runs: the wrapper
+// then exists on both sides of every subsequent diff, so it (and its scroll
+// position) survives streaming re-renders.
+
+const FADE_PX = 24;
+
+// Containers that already carry the delegated scroll listener.
+const LISTENING = new WeakSet<HTMLElement>();
+
+/**
+ * Wrap every unwrapped `<table>` under `root` in a `.persona-table-scroll`
+ * horizontal-scroll container. Idempotent: tables already wrapped are skipped.
+ */
+export function wrapScrollableTables(root: HTMLElement): void {
+  const tables = root.querySelectorAll("table");
+  tables.forEach((table) => {
+    const parent = table.parentElement;
+    if (parent?.classList.contains("persona-table-scroll")) return;
+    const wrapper = document.createElement("div");
+    wrapper.className = "persona-table-scroll";
+    table.replaceWith(wrapper);
+    wrapper.appendChild(table);
+  });
+}
+
+// Toggle the edge-fade mask for one scroll container based on its position.
+function updateFade(el: HTMLElement): void {
+  const overflow = el.scrollWidth - el.clientWidth;
+  if (overflow <= 1) {
+    el.removeAttribute("data-persona-scroll-x");
+    return;
+  }
+  el.setAttribute("data-persona-scroll-x", "");
+  // scrollLeft can be negative in RTL; magnitude is what matters for the edges.
+  const left = Math.abs(el.scrollLeft);
+  el.style.setProperty("--persona-fade-l", left <= 1 ? "0px" : `${FADE_PX}px`);
+  el.style.setProperty(
+    "--persona-fade-r",
+    left >= overflow - 1 ? "0px" : `${FADE_PX}px`
+  );
+}
+
+/**
+ * Refresh edge-fade state for every table scroll container under `container`,
+ * and (once per container) attach the delegated scroll listener that keeps the
+ * fades in sync as the user scrolls. Call after each transcript morph.
+ */
+export function refreshTableScrollFades(container: HTMLElement): void {
+  if (!LISTENING.has(container)) {
+    LISTENING.add(container);
+    // scroll does not bubble, but it does fire in the capture phase, so one
+    // ancestor listener catches every table without per-table wiring that
+    // idiomorph would strip.
+    container.addEventListener(
+      "scroll",
+      (event) => {
+        const target = event.target as HTMLElement | null;
+        if (target?.classList?.contains("persona-table-scroll")) {
+          updateFade(target);
+        }
+      },
+      true
+    );
+  }
+  container
+    .querySelectorAll<HTMLElement>(".persona-table-scroll")
+    .forEach(updateFade);
+}

--- a/packages/widget/src/utils/table-scroll-fade.ts
+++ b/packages/widget/src/utils/table-scroll-fade.ts
@@ -36,10 +36,15 @@ function updateFade(el: HTMLElement): void {
     return;
   }
   el.setAttribute("data-persona-scroll-x", "");
-  // scrollLeft can be negative in RTL; magnitude is what matters for the edges.
-  const left = Math.abs(el.scrollLeft);
-  el.style.setProperty("--persona-fade-l", left <= 1 ? "0px" : FADE);
-  el.style.setProperty("--persona-fade-r", left >= overflow - 1 ? "0px" : FADE);
+  // Each edge fades only when content is hidden past it, so the amounts must be
+  // physical (left/right), not directional. RTL scrolls on the negative model:
+  // scrollLeft runs [-overflow, 0] and starts at 0 with content hidden to the
+  // left, the mirror of LTR. Magnitude alone can't tell them apart at 0.
+  const rtl = getComputedStyle(el).direction === "rtl";
+  const hiddenLeft = rtl ? overflow + el.scrollLeft : el.scrollLeft;
+  const hiddenRight = overflow - hiddenLeft;
+  el.style.setProperty("--persona-fade-l", hiddenLeft <= 1 ? "0px" : FADE);
+  el.style.setProperty("--persona-fade-r", hiddenRight <= 1 ? "0px" : FADE);
 }
 
 /**

--- a/packages/widget/src/utils/table-scroll-fade.ts
+++ b/packages/widget/src/utils/table-scroll-fade.ts
@@ -4,7 +4,10 @@
 // then exists on both sides of every subsequent diff, so it (and its scroll
 // position) survives streaming re-renders.
 
-const FADE_PX = 24;
+// Off-edge fade width, themeable via --persona-md-table-scroll-fade (set it to
+// 0 to disable the fade). Written as a var() reference, not a resolved px value,
+// so a consumer's CSS token wins over this inline style.
+const FADE = "var(--persona-md-table-scroll-fade, 24px)";
 
 // Containers that already carry the delegated scroll listener.
 const LISTENING = new WeakSet<HTMLElement>();
@@ -35,11 +38,8 @@ function updateFade(el: HTMLElement): void {
   el.setAttribute("data-persona-scroll-x", "");
   // scrollLeft can be negative in RTL; magnitude is what matters for the edges.
   const left = Math.abs(el.scrollLeft);
-  el.style.setProperty("--persona-fade-l", left <= 1 ? "0px" : `${FADE_PX}px`);
-  el.style.setProperty(
-    "--persona-fade-r",
-    left >= overflow - 1 ? "0px" : `${FADE_PX}px`
-  );
+  el.style.setProperty("--persona-fade-l", left <= 1 ? "0px" : FADE);
+  el.style.setProperty("--persona-fade-r", left >= overflow - 1 ? "0px" : FADE);
 }
 
 /**

--- a/packages/widget/src/utils/tooltip.test.ts
+++ b/packages/widget/src/utils/tooltip.test.ts
@@ -25,6 +25,7 @@ describe("attachTooltip", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   it("portals outside a clipped wrapper and clamps a long tooltip to the viewport", () => {
@@ -107,6 +108,92 @@ describe("attachTooltip", () => {
 
     button.blur();
     expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
+  });
+
+  it("dismisses an open tooltip with Escape", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    attachTooltip({ anchor: button, text: "Close chat" });
+    button.focus();
+    expect(document.body.querySelector(".persona-control-tooltip")).not.toBeNull();
+
+    button.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+
+    expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
+  });
+
+  it("suppresses hover tooltips when the device has no hover capability", () => {
+    vi.stubGlobal(
+      "matchMedia",
+      vi.fn().mockReturnValue({ matches: true })
+    );
+    const button = document.createElement("button");
+    button.setAttribute("aria-label", "Add context");
+    document.body.appendChild(button);
+
+    attachTooltip({
+      anchor: button,
+      text: () => button.getAttribute("aria-label") ?? "",
+    });
+    button.dispatchEvent(new MouseEvent("mouseenter"));
+
+    expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
+    expect(button.getAttribute("aria-label")).toBe("Add context");
+  });
+
+  it("repositions an open tooltip after resize and scroll", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: 500,
+    });
+    Object.defineProperty(document.documentElement, "clientHeight", {
+      configurable: true,
+      value: 300,
+    });
+    let anchorLeft = 100;
+    vi.spyOn(button, "getBoundingClientRect").mockImplementation(() =>
+      rect(anchorLeft, 200, 40, 40)
+    );
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        return this.classList.contains("persona-control-tooltip")
+          ? rect(0, 0, 120, 32)
+          : rect(0, 0, 0, 0);
+      }
+    );
+
+    attachTooltip({ anchor: button, text: "Add context" });
+    button.focus();
+    const tooltip = document.body.querySelector<HTMLElement>(
+      ".persona-control-tooltip"
+    );
+    expect(tooltip?.style.left).toBe("60px");
+
+    anchorLeft = 200;
+    window.dispatchEvent(new Event("resize"));
+    expect(tooltip?.style.left).toBe("160px");
+
+    anchorLeft = 300;
+    window.dispatchEvent(new Event("scroll"));
+    expect(tooltip?.style.left).toBe("260px");
+  });
+
+  it("cleans up an open tooltip when its anchor is removed", async () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+
+    attachTooltip({ anchor: button, text: "Add context" });
+    button.focus();
+    expect(document.body.querySelector(".persona-control-tooltip")).not.toBeNull();
+
+    button.remove();
+
+    await vi.waitFor(() => {
+      expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
+    });
   });
 
   it("re-attaching replaces old listeners and disabled tooltips stay closed", () => {

--- a/packages/widget/src/utils/tooltip.test.ts
+++ b/packages/widget/src/utils/tooltip.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { attachTooltip } from "./tooltip";
+
+const rect = (
+  left: number,
+  top: number,
+  width: number,
+  height: number
+): DOMRect =>
+  ({
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    x: left,
+    y: top,
+    toJSON: () => ({}),
+  }) as DOMRect;
+
+describe("attachTooltip", () => {
+  afterEach(() => {
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("portals outside a clipped wrapper and clamps a long tooltip to the viewport", () => {
+    const wrapper = document.createElement("div");
+    wrapper.style.overflow = "hidden";
+    const button = document.createElement("button");
+    button.setAttribute("aria-label", "Add context — a slide, element or comment");
+    wrapper.appendChild(button);
+    document.body.appendChild(wrapper);
+
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: 320,
+    });
+    Object.defineProperty(document.documentElement, "clientHeight", {
+      configurable: true,
+      value: 500,
+    });
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue(
+      rect(4, 400, 40, 40)
+    );
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        return this.classList.contains("persona-control-tooltip")
+          ? rect(0, 0, 300, 32)
+          : rect(0, 0, 0, 0);
+      }
+    );
+
+    attachTooltip({
+      anchor: button,
+      trigger: wrapper,
+      text: () => button.getAttribute("aria-label") ?? "",
+    });
+    wrapper.dispatchEvent(new MouseEvent("mouseenter"));
+
+    const tooltip = document.body.querySelector<HTMLElement>(
+      ".persona-control-tooltip"
+    );
+    expect(tooltip).not.toBeNull();
+    expect(wrapper.contains(tooltip)).toBe(false);
+    expect(tooltip!.textContent).toContain("Add context");
+    expect(tooltip!.style.left).toBe("8px");
+    expect(tooltip!.style.getPropertyValue("--persona-tooltip-arrow-x")).toBe(
+      "16px"
+    );
+    expect(tooltip!.dataset.placement).toBe("top");
+  });
+
+  it("flips below the control when there is not enough room above", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    Object.defineProperty(document.documentElement, "clientWidth", {
+      configurable: true,
+      value: 500,
+    });
+    Object.defineProperty(document.documentElement, "clientHeight", {
+      configurable: true,
+      value: 300,
+    });
+    vi.spyOn(button, "getBoundingClientRect").mockReturnValue(
+      rect(200, 4, 40, 40)
+    );
+    vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(
+      function (this: HTMLElement) {
+        return this.classList.contains("persona-control-tooltip")
+          ? rect(0, 0, 120, 32)
+          : rect(0, 0, 0, 0);
+      }
+    );
+
+    attachTooltip({ anchor: button, text: "Close chat" });
+    button.focus();
+
+    const tooltip = document.body.querySelector<HTMLElement>(
+      ".persona-control-tooltip"
+    );
+    expect(tooltip?.dataset.placement).toBe("bottom");
+    expect(tooltip?.style.top).toBe("52px");
+
+    button.blur();
+    expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
+  });
+
+  it("re-attaching replaces old listeners and disabled tooltips stay closed", () => {
+    const button = document.createElement("button");
+    document.body.appendChild(button);
+    const old = attachTooltip({ anchor: button, text: "Old" });
+    const next = attachTooltip({ anchor: button, text: "New", enabled: false });
+
+    expect(old.isOpen).toBe(false);
+    button.focus();
+    expect(next.isOpen).toBe(false);
+    expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
+  });
+
+  it("portals into the anchor's shadow root so widget styles still apply", () => {
+    const host = document.createElement("div");
+    const shadow = host.attachShadow({ mode: "open" });
+    const button = document.createElement("button");
+    shadow.appendChild(button);
+    document.body.appendChild(host);
+
+    attachTooltip({ anchor: button, text: "Shadow tooltip" });
+    button.focus();
+
+    expect(shadow.querySelector(".persona-control-tooltip")?.textContent).toContain(
+      "Shadow tooltip"
+    );
+    expect(document.body.querySelector(".persona-control-tooltip")).toBeNull();
+  });
+});

--- a/packages/widget/src/utils/tooltip.ts
+++ b/packages/widget/src/utils/tooltip.ts
@@ -1,0 +1,245 @@
+import { PORTALED_OVERLAY_Z_INDEX } from "./constants";
+
+const DEFAULT_GAP = 8;
+const DEFAULT_VIEWPORT_PADDING = 8;
+const MIN_ARROW_INSET = 10;
+
+export interface TooltipOptions {
+  /** The control the tooltip describes and positions against. */
+  anchor: HTMLElement;
+  /** Hover target. Defaults to `anchor`; wrappers make small icon buttons easier to hit. */
+  trigger?: HTMLElement;
+  /** Tooltip copy. A callback keeps live aria-label updates in sync. */
+  text: string | (() => string);
+  /** Whether the visual tooltip may open. The anchor's accessible name is unaffected. */
+  enabled?: boolean;
+  /** Gap between the control and tooltip, in pixels. */
+  gap?: number;
+  /** Minimum distance from viewport edges, in pixels. */
+  viewportPadding?: number;
+}
+
+export interface TooltipHandle {
+  readonly isOpen: boolean;
+  show(): void;
+  hide(): void;
+  reposition(): void;
+  destroy(): void;
+}
+
+const handles = new WeakMap<HTMLElement, TooltipHandle>();
+
+const isShadowRoot = (root: Node): root is ShadowRoot =>
+  root.nodeType === Node.DOCUMENT_FRAGMENT_NODE && "host" in root;
+
+const tooltipContainer = (anchor: HTMLElement): HTMLElement | ShadowRoot | null => {
+  const root = anchor.getRootNode?.();
+  if (isShadowRoot(root)) return root;
+  return anchor.ownerDocument.body;
+};
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), Math.max(min, max));
+
+/**
+ * Attach a portaled, viewport-aware tooltip to an icon control.
+ *
+ * The tooltip is created only while visible and is mounted outside the widget
+ * panel's clipping containers. Re-attaching to the same anchor replaces the
+ * previous behavior, which makes controller.update() safe and idempotent.
+ */
+export function attachTooltip(options: TooltipOptions): TooltipHandle {
+  handles.get(options.anchor)?.destroy();
+
+  const {
+    anchor,
+    trigger = anchor,
+    text,
+    enabled = true,
+    gap = DEFAULT_GAP,
+    viewportPadding = DEFAULT_VIEWPORT_PADDING,
+  } = options;
+  const currentDocument = (): Document => anchor.ownerDocument;
+  const currentWindow = (): Window =>
+    currentDocument().defaultView ?? window;
+
+  let tooltip: HTMLElement | null = null;
+  let label: HTMLElement | null = null;
+  let detachOpenListeners: (() => void) | null = null;
+  let hovered = false;
+  let focused = false;
+  let destroyed = false;
+
+  const resolvedText = (): string =>
+    (typeof text === "function" ? text() : text).trim();
+
+  const hide = (): void => {
+    detachOpenListeners?.();
+    detachOpenListeners = null;
+    tooltip?.remove();
+    tooltip = null;
+    label = null;
+  };
+
+  const reposition = (): void => {
+    if (!tooltip) return;
+
+    const ownerDocument = currentDocument();
+    const ownerWindow = currentWindow();
+    const anchorRect = anchor.getBoundingClientRect();
+    const tooltipRect = tooltip.getBoundingClientRect();
+    const viewportWidth =
+      ownerDocument.documentElement.clientWidth || ownerWindow.innerWidth;
+    const viewportHeight =
+      ownerDocument.documentElement.clientHeight || ownerWindow.innerHeight;
+
+    const maxLeft = viewportWidth - viewportPadding - tooltipRect.width;
+    const desiredLeft =
+      anchorRect.left + anchorRect.width / 2 - tooltipRect.width / 2;
+    const left = clamp(desiredLeft, viewportPadding, maxLeft);
+
+    const roomAbove = anchorRect.top - viewportPadding;
+    const roomBelow = viewportHeight - viewportPadding - anchorRect.bottom;
+    const requiredHeight = tooltipRect.height + gap;
+    const placement =
+      roomAbove >= requiredHeight || roomAbove >= roomBelow ? "top" : "bottom";
+    const desiredTop =
+      placement === "top"
+        ? anchorRect.top - gap - tooltipRect.height
+        : anchorRect.bottom + gap;
+    const maxTop = viewportHeight - viewportPadding - tooltipRect.height;
+    const top = clamp(desiredTop, viewportPadding, maxTop);
+
+    const anchorCenter = anchorRect.left + anchorRect.width / 2;
+    const arrowMax = Math.max(MIN_ARROW_INSET, tooltipRect.width - MIN_ARROW_INSET);
+    const arrowX = clamp(
+      anchorCenter - left,
+      MIN_ARROW_INSET,
+      arrowMax
+    );
+
+    tooltip.dataset.placement = placement;
+    tooltip.style.left = `${left}px`;
+    tooltip.style.top = `${top}px`;
+    tooltip.style.setProperty("--persona-tooltip-arrow-x", `${arrowX}px`);
+  };
+
+  const show = (): void => {
+    if (destroyed || !enabled || tooltip || !anchor.isConnected) return;
+    const copy = resolvedText();
+    const container = tooltipContainer(anchor);
+    if (!copy || !container) return;
+
+    const ownerDocument = currentDocument();
+    const ownerWindow = currentWindow();
+    tooltip = ownerDocument.createElement("div");
+    tooltip.className = "persona-control-tooltip";
+    tooltip.setAttribute("role", "tooltip");
+    tooltip.dataset.state = "measuring";
+    tooltip.style.zIndex = String(PORTALED_OVERLAY_Z_INDEX);
+
+    label = ownerDocument.createElement("span");
+    label.className = "persona-control-tooltip__label";
+    label.textContent = copy;
+    tooltip.appendChild(label);
+
+    const arrow = ownerDocument.createElement("span");
+    arrow.className = "persona-control-tooltip__arrow";
+    tooltip.appendChild(arrow);
+
+    container.appendChild(tooltip);
+    reposition();
+    tooltip.dataset.state = "open";
+
+    const onReposition = (): void => {
+      if (!anchor.isConnected) {
+        hide();
+        return;
+      }
+      if (label) label.textContent = resolvedText();
+      reposition();
+    };
+    ownerWindow.addEventListener("scroll", onReposition, true);
+    ownerWindow.addEventListener("resize", onReposition);
+
+    const root = anchor.getRootNode();
+    const mutationTarget =
+      isShadowRoot(root)
+        ? root
+        : ownerDocument.documentElement;
+    const observer =
+      typeof MutationObserver === "undefined"
+        ? null
+        : new MutationObserver(() => {
+            if (!anchor.isConnected) hide();
+          });
+    observer?.observe(mutationTarget, { childList: true, subtree: true });
+
+    detachOpenListeners = () => {
+      ownerWindow.removeEventListener("scroll", onReposition, true);
+      ownerWindow.removeEventListener("resize", onReposition);
+      observer?.disconnect();
+    };
+  };
+
+  const syncVisibility = (): void => {
+    if (hovered || focused) show();
+    else hide();
+  };
+  const onMouseEnter = (): void => {
+    const ownerWindow = currentWindow();
+    const hasHover =
+      !ownerWindow.matchMedia ||
+      !ownerWindow.matchMedia("(hover: none)").matches;
+    if (!hasHover) return;
+    hovered = true;
+    syncVisibility();
+  };
+  const onMouseLeave = (): void => {
+    hovered = false;
+    syncVisibility();
+  };
+  const onFocus = (): void => {
+    focused = true;
+    syncVisibility();
+  };
+  const onBlur = (): void => {
+    focused = false;
+    syncVisibility();
+  };
+  const onKeyDown = (event: KeyboardEvent): void => {
+    if (event.key !== "Escape") return;
+    hovered = false;
+    focused = false;
+    hide();
+  };
+
+  trigger.addEventListener("mouseenter", onMouseEnter);
+  trigger.addEventListener("mouseleave", onMouseLeave);
+  anchor.addEventListener("focus", onFocus);
+  anchor.addEventListener("blur", onBlur);
+  anchor.addEventListener("keydown", onKeyDown);
+
+  const handle: TooltipHandle = {
+    get isOpen() {
+      return tooltip !== null;
+    },
+    show,
+    hide,
+    reposition,
+    destroy: () => {
+      if (destroyed) return;
+      destroyed = true;
+      hide();
+      trigger.removeEventListener("mouseenter", onMouseEnter);
+      trigger.removeEventListener("mouseleave", onMouseLeave);
+      anchor.removeEventListener("focus", onFocus);
+      anchor.removeEventListener("blur", onBlur);
+      anchor.removeEventListener("keydown", onKeyDown);
+      handles.delete(anchor);
+    },
+  };
+
+  handles.set(anchor, handle);
+  return handle;
+}


### PR DESCRIPTION
## What does this PR do?

Updates that improve streaming, styling, and rendering of UI elements. Based on user feedback.

- Adds independent width and max-width configuration for user and assistant messages.
- Adds matching controls to the Theme Configurator and clarifies the Bubble, Minimal, and Flat message styles.
- Makes wide markdown tables horizontally scrollable with responsive, direction-aware edge fades.
- Portals control tooltips and clamps them to the viewport.
- Adds regression tests and updates public documentation.

## Type of change

- [x] Bug fix
- [x] New feature
- [x] Documentation
- [x] Tooling / CI

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run`) and I added tests for new behavior
- [x] **Changeset added if I touched `packages/widget` or `packages/proxy`** (`pnpm changeset`). _Not required for changes only under `examples/`, `docs/`, CI, or tooling_
- [x] Docs updated if I changed public API or behavior

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Improves widget presentation and streaming behavior.
- Adds role-specific message width configuration and theme-editor controls.
- Wraps wide Markdown tables in horizontal scroll regions with responsive edge fades.
- Reworks control tooltips to use viewport-clamped portals.
- Updates styles, generated contract fields, documentation, demos, tests, changesets, and bundle limits.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no blocking failures remaining in the fixes covered by the previous review threads.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/widget/src/utils/table-scroll-fade.ts | Corrects RTL fade-edge calculations and provides delegated fade refresh behavior for scrollable tables. |
| packages/widget/src/ui.ts | Integrates table wrapping, resize-driven fade refreshes, role-specific message sizing, and shared tooltip behavior. |
| packages/widget/src/utils/table-scroll-fade.test.ts | Covers table wrapping, LTR and RTL edge states, overflow removal, and delegated scroll updates. |
| packages/widget/src/styles/widget.css | Adds message-row geometry, portaled tooltip styling, and horizontally scrollable table presentation. |

</details>

<sub>Reviews (4): Last reviewed commit: ["Regen types"](https://github.com/runtypelabs/persona/commit/597a99409637c261b0f7cf98f5b06216f64401ca) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47082353)</sub>

<!-- /greptile_comment -->