### PR TITLE
chore: replace Travrse references with Runtype

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 Travrse Labs, LLC (d/b/a Runtype)
+Copyright (c) 2026 Runtype, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/proxy/CHANGELOG.md
+++ b/packages/proxy/CHANGELOG.md
@@ -386,25 +386,20 @@
 
 ### Minor Changes
 
-- 28132f6: Rename travrse to runtype and update API URLs
+- 28132f6: Rebrand to Runtype and update API URLs
 
-  - Update all references from "travrse" to "runtype" throughout codebase
-  - Change API endpoint from api.travrse.ai to api.runtype.com
-  - Update environment variable names (TRAVRSE_API_KEY -> RUNTYPE_API_KEY)
-  - Update data attribute from data-travrse-token to data-runtype-token
-  - Update CSS variable names from --travrse-_ to --runtype-_
-  - Rename types TravrseFlowConfig -> RuntypeFlowConfig (with deprecated aliases)
+  - Update naming throughout the codebase
+  - API endpoint is `api.runtype.com`
+  - Environment variable is `RUNTYPE_API_KEY`
+  - Data attribute is `data-runtype-token`
+  - CSS variables are `--runtype-*`
+  - Flow config types are `RuntypeFlowConfig` and `RuntypeFlowStep`
 
   **Breaking Changes:**
 
   - Default API endpoint changed to `api.runtype.com`
-  - Data attribute changed from `data-travrse-token` to `data-runtype-token`
-  - CSS variables renamed from `--travrse-*` to `--runtype-*`
-
-  **Backwards Compatibility:**
-
-  - `TRAVRSE_API_KEY` environment variable is still supported as a fallback
-  - `TravrseFlowStep` and `TravrseFlowConfig` types are exported as deprecated aliases
+  - Data attribute is now `data-runtype-token`
+  - CSS variables are now `--runtype-*`
 
 ## 1.36.1
 

--- a/packages/widget/CHANGELOG.md
+++ b/packages/widget/CHANGELOG.md
@@ -1709,25 +1709,20 @@
   - Sensitive data redaction (show PII to user, hide from LLM)
   - Context injection (rich LLM context with minimal UI footprint)
 
-- 28132f6: Rename travrse to runtype and update API URLs
+- 28132f6: Rebrand to Runtype and update API URLs
 
-  - Update all references from "travrse" to "runtype" throughout codebase
-  - Change API endpoint from api.travrse.ai to api.runtype.com
-  - Update environment variable names (TRAVRSE_API_KEY -> RUNTYPE_API_KEY)
-  - Update data attribute from data-travrse-token to data-runtype-token
-  - Update CSS variable names from --travrse-_ to --runtype-_
-  - Rename types TravrseFlowConfig -> RuntypeFlowConfig (with deprecated aliases)
+  - Update naming throughout the codebase
+  - API endpoint is `api.runtype.com`
+  - Environment variable is `RUNTYPE_API_KEY`
+  - Data attribute is `data-runtype-token`
+  - CSS variables are `--runtype-*`
+  - Flow config types are `RuntypeFlowConfig` and `RuntypeFlowStep`
 
   **Breaking Changes:**
 
   - Default API endpoint changed to `api.runtype.com`
-  - Data attribute changed from `data-travrse-token` to `data-runtype-token`
-  - CSS variables renamed from `--travrse-*` to `--runtype-*`
-
-  **Backwards Compatibility:**
-
-  - `TRAVRSE_API_KEY` environment variable is still supported as a fallback
-  - `TravrseFlowStep` and `TravrseFlowConfig` types are exported as deprecated aliases
+  - Data attribute is now `data-runtype-token`
+  - CSS variables are now `--runtype-*`
 
 ## 1.36.1
 


### PR DESCRIPTION
Updates the LICENSE copyright holder to `Runtype, Inc.` and removes the remaining `travrse` mentions from the proxy and widget changelogs. No source changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the project copyright holder and removes remaining legacy Travrse branding from historical proxy and widget changelog entries.
- Changes the LICENSE holder to `Runtype, Inc.`
- Rewords the proxy and widget 1.37.0 changelog entries using current Runtype terminology

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it changes only licensing attribution and historical changelog wording, with no runtime or build behavior affected.

The MIT license terms remain intact, and the changelog edits consistently replace legacy branding without changing source code, package interfaces, or generated artifacts.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| LICENSE | Updates the 2026 copyright holder while leaving the MIT license terms unchanged. |
| packages/proxy/CHANGELOG.md | Rewords the 1.37.0 rebranding notes and removes obsolete compatibility claims that no longer match current proxy source. |
| packages/widget/CHANGELOG.md | Applies the same legacy-brand cleanup to the widget's historical 1.37.0 release entry. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: replace Travrse references with R..."](https://github.com/runtypelabs/persona/commit/4e0d26d37dd6a5bc3b947d1fffc10794e9f9432c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54404433)</sub>

<!-- /greptile_comment -->