### PR TITLE
fix: bump dompurify to 3.4.13 (GHSA-55q2-fjhq-7xh7)

### DIFF
--- a/.changeset/dompurify-cve-bump.md
+++ b/.changeset/dompurify-cve-bump.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Bump `dompurify` to 3.4.13 to fix GHSA-55q2-fjhq-7xh7 (IN_PLACE hook-removal XSS, affects ≤3.4.12) and GHSA-c2j3-45gr-mqc4 (`CUSTOM_ELEMENT_HANDLING` bypass, affects ≤3.4.11).

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -111,7 +111,7 @@
   },
   "dependencies": {
     "@mcp-b/webmcp-polyfill": "^3.0.0",
-    "dompurify": "^3.4.10",
+    "dompurify": "^3.4.13",
     "idiomorph": "^0.7.4",
     "lucide": "^1.18.0",
     "marked": "^12.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2444,11 +2444,11 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
 
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -6478,12 +6478,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@1.1.12:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.0.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -7550,11 +7550,11 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,7 +444,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/widget:
     dependencies:
@@ -452,8 +452,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       dompurify:
-        specifier: ^3.4.10
-        version: 3.4.10
+        specifier: ^3.4.13
+        version: 3.4.13
       idiomorph:
         specifier: ^0.7.4
         version: 0.7.4
@@ -2690,8 +2690,8 @@ packages:
     resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
     engines: {node: '>=6.0.0'}
 
-  dompurify@3.4.10:
-    resolution: {integrity: sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==}
+  dompurify@3.4.13:
+    resolution: {integrity: sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3309,7 +3309,7 @@ packages:
     resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jspaint@https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666:
-    resolution: {gitHosted: true, tarball: https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666}
+    resolution: {gitHosted: true, integrity: sha512-UalE+F2mAqLbISHB92+2Iv3Jyi3vi0oyJcXecoaFj8l8lnfLPwA/YPuPwc6jG6ERody+6mXROn1AR45+68pzNQ==, tarball: https://codeload.github.com/runtypelabs/jspaint/tar.gz/61814a33efbd2021859caf37381f1005dfc25666}
     version: 1.1.0
     hasBin: true
 
@@ -6258,13 +6258,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -6336,7 +6336,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(@vitest/ui@4.0.18)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.1)(@types/node@25.9.3)(@vitest/ui@4.0.18)(jiti@1.21.7)(jsdom@28.1.0)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/utils@4.0.18':
     dependencies:
@@ -6672,7 +6672,7 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  dompurify@3.4.10:
+  dompurify@3.4.13:
     optionalDependencies:
       '@types/trusted-types': 2.0.7
 
@@ -8467,7 +8467,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8476,7 +8476,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.35
-      esbuild: 0.27.3
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.49.0
@@ -8583,10 +8583,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8603,7 +8603,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
Two dependency security fixes:

- **dompurify** `^3.4.10` → `^3.4.13` (runtime dep of the published widget):
  - GHSA-55q2-fjhq-7xh7 (medium) — IN_PLACE hook removal leaves a detached subtree executable → XSS; affects ≤3.4.12.
  - GHSA-c2j3-45gr-mqc4 (low) — `CUSTOM_ELEMENT_HANDLING` bypasses `afterSanitizeElements` for allowed custom elements; affects ≤3.4.11.
- **brace-expansion** (dev-only transitive, via eslint tooling in `packages/proxy`): lockfile bump `1.1.12`→`1.1.18` and `2.0.2`→`2.1.4`, clearing the ReDoS advisories.

Widget build + full test suite (2388 tests) pass; proxy lint clean.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades the widget’s DOMPurify dependency to 3.4.13 to address two published XSS advisories and refreshes the lockfile.
- Adds a patch changeset documenting the security update.
- Updates the widget manifest and lockfile to DOMPurify 3.4.13.
- Re-resolves several transitive build and utility dependencies, including esbuild and brace-expansion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/widget/package.json | Updates the DOMPurify dependency range from 3.4.10 to 3.4.13 consistently with existing manifest conventions. |
| pnpm-lock.yaml | Pins DOMPurify 3.4.13 and records the accompanying transitive dependency re-resolution without an identified blocking failure. |
| .changeset/dompurify-cve-bump.md | Adds an accurate patch release note describing the DOMPurify security fixes. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: bump brace-expansion to patched ver..."](https://github.com/runtypelabs/persona/commit/cd3dca909675c1dd9861d353ec155fc725427fc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51379951)</sub>

<!-- /greptile_comment -->