### PR TITLE
chore: bump installer size limit for CSP-origin warning

### DIFF
--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -32,7 +32,7 @@
   {
     "name": "Script installer (install.global.js)",
     "path": "dist/install.global.js",
-    "limit": "2.8 kB",
+    "limit": "3 kB",
     "gzip": true
   },
   {


### PR DESCRIPTION
PR #397 (`fix: keep first-party CDN version pins first-party and warn on cross-origin asset resolution`) shipped the cross-origin CSP warning + first-party version pinning inside `install.global.js`, which grew the installer 65 B past its 2.8 kB limit (now 2.87 kB gzipped) and turned the size-limit CI check red on main.

The growth is legitimate diagnostic functionality (surfacing silent CSP breakage — the whole point of the fix), so per repo convention the limit is bumped rather than trimming the warning. 2.8 → 3 kB matches the round-number style of the other entries and leaves ~130 B headroom.

Verified locally: `size-limit` exits 0, installer 2.87 kB.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/runtypelabs/codesmith/persona/pr/399"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788659712&installation_model_id=11148&pr_number=399&repository=runtypelabs%2Fpersona&return_to=https%3A%2F%2Fgithub.com%2Fruntypelabs%2Fpersona%2Fpull%2F399&signature=833a456ae595fd742f26d5090aca888a0bbc58a7ff4908f4b71d06a4dd1620f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Raises the gzipped size limit for `install.global.js` from 2.8 kB to 3 kB so the installer’s intentional CSP diagnostic functionality passes the size-limit check.
- Updates only the script installer’s bundle-size threshold.
- Preserves gzip-based size measurement and leaves other bundle limits unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only adjusts the installer’s CI size threshold to accommodate the documented bundle growth.

The changed configuration remains valid and narrowly raises the existing gzipped limit without altering runtime behavior or other bundle budgets.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/widget/.size-limit.json | Increases the installer’s gzipped size budget to 3 kB; no correctness, security, or independently actionable quality issue was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump installer size limit for CSP..."](https://github.com/runtypelabs/persona/commit/e2854c69289d1ed812d89bb43c37079513b93761) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51033503)</sub>

<!-- /greptile_comment -->