### PR TITLE
chore: regenerate Runtype OpenAPI contract types

### DIFF
--- a/.changeset/regen-runtype-openapi-types.md
+++ b/.changeset/regen-runtype-openapi-types.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Regenerate the Runtype OpenAPI contract types to match the current public API spec. Adds visitor/identity fields to client init (`identityProof`, `visitorToken`, `visitorHistory`, `conversationId`), `conversationId`/`conversationRevision`/`visitor`/`app`/`targetId` on the init response, a `requests[]` array and `externalAgent` on await events, `stepErrorCount` on execution completion, and `displayContent` on chat request messages.

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -35,6 +35,7 @@ export type RuntypeExecutionStreamEvent = ({
   iterations?: number;
   kind: "agent" | "flow";
   seq: number;
+  stepErrorCount?: number;
   stopReason?: string;
   success: boolean;
   successfulSteps?: number;
@@ -364,10 +365,21 @@ export type RuntypeExecutionStreamEvent = ({
   mode: "form" | "url";
   pauseCount?: number;
   requestedSchema?: Record<string, unknown>;
+  requests?: Array<{
+  message: string;
+  mode: "form" | "url";
+  name: string;
+  requestedSchema?: Record<string, unknown>;
+  url?: string;
+}>;
   serverName?: string;
   url?: string;
 };
   executionId: string;
+  externalAgent?: {
+  contextId?: string;
+  taskId?: string;
+};
   origin?: "webmcp" | "sdk";
   pageOrigin?: string;
   parameters?: Record<string, unknown>;
@@ -418,23 +430,59 @@ export type RuntypeStopReasonKind = NonNullable<
 
 export type RuntypeClientInitRequest = {
   flowId?: string;
-  sessionId?: string;
+  identityProof?: string;
   token: string;
+  visitorHistory?: boolean;
+  visitorToken?: string;
+} | {
+  flowId?: string;
+  identityProof?: string;
+  sessionId: string;
+  token: string;
+  visitorHistory?: boolean;
+  visitorToken?: string;
+} | {
+  conversationId: string;
+  flowId?: string;
+  identityProof?: string;
+  token: string;
+  visitorHistory?: boolean;
+  visitorToken: string;
+} | {
+  conversationId: string;
+  flowId?: string;
+  identityProof: string;
+  token: string;
+  visitorHistory?: boolean;
+  visitorToken?: string;
 };
 
 export type RuntypeClientInitResponse = {
-  config: {
-  placeholder?: string;
-  theme?: unknown;
-  welcomeMessage?: string | null;
+  app?: {
+  id: string;
 };
+  config: {
+  placeholder: string;
+  theme?: unknown;
+  welcomeMessage: string | null;
+};
+  conversationId: string;
+  conversationRevision: string;
   expiresAt: string;
   flow?: {
   description?: string | null;
   id: string;
-  name?: string | null;
+  name?: string;
 };
   sessionId: string;
+  targetId?: string;
+  visitor?: {
+  endUserId: string | null;
+  expiresAt: string;
+  id: string;
+  identityStatus: "not_provided" | "admitted" | "ignored";
+  token?: string;
+};
 };
 
 export type RuntypeClientChatRequest = {
@@ -474,6 +522,7 @@ export type RuntypeClientChatRequest = {
   text: string;
   type: "reasoning";
 }>);
+  displayContent?: string;
   id?: string;
   role: "user" | "assistant" | "system";
 }>;


### PR DESCRIPTION
## Why

`main` is red on typecheck: https://github.com/runtypelabs/persona/actions/runs/32065299984/job/95495855289

`packages/widget`'s `typecheck` script is `pnpm run check:runtype-types && tsc --noEmit`. That first step fetches `https://api.runtype.com/v1/openapi.json` **live at CI time** and diffs it against the committed `src/generated/runtype-openapi-contract.ts`:

```
packages/widget/src/generated/runtype-openapi-contract.ts is out of date.
Run pnpm --filter @runtypelabs/persona generate:runtype-types.
```

The Runtype public spec shipped changes, so the committed file drifted. This failure is time-dependent, not commit-dependent — it landed on the polyfill bump (#403) by coincidence and will hit every push until the contract is regenerated.

## What changed

Generated-file-only, via `pnpm --filter @runtypelabs/persona generate:runtype-types`:

- **`RuntypeClientInitRequest`** — flat object → 4-way union, adding `identityProof`, `visitorToken`, `visitorHistory`, `conversationId`
- **`RuntypeClientInitResponse`** — new required `conversationId` + `conversationRevision`; new optional `app` / `targetId` / `visitor` (with `identityStatus`); `config.placeholder` and `config.welcomeMessage` flipped optional → required
- **Await event** — new `requests[]` array (multiple concurrent asks) and `externalAgent: { contextId, taskId }`
- **Execution completion** — new `stepErrorCount`
- **Chat request messages** — new `displayContent`

No hand-written source changes were needed; nothing depended on the old shapes.

## Verification

Full CI gate, locally:

- `pnpm build` → 0
- `pnpm lint` → 0
- `pnpm typecheck` → 0 (widget, proxy, and web)
- `pnpm --filter @runtypelabs/persona test:run` → 150 files, 2388 tests passing

## Follow-up worth considering (not in this PR)

Gating `typecheck` on a live network fetch of a third-party spec means unrelated PRs go red whenever the upstream API ships, and it makes CI non-hermetic. Worth moving the drift check to a scheduled job that opens a regen PR, and having `typecheck` compile against the committed contract only.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR regenerates the public Runtype OpenAPI TypeScript declarations to match the current upstream contract.
- Expands client initialization request and response types with conversation, visitor, identity, and app metadata.
- Adds fields for concurrent await requests, external-agent context, execution error counts, and display content.
- Adds a patch changeset documenting the regenerated contract surface.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The changes update generated compile-time declarations to reflect the upstream contract, while existing repository request construction remains compatible and production response handling does not depend on the changed generated response type.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| packages/widget/src/generated/runtype-openapi-contract.ts | Regenerates exported contract declarations with upstream request, response, stream-event, and chat-message fields; no concrete consumer failure was identified. |
| .changeset/regen-runtype-openapi-types.md | Adds an accurate patch-level summary of the generated contract changes. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: regenerate Runtype OpenAPI contra..."](https://github.com/runtypelabs/persona/commit/3aa44f6f64161a2fd575133c4aee86a111ccf4c9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54107461)</sub>

<!-- /greptile_comment -->