### PR TITLE
ci: move off blacksmith runners back to GitHub-hosted

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   size-limit:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   build-and-test:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/r2-release.yml
+++ b/.github/workflows/r2-release.yml
@@ -16,7 +16,7 @@ jobs:
   publish-to-r2:
     name: Publish to R2 CDN
     if: startsWith(inputs.tag, '@runtypelabs/persona@')
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     env:
       R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
       R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}


### PR DESCRIPTION
Replace `blacksmith-4vcpu-ubuntu-2404` with `ubuntu-latest` across `ci.yml`, `bundle-size.yml`, and `r2-release.yml`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/runtypelabs/codesmith/persona/pr/402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789420024&installation_model_id=11148&pr_number=402&repository=runtypelabs%2Fpersona&return_to=https%3A%2F%2Fgithub.com%2Fruntypelabs%2Fpersona%2Fpull%2F402&signature=0561feb1ceb17fe3b5c5d9c1b2c682566ad64bb4197b13c93b167de38ba8f9d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves CI, bundle-size, and R2 release jobs from Blacksmith runners to GitHub-hosted `ubuntu-latest`.
- Updates the bundle-size workflow runner.
- Updates the main build-and-test workflow runner.
- Updates the R2 publishing workflow runner.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the runner-only changes preserve the jobs’ supported Node and pnpm execution environment.

No concrete blocking or non-blocking defect remains; repository precedent shows the same setup, build, and R2 upload operations already running on `ubuntu-latest`.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/bundle-size.yml | Moves the size-limit job to `ubuntu-latest`; its standard Node and pnpm workflow is compatible with the new runner. |
| .github/workflows/ci.yml | Moves build, lint, typecheck, and test execution to `ubuntu-latest` without changing workflow behavior. |
| .github/workflows/r2-release.yml | Moves R2 publishing to `ubuntu-latest`, matching an existing sibling release workflow that uses the same build and upload path. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: move off blacksmith runners back to ..."](https://github.com/runtypelabs/persona/commit/3bcbe6b3171418f4867950d010a1346e78677c16) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53665737)</sub>

<!-- /greptile_comment -->