### PR TITLE
Switch demo model selections from Nemotron Ultra to Gemini 3.7 Flash

### DIFF
--- a/.changeset/gemini-3-7-demo-models.md
+++ b/.changeset/gemini-3-7-demo-models.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Switch the bundled demo flows and server-pinned agents from `nemotron-3-ultra-550b-a55b` to `gemini-3.7-flash`.

--- a/examples/ai-sdk-webmcp/.env.local.example
+++ b/examples/ai-sdk-webmcp/.env.local.example
@@ -1,7 +1,7 @@
 # Copy to `.env.local`.
 #
 # This example routes model calls through the Vercel AI Gateway (the shim uses a
-# bare "nvidia/nemotron-3-ultra-550b-a55b" model id). Auth:
+# bare "google/gemini-3.7-flash" model id). Auth:
 #
 #   • On Vercel:  nothing to set: the gateway authenticates automatically via
 #                 the deployment's OIDC token.

--- a/examples/ai-sdk-webmcp/README.md
+++ b/examples/ai-sdk-webmcp/README.md
@@ -43,7 +43,7 @@ otherwise unchanged. It never learns it isn't talking to a hosted agent runtime.
 ## Run
 
 Model calls route through the **Vercel AI Gateway** (the shim uses a bare
-`nvidia/nemotron-3-ultra-550b-a55b` model id). On Vercel this authenticates
+`google/gemini-3.7-flash` model id). On Vercel this authenticates
 automatically via the deployment's OIDC token: **no key to set**. For local dev
 you need an `AI_GATEWAY_API_KEY`:
 

--- a/examples/ai-sdk-webmcp/app/api/chat/shim.ts
+++ b/examples/ai-sdk-webmcp/app/api/chat/shim.ts
@@ -65,7 +65,7 @@ const WEBMCP_PREFIX = "webmcp:";
 // Bare "creator/model" id → the AI SDK routes through the Vercel AI Gateway
 // (the default provider when no provider instance is given). On Vercel this
 // authenticates automatically via OIDC; locally it uses AI_GATEWAY_API_KEY.
-const MODEL = "nvidia/nemotron-3-ultra-550b-a55b";
+const MODEL = "google/gemini-3.7-flash";
 
 const SYSTEM_PROMPT = `You are the Switchback shopping assistant for a trail & road running store.
 You help shoppers using ONLY the page's own tools (search_products, view_product,

--- a/packages/proxy/README.md
+++ b/packages/proxy/README.md
@@ -89,7 +89,7 @@ export default createChatProxyApp({
   allowedOrigins: ['https://www.example.com'],
   agentConfig: {
     name: 'Shopping Assistant',
-    model: 'nemotron-3-ultra-550b-a55b',
+    model: 'gemini-3.7-flash',
     systemPrompt: 'You are a concise shopping assistant.',
     loopConfig: { maxTurns: 6 }
   }

--- a/packages/proxy/src/agents/analytics-assistant.ts
+++ b/packages/proxy/src/agents/analytics-assistant.ts
@@ -7,7 +7,7 @@ import type { AgentConfig } from "../index.js";
  */
 export const ANALYTICS_ASSISTANT_AGENT: AgentConfig = {
   name: "Northstar Data Analyst",
-  model: "nemotron-3-ultra-550b-a55b",
+  model: "gemini-3.7-flash",
   reasoning: false,
   systemPrompt: `You are Atlas, the embedded data analyst inside Northstar Analytics. You help operators answer business questions with evidence from their browser-local demo warehouse.
 

