### PR TITLE
fix: keep first-party CDN version pins first-party; warn on cross-origin asset resolution

### DIFF
--- a/.changeset/first-party-version-pinning.md
+++ b/.changeset/first-party-version-pinning.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Installer: a `version` in `window.siteAgentConfig` on the first-party CDN (cdn.runtype.com) now stays first-party and resolves to `/persona/<version>/` instead of silently rerouting all widget assets to jsDelivr — which strict-CSP pages (e.g. Runtype-hosted apps) block with no visible error. On other origins `version` keeps the documented npm-CDN behavior. The installer also logs a `console.warn` whenever resolved assets would load from a different origin than the installer itself (explicit `cssUrl`/`jsUrl` overrides excepted), so CSP-blocked installs are diagnosable from the console.

--- a/packages/widget/docs/INSTALLATION-FRAMEWORKS.md
+++ b/packages/widget/docs/INSTALLATION-FRAMEWORKS.md
@@ -37,8 +37,8 @@ The easiest way is to use the automatic installer script. It handles loading CSS
 
 **Installer options:**
 
-- `version` - Package version to load from an npm CDN (setting it switches asset loading to npm-CDN URLs; `"latest"` when only `cdn` is set)
-- `cdn` - npm CDN provider: `"jsdelivr"` or `"unpkg"`. By default the installer loads `widget.css` / `index.global.js` / `launcher.global.js` from the same directory it was itself served from, so self-hosted and first-party CDN copies work with no extra config (and satisfy the same CSP that allowed the installer). Setting `cdn` or `version` opts into npm-CDN URLs instead; jsDelivr `@latest` is the fallback when the installer's own URL can't be determined (e.g. bundled/module usage).
+- `version` - Asset version to pin. On the first-party CDN (`cdn.runtype.com`) this stays first-party and resolves to `/persona/<version>/`; on other origins it switches asset loading to npm-CDN URLs (`"latest"` when only `cdn` is set). **Prefer pinning via the installer script URL itself** (e.g. `https://cdn.runtype.com/persona/4.13.0/install.global.js`) — the sibling assets follow the installer's own directory automatically.
+- `cdn` - npm CDN provider: `"jsdelivr"` or `"unpkg"`. By default the installer loads `widget.css` / `index.global.js` / `launcher.global.js` from the same directory it was itself served from, so self-hosted and first-party CDN copies work with no extra config (and satisfy the same CSP that allowed the installer). Setting `cdn` opts into npm-CDN URLs instead; jsDelivr `@latest` is the fallback when the installer's own URL can't be determined (e.g. bundled/module usage). The installer logs a `console.warn` whenever resolved assets would load from a different origin than the installer itself, since a strict CSP (e.g. Runtype-hosted apps) silently blocks cross-origin assets.
 - `cssUrl` - Custom CSS URL (overrides CDN)
 - `jsUrl` - Custom JS URL (overrides CDN)
 - `target` - CSS selector or element where widget mounts (default: `"body"`)
@@ -55,19 +55,19 @@ The easiest way is to use the automatic installer script. It handles loading CSS
 - `onChatReady` - Fired when the widget is initialized and its controller API is callable (after first open in a deferred install); signature: `(handle) => void`
 - `onError` - Fired when a load step fails (`css` / `bundle` / `init`), so ad-blocked / timed-out installs don't fail silently; signature: `({ phase, error }) => void`
 
-**Example with version pinning:**
+**Example with version pinning** (pin the installer script URL — sibling assets follow its directory, so no `version` key is needed):
 
 ```html
 <script>
   window.siteAgentConfig = {
-    version: '0.1.0', // Pin to specific version
     config: {
       apiUrl: '/api/chat/dispatch',
       launcher: { enabled: true, title: 'Support Chat' }
     }
   };
 </script>
-<script src="https://cdn.jsdelivr.net/npm/@runtypelabs/persona@0.1.0/dist/install.global.js"></script>
+<script src="https://cdn.runtype.com/persona/4.13.0/install.global.js"></script>
+<!-- or from an npm CDN: https://cdn.jsdelivr.net/npm/@runtypelabs/persona@4.13.0/dist/install.global.js -->
 ```
 
 ### Programmatic access with the installer
