### PR TITLE
chore(demos): run Paint Pal on gpt-5.6-luna-fast

### DIFF
--- a/.changeset/paint-demo-luna-fast.md
+++ b/.changeset/paint-demo-luna-fast.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona-proxy": patch
+---
+
+Paint Pal demo flow now runs on `openai/gpt-5.6-luna-fast` instead of `nvidia/nemotron-3-ultra-550b-a55b`.

--- a/packages/proxy/src/flows/webmcp-paint.ts
+++ b/packages/proxy/src/flows/webmcp-paint.ts
@@ -11,7 +11,8 @@ import type { RuntypeFlowConfig } from "../index.js";
  * `get_canvas_snapshot` returns the canvas as an MCP **image** content block
  * through `/resume`, so the model can look at what it painted and correct it
  *: the same image-tool-result path the Theme Copilot's `screenshot_preview`
- * uses, which is why this flow uses the same image-capable model.
+ * uses, which is why this flow pins a model with both vision and native tool
+ * calls rather than the demo default.
  *
  * The page also ships live canvas state as `{{paint_context}}` via the
  * widget's `contextProviders` + `requestMiddleware`: canvas dimensions,
@@ -28,7 +29,7 @@ export const WEBMCP_PAINT_FLOW: RuntypeFlowConfig = {
       type: "prompt",
       enabled: true,
       config: {
-        model: "nvidia/nemotron-3-ultra-550b-a55b",
+        model: "openai/gpt-5.6-luna-fast",
         reasoning: false,
         responseFormat: "markdown",
         outputVariable: "prompt_result",


### PR DESCRIPTION
Paint Pal (`WEBMCP_PAINT_FLOW`) now runs on `openai/gpt-5.6-luna-fast` instead of `nvidia/nemotron-3-ultra-550b-a55b`.

Verified on the local proxy: it emits native `webmcp:draw_stroke` calls, and the model catalog lists `supportsToolUse` + `supportsVision`, so the `get_canvas_snapshot` loop still works.

https://claude.ai/code/session_012i1CpV4T3EBuPHDdtLwT79


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Paint Pal now uses `openai/gpt-5.6-luna-fast` for its WebMCP drawing flow.
- Replaces the previously pinned Nemotron model while retaining markdown output and disabled reasoning.
- Updates the flow documentation to explain the native-tool-call and vision requirements.
- Adds a patch changeset for `@runtypelabs/persona-proxy`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable issues identified.

The change is limited to a verified model substitution and matching release documentation, while preserving the flow’s existing tool, image-feedback, and response configuration.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/proxy/src/flows/webmcp-paint.ts | Changes Paint Pal’s pinned model and updates its capability rationale; no actionable defect was identified. |
| .changeset/paint-demo-luna-fast.md | Correctly records the Paint Pal model change as a proxy package patch. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(demos): run Paint Pal on gpt-5.6-l..."](https://github.com/runtypelabs/persona/commit/07802b409b9db522406198fef0b0cf3bd3825483) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58202787)</sub>

<!-- /greptile_comment -->