### PR TITLE
feat(demos): gemini-3.5-flash-lite for demos; sequential WebMCP tool calls; fix agent-mode stream parsing

### DIFF
--- a/.changeset/agent-text-stream-parser.md
+++ b/.changeset/agent-text-stream-parser.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Run agent-mode text through the configured `streamParser`. Agent `text_delta` chunks previously appended the raw delta straight onto the message, bypassing `streamParser` and leaving `rawContent` unset — so a server-pinned agent that replies with a JSON envelope rendered the raw `{"text": ...}` in the bubble and never dispatched its action. Agent text now flows through the same structured-content path as flow text. Agents using the default plain-text parser are unaffected.

--- a/.changeset/demo-models-gemini-lite.md
+++ b/.changeset/demo-models-gemini-lite.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona-proxy": patch
 ---
 
-Move the demo flows and agents to `google/gemini-3.5-flash-lite`. WebMCP Paint runs on `glm-5.2`: its snapshot-and-look loop needs both vision and native tool calls, and glm-5.2 reaches its first stroke fastest while composing a richer scene.
+Move the demo flows and agents to `google/gemini-3.5-flash-lite`. WebMCP Paint runs on `nvidia/nemotron-3-ultra-550b-a55b`: its snapshot-and-look loop needs both vision and native tool calls.

--- a/.changeset/demo-models-gemini-lite.md
+++ b/.changeset/demo-models-gemini-lite.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona-proxy": patch
 ---
 
-Move the demo flows and agents to `google/gemini-3.5-flash-lite`. WebMCP Paint runs on `gemini-3.7-flash`: its snapshot-and-look loop needs both vision and native tool calls, and the lite tier was slower to its first stroke.
+Move the demo flows and agents to `google/gemini-3.5-flash-lite`. WebMCP Paint runs on `glm-5.2`: its snapshot-and-look loop needs both vision and native tool calls, and glm-5.2 reaches its first stroke fastest while composing a richer scene.

--- a/.changeset/demo-models-gemini-lite.md
+++ b/.changeset/demo-models-gemini-lite.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Move the demo flows and agents to `google/gemini-3.5-flash-lite`. WebMCP Paint runs on `gemini-3.7-flash`: its snapshot-and-look loop needs both vision and native tool calls, and the lite tier was slower to its first stroke.

--- a/.changeset/webmcp-sequential-execution.md
+++ b/.changeset/webmcp-sequential-execution.md
@@ -1,5 +1,5 @@
 ---
