### PR TITLE
Extend durability for client tokens

### DIFF
--- a/.changeset/tidy-cats-reconnect.md
+++ b/.changeset/tidy-cats-reconnect.md
@@ -2,4 +2,4 @@
 "@runtypelabs/persona": minor
 ---
 
-Automatically use Persona's durable reconnect and reload-resume path for history-capable Runtype client-token widgets.
+Automatically use Persona's durable reconnect and reload-resume path for Runtype client-token widgets, independently of whether the embed exposes conversation history, and carry durable cursors and visitor proof through client-tool continuation.

--- a/.changeset/tidy-cats-reconnect.md
+++ b/.changeset/tidy-cats-reconnect.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Automatically use Persona's durable reconnect and reload-resume path for history-capable Runtype client-token widgets.

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "184.5 kB",
+    "limit": "185.25 kB",
     "gzip": true
   },
   {
@@ -20,13 +20,13 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "196.75 kB",
+    "limit": "197.5 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "197.75 kB",
+    "limit": "198.5 kB",
     "gzip": true
   },
   {
@@ -44,7 +44,7 @@
   {
     "name": "Opt-in \u00b7 theme-editor preview subpath (theme-editor-preview.js)",
     "path": "dist/theme-editor-preview.js",
-    "limit": "163.75 kB",
+    "limit": "164.5 kB",
     "gzip": true
   },
   {

--- a/packages/widget/src/client-visitor-history.test.ts
+++ b/packages/widget/src/client-visitor-history.test.ts
@@ -35,6 +35,7 @@ const initBody = (overrides: Partial<ClientInitResponse> = {}): ClientInitRespon
   conversationId: 'conv_1',
   targetId: 'flow_1',
   conversationRevision: 'rev_1',
+  durableRecovery: { enabled: true },
   config: { welcomeMessage: null, placeholder: 'Ask...', theme: null },
   ...overrides,
 });