@@ -176,6 +176,8 @@ Replace `VERSION` with `latest` for auto-updates, or a specific version like `0.
 - `widget.css` - Stylesheet (required)
 - `index.global.js` - Widget JavaScript (IIFE format)
 - `install.global.js` - Automatic installer script
+
+> **Do NOT load `dist/index.js` (the ESM build) directly in a browser.** It keeps dependencies like `marked` as bare import specifiers, so `<script type="module" src=".../index.js">` fails with `Failed to resolve module specifier "marked"` and leaves an empty mount. The ESM build is for bundlers (npm install) only. In a browser, use `install.global.js` (recommended) or `index.global.js` + `window.AgentWidget.initAgentWidget()` — both are self-contained, and function-valued config (theme callbacks, `postprocessMessage`, …) works fine with either via `window.siteAgentConfig` / direct `initAgentWidget` calls.
 
 The script build exposes a `window.AgentWidget` global with `initAgentWidget()` and other exports, including parser functions:
 

--- a/packages/widget/src/install.test.ts
+++ b/packages/widget/src/install.test.ts
@@ -404,10 +404,44 @@ describe("install.ts: CDN base derivation", () => {
     expect(cssHref).toBe("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@latest/dist/widget.css");
   });
 
-  it("an explicit `version` opts back into npm-CDN URLs even when the src is derivable", async () => {
+  it("an explicit `version` on the first-party CDN stays first-party (versioned path)", async () => {
     setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const { cssHref, scripts } = await installedUrls({ version: "1.2.3" });
+    expect(cssHref).toBe("https://cdn.runtype.com/persona/1.2.3/widget.css");
+    expect(scripts).toContain("https://cdn.runtype.com/persona/1.2.3/launcher.global.js");
+  });
+
+  it("an explicit `version` on a non-first-party src opts into npm-CDN URLs", async () => {
+    setCurrentScript("https://assets.example.com/vendor/persona/install.global.js");
     const { cssHref } = await installedUrls({ version: "1.2.3" });
     expect(cssHref).toBe("https://cdn.jsdelivr.net/npm/@runtypelabs/persona@1.2.3/dist/widget.css");
+  });
+
+  it("warns when resolved assets leave the installer's origin (silent-CSP guard)", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await installedUrls({ cdn: "jsdelivr" });
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("strict CSP may silently block"));
+    warn.mockRestore();
+  });
+
+  it("does not warn when assets resolve to the installer's own origin", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await installedUrls({ version: "1.2.3" });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("does not warn for explicit cssUrl + jsUrl overrides on another origin", async () => {
+    setCurrentScript("https://cdn.runtype.com/persona/latest/install.global.js");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await installedUrls({
+      cssUrl: "https://assets.example.com/persona/widget.css",
+      jsUrl: "https://assets.example.com/persona/index.global.js",
+    });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
   });
 
   it("an explicit `cdn` opts back into npm-CDN URLs even when the src is derivable", async () => {

--- a/packages/widget/src/install.ts
+++ b/packages/widget/src/install.ts
@@ -7,9 +7,12 @@
 export {};
 
 interface SiteAgentInstallConfig {
-  // Setting `version` or `cdn` explicitly opts into npm-CDN asset URLs
-  // (jsDelivr/unpkg). When neither is set, assets load from the directory the
-  // installer script itself was served from — see getCdnBase().
+  // Setting `cdn` explicitly opts into npm-CDN asset URLs (jsDelivr/unpkg),
+  // and `version` pins the asset version. When neither is set, assets load
+  // from the directory the installer script itself was served from. On the
+  // first-party CDN (cdn.runtype.com) a `version` stays first-party
+  // (…/persona/<version>/); elsewhere it opts into npm-CDN URLs. Prefer
+  // pinning via the installer script URL itself — see getCdnBase().
   version?: string;
   cdn?: "unpkg" | "jsdelivr";
   cssUrl?: string;
@@ -239,16 +242,30 @@ declare global {
 
     // Default: load assets from wherever the installer was served, so a page
     // whose CSP allows only its own CDN (e.g. cdn.runtype.com) never has
-    // sibling requests fan out to a third-party host. An explicit `cdn` or
-    // `version` keeps the documented npm-CDN behavior.
-    if (!config.cdn && !config.version) {
+    // sibling requests fan out to a third-party host. An explicit `cdn`
+    // keeps the documented npm-CDN behavior.
+    if (!config.cdn) {
       const selfBase = getInstallerBase();
       if (selfBase) {
-        return {
-          cssUrl: `${selfBase}/widget.css`,
-          jsUrl: `${selfBase}/index.global.js`,
-          launcherUrl: `${selfBase}/launcher.global.js` as string | null,
-        };
+        if (!config.version) {
+          return {
+            cssUrl: `${selfBase}/widget.css`,
+            jsUrl: `${selfBase}/index.global.js`,
+            launcherUrl: `${selfBase}/launcher.global.js` as string | null,
+          };
+        }
+        // A `version` on the first-party CDN stays first-party: the bucket
+        // mirrors every release at /persona/<version>/, and rerouting to a
+        // npm CDN would be blocked by the CSP that allowed the installer.
+        const selfOrigin = new URL(selfBase).origin;
+        if (selfOrigin === "https://cdn.runtype.com") {
+          const base = `${selfOrigin}/persona/${config.version}`;
+          return {
+            cssUrl: `${base}/widget.css`,
+            jsUrl: `${base}/index.global.js`,
+            launcherUrl: `${base}/launcher.global.js` as string | null,
+          };
+        }
       }
     }
 
@@ -267,6 +284,25 @@ declare global {
   };
 
   const { cssUrl, jsUrl, launcherUrl } = getCdnBase();
+
+  // Surface silent CSP breakage: when `cdn`/`version` reroutes assets to a
+  // different origin than the one that served the installer, a strict CSP
+  // (e.g. Runtype-hosted apps) blocks them with no visible error. Explicit
+  // cssUrl/jsUrl overrides are a deliberate choice, so they don't warn.
+  if (!(config.cssUrl && config.jsUrl)) {
+    const selfBase = getInstallerBase();
+    try {
+      if (selfBase && new URL(selfBase).origin !== new URL(jsUrl, document.baseURI).origin) {
+        console.warn(
+          `[persona] Widget assets resolve to ${new URL(jsUrl, document.baseURI).origin}, but the installer loaded from ${new URL(selfBase).origin}. ` +
+          "A strict CSP may silently block them. To pin a version, put it in the installer script URL " +
+          "(e.g. https://cdn.runtype.com/persona/<version>/install.global.js) instead of the `version`/`cdn` config keys.",
+        );
+      }
+    } catch {
+      // URL parsing is best-effort; never let diagnostics break installation.
+    }
+  }
 
   // Check if CSS is already loaded
   const isCssLoaded = () => {


### PR DESCRIPTION
Setting `version` in `window.siteAgentConfig` on a page that loaded the installer from cdn.runtype.com rerouted all widget assets to jsDelivr. Under a strict CSP (Runtype-hosted apps) the assets are blocked and the widget silently never mounts.

## Changes

- `version` with no `cdn` override, on an installer served from `https://cdn.runtype.com`, now resolves to `https://cdn.runtype.com/persona/<version>/`. Other origins keep the npm-CDN behavior.
- `console.warn` when resolved assets would load from a different origin than the installer (explicit `cssUrl`/`jsUrl` overrides excepted).
- Docs: pin via the installer script URL, not `version`; `dist/index.js` (ESM) marked bundler-only — bare specifiers (`marked`) fail in browser `<script type=module>`.

## Testing

- 5 new/updated cases in `install.test.ts`.
- Full suite: 2388 tests passing; `tsc` and `eslint` clean. Changeset: minor.