### PR TITLE
chore: bump @mcp-b/webmcp-polyfill to 4.0.0

### DIFF
--- a/.changeset/webmcp-polyfill-4.md
+++ b/.changeset/webmcp-polyfill-4.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Bump `@mcp-b/webmcp-polyfill` to 4.0.0.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,8 +10,8 @@
     "test:run": "vitest run src"
   },
   "dependencies": {
-    "@mcp-b/global": "^3.0.0",
-    "@mcp-b/webmcp-polyfill": "^3.0.0",
+    "@mcp-b/global": "^4.0.0",
+    "@mcp-b/webmcp-polyfill": "^4.0.0",
     "@runtypelabs/persona": "workspace:^",
     "alasql": "^4.17.3",
     "echarts": "^6.1.0",

--- a/examples/ai-sdk-webmcp/package.json
+++ b/examples/ai-sdk-webmcp/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@mcp-b/webmcp-polyfill": "^3.0.0",
+    "@mcp-b/webmcp-polyfill": "^4.0.0",
     "@runtypelabs/persona": "workspace:^",
     "@vercel/functions": "^3.7.1",
     "ai": "^6.0.203",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -110,7 +110,7 @@
     "check:runtype-types": "pnpm run fetch:runtype-openapi && node scripts/generate-runtype-openapi-types.mjs --check"
   },
   "dependencies": {
-    "@mcp-b/webmcp-polyfill": "^3.0.0",
+    "@mcp-b/webmcp-polyfill": "^4.0.0",
     "dompurify": "^3.4.13",
     "idiomorph": "^0.7.4",
     "lucide": "^1.18.0",
@@ -119,11 +119,11 @@
   },
   "devDependencies": {
     "@size-limit/file": "^12.1.0",
-    "acorn": "^8.15.0",
     "@types/node": "^20.12.7",
     "@typescript-eslint/eslint-plugin": "^7.0.0",
     "@typescript-eslint/parser": "^7.0.0",
     "@vitest/ui": "^4.0.9",
+    "acorn": "^8.15.0",
     "esbuild": "^0.21.5",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,11 @@ importers:
   apps/web:
     dependencies:
       '@mcp-b/global':
-        specifier: ^3.0.0
-        version: 3.0.0(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+        specifier: ^4.0.0
+        version: 4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
       '@mcp-b/webmcp-polyfill':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^4.0.0
+        version: 4.0.0
       '@runtypelabs/persona':
         specifier: workspace:^
         version: link:../../packages/widget
@@ -119,8 +119,8 @@ importers:
   examples/ai-sdk-webmcp:
     dependencies:
       '@mcp-b/webmcp-polyfill':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^4.0.0
+        version: 4.0.0
       '@runtypelabs/persona':
         specifier: workspace:^
         version: link:../../packages/widget
@@ -444,13 +444,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/widget:
     dependencies:
       '@mcp-b/webmcp-polyfill':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^4.0.0
+        version: 4.0.0
       dompurify:
         specifier: ^3.4.13
         version: 3.4.13
@@ -1484,19 +1484,19 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
-  '@mcp-b/global@3.0.0':
-    resolution: {integrity: sha512-HZWlR2Gb5v/ROtg0noiiHfrnHVPYxxhOPPaeYlXvCd6UB/u82Q3lwtCdWQLw66N25Zp9VSMGRR1Eq72yDFqcNQ==}
+  '@mcp-b/global@4.0.0':
+    resolution: {integrity: sha512-jDBrAwN/A3jJ+tUxtS5IcM7en8VS38n0TUkibcZspq+Pu4Romh1s99jlkOkk1r1CvIbLJ5zJqgIMzWKFR4067A==}
     engines: {node: '>=18'}
 
-  '@mcp-b/transports@3.0.0':
-    resolution: {integrity: sha512-WMgeb0P9Bhu+0mN07qkvCo+W9Fucdk9+iyp7wPZYAtQ4ZTcbNuu8Zl1qdNM8oWxXgMbA749w4nUcPsbPaMvSvA==}
+  '@mcp-b/transports@4.0.0':
+    resolution: {integrity: sha512-uf8a1zYnpfT0ugBobElhH37Z4jNlBV76WvaHZPKO8DYSvAI4Qs7B+bUQwNpCoSC/tCqdMbHkLxW2G/6Xz9/4Mw==}
 
-  '@mcp-b/webmcp-polyfill@3.0.0':
-    resolution: {integrity: sha512-TCrCOZCTfRWrTp8MpWU8EO4U7r7IvDDaIYW9Ej0aBD2KVR2hvwr4t3T7kPkSYssGhpIZJrq19owSzN1vZabW+A==}
+  '@mcp-b/webmcp-polyfill@4.0.0':
+    resolution: {integrity: sha512-7M6WS3IcxaIEhidbS9N7wrrGjtJf474Vi4Fn1hGkFkmYFT5EoFw/kS/4CSdUR/KmlInO1kyluHRY6t3avMQfFw==}
     engines: {node: '>=18'}
 
-  '@mcp-b/webmcp-ts-sdk@3.0.0':
-    resolution: {integrity: sha512-Lbn7ODKWMYd6xqpcl+OmXseKbjwB+Q3F9CUm9vDFpZgviWc3/5CuG3IDylHg/toVMeZz6v5+E8AmBnv8zj5G5w==}
+  '@mcp-b/webmcp-ts-sdk@4.0.0':
+    resolution: {integrity: sha512-zXdbBdefgcBz077NkvZ3WZhkHOvBU2rpsVK8ytQt/SbiS2tCIFshuB027QceuTyuprOjW0b7XKDnSzDB2DQVMA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25 || ^4.0
@@ -1507,8 +1507,8 @@ packages:
       zod-to-json-schema:
         optional: true
 
-  '@mcp-b/webmcp-types@3.0.0':
-    resolution: {integrity: sha512-MmKHNAtlyZoK5khz5GnmgEj/ehk5esoUbgOaFndrlZvpjq3ppmIY3BDrwCv6xaihuuIMOoLLDlf0E65wUd4q7A==}
+  '@mcp-b/webmcp-types@4.0.0':
+    resolution: {integrity: sha512-CUBBmiut1UBsiD3FAF6xrLKeKAuJkzd6/BlL1C/uo8sVpwY42NW4mls9rLcTxmLF/8Cj5/ZOwJiLzXl/T3GIQg==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -5602,38 +5602,71 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
-  '@mcp-b/global@3.0.0(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
+  '@mcp-b/global@4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@mcp-b/transports': 3.0.0(zod-to-json-schema@3.25.2(zod@3.25.76))
-      '@mcp-b/webmcp-polyfill': 3.0.0
-      '@mcp-b/webmcp-ts-sdk': 3.0.0(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
-      '@mcp-b/webmcp-types': 3.0.0
+      '@mcp-b/transports': 4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))
+      '@mcp-b/webmcp-polyfill': 4.0.0
+      '@mcp-b/webmcp-ts-sdk': 4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+      '@mcp-b/webmcp-types': 4.0.0
     transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
       - zod
       - zod-to-json-schema
 
-  '@mcp-b/transports@3.0.0(zod-to-json-schema@3.25.2(zod@3.25.76))':
+  '@mcp-b/transports@4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))':
     dependencies:
-      '@mcp-b/webmcp-ts-sdk': 3.0.0(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+      '@mcp-b/webmcp-ts-sdk': 4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       zod: 3.25.76
     transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
       - zod-to-json-schema
 
-  '@mcp-b/webmcp-polyfill@3.0.0':
+  '@mcp-b/webmcp-polyfill@4.0.0':
     dependencies:
       '@cfworker/json-schema': 4.1.1
-      '@mcp-b/webmcp-types': 3.0.0
+      '@mcp-b/webmcp-types': 4.0.0
       '@standard-schema/spec': 1.1.0
 
-  '@mcp-b/webmcp-ts-sdk@3.0.0(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
+  '@mcp-b/webmcp-ts-sdk@4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:
-      '@mcp-b/webmcp-polyfill': 3.0.0
-      '@mcp-b/webmcp-types': 3.0.0
+      '@mcp-b/webmcp-polyfill': 4.0.0
+      '@mcp-b/webmcp-types': 4.0.0
+      '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
     optionalDependencies:
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
 
-  '@mcp-b/webmcp-types@3.0.0': {}
+  '@mcp-b/webmcp-types@4.0.0': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
+    dependencies:
+      '@hono/node-server': 1.19.11(hono@4.12.25)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.25
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.1.11)':
     dependencies:
@@ -6258,13 +6291,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -6396,7 +6429,6 @@ snapshots:
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
-    optional: true
 
   ajv@6.14.0:
     dependencies:
@@ -6411,7 +6443,6 @@ snapshots:
       fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-    optional: true
 
   alasql@4.17.3:
     dependencies:
@@ -6597,7 +6628,6 @@ snapshots:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-    optional: true
 
   cross-fetch@4.1.0:
     dependencies:
@@ -6971,7 +7001,6 @@ snapshots:
   eventsource@3.0.7:
     dependencies:
       eventsource-parser: 3.1.0
-    optional: true
 
   execa@5.1.1:
     dependencies:
@@ -6991,7 +7020,6 @@ snapshots:
     dependencies:
       express: 5.2.1
       ip-address: 10.2.0
-    optional: true
 
   express@5.2.1:
     dependencies:
@@ -7046,8 +7074,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.2:
-    optional: true
+  fast-uri@3.1.2: {}
 
   fastq@1.20.1:
     dependencies:
@@ -7287,8 +7314,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ip-address@10.2.0:
-    optional: true
+  ip-address@10.2.0: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -7335,8 +7361,7 @@ snapshots:
 
   jose@5.10.0: {}
 
-  jose@6.2.3:
-    optional: true
+  jose@6.2.3: {}
 
   joycon@3.1.1: {}
 
@@ -7384,11 +7409,9 @@ snapshots:
 
   json-schema-traverse@0.4.1: {}
 
-  json-schema-traverse@1.0.0:
-    optional: true
+  json-schema-traverse@1.0.0: {}
 
-  json-schema-typed@8.0.2:
-    optional: true
+  json-schema-typed@8.0.2: {}
 
   json-schema@0.4.0: {}
 
@@ -7825,8 +7848,7 @@ snapshots:
 
   pirates@4.0.7: {}
 
-  pkce-challenge@5.0.1:
-    optional: true
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -8467,7 +8489,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8476,7 +8498,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.35
-      esbuild: 0.28.1
+      esbuild: 0.27.3
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.49.0
@@ -8583,10 +8605,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8603,7 +8625,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1


### PR DESCRIPTION
Bumps `@mcp-b/webmcp-polyfill` 3.0.0 → 4.0.0 in `packages/widget`, `apps/web`, and `examples/ai-sdk-webmcp`, plus `@mcp-b/global` 3 → 4 in `apps/web` so the tree resolves a single polyfill copy.

The 4.0.0 major only moves schema helpers to a `./schema` subpath and renames `validateArgsWithSchema` → `validateValueWithSchema`; we only import `initializeWebMCPPolyfill`, which is unchanged. Build, lint, tsc, and the 2388 widget tests pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades the WebMCP polyfill dependency from v3 to v4 across the widget, web application, and AI SDK example while aligning `@mcp-b/global` to v4.
- Updates the three affected package manifests and records a patch changeset for `@runtypelabs/persona`.
- Regenerates the pnpm lockfile with a unified v4 WebMCP dependency tree.
- No actionable compatibility, security, or build defect was identified.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The changed manifests and lockfile consistently resolve the WebMCP packages at v4, and the available evidence does not establish an incompatible API use, invalid dependency resolution, or newly introduced security boundary failure.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/widget/package.json | Upgrades the widget’s bundled WebMCP polyfill to v4; the `acorn` movement is ordering-only. |
| apps/web/package.json | Aligns both `@mcp-b/global` and `@mcp-b/webmcp-polyfill` on major version 4. |
| examples/ai-sdk-webmcp/package.json | Upgrades the example application’s WebMCP polyfill dependency to v4. |
| pnpm-lock.yaml | Resolves a consistent WebMCP v4 dependency tree and introduces no established incompatible resolution. |
| .changeset/webmcp-polyfill-4.md | Correctly records the dependency upgrade as a patch release for the widget package. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump @mcp-b/webmcp-polyfill to 4...."](https://github.com/runtypelabs/persona/commit/807c57562e9ef5d5f545751d7dcf20652c62d0b8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54093727)</sub>

<!-- /greptile_comment -->