-"@runtypelabs/persona": patch
+"@runtypelabs/persona": minor
 ---
 
 Add `webmcp.execution: "parallel" | "sequential"`. When a turn emits several `webmcp:*` tool calls at once, the widget ran them all concurrently, which interleaves page tools that share mutable state (the Paint demo's strokes each select a tool and color before drawing). `"sequential"` runs the batch one at a time in emission order, waiting for each call to settle (approval included) before starting the next; outputs still return in a single `/resume`. The default stays `"parallel"`.

--- a/.changeset/webmcp-sequential-execution.md
+++ b/.changeset/webmcp-sequential-execution.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Add `webmcp.execution: "parallel" | "sequential"`. When a turn emits several `webmcp:*` tool calls at once, the widget ran them all concurrently, which interleaves page tools that share mutable state (the Paint demo's strokes each select a tool and color before drawing). `"sequential"` runs the batch one at a time in emission order, waiting for each call to settle (approval included) before starting the next; outputs still return in a single `/resume`. The default stays `"parallel"`.

--- a/apps/web/src/webmcp-paint/main.ts
+++ b/apps/web/src/webmcp-paint/main.ts
@@ -102,6 +102,10 @@ function mountWidget(): void {
         // paint live; only canvas-wiping tools confirm (and ⌘Z reverses
         // everything anyway).
         autoApprove: (info) => !APPROVAL_REQUIRED_TOOL_NAMES.has(info.toolName),
+        // Every stroke selects a tool + color before it draws, so a turn
+        // that emits several strokes at once must land them one after the
+        // other; run in parallel they interleave inside jspaint.
+        execution: "sequential",
       },
       features: {
         ...DEFAULT_WIDGET_CONFIG.features,

--- a/packages/proxy/src/agents/analytics-assistant.ts
+++ b/packages/proxy/src/agents/analytics-assistant.ts
@@ -7,7 +7,7 @@ import type { AgentConfig } from "../index.js";
  */
 export const ANALYTICS_ASSISTANT_AGENT: AgentConfig = {
   name: "Northstar Data Analyst",
-  model: "gemini-3.7-flash",
+  model: "google/gemini-3.5-flash-lite",
   reasoning: false,
   systemPrompt: `You are Atlas, the embedded data analyst inside Northstar Analytics. You help operators answer business questions with evidence from their browser-local demo warehouse.
 

--- a/packages/proxy/src/agents/chat-assistant.ts
+++ b/packages/proxy/src/agents/chat-assistant.ts
@@ -7,7 +7,7 @@ import type { AgentConfig } from "../index.js";
  */
 export const CHAT_ASSISTANT_AGENT: AgentConfig = {
   name: "Chat Assistant",
-  model: "moonshotai/kimi-k2.7-code",
+  model: "google/gemini-3.5-flash-lite",
   systemPrompt:
     "You are a helpful assistant. Be friendly, concise, and helpful. If you don't know something, say so.",
   artifacts: { enabled: true, types: ["markdown", "component"] },

--- a/packages/proxy/src/agents/docs-assistant.ts
+++ b/packages/proxy/src/agents/docs-assistant.ts
@@ -187,7 +187,7 @@ Keep answers concise. Use markdown formatting. When recommending a demo, briefly
  */
 export const DOCS_ASSISTANT_AGENT: AgentConfig = {
   name: "Persona Documentation Assistant",
-  model: "gemini-3.7-flash",
+  model: "google/gemini-3.5-flash-lite",
   systemPrompt: PERSONA_DOCS_SYSTEM_PROMPT,
   temperature: 0.5,
   tools: {

--- a/packages/proxy/src/agents/travel-planner.ts
+++ b/packages/proxy/src/agents/travel-planner.ts
@@ -6,7 +6,7 @@ import type { AgentConfig } from "../index.js";
  */
 export const TRAVEL_PLANNER_AGENT: AgentConfig = {
   name: "Travel Planner Assistant",
-  model: "gemini-3.7-flash",
+  model: "google/gemini-3.5-flash-lite",
   systemPrompt:
     "You are a travel planning assistant with access to the Exa web search tool. " +
     "For itinerary requests, complete work in exactly 3 iterations: " +

--- a/packages/proxy/src/flows/bakery-assistant.ts
+++ b/packages/proxy/src/flows/bakery-assistant.ts
@@ -20,7 +20,7 @@ export const BAKERY_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/components.ts
+++ b/packages/proxy/src/flows/components.ts
@@ -14,7 +14,7 @@ export const COMPONENT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/conversational.ts
+++ b/packages/proxy/src/flows/conversational.ts
@@ -14,7 +14,7 @@ export const CONVERSATIONAL_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/page-context.ts
+++ b/packages/proxy/src/flows/page-context.ts
@@ -31,7 +31,7 @@ export const PAGE_CONTEXT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         responseFormat: "JSON",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/proxy/src/flows/scheduling.ts
+++ b/packages/proxy/src/flows/scheduling.ts
@@ -14,7 +14,7 @@ export const FORM_DIRECTIVE_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/shopping-assistant.ts
+++ b/packages/proxy/src/flows/shopping-assistant.ts
@@ -18,7 +18,7 @@ export const SHOPPING_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",
@@ -97,7 +97,7 @@ export const SHOPPING_ASSISTANT_METADATA_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/storefront-assistant.ts
+++ b/packages/proxy/src/flows/storefront-assistant.ts
@@ -23,7 +23,7 @@ export const STOREFRONT_ASSISTANT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "JSON",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/theme-assistant.ts
+++ b/packages/proxy/src/flows/theme-assistant.ts
@@ -35,7 +35,7 @@ export const THEME_ASSISTANT_FLOW: RuntypeFlowConfig = {
         // blocks). Both are confirmed on this model in the platform catalog.
         // If you swap models, confirm both tags first: a tool-use-only model
         // would silently break the reference-image loop.
-        model: "gemini-3.5-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-calendar.ts
+++ b/packages/proxy/src/flows/webmcp-calendar.ts
@@ -31,7 +31,7 @@ export const WEBMCP_CALENDAR_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-docked.ts
+++ b/packages/proxy/src/flows/webmcp-docked.ts
@@ -24,7 +24,7 @@ export const WEBMCP_DOCKED_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-paint.ts
+++ b/packages/proxy/src/flows/webmcp-paint.ts
@@ -28,7 +28,7 @@ export const WEBMCP_PAINT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.5-flash",
+        model: "gemini-3.7-flash",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-paint.ts
+++ b/packages/proxy/src/flows/webmcp-paint.ts
@@ -28,7 +28,7 @@ export const WEBMCP_PAINT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "glm-5.2",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-paint.ts
+++ b/packages/proxy/src/flows/webmcp-paint.ts
@@ -28,7 +28,7 @@ export const WEBMCP_PAINT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "glm-5.2",
+        model: "nvidia/nemotron-3-ultra-550b-a55b",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-slides.ts
+++ b/packages/proxy/src/flows/webmcp-slides.ts
@@ -31,7 +31,7 @@ export const WEBMCP_SLIDES_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/flows/webmcp-storefront.ts
+++ b/packages/proxy/src/flows/webmcp-storefront.ts
@@ -34,7 +34,7 @@ export const WEBMCP_STOREFRONT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",

--- a/packages/proxy/src/index.ts
+++ b/packages/proxy/src/index.ts
@@ -245,7 +245,7 @@ const DEFAULT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "gemini-3.7-flash",
+        model: "google/gemini-3.5-flash-lite",
         responseFormat: "markdown",
         outputVariable: "prompt_result",
         userPrompt: "{{user_message}}",

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "184.25 kB",
+    "limit": "184.5 kB",
     "gzip": true
   },
   {
@@ -20,7 +20,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "196.5 kB",
+    "limit": "196.75 kB",
     "gzip": true
   },
   {

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -4611,3 +4611,76 @@ describe('AgentWidgetClient - mention context', () => {
     expect(get().context).toBeUndefined();
   });
 });
+
+describe('AgentWidgetClient - agent text runs through the configured stream parser', () => {
+  // Regression: agent-mode text_delta used to append the raw delta straight onto
+  // `content`, bypassing `streamParser` entirely. Demos that pin a server-side
+  // agent AND reply with a JSON envelope (the page-context / smart-dom-reader
+  // demo) therefore rendered the raw `{"text": ...}` in the bubble, and never
+  // populated `rawContent`, so the action manager saw nothing to dispatch.
+  const envelopeStream = (execId: string, chunks: string[]) => [
+    sseEvent('execution_start', { kind: 'agent', executionId: execId, agentId: 'virtual', agentName: 'Test', maxTurns: 1, startedAt: new Date().toISOString(), seq: 1 }),
+    sseEvent('turn_start', { executionId: execId, id: 'turn_1', iteration: 1, role: 'assistant', seq: 2 }),
+    sseEvent('text_start', { executionId: execId, id: 'text_1', role: 'assistant', seq: 3 }),
+    ...chunks.map((delta, i) =>
+      sseEvent('text_delta', { executionId: execId, id: 'text_1', delta, seq: 4 + i })
+    ),
+    sseEvent('text_complete', { executionId: execId, id: 'text_1', seq: 90 }),
+    sseEvent('turn_complete', { executionId: execId, id: 'turn_1', iteration: 1, role: 'assistant', completedAt: new Date().toISOString(), seq: 91 }),
+    sseEvent('execution_complete', { kind: 'agent', executionId: execId, success: true, completedAt: new Date().toISOString(), seq: 92 }),
+  ];
+
+  const lastAssistant = (events: AgentWidgetEvent[]): AgentWidgetMessage | null => {
+    for (let i = events.length - 1; i >= 0; i--) {
+      const e = events[i];
+      if (e.type === 'message' && e.message.role === 'assistant') return e.message;
+    }
+    return null;
+  };
+
+  const runAgent = async (
+    chunks: string[],
+    config: Record<string, unknown> = {}
+  ): Promise<AgentWidgetMessage | null> => {
+    global.fetch = createRawStreamFetch(envelopeStream('exec_env', chunks));
+    const events: AgentWidgetEvent[] = [];
+    const client = new AgentWidgetClient({
+      apiUrl: 'http://localhost:8000',
+      agent: { name: 'Test', model: 'openai:gpt-4o-mini', systemPrompt: 'test' },
+      ...config,
+    } as any);
+    await client.dispatch(
+      { messages: [{ id: 'u1', role: 'user', content: 'Hi', createdAt: new Date().toISOString() }] },
+      (e) => events.push(e)
+    );
+    return lastAssistant(events);
+  };
+
+  it('extracts `text` from a JSON envelope streamed across agent text_delta chunks', async () => {
+    const msg = await runAgent(
+      ['{"text": "In the ', '**Featured drop**', ', we have 2 items."}'],
+      { streamParser: () => createJsonStreamParser() }
+    );
+
+    expect(msg?.content).toBe('In the **Featured drop**, we have 2 items.');
+    // The bubble must not show the envelope itself.
+    expect(msg?.content).not.toContain('{"text"');
+  });
+
+  it('keeps the raw envelope on rawContent so the action manager can dispatch it', async () => {
+    const envelope = '{"action": "add_to_cart", "product": "headphones", "text": "Added it!"}';
+    const msg = await runAgent([envelope], {
+      streamParser: () => createJsonStreamParser(),
+    });
+
+    expect(msg?.content).toBe('Added it!');
+    expect(msg?.rawContent).toBe(envelope);
+  });
+
+  it('still plain-appends agent prose when no custom parser is configured', async () => {
+    const msg = await runAgent(['Hello', ' World']);
+
+    expect(msg?.content).toBe('Hello World');
+    expect(msg?.rawContent).toBeUndefined();
+  });
+});

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -2737,9 +2737,10 @@ export class AgentWidgetClient {
     // bubble-id segmentation on the wire in place of the legacy `partId`:
     // a new block id means a new bubble, sealed at `text_complete`/tool boundaries.
     let currentTextBlockId: string | null = null;
-    // Raw text accumulated for the open flow block before its bubble is
-    // materialized — lets a whitespace-only block resolve without a stray bubble.
-    let pendingFlowRaw = "";
+    // Raw text accumulated for the open text block, on both the flow and agent
+    // paths — lets a whitespace-only flow block resolve without a stray bubble,
+    // and gives the structured-content parser the whole block on either path.
+    let pendingTextRaw = "";
     // Nested flow-as-tool attribution (PR #4602): a text/reasoning block whose
     // `parentToolCallId` matches a `tool_start.toolCallId` belongs to a flow
     // running as that tool. Keyed by the wire block id, these route the block's
@@ -3134,20 +3135,20 @@ export class AgentWidgetClient {
       finalizeCleanup();
     };
 
-    // === Unified flow text channel ===
-    // Flow prompt-step text streams as `text_delta` blocks (segmented by
-    // `text_start`/`text_complete`) and can be structured JSON, so each block
-    // runs through the per-bubble structured-content parser — agent text stays
-    // plain. This is the legacy step_delta parser core, re-keyed from `partId`
-    // to the wire block-id bubble. The caller materializes the bubble lazily
-    // (whitespace-only blocks around tool boundaries never leave a stray bubble)
-    // and `step_complete.result.response` reconciles the authoritative final.
+    // === Unified text channel ===
+    // Prompt-step and agent text both stream as `text_delta` blocks (segmented by
+    // `text_start`/`text_complete`) and can be structured JSON, so each block runs
+    // through the per-bubble structured-content parser. This is the legacy
+    // step_delta parser core, re-keyed from `partId` to the wire block-id bubble.
+    // The caller materializes the bubble lazily (whitespace-only blocks around
+    // tool boundaries never leave a stray bubble) and `step_complete.result.response`
+    // reconciles the authoritative final.
     let lastSealedFlowBubble: AgentWidgetMessage | null = null;
 
-    // Stream one accumulated chunk of flow block text through the parser, setting
+    // Stream one accumulated chunk of block text through the parser, setting
     // display `content` (extracted) + `rawContent` (raw) and emitting. Mirrors the
     // legacy step_delta chunk path; plain text bypasses the structured parser.
-    const applyFlowTextChunk = (
+    const applyTextChunk = (
       assistant: AgentWidgetMessage,
       accumulatedRaw: string,
       chunk: string,
@@ -3773,7 +3774,7 @@ export class AgentWidgetClient {
           }
           currentTextBlockId =
             typeof payload.id === "string" ? payload.id : currentTextBlockId;
-          pendingFlowRaw = "";
+          pendingTextRaw = "";
         } else if (payloadType === "text_delta") {
           // Nested flow-as-tool text: route to the parent tool's row, through the
           // same structured-content parser, never the top-level assistant channel.
@@ -3793,7 +3794,7 @@ export class AgentWidgetClient {
               executionId: payload.executionId,
               parentToolId: nestedParent,
             };
-            applyFlowTextChunk(nested, nestedRaw, nestedDelta, undefined);
+            applyTextChunk(nested, nestedRaw, nestedDelta, undefined);
             continue;
           }
           currentTextBlockId =
@@ -3804,27 +3805,36 @@ export class AgentWidgetClient {
             // block-id bubble. Materialize lazily so a whitespace-only block
             // (newlines around a tool boundary) never leaves a stray bubble.
             const delta = typeof payload.delta === "string" ? payload.delta : "";
-            pendingFlowRaw += delta;
-            if (pendingFlowRaw.trim() === "") continue;
+            pendingTextRaw += delta;
+            if (pendingTextRaw.trim() === "") continue;
             const assistant = ensureAssistantMessage();
             assistant.agentMetadata = {
               executionId: payload.executionId,
               iteration: payload.iteration,
             };
-            applyFlowTextChunk(assistant, pendingFlowRaw, delta, undefined);
+            applyTextChunk(assistant, pendingTextRaw, delta, undefined);
             lastAssistantInTurn = assistant;
             continue;
           }
+          // Agent text can be structured JSON too, whenever the host configures a
+          // custom `streamParser` (e.g. the page-context demo's `{"text": ...}` /
+          // `{"action": "add_to_cart", ...}` envelope). Accumulate the open block's
+          // raw text and run it through the same structured-content path the flow
+          // branch uses, so the parser sees the whole block and `rawContent` stays
+          // populated for the action manager. With the default plain-text parser
+          // this is byte-identical to appending the delta, so agent demos that
+          // stream prose are unaffected.
+          const agentDelta = typeof payload.delta === "string" ? payload.delta : "";
+          pendingTextRaw += agentDelta;
           const assistant = ensureAssistantMessage();
-          assistant.content += payload.delta ?? '';
           assistant.agentMetadata = {
             executionId: payload.executionId,
             iteration: payload.iteration,
             turnId: openTurnId ?? undefined,
             agentName: agentExecution?.agentName
           };
+          applyTextChunk(assistant, pendingTextRaw, agentDelta, undefined);
           lastAssistantInTurn = assistant;
-          emitMessage(assistant);
         } else if (payloadType === "text_complete") {
           // Nested flow-as-tool text block close: seal its parent-tool-row message.
           const completeBlockId = typeof payload.id === "string" ? payload.id : null;
@@ -3857,7 +3867,7 @@ export class AgentWidgetClient {
             assistantMessage = null;
           }
           currentTextBlockId = null;
-          pendingFlowRaw = "";
+          pendingTextRaw = "";
         } else if (payloadType === "step_complete") {
           // Only process completions for prompt steps, not tool/context steps
           const stepType = (payload as any).stepType;
@@ -4201,7 +4211,7 @@ export class AgentWidgetClient {
             assistantMessage = null;
           }
           currentTextBlockId = null;
-          pendingFlowRaw = "";
+          pendingTextRaw = "";
           lastSealedFlowBubble = null;
 
           // `terminal: true` marks this as a graceful finish (not a drop). The

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -3566,10 +3566,12 @@ export class AgentWidgetSession {
   /**
    * Resolve one or more parallel local-tool awaits sharing one paused
    * executionId with a SINGLE `/resume` (core#3878); `resolveWebMcpToolCall`
-   * delegates size-1 resolves here after its guards. Each call is executed
-   * against the page registry concurrently: every gated call renders its own
-   * native approval bubble, and a sibling's confirm Promise never blocks
-   * another's execution. Outputs are keyed by per-call `webMcpToolCallId`
+   * delegates size-1 resolves here after its guards. By default each call is
+   * executed against the page registry concurrently: every gated call renders
+   * its own native approval bubble, and a sibling's confirm Promise never
+   * blocks another's execution. With `webmcp.execution: "sequential"` the
+   * calls run one at a time in emission order instead (see the config docs
+   * for when that matters). Outputs are keyed by per-call `webMcpToolCallId`
    * (server prefers it over tool name; name-keying remains the fallback for
    * legacy single/distinct-tool turns), so two calls to the SAME tool no longer
    * collide. The server is tolerant: any call we omit (declined-after-abort,
@@ -3599,111 +3601,125 @@ export class AgentWidgetSession {
     this.webMcpResolveControllers.add(batchController);
     this.setStreaming(true);
 
-    // Phase 1: execute every pending call concurrently. A null result means
-    // the call was deduped, aborted, or threw; it's omitted from the resume and
-    // (per the tolerant server) re-pauses for retry.
-    const executed = await Promise.all(
-      snapshots.map(async (toolMessage) => {
-        const wireToolName = toolMessage.toolCall?.name;
-        const callId = toolMessage.toolCall?.id;
-        if (!wireToolName || !callId) return null;
+    // Phase 1: execute every pending call. A null result means the call was
+    // deduped, aborted, or threw; it's omitted from the resume and (per the
+    // tolerant server) re-pauses for retry.
+    const executeOne = async (
+      toolMessage: AgentWidgetMessage,
+    ): Promise<ExecutedWebMcpTool | null> => {
+      const wireToolName = toolMessage.toolCall?.name;
+      const callId = toolMessage.toolCall?.id;
+      if (!wireToolName || !callId) return null;
 
-        const dedupeKey = `${executionId}:${callId}`;
-        if (
-          this.webMcpInflightKeys.has(dedupeKey) ||
-          this.webMcpResolvedKeys.has(dedupeKey) ||
-          this.isSuggestRepliesAlreadyResolved(toolMessage)
-        ) {
-          return null;
-        }
-        this.webMcpInflightKeys.add(dedupeKey);
-        claimedKeys.push(dedupeKey);
+      const dedupeKey = `${executionId}:${callId}`;
+      if (
+        this.webMcpInflightKeys.has(dedupeKey) ||
+        this.webMcpResolvedKeys.has(dedupeKey) ||
+        this.isSuggestRepliesAlreadyResolved(toolMessage)
+      ) {
+        return null;
+      }
+      this.webMcpInflightKeys.add(dedupeKey);
+      claimedKeys.push(dedupeKey);
 
-        // Clear the awaiting flag and keep the tool bubble running while the
-        // browser-side WebMCP promise is in flight. The initial `step_await`
-        // only means the server paused for a local tool; it is not completion.
-        const startedAt = this.markWebMcpToolRunning(toolMessage);
+      // Clear the awaiting flag and keep the tool bubble running while the
+      // browser-side WebMCP promise is in flight. The initial `step_await`
+      // only means the server paused for a local tool; it is not completion.
+      const startedAt = this.markWebMcpToolRunning(toolMessage);
 
-        // Per-call id wins for resume keying; fall back to the wire tool name
-        // for legacy servers that don't emit `webMcpToolCallId`.
-        const resumeKey =
-          toolMessage.agentMetadata?.webMcpToolCallId ?? wireToolName;
+      // Per-call id wins for resume keying; fall back to the wire tool name
+      // for legacy servers that don't emit `webMcpToolCallId`.
+      const resumeKey =
+        toolMessage.agentMetadata?.webMcpToolCallId ?? wireToolName;
 
-        // Built-in fire-and-forget tool: no bridge, no confirm gate, no
-        // browser-side execution: the chips render from the message list and
-        // the canned output joins the batch's single /resume.
-        if (wireToolName === SUGGEST_REPLIES_TOOL_NAME) {
-          return {
-            dedupeKey,
-            resumeKey,
-            output: suggestRepliesToolResult(),
-            toolMessage,
-            startedAt,
-            completedAt: Date.now(),
-          };
-        }
-
-        const execPromise = this.client.executeWebMcpToolCall(
-          wireToolName,
-          toolMessage.toolCall?.args,
-          batchController.signal,
-        );
-
-        let output: unknown;
-        if (!execPromise) {
-          output = {
-            isError: true,
-            content: [
-              { type: "text", text: "WebMCP not enabled on this widget." },
-            ],
-          };
-        } else {
-          try {
-            output = await execPromise;
-          } catch (error) {
-            const isAbortError =
-              error instanceof Error &&
-              (error.name === "AbortError" ||
-                error.message.includes("aborted") ||
-                error.message.includes("abort"));
-            if (!isAbortError) {
-              this.callbacks.onError?.(
-                error instanceof Error ? error : new Error(String(error)),
-              );
-            }
-            this.markWebMcpToolComplete(
-              toolMessage,
-              buildWebMcpErrorResult(
-                isAbortError
-                  ? "Aborted by cancel()"
-                  : getWebMcpErrorMessage(error),
-              ),
-              startedAt,
-            );
-            // Release the dedupe claim so a re-emit can retry this call.
-            this.webMcpInflightKeys.delete(dedupeKey);
-            return null;
-          }
-        }
-        if (batchController.signal.aborted) {
-          this.markWebMcpToolComplete(
-            toolMessage,
-            buildWebMcpErrorResult("Aborted by cancel()"),
-            startedAt,
-          );
-          this.webMcpInflightKeys.delete(dedupeKey);
-          return null;
-        }
+      // Built-in fire-and-forget tool: no bridge, no confirm gate, no
+      // browser-side execution: the chips render from the message list and
+      // the canned output joins the batch's single /resume.
+      if (wireToolName === SUGGEST_REPLIES_TOOL_NAME) {
         return {
           dedupeKey,
           resumeKey,
-          output,
+          output: suggestRepliesToolResult(),
           toolMessage,
           startedAt,
           completedAt: Date.now(),
         };
-      }),
-    );
+      }
+
+      const execPromise = this.client.executeWebMcpToolCall(
+        wireToolName,
+        toolMessage.toolCall?.args,
+        batchController.signal,
+      );
+
+      let output: unknown;
+      if (!execPromise) {
+        output = {
+          isError: true,
+          content: [
+            { type: "text", text: "WebMCP not enabled on this widget." },
+          ],
+        };
+      } else {
+        try {
+          output = await execPromise;
+        } catch (error) {
+          const isAbortError =
+            error instanceof Error &&
+            (error.name === "AbortError" ||
+              error.message.includes("aborted") ||
+              error.message.includes("abort"));
+          if (!isAbortError) {
+            this.callbacks.onError?.(
+              error instanceof Error ? error : new Error(String(error)),
+            );
+          }
+          this.markWebMcpToolComplete(
+            toolMessage,
+            buildWebMcpErrorResult(
+              isAbortError
+                ? "Aborted by cancel()"
+                : getWebMcpErrorMessage(error),
+            ),
+            startedAt,
+          );
+          // Release the dedupe claim so a re-emit can retry this call.
+          this.webMcpInflightKeys.delete(dedupeKey);
+          return null;
+        }
+      }
+      if (batchController.signal.aborted) {
+        this.markWebMcpToolComplete(
+          toolMessage,
+          buildWebMcpErrorResult("Aborted by cancel()"),
+          startedAt,
+        );
+        this.webMcpInflightKeys.delete(dedupeKey);
+        return null;
+      }
+      return {
+        dedupeKey,
+        resumeKey,
+        output,
+        toolMessage,
+        startedAt,
+        completedAt: Date.now(),
+      };
+    };
+
+    // Parallel (default): a gated sibling's approval never blocks another's
+    // execution. Sequential: one at a time in emission order, so tools that
+    // share page state (a canvas, a form) don't interleave; the next call
+    // starts only once the previous one has settled, approval included.
+    let executed: Array<ExecutedWebMcpTool | null>;
+    if (this.config.webmcp?.execution === "sequential") {
+      executed = [];
+      for (const toolMessage of snapshots) {
+        executed.push(await executeOne(toolMessage));
+      }
+    } else {
+      executed = await Promise.all(snapshots.map(executeOne));
+    }
 
     let ready: ExecutedWebMcpTool[] = [];
     try {

--- a/packages/widget/src/session.webmcp.test.ts
+++ b/packages/widget/src/session.webmcp.test.ts
@@ -13,9 +13,10 @@ const makeSession = (overrides?: {
   resumeOk?: boolean;
   isOperational?: boolean;
   executeImpl?: () => Promise<WebMcpToolResult>;
+  webmcp?: Record<string, unknown>;
 }) => {
   const session = new AgentWidgetSession(
-    { apiUrl: "http://test", webmcp: { enabled: true } },
+    { apiUrl: "http://test", webmcp: { enabled: true, ...overrides?.webmcp } },
     {
       onMessagesChanged: () => undefined,
       onStatusChanged: () => undefined,
@@ -940,6 +941,52 @@ describe("AgentWidgetSession: WebMCP parallel batched resume (core#3878)", () =>
     await flushMicrotasks();
     expect(resumeSpy).not.toHaveBeenCalled();
     releaseA({ content: [{ type: "text", text: "a" }] });
+    await flushMicrotasks();
+    expect(resumeSpy).toHaveBeenCalledTimes(1);
+    const toolOutputs = (resumeSpy.mock.calls[0]! as unknown[])[1] as Record<
+      string,
+      unknown
+    >;
+    expect(Object.keys(toolOutputs).sort()).toEqual(["toolu_A", "toolu_B"]);
+  });
+
+  it("webmcp.execution: 'sequential' runs siblings one at a time, in emission order", async () => {
+    // Paint-style tools share page state (select tool + color, then draw), so
+    // a multi-call turn must not interleave. The second execute must not even
+    // START until the first has resolved; the batch still posts ONE /resume.
+    let releaseA: (r: WebMcpToolResult) => void = () => undefined;
+    let releaseB: (r: WebMcpToolResult) => void = () => undefined;
+    const pA = new Promise<WebMcpToolResult>((r) => (releaseA = r));
+    const pB = new Promise<WebMcpToolResult>((r) => (releaseB = r));
+    const started: string[] = [];
+
+    const { session, resumeSpy } = makeSession({
+      webmcp: { execution: "sequential" },
+    });
+    const client = (session as unknown as { client: Record<string, unknown> })
+      .client;
+    (client.executeWebMcpToolCall as ReturnType<typeof vi.fn>).mockImplementation(
+      (_name: string, args: { sku: string }) => {
+        started.push(args.sku);
+        return args.sku === "SHOE-001" ? pA : pB;
+      },
+    );
+
+    feed(session, parallelAwait("toolu_A", "SHOE-001"));
+    feed(session, parallelAwait("toolu_B", "SHOE-007"));
+    endStream(session);
+    await flushMicrotasks();
+
+    // Only the first call is in flight; the second waits on it.
+    expect(started).toEqual(["SHOE-001"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    releaseA({ content: [{ type: "text", text: "a" }] });
+    await flushMicrotasks();
+    expect(started).toEqual(["SHOE-001", "SHOE-007"]);
+    expect(resumeSpy).not.toHaveBeenCalled();
+
+    releaseB({ content: [{ type: "text", text: "b" }] });
     await flushMicrotasks();
     expect(resumeSpy).toHaveBeenCalledTimes(1);
     const toolOutputs = (resumeSpy.mock.calls[0]! as unknown[])[1] as Record<

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -908,6 +908,22 @@ export type AgentWidgetWebMcpConfig = {
    * `window.confirm` fallback only applies when no widget UI is attached.
    */
   onConfirm?: WebMcpConfirmHandler;
+  /**
+   * How the widget runs the `webmcp:*` calls of ONE turn when the model emits
+   * several at once.
+   *
+   * - `'parallel'` (default): every call executes concurrently and a gated
+   *   sibling's approval never blocks another's execution. Right for
+   *   independent, order-insensitive tools (catalog lookups, add-to-cart).
+   * - `'sequential'`: calls execute one at a time, in the order the model
+   *   emitted them; the next starts only after the previous one settles
+   *   (including its approval bubble). Use this when the page tools share
+   *   mutable state that concurrent execution would interleave, e.g. a
+   *   canvas where every stroke selects a color/tool before drawing.
+   *
+   * Either way, all outputs still return to the server in a single `/resume`.
+   */
+  execution?: 'parallel' | 'sequential';
 };
 
 /**


### PR DESCRIPTION
## Model changes

Points the demo flows and agents at `google/gemini-3.5-flash-lite` (18 pins across `packages/proxy`).

**WebMCP Paint runs on `nvidia/nemotron-3-ultra-550b-a55b`** (the model the demos originally shipped on). Its snapshot-and-look loop needs vision *and* native tool calls. For reference, the same prompt ("Draw a house with a sun in the sky") on the other candidates, tool calls serialized:

| Model | First stroke | Notes |
|---|---|---|
| `glm-5.2` | ~7s | richest scene, 15+ calls by 3 min |
| `gemini-3.7-flash` | ~10s | simpler house, done ~50s |
| `glm-5.3-flash` | 107s | resolves now (was a registry gap), but ~2 min cold open |
| `nemotron-3-ultra` | — | 16.5s API round trip for a one-word reply; not timed on Paint |

Paint's model is a one-line pin in `packages/proxy/src/flows/webmcp-paint.ts`, easy to revisit.

## Sequential WebMCP tool-call execution

New `webmcp.execution: "parallel" | "sequential"` widget option. When a turn emits several `webmcp:*` calls at once, `session.ts` ran them all through `Promise.all`, which interleaves page tools that share mutable state — every Paint stroke selects a tool + color before it drags, so concurrent strokes corrupted each other inside jspaint.

`"sequential"` runs the batch one at a time in emission order, waiting for each call to settle (approval bubble included) before starting the next. Outputs still return in a single `/resume`. **Default stays `"parallel"`**, so existing consumers are untouched; the Paint demo opts in.

- Test in `session.webmcp.test.ts`: the second execute must not start until the first resolves. Fails under `parallel`, passes under `sequential`.
- Browser: 15 Paint calls landed strictly back to back on glm-5.2, canvas intact.

## Agent-mode stream parser fix

Agent `text_delta` chunks appended the raw delta straight onto the message, bypassing the configured `streamParser` and never populating `rawContent`. Flow text already ran through the structured-content path; agent text did not.

This silently broke any route that is both a **server-pinned agent** and replies with a **JSON envelope**. The smart-dom-reader / page-context demo is the only such route, and it broke two ways:

1. the bubble rendered the raw `{"text": ...}` envelope, and
2. `add_to_cart` never dispatched, because the action manager reads `rawContent`.

Pre-existing since `78b8930` (server-pinned agent dispatch) — not introduced by the model change; reverting the model reproduced it identically.

Agent text now flows through the same path as flow text. Agents on the **default plain-text parser are byte-identical** to before, so prose-streaming agent demos are unaffected.

### Verification

- 3 new tests in `client.test.ts`. The two envelope tests fail without the fix with exactly the reported symptom; the plain-prose guard passes both ways.
- Full suite: no new failures (86 files / 6 tests fail identically on and off this branch — stale `dist/` bundle tests + jsdom collection errors, all pre-existing).
- `pnpm typecheck` and `pnpm lint` clean.
- Browser: demo renders "I've added the Studio Headphones to your cart!" and the cart badge increments to 1.

https://claude.ai/code/session_0156m75tMAUmcozq3trP8Aw8




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates demo model selections, adds opt-in sequential execution for WebMCP calls that share mutable page state, and routes agent text through configured stream parsers.
- Pins most proxy demos to `google/gemini-3.5-flash-lite` while retaining a vision-and-tool-capable model for Paint.
- Adds `webmcp.execution`, preserving parallel execution by default and enabling sequential execution for Paint.
- Unifies flow and agent text parsing so structured agent responses retain raw content and expose parsed display text.
- Adds regression coverage and adjusts widget bundle-size limits.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/widget/src/session.ts | Adds an opt-in serial execution loop for batched WebMCP calls while retaining the existing parallel default and single-resume behavior. |
| packages/widget/src/client.ts | Routes agent text deltas through the structured-content parser and retains accumulated raw content for downstream actions. |
| packages/widget/src/types.ts | Extends the public WebMCP configuration with documented parallel and sequential execution modes. |
| apps/web/src/webmcp-paint/main.ts | Enables sequential WebMCP execution for Paint to prevent interleaving operations against shared canvas state. |
| packages/widget/src/session.webmcp.test.ts | Verifies that sequential execution preserves emission order and delays each call until its predecessor settles. |
| packages/widget/src/client.test.ts | Covers structured agent envelopes, raw-content retention, and unchanged plain-text streaming behavior. |
| packages/proxy/src/index.ts | Updates the default proxy flow to use the new Gemini Flash Lite model selection. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Model
  participant Session as Widget session
  participant Page as WebMCP page
  participant Proxy
  Model->>Session: Emit ordered WebMCP calls
  loop Each call in emission order
    Session->>Page: Execute one tool
    Page-->>Session: Return tool result
  end
  Session->>Proxy: Single resume with all outputs
  Proxy-->>Session: Continued response stream
  Session->>Session: Parse agent text through streamParser
```
</details>

<sub>Reviews (3): Last reviewed commit: ["chore: webmcp.execution is a new option,..."](https://github.com/runtypelabs/persona/commit/68e64f5031e1a16c1568659c5f5730bc70c2a131) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57605756)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Widget conversation and session runtime](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-conversation-runtime.md)
- Knowledge Base — [Widget WebMCP bridge](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-webmcp.md)
- Knowledge Base — [WebMCP demo experiences](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/webmcp-demo-experiences.md)
</details>


<!-- /greptile_comment -->