@@ -168,6 +169,7 @@ describe('client visitor history - init capability shape', () => {
       body: {
         token: CLIENT_TOKEN,
         visitorHistory: true,
+        durableRecovery: true,
         visitorToken: 'cvt_stored',
         sessionId: 'sess_old',
       },
@@ -175,7 +177,7 @@ describe('client visitor history - init capability shape', () => {
     expect(requests[0].body).not.toHaveProperty('conversationId');
   });
 
-  it('omits every visitor field when history is disabled', async () => {
+  it('negotiates recovery without enabling the history UI', async () => {
     await seedToken('cvt_stored');
     installFetch([ok()]);
     const h = makeClient({ history: false, storedSessionId: 'sess_old' });
@@ -184,6 +186,8 @@ describe('client visitor history - init capability shape', () => {
 
     expect(requests[0].body).toEqual({
       token: CLIENT_TOKEN,
+      durableRecovery: true,
+      visitorToken: 'cvt_stored',
       sessionId: 'sess_old',
     });
   });
@@ -348,6 +352,7 @@ describe('client visitor history - boot resume', () => {
     expect(requests[0].body).toEqual({
       token: CLIENT_TOKEN,
       visitorHistory: true,
+      durableRecovery: true,
       visitorToken: 'cvt_stored',
       conversationId: 'conv_1',
     });
@@ -452,6 +457,7 @@ describe('client visitor history - prepared sessions', () => {
     expect(requests[1].body).toEqual({
       token: CLIENT_TOKEN,
       visitorHistory: true,
+      durableRecovery: true,
       visitorToken: 'cvt_stored',
       conversationId: 'conv_other',
     });
@@ -513,6 +519,7 @@ describe('client visitor history - prepared sessions', () => {
     expect(requests[0].body).toEqual({
       token: CLIENT_TOKEN,
       visitorHistory: true,
+      durableRecovery: true,
       visitorToken: 'cvt_stored',
     });
     expect(prepared.session.sessionId).toBe('sess_new');
@@ -539,10 +546,15 @@ describe('client visitor history - 403 degrade', () => {
     expect(h.availability).toEqual([false]);
     expect(warn).toHaveBeenCalledTimes(1);
 
-    // Latched for the client's lifetime: later inits skip the visitor fields.
+    // History remains latched off, but recovery negotiates independently and
+    // can reuse the exact-browser credential plus conversation.
     h.client.clearClientSession();
     await h.client.initSession();
-    expect(requests[2].body).toEqual({ token: CLIENT_TOKEN, sessionId: 'sess_plain' });
+    expect(requests[2].body).toEqual({
+      token: CLIENT_TOKEN,
+      durableRecovery: true,
+      visitorToken: 'cvt_stored',
+    });
   });
 
   it('rejects rather than degrading a conversation resume into another record', async () => {
@@ -601,6 +613,7 @@ describe('controller wiring', () => {
     expect(requests[0].body).toEqual({
       token: CLIENT_TOKEN,
       visitorHistory: true,
+      durableRecovery: true,
       visitorToken: 'cvt_stored',
       conversationId: 'conv_stored',
     });
@@ -609,7 +622,7 @@ describe('controller wiring', () => {
     mount.remove();
   });
 
-  it('persists the built-in durable handle and clears it at terminal', async () => {
+  it('persists the built-in durable handle without history UI config and clears it at terminal', async () => {
     await seedToken('cvt_stored');
     installFetch([ok({ sessionId: 'sess_ui' })]);
     const mount = document.createElement('div');
@@ -618,7 +631,6 @@ describe('controller wiring', () => {
       apiUrl: API_URL,
       clientToken: CLIENT_TOKEN,
       launcher: { enabled: false },
-      features: { history: { enabled: true } },
     });
     await vi.waitFor(() => expect(requests).toHaveLength(1));
 

--- a/packages/widget/src/client-visitor-history.test.ts
+++ b/packages/widget/src/client-visitor-history.test.ts
@@ -203,6 +203,41 @@ describe('client visitor history - init capability shape', () => {
     expect(a.flow.id).toBe('flow_1');
     expect(b.targetId).toBe('flow_7');
   });
+
+  it('uses the exact visitor credential and durable cursor for reconnect', async () => {
+    await seedToken('cvt_stored');
+    const events = new Response('event: ping\ndata: {}\n\n', {
+      headers: { 'Content-Type': 'text/event-stream' },
+    });
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(ok()())
+      .mockResolvedValueOnce(events);
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const h = makeClient({});
+    await h.client.initSession();
+
+    const controller = new AbortController();
+    const response = await h.client.reconnectClientTokenStream({
+      executionId: 'exec_7',
+      after: '12',
+      signal: controller.signal,
+    });
+
+    expect(response).toBe(events);
+    expect(fetchMock.mock.calls[1]?.[0]).toBe(
+      `${API_URL}/v1/client/conversations/conv_1/executions/exec_7/events` +
+        '?sessionId=sess_1&after=12'
+    );
+    expect(fetchMock.mock.calls[1]?.[1]).toMatchObject({
+      method: 'GET',
+      headers: {
+        'X-Persona-Version': expect.any(String),
+        'X-Visitor-Token': 'cvt_stored',
+      },
+      signal: controller.signal,
+    });
+  });
 });
 
 describe('client visitor history - mint persistence and immediate claim', () => {
@@ -569,6 +604,52 @@ describe('controller wiring', () => {
       visitorToken: 'cvt_stored',
       conversationId: 'conv_stored',
     });
+
+    controller.destroy();
+    mount.remove();
+  });
+
+  it('persists the built-in durable handle and clears it at terminal', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_ui' })]);
+    const mount = document.createElement('div');
+    document.body.appendChild(mount);
+    const controller = createAgentExperience(mount, {
+      apiUrl: API_URL,
+      clientToken: CLIENT_TOKEN,
+      launcher: { enabled: false },
+      features: { history: { enabled: true } },
+    });
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(value) {
+        streamController = value;
+      },
+    });
+    const connected = controller.connectStream(stream);
+    const encoder = new TextEncoder();
+    streamController.enqueue(
+      encoder.encode(
+        'id: 7\nevent: text_delta\ndata: {"type":"text_delta","executionId":"exec_ui","id":"text_ui","delta":"Hi"}\n\n'
+      )
+    );
+    await vi.waitFor(() =>
+      expect(controller.getPersistentMetadata().durableResume).toEqual({
+        executionId: 'exec_ui',
+        after: '7',
+      })
+    );
+
+    streamController.enqueue(
+      encoder.encode(
+        'id: 8\nevent: execution_complete\ndata: {"type":"execution_complete","executionId":"exec_ui","kind":"agent","success":true}\n\n'
+      )
+    );
+    streamController.close();
+    await connected;
+    expect(controller.getPersistentMetadata()).not.toHaveProperty('durableResume');
 
     controller.destroy();
     mount.remove();

--- a/packages/widget/src/client-visitor-history.test.ts
+++ b/packages/widget/src/client-visitor-history.test.ts
@@ -86,6 +86,8 @@ type Harness = {
   sessionInits: ClientSession[];
   continuity: Array<{ previousConversationId: string | null; conversationId: string }>;
   availability: boolean[];
+  durableResumePending: boolean;
+  resumableWrites: Array<{ executionId: string; after: string } | null>;
   writes: string[];
 };
 
@@ -93,6 +95,7 @@ const makeClient = (options: {
   history?: boolean;
   storedSessionId?: string | null;
   storedConversationId?: string | null;
+  durableResumePending?: boolean;
   historyBootstrapReady?: Promise<void>;
   config?: Partial<AgentWidgetConfig>;
 }): Harness => {
@@ -105,6 +108,8 @@ const makeClient = (options: {
     sessionInits: [],
     continuity: [],
     availability: [],
+    durableResumePending: options.durableResumePending ?? false,
+    resumableWrites: [],
     writes: [],
   };
   const internals: WidgetHistoryInternals = {
@@ -120,6 +125,11 @@ const makeClient = (options: {
     onHistoryContinuityChanged: (info) => {
       harness.continuity!.push(info);
       harness.writes!.push(`continuity:${info.previousConversationId}->${info.conversationId}`);
+    },
+    shouldResumeDurableConversation: () => harness.durableResumePending === true,
+    setStoredResumableHandle: (handle) => {
+      harness.durableResumePending = handle !== null;
+      harness.resumableWrites!.push(handle);
     },
   };
   const config: AgentWidgetConfig = {
@@ -190,6 +200,7 @@ describe('client visitor history - init capability shape', () => {
       visitorToken: 'cvt_stored',
       sessionId: 'sess_old',
     });
+    expect(requests[0].body).not.toHaveProperty('conversationId');
   });
 
   it('normalizes targetId, preferring the top-level field over flow.id', async () => {
@@ -369,6 +380,103 @@ describe('client visitor history - boot resume', () => {
 
     expect(requests[0].body).toMatchObject({ sessionId: 'sess_old' });
     expect(requests[0].body).not.toHaveProperty('conversationId');
+  });
+
+  it('reopens a durable conversation without enabling the history UI', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_resumed' })]);
+    const h = makeClient({
+      history: false,
+      storedSessionId: 'sess_old',
+      storedConversationId: 'conv_1',
+      durableResumePending: true,
+    });
+
+    await h.client.initSession();
+
+    expect(requests[0].body).toEqual({
+      token: CLIENT_TOKEN,
+      durableRecovery: true,
+      visitorToken: 'cvt_stored',
+      conversationId: 'conv_1',
+    });
+    expect(h.resumableWrites).toHaveLength(0);
+  });
+
+  it('keeps ordinary no-history initialization unchanged without a durable handle', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_ordinary', conversationId: 'conv_2' })]);
+    const h = makeClient({
+      history: false,
+      storedSessionId: 'sess_old',
+      storedConversationId: 'conv_1',
+    });
+
+    await h.client.initSession();
+
+    expect(requests[0].body).toEqual({
+      token: CLIENT_TOKEN,
+      durableRecovery: true,
+      visitorToken: 'cvt_stored',
+    });
+    expect(requests[0].body).not.toHaveProperty('sessionId');
+    expect(requests[0].body).not.toHaveProperty('conversationId');
+  });
+
+  it('drops a pending handle when the server does not enable recovery', async () => {
+    await seedToken('cvt_stored');
+    installFetch([
+      ok({ sessionId: 'sess_resumed', durableRecovery: { enabled: false } }),
+    ]);
+    const h = makeClient({
+      history: false,
+      storedConversationId: 'conv_1',
+      durableResumePending: true,
+    });
+
+    const session = await h.client.initSession();
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0].body).toMatchObject({ conversationId: 'conv_1' });
+    expect(session.durableRecovery).toEqual({ enabled: false });
+    expect(h.resumableWrites).toEqual([null]);
+  });
+
+  it('drops a pending handle when an old server omits the recovery capability', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_legacy', durableRecovery: undefined })]);
+    const h = makeClient({
+      history: false,
+      storedConversationId: 'conv_1',
+      durableResumePending: true,
+    });
+
+    const session = await h.client.initSession();
+
+    expect(session.durableRecovery).toBeUndefined();
+    expect(h.resumableWrites).toEqual([null]);
+  });
+
+  it('clears a stale pending handle before its single ordinary fallback', async () => {
+    await seedToken('cvt_stored');
+    installFetch([
+      fail(404, { error: 'Conversation not found' }),
+      ok({ sessionId: 'sess_new', conversationId: 'conv_2' }),
+    ]);
+    const h = makeClient({
+      history: false,
+      storedSessionId: 'sess_old',
+      storedConversationId: 'conv_1',
+      durableResumePending: true,
+    });
+
+    await h.client.initSession();
+
+    expect(requests).toHaveLength(2);
+    expect(requests[0].body).toMatchObject({ conversationId: 'conv_1' });
+    expect(requests[1].body).toMatchObject({ sessionId: 'sess_old' });
+    expect(requests[1].body).not.toHaveProperty('conversationId');
+    expect(h.resumableWrites).toEqual([null]);
   });
 
   it('falls back exactly once on a resume 404 and reports the continuity break', async () => {
@@ -662,6 +770,143 @@ describe('controller wiring', () => {
     streamController.close();
     await connected;
     expect(controller.getPersistentMetadata()).not.toHaveProperty('durableResume');
+
+    controller.destroy();
+    mount.remove();
+  });
+
+  it('retains the built-in durable handle during page exit', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_ui' })]);
+    const mount = document.createElement('div');
+    document.body.appendChild(mount);
+    const controller = createAgentExperience(mount, {
+      apiUrl: API_URL,
+      clientToken: CLIENT_TOKEN,
+      launcher: { enabled: false },
+    });
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+
+    let firstStreamController!: ReadableStreamDefaultController<Uint8Array>;
+    const firstStream = new ReadableStream<Uint8Array>({
+      start(value) {
+        firstStreamController = value;
+      },
+    });
+    const firstConnected = controller.connectStream(firstStream);
+    const encoder = new TextEncoder();
+    firstStreamController.enqueue(
+      encoder.encode(
+        'id: 7\nevent: text_delta\ndata: {"type":"text_delta","executionId":"exec_exit","id":"text_exit","delta":"Hi"}\n\n'
+      )
+    );
+    await vi.waitFor(() =>
+      expect(controller.getPersistentMetadata().durableResume).toEqual({
+        executionId: 'exec_exit',
+        after: '7',
+      })
+    );
+
+    window.dispatchEvent(new Event('pagehide'));
+    firstStreamController.enqueue(
+      encoder.encode(
+        'id: 8\nevent: execution_complete\ndata: {"type":"execution_complete","executionId":"exec_exit","kind":"agent","success":true}\n\n'
+      )
+    );
+    firstStreamController.close();
+    await firstConnected;
+    expect(controller.getPersistentMetadata().durableResume).toEqual({
+      executionId: 'exec_exit',
+      after: '7',
+    });
+
+    controller.destroy();
+    mount.remove();
+  });
+
+  it('uses Persona-owned stored recovery state to reopen the durable conversation', async () => {
+    await seedToken('cvt_stored');
+    global.fetch = vi.fn(async (url: string | URL | Request, options?: RequestInit) => {
+      if (String(url) === INIT_URL) {
+        requests.push({
+          url: String(url),
+          body: JSON.parse(String(options?.body)) as Record<string, unknown>,
+          headers: (options?.headers ?? {}) as Record<string, string>,
+        });
+        return new Response(
+          JSON.stringify(
+            initBody({
+              sessionId: 'sess_resumed',
+              conversationId: 'conv_durable',
+            })
+          ),
+          { status: 200, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+      return new Response(
+        'id: 20\nevent: execution_complete\ndata: {"type":"execution_complete","executionId":"exec_durable","kind":"agent","success":true}\n\n',
+        { status: 200, headers: { 'Content-Type': 'text/event-stream' } }
+      );
+    }) as unknown as typeof fetch;
+    const mount = document.createElement('div');
+    document.body.appendChild(mount);
+    const controller = createAgentExperience(mount, {
+      apiUrl: API_URL,
+      clientToken: CLIENT_TOKEN,
+      launcher: { enabled: false },
+      storageAdapter: {
+        load: async () => ({
+          messages: [],
+          metadata: {
+            conversationId: 'conv_durable',
+            durableResume: { executionId: 'exec_durable', after: '19' },
+          },
+        }),
+        save: () => undefined,
+      },
+    });
+
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    expect(requests[0].body).toMatchObject({
+      durableRecovery: true,
+      visitorToken: 'cvt_stored',
+      conversationId: 'conv_durable',
+    });
+    expect(requests[0].body).not.toHaveProperty('visitorHistory');
+
+    controller.destroy();
+    mount.remove();
+  });
+
+  it('does not pass Persona-stored recovery state to a custom reconnect transport', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_ui' })]);
+    const reconnectStream = vi.fn(
+      () => new Promise<Response>(() => undefined)
+    );
+    const mount = document.createElement('div');
+    document.body.appendChild(mount);
+    const controller = createAgentExperience(mount, {
+      apiUrl: API_URL,
+      clientToken: CLIENT_TOKEN,
+      launcher: { enabled: false },
+      reconnectStream,
+      storageAdapter: {
+        load: async () => ({
+          messages: [],
+          metadata: {
+            conversationId: 'conv_host',
+            durableResume: { executionId: 'exec_host', after: '19' },
+          },
+        }),
+        save: () => undefined,
+      },
+    });
+
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    expect(requests[0].body).not.toHaveProperty('conversationId');
+    expect(controller.getStatus()).toBe('idle');
+    expect(reconnectStream).not.toHaveBeenCalled();
 
     controller.destroy();
     mount.remove();

--- a/packages/widget/src/client-visitor-history.test.ts
+++ b/packages/widget/src/client-visitor-history.test.ts
@@ -403,7 +403,7 @@ describe('client visitor history - boot resume', () => {
     expect(h.resumableWrites).toHaveLength(0);
   });
 
-  it('keeps ordinary no-history initialization unchanged without a durable handle', async () => {
+  it('preserves the stored session without history or a durable handle', async () => {
     await seedToken('cvt_stored');
     installFetch([ok({ sessionId: 'sess_ordinary', conversationId: 'conv_2' })]);
     const h = makeClient({
@@ -418,8 +418,8 @@ describe('client visitor history - boot resume', () => {
       token: CLIENT_TOKEN,
       durableRecovery: true,
       visitorToken: 'cvt_stored',
+      sessionId: 'sess_old',
     });
-    expect(requests[0].body).not.toHaveProperty('sessionId');
     expect(requests[0].body).not.toHaveProperty('conversationId');
   });
 
@@ -654,14 +654,15 @@ describe('client visitor history - 403 degrade', () => {
     expect(h.availability).toEqual([false]);
     expect(warn).toHaveBeenCalledTimes(1);
 
-    // History remains latched off, but recovery negotiates independently and
-    // can reuse the exact-browser credential plus conversation.
+    // History remains latched off, while recovery negotiates independently
+    // without breaking ordinary session continuity.
     h.client.clearClientSession();
     await h.client.initSession();
     expect(requests[2].body).toEqual({
       token: CLIENT_TOKEN,
       durableRecovery: true,
       visitorToken: 'cvt_stored',
+      sessionId: 'sess_plain',
     });
   });
 

--- a/packages/widget/src/client.test.ts
+++ b/packages/widget/src/client.test.ts
@@ -911,6 +911,60 @@ describe('AgentWidgetClient - Agent Payload Building', () => {
     });
   });
 
+  it('proves the exact recovery visitor on durable client-token chat', async () => {
+    let capturedHeaders: Record<string, string> | undefined;
+    global.fetch = vi.fn().mockImplementation(async (_url: string, options: RequestInit) => {
+      capturedHeaders = options.headers as Record<string, string>;
+      const encoder = new TextEncoder();
+      return {
+        ok: true,
+        body: new ReadableStream({
+          start(controller) {
+            controller.enqueue(encoder.encode(sseEvent('agent_complete', {
+              executionId: 'exec_1',
+              agentId: 'agent_123',
+              success: true,
+              iterations: 1,
+              completedAt: new Date().toISOString(),
+              seq: 1,
+            })));
+            controller.close();
+          },
+        }),
+      };
+    });
+
+    const client = new AgentWidgetClient({
+      apiUrl: 'https://api.runtype.com',
+      clientToken: 'ct_live_demo',
+      agentId: 'agent_123',
+    });
+    (client as unknown as {
+      clientSession: {
+        sessionId: string;
+        expiresAt: Date;
+        durableRecovery: { enabled: boolean };
+      };
+    }).clientSession = {
+      sessionId: 'sess_durable',
+      expiresAt: new Date(Date.now() + 10 * 60_000),
+      durableRecovery: { enabled: true },
+    };
+    (client as unknown as { readVisitorToken: () => Promise<string> }).readVisitorToken =
+      async () => 'cvt_owner';
+
+    await client.dispatch({
+      messages: [{
+        id: 'usr_1',
+        role: 'user',
+        content: 'Hello durable agent',
+        createdAt: '2025-01-01T00:00:00.000Z',
+      }],
+    }, () => {});
+
+    expect(capturedHeaders?.['X-Visitor-Token']).toBe('cvt_owner');
+  });
+
   it('should build agent payload with agent config', async () => {
     let capturedPayload: any = null;
     global.fetch = vi.fn().mockImplementation(async (_url: string, options: any) => {
@@ -3011,7 +3065,7 @@ describe('AgentWidgetClient.resumeFlow', () => {
     expect(capturedUrl).toBe('http://localhost:43111/api/chat/dispatch/resume');
   });
 
-  it('routes to /v1/client/resume with sessionId in client-token mode (core#3889)', async () => {
+  it('routes durable client-token resume with the live session, visitor proof, and cursor', async () => {
     let capturedUrl: string | undefined;
     let capturedBody: Record<string, unknown> | undefined;
     let capturedHeaders: Record<string, string> | undefined;
@@ -3027,12 +3081,21 @@ describe('AgentWidgetClient.resumeFlow', () => {
       apiUrl: 'https://api.runtype.com',
     });
     // Simulate an initialized client session (resumeFlow reads sessionId off it).
-    (client as unknown as { clientSession: { sessionId: string; expiresAt: Date } }).clientSession = {
+    (client as unknown as {
+      clientSession: {
+        sessionId: string;
+        expiresAt: Date;
+        durableRecovery: { enabled: boolean };
+      };
+    }).clientSession = {
       sessionId: 'cs_123',
       expiresAt: new Date(Date.now() + 60_000),
+      durableRecovery: { enabled: true },
     };
+    (client as unknown as { readVisitorToken: () => Promise<string> }).readVisitorToken =
+      async () => 'cvt_resume';
 
-    await client.resumeFlow('exec_xyz', { toolu_A: { ok: true } });
+    await client.resumeFlow('exec_xyz', { toolu_A: { ok: true } }, { after: '18' });
 
     // Session-authed sibling of /v1/client/chat: no Bearer key, sessionId in body.
     expect(capturedUrl).toBe('https://api.runtype.com/v1/client/resume');
@@ -3041,8 +3104,10 @@ describe('AgentWidgetClient.resumeFlow', () => {
       toolOutputs: { toolu_A: { ok: true } },
       streamResponse: true,
       sessionId: 'cs_123',
+      after: '18',
     });
     expect(capturedHeaders!['Authorization']).toBeUndefined();
+    expect(capturedHeaders!['X-Visitor-Token']).toBe('cvt_resume');
   });
 
   it('strips a trailing /v1/dispatch from apiUrl when building the client resume URL', async () => {

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -567,6 +567,59 @@ export class AgentWidgetClient {
   }
 
   /**
+   * Persona's built-in reconnect transport for history-capable client-token
+   * sessions. It deliberately reuses the exact-browser visitor credential and
+   * live session admission used by the conversation-history surface.
+   */
+  public async reconnectClientTokenStream(ctx: {
+    executionId: string;
+    after: string;
+    signal: AbortSignal;
+  }): Promise<Response> {
+    this.assertHistoryUsable();
+    let session = await this.initSession();
+    let recovered = false;
+
+    for (;;) {
+      const conversationId = session.conversationId;
+      const visitorToken = await this.readVisitorToken();
+      if (!conversationId || !visitorToken) {
+        throw new HistoryClientError(
+          'visitor_token_missing',
+          'A live conversation and visitor credential are required to reconnect'
+        );
+      }
+      const path =
+        `${this.clientApiBase()}/v1/client/conversations/` +
+        `${encodeURIComponent(conversationId)}/executions/` +
+        `${encodeURIComponent(ctx.executionId)}/events`;
+      const query = new URLSearchParams({
+        sessionId: session.sessionId,
+        after: ctx.after,
+      });
+      const response = await fetch(`${path}?${query}`, {
+        method: 'GET',
+        headers: {
+          'X-Persona-Version': VERSION,
+          'X-Visitor-Token': visitorToken,
+        },
+        signal: ctx.signal,
+      });
+      if (response.status === 401 && !recovered) {
+        recovered = true;
+        session = await this.recoverFromUnauthorized(
+          await this.readErrorCode(response),
+          null,
+          true
+        );
+        continue;
+      }
+      if (!response.ok) throw await this.historyErrorFor(response, true);
+      return response;
+    }
+  }
+
+  /**
    * Initialize session for client token mode.
    * Called automatically on first message if not already initialized.
    */

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -566,27 +566,22 @@ export class AgentWidgetClient {
     return this.clientSession;
   }
 
-  /**
-   * Persona's built-in reconnect transport for history-capable client-token
-   * sessions. It deliberately reuses the exact-browser visitor credential and
-   * live session admission used by the conversation-history surface.
-   */
+  /** Persona's built-in reconnect transport for client-token sessions. */
   public async reconnectClientTokenStream(ctx: {
     executionId: string;
     after: string;
     signal: AbortSignal;
   }): Promise<Response> {
-    this.assertHistoryUsable();
     let session = await this.initSession();
     let recovered = false;
 
     for (;;) {
       const conversationId = session.conversationId;
       const visitorToken = await this.readVisitorToken();
-      if (!conversationId || !visitorToken) {
+      if (session.durableRecovery?.enabled !== true || !conversationId || !visitorToken) {
         throw new HistoryClientError(
           'visitor_token_missing',
-          'A live conversation and visitor credential are required to reconnect'
+          'Durable recovery is not enabled for this client session'
         );
       }
       const path =
@@ -767,8 +762,12 @@ export class AgentWidgetClient {
     omitVisitorFields?: boolean;
   }): Promise<ClientSession> {
     const historyCapable = this.isHistoryCapable() && !opts.omitVisitorFields;
+    // Recovery is negotiated independently from the history UI. New servers
+    // return an explicit capability bit; old strict servers reject the
+    // additive request field, which the fallback below handles once.
+    const durableRecoveryRequested = !opts.omitVisitorFields;
     let visitorToken: string | null = null;
-    if (historyCapable) {
+    if (historyCapable || durableRecoveryRequested) {
       // Never read persisted state before the controller's stored-state gate.
       await this.historyInternals.historyBootstrapReady;
       visitorToken = await this.readVisitorToken();
@@ -781,7 +780,10 @@ export class AgentWidgetClient {
       token: this.config.clientToken,
       ...(sessionTargetId && { flowId: sessionTargetId }),
       ...(historyCapable && { visitorHistory: true }),
-      ...(historyCapable && visitorToken ? { visitorToken } : {}),
+      ...(durableRecoveryRequested && { durableRecovery: true }),
+      ...((historyCapable || durableRecoveryRequested) && visitorToken
+        ? { visitorToken }
+        : {}),
       // Independent of the strict conversationId/sessionId union: a proof also
       // binds the visitor on an ordinary init.
       ...(historyCapable && opts.identityProof
@@ -794,7 +796,7 @@ export class AgentWidgetClient {
           : {}),
     };
 
-    const response = await fetch(this.getClientApiUrl('init'), {
+    let response = await fetch(this.getClientApiUrl('init'), {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -802,6 +804,22 @@ export class AgentWidgetClient {
       },
       body: JSON.stringify(requestBody),
     });
+
+    // Rolling/self-hosted compatibility: pre-recovery servers use a strict
+    // init schema and answer 400 to the additive field. Retry once without it;
+    // the absent response capability keeps Persona on ordinary streaming.
+    if (response.status === 400 && durableRecoveryRequested) {
+      const fallbackBody = { ...requestBody };
+      delete fallbackBody.durableRecovery;
+      response = await fetch(this.getClientApiUrl('init'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Persona-Version': VERSION,
+        },
+        body: JSON.stringify(fallbackBody),
+      });
+    }
 
     if (!response.ok) {
       const error = await response.json().catch(() => ({ error: 'Session initialization failed' }));
@@ -815,6 +833,12 @@ export class AgentWidgetClient {
           );
         }
         return this.createClientSession({ ...opts, omitVisitorFields: true });
+      }
+      if (response.status === 403 && error.error === 'durable_recovery_disabled') {
+        throw new HistoryClientError(
+          'history_disabled',
+          'Durable recovery is disabled for this surface'
+        );
       }
       if (historyCapable && response.status === 401 && error.error === 'visitor_required') {
         throw new HistoryClientError('visitor_required', 'Visitor credential no longer resolves');
@@ -850,6 +874,7 @@ export class AgentWidgetClient {
       ...(data.conversationRevision
         ? { conversationRevision: data.conversationRevision }
         : {}),
+      ...(data.durableRecovery ? { durableRecovery: data.durableRecovery } : {}),
       ...(data.visitor ? { visitor: data.visitor } : {}),
       config: {
         welcomeMessage: data.config.welcomeMessage,
@@ -860,13 +885,6 @@ export class AgentWidgetClient {
   }
 
   private async _doInitSession(): Promise<ClientSession> {
-    if (!this.isHistoryCapable()) {
-      const storedSessionId = this.config.getStoredSessionId?.() || null;
-      const session = await this.createClientSession({ storedSessionId });
-      this.config.setStoredSessionId?.(session.sessionId);
-      return session;
-    }
-
     await this.historyInternals.historyBootstrapReady;
     const previousConversationId = this.config.getStoredConversationId?.() || null;
     const storedToken = await this.readVisitorToken();
@@ -882,7 +900,8 @@ export class AgentWidgetClient {
       } catch (error) {
         if (
           !isHistoryClientError(error, 'not_found') &&
-          !isHistoryClientError(error, 'visitor_required')
+          !isHistoryClientError(error, 'visitor_required') &&
+          !isHistoryClientError(error, 'history_disabled')
         ) {
           throw error;
         }
@@ -904,7 +923,7 @@ export class AgentWidgetClient {
     continuityBroken: boolean
   ): Promise<ClientSession> {
     const store = this.historyInternals.visitorStore;
-    if (store && this.isHistoryCapable() && !(await this.readVisitorToken())) {
+    if (store && !(await this.readVisitorToken())) {
       return store.withFirstInitLock(() =>
         this.doOrdinaryInit(previousConversationId, continuityBroken)
       );
@@ -946,7 +965,11 @@ export class AgentWidgetClient {
    * unowned; one immediate re-init with `{visitorToken, sessionId}` claims it.
    */
   private async claimFirstConversation(first: ClientSession): Promise<ClientSession> {
-    if (!first.visitor?.token || this.claimInFlight || !this.isHistoryCapable()) {
+    if (
+      !first.visitor?.token ||
+      this.claimInFlight ||
+      (!this.isHistoryCapable() && first.durableRecovery?.enabled !== true)
+    ) {
       return first;
     }
     this.claimInFlight = true;
@@ -1807,6 +1830,10 @@ export class AgentWidgetClient {
 
       // Build the standard payload to get context/metadata from middleware
       const basePayload = await this.buildPayload(options.messages);
+      const recoveryVisitorToken =
+        session.durableRecovery?.enabled === true
+          ? await this.readVisitorToken()
+          : null;
 
       // Build the chat request payload with message IDs for feedback tracking
       // Filter out sessionId from metadata if present (it's only for local storage)
@@ -1866,6 +1893,9 @@ export class AgentWidgetClient {
             headers: {
               'Content-Type': 'application/json',
               'X-Persona-Version': VERSION,
+              ...(recoveryVisitorToken
+                ? { 'X-Visitor-Token': recoveryVisitorToken }
+                : {}),
             },
             body: JSON.stringify(chatRequest),
             signal: options.signal,
@@ -2274,7 +2304,7 @@ export class AgentWidgetClient {
   public async resumeFlow(
     executionId: string,
     toolOutputs: Record<string, unknown>,
-    options?: { streamResponse?: boolean; signal?: AbortSignal }
+    options?: { streamResponse?: boolean; signal?: AbortSignal; after?: string }
   ): Promise<Response> {
     const isClientToken = this.isClientTokenMode();
     const url = isClientToken
@@ -2289,12 +2319,18 @@ export class AgentWidgetClient {
     // trusting the possibly-stale `this.clientSession`. (core#3889; BugBot
     // PR #214 r3367875360.)
     let resumeSessionId: string | undefined;
+    let resumeVisitorToken: string | null = null;
     if (isClientToken) {
-      resumeSessionId = (await this.initSession()).sessionId;
+      const session = await this.initSession();
+      resumeSessionId = session.sessionId;
+      if (session.durableRecovery?.enabled === true) {
+        resumeVisitorToken = await this.readVisitorToken();
+      }
     }
 
     let headers: Record<string, string> = {
       'Content-Type': 'application/json',
+      ...(resumeVisitorToken ? { 'X-Visitor-Token': resumeVisitorToken } : {}),
       ...this.headers
     };
     if (this.getHeaders) {
@@ -2305,6 +2341,7 @@ export class AgentWidgetClient {
       executionId,
       toolOutputs,
       streamResponse: options?.streamResponse ?? true,
+      ...(options?.after ? { after: options.after } : {}),
     };
     // Thread the (refreshed) sessionId through like `/v1/client/chat` does.
     if (resumeSessionId) {

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -757,6 +757,7 @@ export class AgentWidgetClient {
    */
   private async createClientSession(opts: {
     conversationId?: string;
+    durableResume?: boolean;
     identityProof?: string | null;
     storedSessionId?: string | null;
     omitVisitorFields?: boolean;
@@ -775,7 +776,8 @@ export class AgentWidgetClient {
 
     const routed = this.routing();
     const sessionTargetId = routed.agentId ?? routed.flowId;
-    const resumeConversationId = historyCapable ? opts.conversationId : undefined;
+    const resumeConversationId =
+      historyCapable || opts.durableResume ? opts.conversationId : undefined;
     const requestBody: Record<string, unknown> = {
       token: this.config.clientToken,
       ...(sessionTargetId && { flowId: sessionTargetId }),
@@ -840,7 +842,11 @@ export class AgentWidgetClient {
           'Durable recovery is disabled for this surface'
         );
       }
-      if (historyCapable && response.status === 401 && error.error === 'visitor_required') {
+      if (
+        (historyCapable || opts.durableResume) &&
+        response.status === 401 &&
+        error.error === 'visitor_required'
+      ) {
         throw new HistoryClientError('visitor_required', 'Visitor credential no longer resolves');
       }
       if (resumeConversationId && response.status === 404) {
@@ -888,6 +894,8 @@ export class AgentWidgetClient {
     await this.historyInternals.historyBootstrapReady;
     const previousConversationId = this.config.getStoredConversationId?.() || null;
     const storedToken = await this.readVisitorToken();
+    const durableResume =
+      this.historyInternals.shouldResumeDurableConversation?.() === true;
 
     // Boot resume: reopening the record beats replaying a possibly idle-expired
     // session id, so benign expiry never forks or wipes the conversation.
@@ -895,7 +903,11 @@ export class AgentWidgetClient {
       try {
         const resumed = await this.createClientSession({
           conversationId: previousConversationId,
+          durableResume,
         });
+        if (durableResume && resumed.durableRecovery?.enabled !== true) {
+          this.historyInternals.setStoredResumableHandle?.(null);
+        }
         return this.finishInit(resumed, previousConversationId, false);
       } catch (error) {
         if (
@@ -904,6 +916,9 @@ export class AgentWidgetClient {
           !isHistoryClientError(error, 'history_disabled')
         ) {
           throw error;
+        }
+        if (durableResume) {
+          this.historyInternals.setStoredResumableHandle?.(null);
         }
         // Record gone or credential dead: exactly one ordinary fallback, never a loop.
         return this.ordinaryInit(previousConversationId, true);

--- a/packages/widget/src/client.ts
+++ b/packages/widget/src/client.ts
@@ -893,9 +893,12 @@ export class AgentWidgetClient {
   private async _doInitSession(): Promise<ClientSession> {
     await this.historyInternals.historyBootstrapReady;
     const previousConversationId = this.config.getStoredConversationId?.() || null;
-    const storedToken = await this.readVisitorToken();
     const durableResume =
       this.historyInternals.shouldResumeDurableConversation?.() === true;
+    if (!this.isHistoryCapable() && !durableResume) {
+      return this.ordinaryInit(previousConversationId, false);
+    }
+    const storedToken = await this.readVisitorToken();
 
     // Boot resume: reopening the record beats replaying a possibly idle-expired
     // session id, so benign expiry never forks or wipes the conversation.

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -58,8 +58,10 @@ export type RuntypeExecutionStreamEvent = ({
   message: string;
 };
   executionId: string;
+  finalOutput?: string;
   kind: "agent" | "flow";
   seq: number;
+  stopReason?: string;
   type: "execution_error";
   upgradeUrl?: string;
 }) | ({

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -3342,9 +3342,16 @@ export class AgentWidgetSession {
     }
 
     try {
-      const response = await this.client.resumeFlow(executionId, {
-        [toolName]: answer,
-      });
+      const response = await this.client.resumeFlow(
+        executionId,
+        { [toolName]: answer },
+        {
+          after:
+            this.resumable?.executionId === executionId
+              ? this.resumable.lastEventId
+              : undefined,
+        },
+      );
 
       if (!response.ok) {
         const errorData = await response.json().catch(() => null);
@@ -3737,6 +3744,10 @@ export class AgentWidgetSession {
 
       const response = await this.client.resumeFlow(executionId, toolOutputs, {
         signal: batchController.signal,
+        after:
+          this.resumable?.executionId === executionId
+            ? this.resumable.lastEventId
+            : undefined,
       });
       if (!response.ok) {
         const errorData = await response.json().catch(() => null);
@@ -3912,7 +3923,13 @@ export class AgentWidgetSession {
     const response = await this.client.resumeFlow(
       executionId,
       { [resumeKey]: output },
-      { signal: options?.signal },
+      {
+        signal: options?.signal,
+        after:
+          this.resumable?.executionId === executionId
+            ? this.resumable.lastEventId
+            : undefined,
+      },
     );
     if (!response.ok) {
       const errorData = await response.json().catch(() => null);
@@ -4340,9 +4357,11 @@ export class AgentWidgetSession {
       if (event.status === "connecting") {
         this.setStreaming(true);
       } else if (event.status === "idle" || event.status === "error") {
-        // Graceful terminal or terminal error: the durable turn is over, so
-        // drop the resume handle (no reconnect should arm after this).
-        this.clearResumable();
+        // A client-tool pause is an intentional stream end but NOT a terminal:
+        // retain its cursor so `/client/resume` can attach after the await
+        // frame instead of replaying the whole turn. Real terminals and
+        // ordinary non-durable idles still clear the handle.
+        if (!this.isAwaitPending()) this.clearResumable();
         // Keep the typing indicator up while a WebMCP resolve is still in
         // flight: in a chained turn the intermediate resume stream ends with an
         // idle status, but the successor tool is still executing. The resolve's

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -1553,6 +1553,7 @@ export class AgentWidgetSession {
 
   /** Conversation-scoped caches that must not leak across records. */
   private resetConversationScopedState(): void {
+    this.historyInternals.setStoredResumableHandle?.(null);
     this.agentExecution = null;
     this.clearArtifactState();
     this.webMcpInflightKeys.clear();

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -5821,6 +5821,14 @@ export interface WidgetHistoryInternals {
   /** Persist the revision beside the active conversation id (internal only). */
   setStoredConversationRevision?: (revision: string | null) => void;
   getStoredConversationRevision?: () => string | null;
+  /** Internal client-token durable resume handle, persisted with widget state. */
+  setStoredResumableHandle?: (
+    handle: { executionId: string; after: string } | null
+  ) => void;
+  getStoredResumableHandle?: () => {
+    executionId: string;
+    after: string;
+  } | null;
   /** "Show earlier messages" cursor for the persisted transcript. */
   setStoredMessageCursor?: (cursor: string | null) => void;
   getStoredMessageCursor?: () => string | null;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -5833,6 +5833,8 @@ export interface WidgetHistoryInternals {
     executionId: string;
     after: string;
   } | null;
+  /** True only while Persona owns a persisted client-token recovery attempt. */
+  shouldResumeDurableConversation?: () => boolean;
   /** "Show earlier messages" cursor for the persisted transcript. */
   setStoredMessageCursor?: (cursor: string | null) => void;
   getStoredMessageCursor?: () => string | null;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -5690,6 +5690,8 @@ export type ClientSession = {
   targetId?: string;
   /** Opaque change token; differs whenever the conversation transcript mutated. */
   conversationRevision?: string;
+  /** Server-negotiated durable reconnect support for this client-token session. */
+  durableRecovery?: { enabled: boolean };
   /** Visitor grant backing history. `token` appears only at mint. */
   visitor?: ClientVisitorGrant;
   /** Configuration from the server */
@@ -5730,6 +5732,8 @@ export type ClientInitResponse = {
   conversationId?: string;
   targetId?: string;
   conversationRevision?: string;
+  /** Present on servers that understand the durable-recovery negotiation. */
+  durableRecovery?: { enabled: boolean };
   visitor?: ClientVisitorGrant;
   config: {
     welcomeMessage: string | null;

--- a/packages/widget/src/ui.history-lifecycle.test.ts
+++ b/packages/widget/src/ui.history-lifecycle.test.ts
@@ -212,7 +212,7 @@ describe("history controller lifecycle", () => {
       expect(window.localStorage.getItem(keysA.storageKey)).toBe("cvt_alpha");
     });
 
-    it("drops the store entirely when history is disabled", async () => {
+    it("keeps the recovery credential store when history UI is disabled", async () => {
       await seed();
       const { controller } = mount({
         clientToken: TOKEN_A,
@@ -224,7 +224,7 @@ describe("history controller lifecycle", () => {
       await flush(20);
 
       expect(recorder.instances.length).toBe(1);
-      expect(recorder.instances[0]!.destroy).toHaveBeenCalledTimes(1);
+      expect(recorder.instances[0]!.destroy).not.toHaveBeenCalled();
       expect(recorder.instances[0]!.clear).not.toHaveBeenCalled();
     });
   });

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8408,11 +8408,11 @@ export const createAgentExperience = (
     };
   }
 
-  // Visitor-history credential store, keyed on (clientToken, keyPrefix,
-  // persistence-disabled). Owned here and injected into every client the
-  // session builds; `update()` rebuilds it when that tuple changes.
+  // Exact-browser visitor credential store, keyed on (clientToken, keyPrefix,
+  // persistence-disabled). Durable reconnect and optional visitor history use
+  // the same credential but negotiate independent server capabilities.
   const historyStoreToken = (): string | null =>
-    config.features?.history?.enabled === true ? (config.clientToken ?? null) : null;
+    config.clientToken ?? null;
   const buildVisitorStore = (token: string) =>
     createVisitorStore(token, currentKeyPrefix(), config.persistState === false);
   const initialStoreToken = historyStoreToken();
@@ -8490,8 +8490,7 @@ export const createAgentExperience = (
   // and exact-browser visitor credential needed by the public reconnect route.
   // Install Persona's existing reconnect hooks by default so this mode follows
   // the same path as host-configured durable dashboard chats.
-  const clientTokenDurableReconnect =
-    Boolean(config.clientToken) && config.features?.history?.enabled === true;
+  const clientTokenDurableReconnect = Boolean(config.clientToken);
   if (clientTokenDurableReconnect) {
     const hostExecutionState = config.onExecutionState;
     config = {

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8370,6 +8370,20 @@ export const createAgentExperience = (
     const stored = persistentMetadata[key];
     return typeof stored === 'string' ? stored : null;
   };
+  const readStoredResumableHandle = (): {
+    executionId: string;
+    after: string;
+  } | null => {
+    const stored = persistentMetadata.durableResume;
+    if (!stored || typeof stored !== 'object') return null;
+    const candidate = stored as Record<string, unknown>;
+    return typeof candidate.executionId === 'string' &&
+      candidate.executionId.length > 0 &&
+      typeof candidate.after === 'string' &&
+      candidate.after.length > 0
+      ? { executionId: candidate.executionId, after: candidate.after }
+      : null;
+  };
   if (config.clientToken) {
     config = {
       ...config,
@@ -8446,6 +8460,14 @@ export const createAgentExperience = (
         pendingDisplayProjections: pending,
       }));
     },
+    getStoredResumableHandle: readStoredResumableHandle,
+    setStoredResumableHandle: (handle) => {
+      if (!handle) {
+        dropMetadataKey('durableResume');
+        return;
+      }
+      updateSessionMetadata((prev) => ({ ...prev, durableResume: handle }));
+    },
     ...(hostOwnsConversationId
       ? {}
       : {
@@ -8463,6 +8485,30 @@ export const createAgentExperience = (
           },
         }),
   };
+
+  // Runtype client-token widgets already possess the session, conversation,
+  // and exact-browser visitor credential needed by the public reconnect route.
+  // Install Persona's existing reconnect hooks by default so this mode follows
+  // the same path as host-configured durable dashboard chats.
+  const clientTokenDurableReconnect =
+    Boolean(config.clientToken) && config.features?.history?.enabled === true;
+  if (clientTokenDurableReconnect) {
+    const hostExecutionState = config.onExecutionState;
+    config = {
+      ...config,
+      reconnectStream:
+        config.reconnectStream ??
+        ((ctx) => session.getClient().reconnectClientTokenStream(ctx)),
+      onExecutionState: (handle) => {
+        historyInternals.setStoredResumableHandle?.(
+          handle
+            ? { executionId: handle.executionId, after: handle.lastEventId }
+            : null
+        );
+        hostExecutionState?.(handle);
+      },
+    };
+  }
   const syncVisitorStore = () => {
     const token = historyStoreToken();
     if (
@@ -11297,8 +11343,13 @@ export const createAgentExperience = (
   // the restored conversation. Fires AFTER hydration so the trailing partial
   // assistant bubble exists for the replay to append to.
   const maybeBootResume = () => {
-    if (config.resume && typeof config.reconnectStream === "function") {
-      session.resumeFromHandle(config.resume);
+    const resume =
+      config.resume ??
+      (clientTokenDurableReconnect
+        ? historyInternals.getStoredResumableHandle?.()
+        : null);
+    if (resume && typeof config.reconnectStream === "function") {
+      session.resumeFromHandle(resume);
     }
   };
 

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8384,6 +8384,8 @@ export const createAgentExperience = (
       ? { executionId: candidate.executionId, after: candidate.after }
       : null;
   };
+  const personaOwnsClientTokenRecovery =
+    Boolean(config.clientToken) && typeof config.reconnectStream !== "function";
   if (config.clientToken) {
     config = {
       ...config,
@@ -8468,6 +8470,8 @@ export const createAgentExperience = (
       }
       updateSessionMetadata((prev) => ({ ...prev, durableResume: handle }));
     },
+    shouldResumeDurableConversation: () =>
+      personaOwnsClientTokenRecovery && readStoredResumableHandle() !== null,
     ...(hostOwnsConversationId
       ? {}
       : {
@@ -8490,20 +8494,37 @@ export const createAgentExperience = (
   // and exact-browser visitor credential needed by the public reconnect route.
   // Install Persona's existing reconnect hooks by default so this mode follows
   // the same path as host-configured durable dashboard chats.
-  const clientTokenDurableReconnect = Boolean(config.clientToken);
-  if (clientTokenDurableReconnect) {
+  if (personaOwnsClientTokenRecovery) {
     const hostExecutionState = config.onExecutionState;
+    const recoveryWindow = mount.ownerDocument.defaultView;
+    let pageExitInProgress = false;
+    const markPageExit = () => {
+      pageExitInProgress = true;
+    };
+    const markPageActive = () => {
+      pageExitInProgress = false;
+    };
+    recoveryWindow?.addEventListener("beforeunload", markPageExit);
+    recoveryWindow?.addEventListener("pagehide", markPageExit);
+    recoveryWindow?.addEventListener("pageshow", markPageActive);
+    destroyCallbacks.push(() => {
+      recoveryWindow?.removeEventListener("beforeunload", markPageExit);
+      recoveryWindow?.removeEventListener("pagehide", markPageExit);
+      recoveryWindow?.removeEventListener("pageshow", markPageActive);
+    });
     config = {
       ...config,
       reconnectStream:
         config.reconnectStream ??
         ((ctx) => session.getClient().reconnectClientTokenStream(ctx)),
       onExecutionState: (handle) => {
-        historyInternals.setStoredResumableHandle?.(
-          handle
-            ? { executionId: handle.executionId, after: handle.lastEventId }
-            : null
-        );
+        if (handle || !pageExitInProgress) {
+          historyInternals.setStoredResumableHandle?.(
+            handle
+              ? { executionId: handle.executionId, after: handle.lastEventId }
+              : null
+          );
+        }
         hostExecutionState?.(handle);
       },
     };
@@ -11344,7 +11365,7 @@ export const createAgentExperience = (
   const maybeBootResume = () => {
     const resume =
       config.resume ??
-      (clientTokenDurableReconnect
+      (personaOwnsClientTokenRecovery
         ? historyInternals.getStoredResumableHandle?.()
         : null);
     if (resume && typeof config.reconnectStream === "function") {


### PR DESCRIPTION
## What does this PR do?

Adds automatic durable recovery for client-token widgets so active replies reconnect after a page reload or navigation. Custom reconnect transports and non-durable widgets remain unchanged.

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Tooling / CI

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run`) and I added tests for new behavior
- [x] **Changeset added if I touched `packages/widget` or `packages/proxy`** (`pnpm changeset`). _Not required for changes only under `examples/`, `docs/`, CI, or tooling_
- [ ] Docs updated if I changed public API or behavior







<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds automatic durable recovery for client-token widgets while preserving custom reconnect transports and ordinary non-durable session continuity.
- Negotiates durable recovery independently from the optional history UI.
- Persists execution cursors and resumes active replies after reload or navigation.
- Adds visitor proof and cursor propagation to reconnect, dispatch, and client-tool continuation requests.
- Preserves stored session IDs when no durable handle is present and adds focused lifecycle coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; the previously reported stored-session continuity issue is fixed by routing non-durable, history-disabled initialization through the ordinary path that forwards the stored session ID.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/widget/src/client.ts | Negotiates durable recovery, preserves ordinary stored-session continuity, and adds authenticated reconnect and continuation requests. |
| packages/widget/src/session.ts | Retains durable cursors across intentional client-tool pauses and forwards them when resuming execution. |
| packages/widget/src/ui.ts | Persists Persona-owned recovery handles, restores them after hydration, and protects them during page exit. |
| packages/widget/src/types.ts | Extends internal session and history contracts with durable-recovery capability and persisted-handle hooks. |
| packages/widget/src/client-visitor-history.test.ts | Covers non-history recovery negotiation, ordinary stored-session continuity, stale-handle fallback, and reload recovery. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Browser
  participant Widget
  participant API
  Browser->>Widget: Restore conversation, session, and durable cursor
  Widget->>API: Initialize client session
  alt Durable cursor exists
    Widget->>API: Reopen stored conversation
    Widget->>API: Request execution events after cursor
    API-->>Widget: Remaining streamed events
  else No durable cursor
    Widget->>API: Continue using stored session ID
  end
  Widget->>Browser: Clear durable cursor at terminal completion
```
</details>

<sub>Reviews (4): Last reviewed commit: ["chore(widget): refresh Runtype OpenAPI c..."](https://github.com/runtypelabs/persona/commit/01abfb44104e7456e86af51a885743fd4fa8ef3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58260677)</sub>

<!-- /greptile_comment -->