### PR TITLE
fix: load installer sibling assets from the installer's own CDN directory

### DIFF
--- a/.changeset/installer-self-cdn-base.md
+++ b/.changeset/installer-self-cdn-base.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+The script-tag installer now loads its sibling assets (`widget.css`, `index.global.js`, `launcher.global.js`, `markdown-parsers.js`) from the directory it was itself served from, instead of always from jsDelivr. Self-hosted and first-party CDN installs (e.g. `cdn.runtype.com`) now work under a strict CSP with no extra config, and npm-CDN installs pinned to a range (`@4`) no longer skew siblings to `@latest`. Explicit `cdn` / `version` options keep the documented npm-CDN behavior, and jsDelivr `@latest` remains the fallback when the installer's own URL can't be determined. Also: `generateCodeSnippet()` accepts a new `cdnBase` option so generated script snippets can point at a first-party CDN, and `cdn: "unpkg"` now produces correct unpkg URLs (they previously 404'd due to a stray `/npm/` path prefix).

--- a/packages/widget/docs/INSTALLATION-FRAMEWORKS.md
+++ b/packages/widget/docs/INSTALLATION-FRAMEWORKS.md
@@ -37,8 +37,8 @@ The easiest way is to use the automatic installer script. It handles loading CSS
 
 **Installer options:**
 
-- `version` - Package version to load (default: `"latest"`)
-- `cdn` - CDN provider: `"jsdelivr"` or `"unpkg"` (default: `"jsdelivr"`)
+- `version` - Package version to load from an npm CDN (setting it switches asset loading to npm-CDN URLs; `"latest"` when only `cdn` is set)
+- `cdn` - npm CDN provider: `"jsdelivr"` or `"unpkg"`. By default the installer loads `widget.css` / `index.global.js` / `launcher.global.js` from the same directory it was itself served from, so self-hosted and first-party CDN copies work with no extra config (and satisfy the same CSP that allowed the installer). Setting `cdn` or `version` opts into npm-CDN URLs instead; jsDelivr `@latest` is the fallback when the installer's own URL can't be determined (e.g. bundled/module usage).
 - `cssUrl` - Custom CSS URL (overrides CDN)
 - `jsUrl` - Custom JS URL (overrides CDN)
 - `target` - CSS selector or element where widget mounts (default: `"body"`)

--- a/packages/widget/src/codegen.test.ts
+++ b/packages/widget/src/codegen.test.ts
@@ -43,6 +43,22 @@ describe("codegen subpath", () => {
       expect(code).toContain(`src="${cdnBase}/install.global.js"`);
     });
 
+    it("percent-encodes characters that could break the emitted JS/HTML contexts", () => {
+      const hostile = "https://cdn.example.com/x'\"\\`/persona";
+      const encoded = "https://cdn.example.com/x%27%22%5C%60/persona";
+      // script-advanced emits into a single-quoted JS literal
+      expect(fromSubpath(config, "script-advanced", { cdnBase: hostile })).toContain(
+        `var CDN_BASE = '${encoded}';`
+      );
+      // script-installer / script-manual emit into double-quoted HTML attributes
+      expect(fromSubpath(config, "script-installer", { cdnBase: hostile })).toContain(
+        `src="${encoded}/install.global.js"`
+      );
+      expect(fromSubpath(config, "script-manual", { cdnBase: hostile })).toContain(
+        `href="${encoded}/widget.css"`
+      );
+    });
+
     it("leaves no jsDelivr URL behind when a custom base is set", () => {
       for (const format of ["script-installer", "script-manual", "script-advanced"] as const) {
         expect(fromSubpath(config, format, { cdnBase })).not.toContain("jsdelivr");

--- a/packages/widget/src/codegen.test.ts
+++ b/packages/widget/src/codegen.test.ts
@@ -23,6 +23,33 @@ describe("codegen subpath", () => {
     expect(code).not.toContain("@latest");
   });
 
+  describe("cdnBase option", () => {
+    const cdnBase = "https://cdn.runtype.com/persona/latest";
+
+    it("emits the custom base in every script format", () => {
+      expect(fromSubpath(config, "script-installer", { cdnBase })).toContain(
+        `src="${cdnBase}/install.global.js"`
+      );
+      const manual = fromSubpath(config, "script-manual", { cdnBase });
+      expect(manual).toContain(`href="${cdnBase}/widget.css"`);
+      expect(manual).toContain(`src="${cdnBase}/index.global.js"`);
+      expect(fromSubpath(config, "script-advanced", { cdnBase })).toContain(
+        `var CDN_BASE = '${cdnBase}';`
+      );
+    });
+
+    it("tolerates a trailing slash", () => {
+      const code = fromSubpath(config, "script-installer", { cdnBase: `${cdnBase}/` });
+      expect(code).toContain(`src="${cdnBase}/install.global.js"`);
+    });
+
+    it("leaves no jsDelivr URL behind when a custom base is set", () => {
+      for (const format of ["script-installer", "script-manual", "script-advanced"] as const) {
+        expect(fromSubpath(config, format, { cdnBase })).not.toContain("jsdelivr");
+      }
+    });
+  });
+
   describe("mount target option", () => {
     it("defaults to body when no target is given", () => {
       expect(fromSubpath(config, "react-component")).toContain("target: 'body'");

--- a/packages/widget/src/install.test.ts
+++ b/packages/widget/src/install.test.ts
@@ -343,6 +343,89 @@ describe("install.ts: deferral gate", () => {
   });
 });
 
+describe("install.ts: CDN base derivation", () => {
+  // The installer captures document.currentScript.src synchronously at module
+  // evaluation; fake it with an own-property override (jsdom's getter lives on
+  // the prototype, so a configurable instance property shadows it cleanly).
+  function setCurrentScript(src: string) {
+    const script = document.createElement("script");
+    script.src = src;
+    Object.defineProperty(document, "currentScript", { value: script, configurable: true });
+  }
+
+  afterEach(() => {
+    delete (document as any).currentScript;
+  });
+
+  /**
+   * Run the deferred path with NO bundles provided so loadCSS/loadLauncher
+   * inject real (never-resolving in jsdom) elements whose URLs we can read.
+   */
+  async function installedUrls(installerOptions: any) {
+    await install({ config: { apiUrl: "/api", launcher: { enabled: true } }, ...installerOptions });
+    await flush();
+    const css = document.head.querySelector("link[rel=\"stylesheet\"][data-persona]") as HTMLLinkElement | null;
+    const scripts = Array.from(document.head.querySelectorAll("script")).map((s) => s.src);
+    return { cssHref: css?.href ?? null, scripts };
+  }
+
+  it("derives asset URLs from the installer's own script directory (first-party CDN)", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const { cssHref, scripts } = await installedUrls({});
+    expect(cssHref).toBe("https://cdn.runtype.com/persona/latest/widget.css");
+    expect(scripts).toContain("https://cdn.runtype.com/persona/latest/launcher.global.js");
+  });
+
+  it("keeps npm-CDN siblings on the installer's own pinned range (no @latest skew)", async () => {
+    setCurrentScript("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/install.global.js");
+    const { cssHref, scripts } = await installedUrls({});
+    expect(cssHref).toBe("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/widget.css");
+    expect(scripts).toContain("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4/dist/launcher.global.js");
+  });
+
+  it("the full bundle URL follows the installer directory on the eager path", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    markCssLoaded();
+    await install({ config: { apiUrl: "/api", launcher: { enabled: false } } });
+    await flush();
+    const scripts = Array.from(document.head.querySelectorAll("script")).map((s) => s.src);
+    expect(scripts).toContain("https://cdn.runtype.com/persona/latest/index.global.js");
+  });
+
+  it("falls back to jsDelivr@latest when currentScript is unavailable", async () => {
+    // No setCurrentScript: module/inline contexts have no script src.
+    const { cssHref } = await installedUrls({});
+    expect(cssHref).toBe("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/widget.css");
+  });
+
+  it("falls back to the npm CDN for a non-http(s) installer source", async () => {
+    setCurrentScript("data:text/javascript,void%200");
+    const { cssHref } = await installedUrls({});
+    expect(cssHref).toBe("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/widget.css");
+  });
+
+  it("an explicit `version` opts back into npm-CDN URLs even when the src is derivable", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const { cssHref } = await installedUrls({ version: "1.2.3" });
+    expect(cssHref).toBe("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@1.2.3/dist/widget.css");
+  });
+
+  it("an explicit `cdn` opts back into npm-CDN URLs even when the src is derivable", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const { cssHref } = await installedUrls({ cdn: "unpkg" });
+    expect(cssHref).toBe("https://unpkg.com/@runtypelabs/persona@latest/dist/widget.css");
+  });
+
+  it("explicit cssUrl + jsUrl win over the derived installer base", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const { cssHref } = await installedUrls({
+      cssUrl: "https://assets.example.com/persona/widget.css",
+      jsUrl: "https://assets.example.com/persona/index.global.js",
+    });
+    expect(cssHref).toBe("https://assets.example.com/persona/widget.css");
+  });
+});
+
 describe("install.ts: onError", () => {
   it("fires onError with phase 'init' and dispatches persona:error when initialization throws", async () => {
     markCssLoaded();

--- a/packages/widget/src/install.ts
+++ b/packages/widget/src/install.ts
@@ -7,6 +7,9 @@
 export {};
 
 interface SiteAgentInstallConfig {
+  // Setting `version` or `cdn` explicitly opts into npm-CDN asset URLs
+  // (jsDelivr/unpkg). When neither is set, assets load from the directory the
+  // installer script itself was served from — see getCdnBase().
   version?: string;
   cdn?: "unpkg" | "jsdelivr";
   cssUrl?: string;
@@ -137,6 +140,10 @@ declare global {
   // Get config from script attributes (must be called synchronously during script execution)
   const scriptConfig = getConfigFromScript();
 
+  // The installer's own URL, captured now because document.currentScript is
+  // null once synchronous execution ends (and always inside modules).
+  const installerSrc = (document.currentScript as HTMLScriptElement | null)?.src || "";
+
   // Merge script attributes with window config (script attributes take precedence)
   const windowConfig: SiteAgentInstallConfig = window.siteAgentConfig || {};
   const config: SiteAgentInstallConfig = { ...windowConfig, ...scriptConfig };
@@ -194,7 +201,28 @@ declare global {
   const cdn = config.cdn || "jsdelivr";
   const autoInit = config.autoInit !== false; // Default to true
 
-  // Determine CDN base URL
+  // Directory the installer itself was served from. Every published layout
+  // (npm CDN dist/, first-party CDN, self-hosted copies) keeps the sibling
+  // assets next to install.global.js, so this base is valid wherever the
+  // installer loaded from — and always satisfies the same CSP/origin rules
+  // that let the installer through. Non-http(s) sources (inline, blob:) and
+  // module contexts (no currentScript) yield null.
+  const getInstallerBase = (): string | null => {
+    if (!installerSrc) return null;
+    try {
+      const url = new URL(installerSrc, document.baseURI);
+      if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+      return url.origin + url.pathname.slice(0, url.pathname.lastIndexOf("/"));
+    } catch {
+      return null;
+    }
+  };
+
+  // Determine CDN base URL. Precedence:
+  //   1. explicit cssUrl + jsUrl
+  //   2. explicit `cdn` / `version` → npm CDN construction
+  //   3. the installer's own directory (default)
+  //   4. npm CDN construction (currentScript unavailable)
   const getCdnBase = () => {
     // For a custom URL override, derive the sibling launcher URL when the
     // override mirrors the dist layout (…/index.global.js → …/launcher.global.js)
@@ -209,8 +237,26 @@ declare global {
       };
     }
 
+    // Default: load assets from wherever the installer was served, so a page
+    // whose CSP allows only its own CDN (e.g. cdn.runtype.com) never has
+    // sibling requests fan out to a third-party host. An explicit `cdn` or
+    // `version` keeps the documented npm-CDN behavior.
+    if (!config.cdn && !config.version) {
+      const selfBase = getInstallerBase();
+      if (selfBase) {
+        return {
+          cssUrl: `${selfBase}/widget.css`,
+          jsUrl: `${selfBase}/index.global.js`,
+          launcherUrl: `${selfBase}/launcher.global.js` as string | null,
+        };
+      }
+    }
+
     const packageName = "@runtypelabs/persona";
-    const basePath = `/npm/${packageName}@${version}/dist`;
+    // jsDelivr namespaces npm packages under /npm/; unpkg serves them at the root.
+    const basePath = cdn === "unpkg"
+      ? `/${packageName}@${version}/dist`
+      : `/npm/${packageName}@${version}/dist`;
     const host = cdn === "unpkg" ? "https://unpkg.com" : "https://cdn.jsdelivr.net";
 
     return {

--- a/packages/widget/src/utils/code-generators.ts
+++ b/packages/widget/src/utils/code-generators.ts
@@ -151,7 +151,23 @@ export type CodeGeneratorOptions = {
    * @default "body"
    */
   target?: string;
+
+  /**
+   * Base URL of the directory holding the widget assets (install.global.js,
+   * index.global.js, widget.css) for the script formats (script-installer,
+   * script-manual, script-advanced). Pass a first-party base such as
+   * "https://cdn.runtype.com/persona/latest" when the embedding page's CSP
+   * does not allow third-party CDNs. A trailing slash is tolerated.
+   * @default the jsDelivr dist directory pinned to this package version
+   */
+  cdnBase?: string;
 };
+
+/** Asset directory for script formats: explicit cdnBase or the version-pinned jsDelivr dist. */
+function resolveCdnBase(options?: CodeGeneratorOptions): string {
+  const base = options?.cdnBase?.trim().replace(/\/+$/, "");
+  return base || `https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist`;
+}
 
 // Internal type for normalized hooks (always strings)
 type NormalizedHooks = {
@@ -1402,7 +1418,7 @@ function generateScriptInstallerCode(config: any, options?: CodeGeneratorOptions
   // Escape single quotes in JSON for HTML attribute
   const configJson = JSON.stringify(payload, null, 0).replace(/'/g, "&#39;");
 
-  return `<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist/install.global.js" data-config='${configJson}'></script>`;
+  return `<script src="${resolveCdnBase(options)}/install.global.js" data-config='${configJson}'></script>`;
 }
 
 function generateScriptManualCode(config: any, options?: CodeGeneratorOptions): string {
@@ -1410,12 +1426,13 @@ function generateScriptManualCode(config: any, options?: CodeGeneratorOptions): 
   const parserType = getParserTypeFromConfig(config as AgentWidgetConfig);
   const shouldEmitParserType = parserType !== "plain";
 
+  const cdnBase = resolveCdnBase(options);
   const lines: string[] = [
     "<!-- Load CSS -->",
-    `<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist/widget.css" />`,
+    `<link rel="stylesheet" href="${cdnBase}/widget.css" />`,
     "",
     "<!-- Load JavaScript -->",
-    `<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist/index.global.js"></script>`,
+    `<script src="${cdnBase}/index.global.js"></script>`,
     "",
     "<!-- Initialize widget -->",
     "<script>",
@@ -1565,7 +1582,7 @@ function generateScriptAdvancedCode(config: any, options?: CodeGeneratorOptions)
     `  var CONFIG = ${configJson.split('\n').map((line, i) => i === 0 ? line : '  ' + line).join('\n')};`,
     "",
     "  // Constants",
-    `  var CDN_BASE = 'https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist';`,
+    `  var CDN_BASE = '${resolveCdnBase(options)}';`,
     "  var STORAGE_KEY = 'chat-widget-state';",
     "  var PROCESSED_ACTIONS_KEY = 'chat-widget-processed-actions';",
     "",

--- a/packages/widget/src/utils/code-generators.ts
+++ b/packages/widget/src/utils/code-generators.ts
@@ -163,9 +163,18 @@ export type CodeGeneratorOptions = {
   cdnBase?: string;
 };
 
-/** Asset directory for script formats: explicit cdnBase or the version-pinned jsDelivr dist. */
+/**
+ * Asset directory for script formats: explicit cdnBase or the version-pinned
+ * jsDelivr dist. The base is emitted into single-quoted JS literals AND
+ * double-quoted HTML attributes, so percent-encode the characters that could
+ * break out of either context. All of them are illegal unencoded in a URL
+ * (RFC 3986), so encoding never changes the meaning of a valid base URL.
+ */
 function resolveCdnBase(options?: CodeGeneratorOptions): string {
-  const base = options?.cdnBase?.trim().replace(/\/+$/, "");
+  const base = options?.cdnBase
+    ?.trim()
+    .replace(/\/+$/, "")
+    .replace(/[\\'"<>`]/g, (ch) => `%${ch.charCodeAt(0).toString(16).toUpperCase().padStart(2, "0")}`);
   return base || `https://cdn.jsdelivr.net/npm/@runtypelabs/persona@${VERSION}/dist`;
 }
 


### PR DESCRIPTION
## Problem

The script-tag installer always requested its sibling assets (`widget.css`, `index.global.js`, `launcher.global.js`, `markdown-parsers.js`) from jsDelivr, regardless of where `install.global.js` itself was served from. On a page whose CSP only allows a first-party CDN (e.g. Runtype-hosted pages allowing `cdn.runtype.com`), the installer script loads successfully but every sibling request is blocked — the widget silently never appears, and the green first request makes it confusing to debug.

## Fix

The installer captures `document.currentScript.src` synchronously at execution time (it's `null` afterwards and inside modules) and derives the asset base from its own directory. Precedence in `getCdnBase()`:

1. explicit `cssUrl` + `jsUrl` (unchanged)
2. explicit `cdn` / `version` → npm-CDN construction (unchanged, keeps documented behavior)
3. **the installer's own directory (new default)**
4. jsDelivr `@latest` when `currentScript` is unavailable (bundled/module contexts)

Both published layouts keep every sibling next to `install.global.js` (verified against the live `cdn.runtype.com/persona/latest/` flat tree and jsDelivr's `dist/`), so the dirname derivation is self-consistent by construction: self-hosting, first-party CDN, and npm CDNs all work with zero config. Side benefit: an embed pinned to `@4` on jsDelivr no longer skews its siblings to `@latest`.

## Also in this PR

- **`cdnBase` option for `generateCodeSnippet()`** — the script formats (`script-installer`, `script-manual`, `script-advanced`) hardcoded jsDelivr, so dashboard-generated embed snippets were guaranteed to fail on CSP-restricted pages. Default is unchanged (version-pinned jsDelivr); callers can pass a first-party base like `https://cdn.runtype.com/persona/latest`.
- **`cdn: "unpkg"` fix** — the unpkg branch reused jsDelivr's `/npm/` path prefix, producing URLs that have always 404'd (verified live). The prefix is now jsDelivr-only.
- Docs update in `INSTALLATION-FRAMEWORKS.md` and a `minor` changeset.

## Testing

- 8 new installer tests cover the full precedence ladder, including the `currentScript === null` and non-http(s) source fallbacks (faked via a configurable own-property override of `document.currentScript` in jsdom).
- 3 new codegen tests for `cdnBase` across all script formats.
- Full suite: 2053 tests, lint, typecheck, build all green.
- E2E on the **built** IIFE: served `dist/` on one local origin, loaded from a page on a different origin — both `widget.css` and `index.global.js` resolved to the installer's origin and the full bundle executed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/runtypelabs/codesmith/persona/pr/387"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787781034&installation_model_id=11148&pr_number=387&repository=runtypelabs%2Fpersona&return_to=https%3A%2F%2Fgithub.com%2Fruntypelabs%2Fpersona%2Fpull%2F387&signature=d557edc1732b12c189c20665fe33853a199335e6b77c80f1648b15c25aabac0c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns generated and runtime-loaded widget assets with configurable or installer-relative CDN directories.
- Derives sibling asset URLs from the executing installer while preserving explicit npm-CDN and URL overrides.
- Adds configurable CDN bases to generated script snippets and corrects unpkg URL construction.
- Adds installer and code-generation coverage and updates installation documentation and release metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/widget/src/install.ts | Implements installer-relative asset resolution with explicit override precedence and corrected unpkg paths. |
| packages/widget/src/utils/code-generators.ts | Adds normalized, context-safe CDN-base support across all generated script formats. |
| packages/widget/src/install.test.ts | Covers installer URL derivation, fallback behavior, explicit overrides, and eager and deferred asset loading. |
| packages/widget/src/codegen.test.ts | Verifies custom CDN output, trailing-slash normalization, and escaping across generated formats. |
| packages/widget/docs/INSTALLATION-FRAMEWORKS.md | Documents installer-relative loading and the behavior of explicit CDN and version options. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address Greptile finding — percent-..."](https://github.com/runtypelabs/persona/commit/53bc2dc2e9d0e0889379d2cc3519903f4d25b57f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47745720)</sub>

<!-- /greptile_comment -->