### PR TITLE
chore: bump pnpm to 12.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "@playwright/test": "^1.62.1",
     "concurrently": "^8.2.2"
   },
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
+  "packageManager": "pnpm@12.0.0+sha512.9e2e3dc3911995868dc94b8175c217c27e95408fa03b4a22749778f2b34f773b77cdd3b39ede8171b22fcd53be6a35342e9fac9948a68ef58df6488ce89a7e67"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.0.0
+        version: 12.0.0
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    resolution: {integrity: sha512-sqeoPfVMIfQhbwzDrKraXY2ynyuWClFqzvfImzAS/yczEru1m5SGvQ9kgFPDvQzJZ9AetedgJeDZC6qYvH8/tQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    resolution: {integrity: sha512-Quc3J6c9cGTy+LDgz1cLVgCNOU9IERuyAlDoEj0DCilKqvo50Jx1GV8k74iwn4J9fFSKkm8JrwNvtTDj3uWnUA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    resolution: {integrity: sha512-EVWd3OTmgsMFhXx69b5JxIzoabG9Ma7m4OeTaf0ZKBzMnfYi8u21NDQo92ToMrdYL5dYDDCHsyYIjXzk+d0HhA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    resolution: {integrity: sha512-cXHHW8M4rAPsYNkKZO9WVcpLLK55i9EaIsZPfIqUuY2eopd5LqnFyBge54HCh1GC0yCX8ySn0hYIi+4OyAEoDg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    resolution: {integrity: sha512-UcXwMdFjly0mpddkGigHKTxe27IMv2fUK4IWW/MHmJ3yMguxXmkwNlEI4aE+G1HO2TLo20uNEUWD4ymLe/DaCQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    resolution: {integrity: sha512-6Rsl+zEWMOmus7v7/9J3OE8EMvHyNAfxYmDfmhQG4J0985OuT3G3Ho9NSGHjkBn4aU4bgklWifRhe1HX8dUSyw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    resolution: {integrity: sha512-O5F76A4oVFrpDGdFxEszRIThOSBfjHdH5c006gR+7UTCfiXrukr1XfqPungUI1DXcSR5gb9jBsPQqQZOAoOOxw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    resolution: {integrity: sha512-5dKFajIEWJ1ai+KHXFJvskY6vchbunmLwSUV2ywbLymcmJjfY5XJVpgzPCyIoVCMVG0zHorr66+hM8h8b3aRfQ==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.0.0:
+    resolution: {integrity: sha512-ni49w5EZlYaNyUuBdcIXwn6VQI+gO0oidJd48rNPdzt3zdOznt6BcbIvzVO+ajU0Lp+smUimjvWN9kiM6Jp+Zw==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.0.0':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.0.0':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.0.0':
+    optional: true
+
+  pnpm@12.0.0:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.0.0
+      '@pnpm/exe.darwin-x64': 12.0.0
+      '@pnpm/exe.linux-arm64': 12.0.0
+      '@pnpm/exe.linux-arm64-musl': 12.0.0
+      '@pnpm/exe.linux-x64': 12.0.0
+      '@pnpm/exe.linux-x64-musl': 12.0.0
+      '@pnpm/exe.win32-arm64': 12.0.0
+      '@pnpm/exe.win32-x64': 12.0.0
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
Bumps the repo's `packageManager` from pnpm **11.9.0** → **12.0.0**.

## Changes

- `package.json` — `packageManager: "pnpm@12.0.0+sha512..."` (hash written by `corepack use pnpm@12.0.0`).
- `pnpm-lock.yaml` — pnpm 12 self-manages its own version, so the install prepends a `packageManagerDependencies` document pinning the `@pnpm/exe` binaries for 12.0.0. **Project dependency resolution is unchanged** — no package versions moved, and the existing lockfile body is byte-identical.

No CI changes needed: all five workflows use `pnpm/action-setup@v4` with no pinned `version:`, so they read the version from `packageManager`.

## Verification

- `pnpm install --frozen-lockfile` — clean, no lockfile drift.
- `pnpm verify` (build + lint + typecheck + full test suite) — green.

## Note

pnpm 12.0.0 is currently published under the `next-12` dist-tag; `latest` is still 11.24.0. Merging this puts the repo on the 12.x line ahead of its promotion to `latest`.

No changeset: root tooling only, no published-package source touched.

https://claude.ai/code/session_0165MFssXK1Cehw9VNSdBFUx

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR upgrades the repository’s package-manager pin from pnpm 11.9.0 to 12.0.0 without changing project dependency resolution.
- Updates the root `packageManager` declaration and Corepack integrity hash.
- Adds pnpm 12’s self-managed executable metadata as a separate lockfile document.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete repository build, install, or dependency-resolution failure identified.

The configured Node environments and package-manager selection paths are compatible with the new pin, while pnpm 12 natively consumes the generated multi-document lockfile.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Updates the package-manager pin and integrity hash to pnpm 12.0.0; no actionable issue was identified. |
| pnpm-lock.yaml | Adds pnpm 12’s generated package-manager executable metadata while preserving the existing project dependency lock data. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump pnpm to 12.0.0"](https://github.com/runtypelabs/persona/commit/c56fec3cc02541284dec11e050d7465903c89a68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58201178)</sub>

<!-- /greptile_comment -->