--- a/packages/proxy/src/agents/docs-assistant.ts
+++ b/packages/proxy/src/agents/docs-assistant.ts
@@ -187,7 +187,7 @@ Keep answers concise. Use markdown formatting. When recommending a demo, briefly
  */
 export const DOCS_ASSISTANT_AGENT: AgentConfig = {
   name: "Persona Documentation Assistant",
-  model: "nemotron-3-ultra-550b-a55b",
+  model: "gemini-3.7-flash",
   systemPrompt: PERSONA_DOCS_SYSTEM_PROMPT,
   temperature: 0.5,
   tools: {

--- a/packages/proxy/src/agents/travel-planner.ts
+++ b/packages/proxy/src/agents/travel-planner.ts
@@ -6,7 +6,7 @@ import type { AgentConfig } from "../index.js";
  */
 export const TRAVEL_PLANNER_AGENT: AgentConfig = {
   name: "Travel Planner Assistant",
-  model: "nemotron-3-ultra-550b-a55b",
+  model: "gemini-3.7-flash",
   systemPrompt:
     "You are a travel planning assistant with access to the Exa web search tool. " +
     "For itinerary requests, complete work in exactly 3 iterations: " +

--- a/packages/proxy/src/flows/bakery-assistant.ts
+++ b/packages/proxy/src/flows/bakery-assistant.ts
@@ -20,7 +20,7 @@ export const BAKERY_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/components.ts
+++ b/packages/proxy/src/flows/components.ts
@@ -14,7 +14,7 @@ export const COMPONENT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/conversational.ts
+++ b/packages/proxy/src/flows/conversational.ts
@@ -14,7 +14,7 @@ export const CONVERSATIONAL_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/page-context.ts
+++ b/packages/proxy/src/flows/page-context.ts
@@ -31,7 +31,7 @@ export const PAGE_CONTEXT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         responseFormat: "JSON",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/scheduling.ts
+++ b/packages/proxy/src/flows/scheduling.ts
@@ -14,7 +14,7 @@ export const FORM_DIRECTIVE_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/shopping-assistant.ts
+++ b/packages/proxy/src/flows/shopping-assistant.ts
@@ -18,7 +18,7 @@ export const SHOPPING_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",
@@ -97,7 +97,7 @@ export const SHOPPING_ASSISTANT_METADATA_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/storefront-assistant.ts
+++ b/packages/proxy/src/flows/storefront-assistant.ts
@@ -23,7 +23,7 @@ export const STOREFRONT_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/theme-assistant.ts
+++ b/packages/proxy/src/flows/theme-assistant.ts
@@ -32,10 +32,9 @@ export const THEME_ASSISTANT_FLOW: RuntypeFlowConfig = {
         // Needs BOTH native structured tool calls (for the page-discovered
         // `clientTools[]`: text-emitted calls never execute) AND vision (the
         // user pastes reference images; screenshot_preview returns image
-        // blocks). This is why it diverges from the other flows'
-        // `nemotron-3-ultra-550b-a55b`: the platform catalog tags nemotron
-        // ultra as tool-use but NOT vision, which would silently break the
-        // reference-image loop. If you swap models, confirm both first.
+        // blocks). Both are confirmed on this model in the platform catalog.
+        // If you swap models, confirm both tags first: a tool-use-only model
+        // would silently break the reference-image loop.
         model: "gemini-3.5-flash",
         reasoning: false,
         responseFormat: "markdown",

--- a/packages/proxy/src/flows/webmcp-calendar.ts
+++ b/packages/proxy/src/flows/webmcp-calendar.ts
@@ -31,7 +31,7 @@ export const WEBMCP_CALENDAR_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-docked.ts
+++ b/packages/proxy/src/flows/webmcp-docked.ts
@@ -24,7 +24,7 @@ export const WEBMCP_DOCKED_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -31,7 +31,7 @@ export const WEBMCP_SLIDES_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-storefront.ts
+++ b/packages/proxy/src/flows/webmcp-storefront.ts
@@ -17,7 +17,7 @@ import type { RuntypeFlowConfig } from "../index.js";
  * needs a tool-capable model and a system prompt that knows how to shop the
  * (page-provided) catalog.
  *
- * Model: `nemotron-3-ultra-550b-a55b`. WebMCP depends on the model
+ * Model: `gemini-3.7-flash`. WebMCP depends on the model
  * emitting **native** tool calls (each surfaces as a `step_await` the widget
  * resumes), so a tool-reliable model is required here. `responseFormat` is
  * markdown (not JSON) so the model is free to interleave tool calls with a
@@ -34,7 +34,7 @@ export const WEBMCP_STOREFRONT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -245,7 +245,7 @@ const DEFAULT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nemotron-3-ultra-550b-a55b",
+        model: "gemini-3.7-flash",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",


### PR DESCRIPTION
## What does this PR do?

Replaces every `nemotron-3-ultra-550b-a55b` model selection in the demos with Gemini 3.7 Flash due to decreasing performance of Nemotron Ultra likely due to its decreasing popularity amongst our gateway providers, leading to contention.

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Tooling / CI

_(Closest fit: this is a configuration change to bundled demo flows and examples, not a library API change.)_

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes — run per package (`tsc --noEmit` in `packages/widget` and `packages/proxy`); the root script's `check:runtype-types` prestep additionally fetches `api.runtype.com/v1/openapi.json`, which is blocked from this sandbox
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run` — 3788 passed; `packages/proxy` also run: 47 passed). No new tests: this changes configuration values only, with no behavioral branch to cover
- [x] **Changeset added if I touched `packages/widget` or `packages/proxy`** — `.changeset/gemini-3-7-demo-models.md`, patch on `@runtypelabs/persona-proxy`
- [x] Docs updated if I changed public API or behavior — `packages/proxy/README.md` and the `ai-sdk-webmcp` README/env example


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates bundled proxy demos and server-pinned agents to use the routed Gemini 3.7 Flash model, while the standalone AI SDK example uses its provider-qualified Vercel AI Gateway identifier.
- Updates the default proxy flow, reusable demo flows, and three server-owned agents.
- Keeps the vision-dependent theme assistant on Gemini 3.5 Flash and refreshes its capability comment.
- Aligns the standalone example’s shim, environment template, documentation, and package changeset.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the model identifiers are applied consistently for their respective routing layers and no concrete regression was identified.

The changes are limited to model selections and aligned documentation, preserve the existing flow, tool, and response contracts, and use distinct routed and provider-qualified identifiers where each integration expects them.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/proxy/src/index.ts | Updates the proxy’s default conversational flow to the new routed model identifier without changing dispatch behavior. |
| packages/proxy/src/flows/webmcp-storefront.ts | Moves the representative WebMCP storefront flow to Gemini 3.7 Flash and updates its model documentation while preserving its native tool-call contract. |
| packages/proxy/src/flows/theme-assistant.ts | Leaves the vision-dependent model unchanged and rewrites the comment to state the required tool-call and vision capabilities directly. |
| packages/proxy/src/agents/docs-assistant.ts | Changes the server-pinned documentation assistant’s model while retaining its prompt, MCP configuration, and tool-call limit. |
| examples/ai-sdk-webmcp/app/api/chat/shim.ts | Replaces the AI Gateway model identifier with the provider-qualified Gemini 3.7 Flash identifier without altering the shim protocol. |
| .changeset/gemini-3-7-demo-models.md | Adds the expected proxy package patch changeset describing the bundled model migration. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    W[Persona widget] --> P[Persona proxy]
    P --> R[Gemini 3.7 Flash via Runtype routed ID]
    W --> E[Standalone AI SDK example]
    E --> G[Gemini 3.7 Flash via Vercel AI Gateway]
    R --> T[Text, structured responses, or tool calls]
    G --> T
```
</details>

<sub>Reviews (1): Last reviewed commit: ["Switch demo model selections from Nemotr..."](https://github.com/runtypelabs/persona/commit/7f180b9d3fc7eccb214f97495db13871fd09ff48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57368896)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Assistant proxy service](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/assistant-proxy.md)
- Knowledge Base — [Proxy agent definitions](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/proxy-agents.md)
- Knowledge Base — [Proxy conversational flows](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/proxy-conversation-flows.md)
</details>


<!-- /greptile_comment -->