### PR TITLE
Flush durable cursor on page exit

### DIFF
--- a/.changeset/flush-durable-cursor-on-exit.md
+++ b/.changeset/flush-durable-cursor-on-exit.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Flush the latest durable event cursor with the persisted transcript when a page exits so reconnect does not replay text that the widget already rendered.

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "185.25 kB",
+    "limit": "185.5 kB",
     "gzip": true
   },
   {
@@ -20,7 +20,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "197.5 kB",
+    "limit": "197.75 kB",
     "gzip": true
   },
   {

--- a/packages/widget/src/client-visitor-history.test.ts
+++ b/packages/widget/src/client-visitor-history.test.ts
@@ -825,7 +825,7 @@ describe('controller wiring', () => {
     mount.remove();
   });
 
-  it('flushes the latest durable cursor with the transcript during page exit', async () => {
+  it('persists the latest durable cursor with the transcript before page exit', async () => {
     await seedToken('cvt_stored');
     installFetch([ok({ sessionId: 'sess_ui' })]);
     const mount = document.createElement('div');
@@ -867,16 +867,14 @@ describe('controller wiring', () => {
         'Hi there'
       )
     );
-    expect(controller.getPersistentMetadata().durableResume).toEqual({
-      executionId: 'exec_exit_latest',
-      after: '7',
-    });
+    await vi.waitFor(() =>
+      expect(controller.getPersistentMetadata().durableResume).toEqual({
+        executionId: 'exec_exit_latest',
+        after: '8',
+      })
+    );
 
     window.dispatchEvent(new Event('pagehide'));
-    expect(controller.getPersistentMetadata().durableResume).toEqual({
-      executionId: 'exec_exit_latest',
-      after: '8',
-    });
 
     streamController.close();
     await connected;
@@ -941,6 +939,11 @@ describe('controller wiring', () => {
       executionId: 'exec_async',
       after: '8',
     });
+    await Promise.resolve();
+    const savesBeforeExit = saves.length;
+    window.dispatchEvent(new Event('pagehide'));
+    await Promise.resolve();
+    expect(saves).toHaveLength(savesBeforeExit);
 
     streamController.enqueue(
       encoder.encode(

--- a/packages/widget/src/client-visitor-history.test.ts
+++ b/packages/widget/src/client-visitor-history.test.ts
@@ -825,6 +825,65 @@ describe('controller wiring', () => {
     mount.remove();
   });
 
+  it('flushes the latest durable cursor with the transcript during page exit', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_ui' })]);
+    const mount = document.createElement('div');
+    document.body.appendChild(mount);
+    const controller = createAgentExperience(mount, {
+      apiUrl: API_URL,
+      clientToken: CLIENT_TOKEN,
+      launcher: { enabled: false },
+    });
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(value) {
+        streamController = value;
+      },
+    });
+    const connected = controller.connectStream(stream);
+    const encoder = new TextEncoder();
+    streamController.enqueue(
+      encoder.encode(
+        'id: 7\nevent: text_delta\ndata: {"type":"text_delta","executionId":"exec_exit_latest","id":"text_exit_latest","delta":"Hi"}\n\n'
+      )
+    );
+    await vi.waitFor(() =>
+      expect(controller.getPersistentMetadata().durableResume).toEqual({
+        executionId: 'exec_exit_latest',
+        after: '7',
+      })
+    );
+
+    streamController.enqueue(
+      encoder.encode(
+        'id: 8\nevent: text_delta\ndata: {"type":"text_delta","executionId":"exec_exit_latest","id":"text_exit_latest","delta":" there"}\n\n'
+      )
+    );
+    await vi.waitFor(() =>
+      expect(controller.getMessages().find((message) => message.role === 'assistant')?.content).toBe(
+        'Hi there'
+      )
+    );
+    expect(controller.getPersistentMetadata().durableResume).toEqual({
+      executionId: 'exec_exit_latest',
+      after: '7',
+    });
+
+    window.dispatchEvent(new Event('pagehide'));
+    expect(controller.getPersistentMetadata().durableResume).toEqual({
+      executionId: 'exec_exit_latest',
+      after: '8',
+    });
+
+    streamController.close();
+    await connected;
+    controller.destroy();
+    mount.remove();
+  });
+
   it('uses Persona-owned stored recovery state to reopen the durable conversation', async () => {
     await seedToken('cvt_stored');
     global.fetch = vi.fn(async (url: string | URL | Request, options?: RequestInit) => {

--- a/packages/widget/src/client-visitor-history.test.ts
+++ b/packages/widget/src/client-visitor-history.test.ts
@@ -884,6 +884,75 @@ describe('controller wiring', () => {
     mount.remove();
   });
 
+  it('keeps async transcript snapshots aligned with the durable cursor', async () => {
+    await seedToken('cvt_stored');
+    installFetch([ok({ sessionId: 'sess_ui' })]);
+    const saves: AgentWidgetStoredState[] = [];
+    const mount = document.createElement('div');
+    document.body.appendChild(mount);
+    const controller = createAgentExperience(mount, {
+      apiUrl: API_URL,
+      clientToken: CLIENT_TOKEN,
+      launcher: { enabled: false },
+      storageAdapter: {
+        save: async (state) => {
+          await Promise.resolve();
+          saves.push(state);
+        },
+      },
+    });
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+
+    let streamController!: ReadableStreamDefaultController<Uint8Array>;
+    const stream = new ReadableStream<Uint8Array>({
+      start(value) {
+        streamController = value;
+      },
+    });
+    const connected = controller.connectStream(stream);
+    const encoder = new TextEncoder();
+    streamController.enqueue(
+      encoder.encode(
+        'id: 7\nevent: text_delta\ndata: {"type":"text_delta","executionId":"exec_async","id":"text_async","delta":"Hi"}\n\n'
+      )
+    );
+    await vi.waitFor(() =>
+      expect(controller.getPersistentMetadata().durableResume).toEqual({
+        executionId: 'exec_async',
+        after: '7',
+      })
+    );
+
+    streamController.enqueue(
+      encoder.encode(
+        'id: 8\nevent: text_delta\ndata: {"type":"text_delta","executionId":"exec_async","id":"text_async","delta":" there"}\n\n'
+      )
+    );
+    let firstCompleteTranscript: AgentWidgetStoredState | undefined;
+    await vi.waitFor(() => {
+      firstCompleteTranscript = saves.find((state) =>
+        state.messages?.some(
+          (message) => message.role === 'assistant' && message.content === 'Hi there'
+        )
+      );
+      expect(firstCompleteTranscript).toBeDefined();
+    });
+    expect(firstCompleteTranscript?.metadata?.durableResume).toEqual({
+      executionId: 'exec_async',
+      after: '8',
+    });
+
+    streamController.enqueue(
+      encoder.encode(
+        'id: 9\nevent: execution_complete\ndata: {"type":"execution_complete","executionId":"exec_async","kind":"agent","success":true}\n\n'
+      )
+    );
+    streamController.close();
+    await connected;
+    controller.destroy();
+    mount.remove();
+  });
+
   it('uses Persona-owned stored recovery state to reopen the durable conversation', async () => {
     await seedToken('cvt_stored');
     global.fetch = vi.fn(async (url: string | URL | Request, options?: RequestInit) => {

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8500,6 +8500,13 @@ export const createAgentExperience = (
     let pageExitInProgress = false;
     const markPageExit = () => {
       pageExitInProgress = true;
+      const handle = session.getResumableHandle();
+      if (handle) {
+        historyInternals.setStoredResumableHandle?.({
+          executionId: handle.executionId,
+          after: handle.lastEventId,
+        });
+      }
     };
     const markPageActive = () => {
       pageExitInProgress = false;

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -5315,21 +5315,20 @@ export const createAgentExperience = (
         ? getMessagesForPersistence()
         : [];
 
-    const durableHandle = personaOwnsClientTokenRecovery
-      ? session?.getResumableHandle()
-      : null;
-    const metadata = durableHandle
-      ? {
-          ...persistentMetadata,
-          durableResume: {
-            executionId: durableHandle.executionId,
-            after: durableHandle.lastEventId,
-          },
-        }
-      : persistentMetadata;
+    const durableHandle =
+      personaOwnsClientTokenRecovery && session?.getResumableHandle();
+    if (durableHandle) {
+      persistentMetadata = {
+        ...persistentMetadata,
+        durableResume: {
+          executionId: durableHandle.executionId,
+          after: durableHandle.lastEventId,
+        },
+      };
+    }
     const payload: AgentWidgetStoredState = {
       messages,
-      metadata,
+      metadata: persistentMetadata,
       artifacts: lastArtifactsState.artifacts,
       selectedArtifactId: lastArtifactsState.selectedId,
       ...(currentStoredDraft ? { draft: currentStoredDraft } : {})
@@ -8510,24 +8509,11 @@ export const createAgentExperience = (
     const hostExecutionState = config.onExecutionState;
     const recoveryWindow = mount.ownerDocument.defaultView;
     let pageExitInProgress = false;
-    const markPageExit = () => {
-      pageExitInProgress = true;
-      const handle = session.getResumableHandle();
-      if (handle) {
-        historyInternals.setStoredResumableHandle?.({
-          executionId: handle.executionId,
-          after: handle.lastEventId,
-        });
-      }
-    };
-    const markPageActive = () => {
-      pageExitInProgress = false;
-    };
-    recoveryWindow?.addEventListener("beforeunload", markPageExit);
+    const markPageExit = () => (pageExitInProgress = true);
+    const markPageActive = () => (pageExitInProgress = false);
     recoveryWindow?.addEventListener("pagehide", markPageExit);
     recoveryWindow?.addEventListener("pageshow", markPageActive);
     destroyCallbacks.push(() => {
-      recoveryWindow?.removeEventListener("beforeunload", markPageExit);
       recoveryWindow?.removeEventListener("pagehide", markPageExit);
       recoveryWindow?.removeEventListener("pageshow", markPageActive);
     });
@@ -8658,24 +8644,15 @@ export const createAgentExperience = (
   let pendingStreamingTextMessages: AgentWidgetMessage[] | null = null;
   let streamingTextRAF: number | null = null;
   let pendingDurablePersistenceMessages: AgentWidgetMessage[] | null = null;
-  let durablePersistenceQueued = false;
 
   const persistMessages = (messages: AgentWidgetMessage[]) => {
-    const hasStreamingAssistant = messages.some(
-      (message) => message.role === "assistant" && message.streaming === true
-    );
-    if (!personaOwnsClientTokenRecovery || !hasStreamingAssistant) {
-      persistState(messages);
-      return;
-    }
+    if (!personaOwnsClientTokenRecovery) return persistState(messages);
     pendingDurablePersistenceMessages = messages;
-    if (durablePersistenceQueued) return;
-    durablePersistenceQueued = true;
     queueMicrotask(() => {
-      durablePersistenceQueued = false;
-      const pending = pendingDurablePersistenceMessages;
-      pendingDurablePersistenceMessages = null;
-      if (pending) persistState(pending);
+      if (pendingDurablePersistenceMessages === messages) {
+        pendingDurablePersistenceMessages = null;
+        persistState(messages);
+      }
     });
   };
 

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1054,6 +1054,8 @@ export const createAgentExperience = (
     messagePersistenceDisabled
       ? null
       : (config.storageAdapter ?? createLocalStorageAdapter());
+  const personaOwnsClientTokenRecovery =
+    Boolean(config.clientToken) && typeof config.reconnectStream !== "function";
   let persistentMetadata: Record<string, unknown> = {};
   let pendingStoredState: Promise<AgentWidgetStoredState | null> | null = null;
   // Resolves once stored state has been applied (or its load failed). Every
@@ -5313,9 +5315,21 @@ export const createAgentExperience = (
         ? getMessagesForPersistence()
         : [];
 
+    const durableHandle = personaOwnsClientTokenRecovery
+      ? session?.getResumableHandle()
+      : null;
+    const metadata = durableHandle
+      ? {
+          ...persistentMetadata,
+          durableResume: {
+            executionId: durableHandle.executionId,
+            after: durableHandle.lastEventId,
+          },
+        }
+      : persistentMetadata;
     const payload: AgentWidgetStoredState = {
       messages,
-      metadata: persistentMetadata,
+      metadata,
       artifacts: lastArtifactsState.artifacts,
       selectedArtifactId: lastArtifactsState.selectedId,
       ...(currentStoredDraft ? { draft: currentStoredDraft } : {})
@@ -8384,8 +8398,6 @@ export const createAgentExperience = (
       ? { executionId: candidate.executionId, after: candidate.after }
       : null;
   };
-  const personaOwnsClientTokenRecovery =
-    Boolean(config.clientToken) && typeof config.reconnectStream !== "function";
   if (config.clientToken) {
     config = {
       ...config,
@@ -8645,6 +8657,27 @@ export const createAgentExperience = (
   let activeStreamingTextCandidate: { index: number; id: string } | null = null;
   let pendingStreamingTextMessages: AgentWidgetMessage[] | null = null;
   let streamingTextRAF: number | null = null;
+  let pendingDurablePersistenceMessages: AgentWidgetMessage[] | null = null;
+  let durablePersistenceQueued = false;
+
+  const persistMessages = (messages: AgentWidgetMessage[]) => {
+    const hasStreamingAssistant = messages.some(
+      (message) => message.role === "assistant" && message.streaming === true
+    );
+    if (!personaOwnsClientTokenRecovery || !hasStreamingAssistant) {
+      persistState(messages);
+      return;
+    }
+    pendingDurablePersistenceMessages = messages;
+    if (durablePersistenceQueued) return;
+    durablePersistenceQueued = true;
+    queueMicrotask(() => {
+      durablePersistenceQueued = false;
+      const pending = pendingDurablePersistenceMessages;
+      pendingDurablePersistenceMessages = null;
+      if (pending) persistState(pending);
+    });
+  };
 
   const applyMessagesChanged = (messages: AgentWidgetMessage[]) => {
     lastAppliedMessages = messages;
@@ -8705,7 +8738,7 @@ export const createAgentExperience = (
     }
 
     voiceState.lastUserMessageWasVoice = Boolean(lastUserMessage?.viaVoice);
-    persistState(messages);
+    persistMessages(messages);
     syncComposerBarPeek();
   };
 


### PR DESCRIPTION
## What does this PR do?

Prevents duplicated assistant text after leaving or reloading during an active response.

Previously:
- Persona persisted streamed text immediately.
- It persisted the event cursor on a 500 ms throttle.
- A reload between those updates could save newer text with an older cursor.
- Reconnect replayed events after that older cursor, duplicating text already displayed.

The fix persists each transcript snapshot with its matching in-memory execution cursor. Page exit preserves the active recovery handle, and reload replays any frames after the last committed cursor.

It only affects active durable client-token sessions; ordinary Persona users and non-durable integrations are unchanged.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Tooling / CI

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run`) and I added tests for new behavior
- [x] **Changeset added if I touched `packages/widget` or `packages/proxy`** (`pnpm changeset`). _Not required for changes only under `examples/`, `docs/`, CI, or tooling_
- [ ] Docs updated if I changed public API or behavior






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns durable reconnect cursors with persisted transcript snapshots for active Persona-owned client-token sessions.
- Refreshes durable cursor metadata whenever transcript state is persisted.
- Coalesces durable transcript persistence through a microtask.
- Updates page lifecycle handling and adds focused cursor-alignment tests.
- Raises the widget browser-bundle size limits and adds a patch changeset.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because asynchronous storage saves can remain unfinished when the page exits.

The cursor and transcript are aligned when a save is invoked, but pagehide and destroy do not wait for the permitted asynchronous storage-adapter promise, so teardown can still leave durable storage at an older snapshot.

**Files Needing Attention:** packages/widget/src/ui.ts and packages/widget/src/client-visitor-history.test.ts

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/widget/src/ui.ts | Aligns durable cursor metadata with transcript persistence and revises page-exit lifecycle handling. |
| packages/widget/src/client-visitor-history.test.ts | Adds coverage for durable cursor/transcript alignment with synchronous and asynchronous adapters. |
| packages/widget/.size-limit.json | Raises the critical CDN and ESM browser-bundle limits by 0.25 kB. |
| .changeset/flush-durable-cursor-on-exit.md | Records the durable cursor-on-exit fix as a patch release. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Stream
  participant Session
  participant UI
  participant Storage
  Stream-->>Session: text event with cursor
  Session-->>UI: updated transcript and resumable handle
  UI->>UI: queue persistence microtask
  UI->>Storage: save cursor-aligned snapshot
  Stream-->>Session: next event
  Session-->>UI: advance transcript and cursor
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(widget): avoid async recovery save o..."](https://github.com/runtypelabs/persona/commit/29d3f606a24ffdff829b8b0e98289608bfe40ff6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58321426)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Widget runtime and integration surface](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-runtime.md)
- Knowledge Base — [Widget conversation and session runtime](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-conversation-runtime.md)
- Knowledge Base — [Widget history and durable reconnect](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-history-and-reconnect.md)
</details>


<!-- /greptile_comment -->