### PR TITLE
History, reasoning, and select plugin updates

### DIFF
--- a/.changeset/completed-visibility-seams.md
+++ b/.changeset/completed-visibility-seams.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add `features.reasoningDisplay.completedVisibility: "removed-when-short"` to drop a completed reasoning row only when the trace was short (configurable via `shortThinkThreshold`), and add `features.toolCallDisplay.completedVisibility: "kept" | "removed"` so a completed tool-call row can disappear entirely, matching the existing reasoning removal behavior.

--- a/.changeset/widget-handle-registry.md
+++ b/.changeset/widget-handle-registry.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Add `getAgentWidgetHandles()`: a registry of every mounted `initAgentWidget()` handle, oldest first, deregistered on `destroy()`. `persona:chat-ready` is a one-shot broadcast and `windowKey` is opt-in, so host code created after a widget mounted previously had no way to reach it. Late companions (selection toolbars, host integrations) can now adopt the most recent mount via `getAgentWidgetHandles().at(-1)` — importable from the package, or `window.AgentWidget.getAgentWidgetHandles()` on CDN builds.

--- a/apps/web/selection-explain-demo.html
+++ b/apps/web/selection-explain-demo.html
@@ -1,0 +1,351 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="stylesheet" href="/src/demo-shared.css" />
+    <link rel="icon" href="/favicon.ico" sizes="any" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <title>Select-to-Explain: Persona</title>
+
+    <style>
+      /* Scope article styles to the preview pane so they don't leak into the rail. */
+      .article-pane {
+        padding: 0;
+        overflow-y: auto;
+        background: #fdfcfa;
+      }
+      .article-body {
+        max-width: 680px;
+        margin: 0 auto;
+        padding: 2.5rem 1.5rem 4rem;
+        color: #1f2937;
+        font-size: 0.95rem;
+        line-height: 1.7;
+      }
+      .article-kicker {
+        margin: 0 0 0.4rem;
+        font-size: 0.72rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        color: #b45309;
+      }
+      .article-body h1 {
+        margin: 0 0 0.5rem;
+        font-size: 1.7rem;
+        line-height: 1.25;
+        color: #111827;
+      }
+      .article-standfirst {
+        margin: 0 0 2rem;
+        font-size: 1.02rem;
+        color: #6b7280;
+      }
+      .article-body h2 {
+        margin: 2rem 0 0.6rem;
+        font-size: 1.15rem;
+        color: #111827;
+      }
+      .article-body p {
+        margin: 0 0 1rem;
+      }
+      .article-body ::selection {
+        background: #fde68a;
+      }
+      .article-hint {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        margin: 0 0 2rem;
+        padding: 0.65rem 0.9rem;
+        border: 1px dashed #d1d5db;
+        border-radius: 8px;
+        font-size: 0.8rem;
+        color: #6b7280;
+        background: #fff;
+      }
+
+      /* Copy buttons on the notes code blocks */
+      .notes .code-block {
+        position: relative;
+      }
+      .code-copy-btn {
+        position: absolute;
+        top: 0.5rem;
+        right: 0.5rem;
+        border: 1px solid color-mix(in srgb, var(--code-fg) 25%, var(--code-bg));
+        border-radius: 6px;
+        /* Opaque: the button floats over code, so text must not show through. */
+        background: color-mix(in srgb, var(--code-fg) 12%, var(--code-bg));
+        color: var(--code-fg);
+        font-family: inherit;
+        font-size: 0.68rem;
+        font-weight: 600;
+        padding: 0.25rem 0.55rem;
+        cursor: pointer;
+        white-space: nowrap;
+      }
+      .code-copy-btn:hover {
+        background: color-mix(in srgb, var(--code-fg) 20%, var(--code-bg));
+      }
+
+      /* Selection action log (left rail) */
+      .selection-log-wrap[data-empty] .selection-log {
+        display: none;
+      }
+      .selection-log-wrap:not([data-empty]) .selection-log-empty {
+        display: none;
+      }
+      .selection-log-empty {
+        margin: 0;
+        font-size: 0.78rem;
+        color: #94a3b8;
+      }
+      .selection-log {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        display: grid;
+        gap: 0.4rem;
+      }
+      .selection-log li {
+        font-size: 0.78rem;
+        line-height: 1.4;
+        color: #334155;
+        border: 1px solid #e2e8f0;
+        border-radius: 6px;
+        background: #fff;
+        padding: 0.45rem 0.6rem;
+      }
+      .selection-log li span {
+        color: #94a3b8;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="shell-main">
+      <div class="stage">
+        <aside class="stage-controls">
+          <header class="demo-meta">
+            <h1>Select-to-Explain</h1>
+            <p>
+              A host-page toolbar appears when you select article text. It
+              quotes the selection into the widget with
+              <code>controller.setQuote()</code>, then sends it or focuses the
+              composer.
+            </p>
+            <div class="mount-toolbar" data-mount-toolbar></div>
+          </header>
+
+          <div class="info-section">
+            <h3>Try it</h3>
+            <div class="section">
+              <p style="font-size: 0.8rem; margin: 0 0 0.5rem;">
+                Highlight a sentence or two in the article. Then pick an
+                action:
+              </p>
+              <ul style="font-size: 0.8rem; margin: 0; padding-left: 1.1rem;">
+                <li><strong>Explain this</strong> — sends the selection with a canned prompt.</li>
+                <li><strong>Ask about it</strong> — quotes the selection. You type the question.</li>
+              </ul>
+              <p style="font-size: 0.8rem; margin: 0.5rem 0 0;">
+                The echo backend replies with what it received.
+              </p>
+            </div>
+          </div>
+
+          <div class="info-section selection-log-wrap" data-empty>
+            <h3>Selection actions</h3>
+            <p class="selection-log-empty">Nothing yet — highlight some text.</p>
+            <ul class="selection-log" id="selection-log"></ul>
+          </div>
+
+          <div data-config-inspector></div>
+        </aside>
+
+        <div class="stage-widget article-pane">
+          <article class="article-body">
+            <p class="article-kicker">Field Notes</p>
+            <h1>How Espresso Extraction Works</h1>
+            <p class="article-standfirst">
+              Nine bars of pressure, thirty seconds, and a surprising amount of
+              chemistry: what actually happens inside the puck.
+            </p>
+            <p class="article-hint">
+              💡 Highlight any passage below to ask the assistant about it.
+            </p>
+
+            <h2>Solubles in a hurry</h2>
+            <p>
+              Espresso is a forced-percolation brew: hot water at roughly nine
+              bars of pressure is pushed through a compacted bed of finely
+              ground coffee, dissolving and emulsifying its soluble material in
+              well under a minute. Extraction yield — the percentage of the dry
+              grounds' mass that ends up in the cup — typically lands between 18
+              and 22 percent. Below that range the shot tastes sour and thin
+              because the fast-dissolving fruit acids arrive first; above it,
+              slow-moving bitter phenolics and dry-tasting melanoidins dominate.
+            </p>
+            <p>
+              The order of dissolution is the whole game. Acids and simple
+              sugars give up quickly; caramelized sugars take longer; the harsh,
+              papery compounds emerge last. A barista chasing balance is really
+              adjusting time, temperature, and surface area so the extraction
+              stops at the right point on that curve.
+            </p>
+
+            <h2>The puck is a filter bed</h2>
+            <p>
+              Grind size sets the surface area, but the puck's real job is
+              hydraulic. Tamping compresses the grounds into a uniform filter
+              bed with predictable resistance. If the bed is uneven, water finds
+              the path of least resistance and carves a channel — a phenomenon
+              called channeling — over-extracting a narrow column of coffee
+              while leaving the rest of the puck barely touched. The result is
+              a shot that is somehow both bitter and sour at once.
+            </p>
+            <p>
+              Modern technique obsesses over puck preparation for exactly this
+              reason: distribution tools, Weiss Distribution Technique needles,
+              and precision baskets all exist to make the bed's permeability
+              boring and uniform.
+            </p>
+
+            <h2>Crema, an emulsion with a deadline</h2>
+            <p>
+              The reddish-brown foam capping a fresh shot is crema: carbon
+              dioxide trapped during roasting, released under pressure and
+              stabilized into a foam by emulsified oils and melanoidins. It is
+              also a freshness gauge — beans more than a few weeks past roast
+              have out-gassed most of their CO₂ and produce a thin, fleeting
+              crema. Contrary to café mythology, crema itself tastes mostly
+              bitter; its value is textural and diagnostic, not flavor.
+            </p>
+
+            <h2>Why ratios beat recipes</h2>
+            <p>
+              A "double shot" means little without a brew ratio: the weight of
+              beverage in the cup divided by the weight of dry grounds. A 1:2
+              ratio pulled in 25 to 30 seconds is the modern starting point — 18
+              grams in, 36 grams out. Tighter ratios (ristretto) concentrate
+              texture at the cost of clarity; longer ones (lungo) trade body for
+              extraction. Because the ratio pins down strength independently of
+              grind and time, it is the one variable worth fixing first and
+              adjusting last.
+            </p>
+          </article>
+        </div>
+      </div>
+
+      <section class="notes">
+        <h2 class="notes-heading">Notes</h2>
+
+        <div class="notes-section">
+          <h3 class="notes-section-title">How it works</h3>
+          <p>The toolbar is host-page code, not widget UI.</p>
+          <ol>
+            <li>
+              A debounced <code>selectionchange</code> listener waits for a
+              selection inside the article.
+            </li>
+            <li>
+              The toolbar opens in a plugin-kit <code>createPopover</code>
+              anchored over the selection.
+            </li>
+            <li>
+              Both actions call
+              <code>controller.setQuote({ text, sourceLabel })</code>. That
+              shows the quote banner above the composer.
+            </li>
+            <li>
+              <strong>Explain this</strong> calls
+              <code>submitMessage(prompt)</code>. <strong>Ask about it</strong>
+              calls <code>focusInput()</code>.
+            </li>
+          </ol>
+          <p>
+            On the wire, the quote travels ahead of the message as a
+            <code>```quoted-text source=…```</code> block. It is all one user
+            turn. The agent needs no extra context plumbing.
+          </p>
+        </div>
+
+        <div class="notes-section">
+          <h3 class="notes-section-title">Integrate it</h3>
+          <p>
+            Copy
+            <a
+              href="https://github.com/runtypelabs/persona/blob/main/apps/web/src/plugins/selection-explain-plugin.ts"
+              target="_blank"
+              rel="noopener"
+            ><code>selection-explain-plugin.ts</code></a>
+            into your project. Then one call wires it up:
+          </p>
+          <div class="code-block"><span class="keyword">import</span> { <span class="function">createSelectionExplainPlugin</span> } <span class="keyword">from</span> <span class="string">"./selection-explain-plugin"</span>;
+
+<span class="comment">// Bundler: pass the handle returned by initAgentWidget().</span>
+<span class="function">createSelectionExplainPlugin</span>({ <span class="prop">container</span>: <span class="string">"#article"</span>, <span class="prop">controller</span> });
+
+<span class="comment">// Script tag: omit controller. It attaches itself on persona:chat-ready.</span>
+<span class="function">createSelectionExplainPlugin</span>({ <span class="prop">container</span>: <span class="string">"#article"</span> });</div>
+          <p>
+            It is not an <code>AgentWidgetPlugin</code>, on purpose. Plugin
+            hooks render UI inside the widget and never receive the
+            controller. This toolbar lives on the page and drives the
+            controller, so it follows the companion pattern instead.
+          </p>
+        </div>
+
+        <div class="notes-section">
+          <h3 class="notes-section-title">Customize it</h3>
+          <p>Every option, annotated:</p>
+          <div class="code-block"><span class="function">createSelectionExplainPlugin</span>({
+  <span class="prop">container</span>: <span class="string">"#article"</span>,        <span class="comment">// element or selector, resolved lazily</span>
+  <span class="prop">controller</span>,                  <span class="comment">// from initAgentWidget(); omit for script-tag installs</span>
+  <span class="prop">sourceLabel</span>: <span class="string">"Field Notes"</span>, <span class="comment">// quote attribution; string or (text) =&gt; string</span>
+  <span class="prop">minLength</span>: <span class="keyword">8</span>,                <span class="comment">// characters before the toolbar shows</span>
+  <span class="prop">shouldShow</span>: ({ range }) =&gt;  <span class="comment">// veto selections, e.g. skip code blocks</span>
+    !range.commonAncestorContainer.parentElement?.closest(<span class="string">"pre"</span>),
+  <span class="prop">className</span>: <span class="string">"my-toolbar"</span>,    <span class="comment">// your CSS hook on .selection-explain</span>
+  <span class="prop">actions</span>: [                   <span class="comment">// replaces the default buttons</span>
+    {
+      <span class="prop">id</span>: <span class="string">"explain"</span>,
+      <span class="prop">label</span>: <span class="string">"Explain this"</span>,
+      <span class="prop">mode</span>: <span class="string">"send"</span>,           <span class="comment">// quotes the selection, sends prompt</span>
+      <span class="prop">prompt</span>: <span class="string">"Explain the highlighted passage in plain language."</span>,
+    },
+    {
+      <span class="prop">id</span>: <span class="string">"ask"</span>,
+      <span class="prop">label</span>: <span class="string">"Ask about it"</span>,
+      <span class="prop">mode</span>: <span class="string">"draft"</span>,          <span class="comment">// quotes the selection, focuses the composer</span>
+    },
+  ],
+  <span class="prop">onAction</span>: (action, text) =&gt; <span class="function">console</span>.<span class="function">log</span>(action.<span class="prop">id</span>, text),
+});</div>
+          <p>
+            Colors follow the <code>--persona-*</code> theme variables, so the
+            toolbar matches your widget theme by default.
+          </p>
+        </div>
+
+        <div class="notes-section">
+          <h3 class="notes-section-title">Streaming</h3>
+          <p>
+            <code>submitMessage()</code> returns <code>false</code> while a
+            reply is streaming. The toolbar falls back to the draft flow. The
+            staged quote stays in the composer.
+          </p>
+        </div>
+      </section>
+    </main>
+
+    <div id="launcher-root"></div>
+    <script type="module" src="/src/selection-explain-demo.ts"></script>
+    <script type="module">
+      import { renderExamplesShell } from "/src/examples-nav.ts";
+      renderExamplesShell("selection-explain-demo");
+    </script>
+  </body>
+</html>

--- a/apps/web/selection-explain-demo.html
+++ b/apps/web/selection-explain-demo.html
@@ -288,7 +288,8 @@
 <span class="comment">// Bundler: pass the handle returned by initAgentWidget().</span>
 <span class="function">createSelectionExplainPlugin</span>({ <span class="prop">container</span>: <span class="string">"#article"</span>, <span class="prop">controller</span> });
 
-<span class="comment">// Script tag: omit controller. It attaches itself on persona:chat-ready.</span>
+<span class="comment">// Script tag: omit controller. It attaches on persona:chat-ready, or</span>
+<span class="comment">// adopts an already-mounted widget via getAgentWidgetHandles().</span>
 <span class="function">createSelectionExplainPlugin</span>({ <span class="prop">container</span>: <span class="string">"#article"</span> });</div>
           <p>
             It is not an <code>AgentWidgetPlugin</code>, on purpose. Plugin

--- a/apps/web/src/examples-nav.ts
+++ b/apps/web/src/examples-nav.ts
@@ -218,6 +218,15 @@ export const ADVANCED_EXAMPLES: readonly AdvancedExample[] = [
     modes: ["inline", "launcher"],
   },
   {
+    slug: "selection-explain-demo",
+    href: "/selection-explain-demo.html",
+    title: "Select-to-Explain",
+    blurb: "A selection toolbar quotes highlighted page text into the composer via setQuote().",
+    tier: "patterns",
+    tags: ["interaction", "context"],
+    modes: ["launcher"],
+  },
+  {
     slug: "ask-user-question-demo",
     href: "/ask-user-question-demo.html",
     title: "Ask User Question & Suggested Replies",

--- a/apps/web/src/history-demo.ts
+++ b/apps/web/src/history-demo.ts
@@ -247,7 +247,7 @@ function renderLiveSetup(stage: HTMLElement): () => void {
   const code = document.createElement("pre");
   code.className = "code-block";
   code.textContent =
-    "VITE_CLIENT_TOKEN_HISTORY=ct_live_…\n# Optional, defaults to https://api.runtype.com:\n# VITE_HISTORY_API_URL=https://api.runtype-staging.com";
+    "VITE_CLIENT_TOKEN_HISTORY=ct_live_…\n# Optional, defaults to https://api.runtype.com:\n# VITE_HISTORY_API_URL=https://api.your-domain.com";
   panel.appendChild(code);
 
   addLine(

--- a/apps/web/src/plugins/selection-explain-plugin.ts
+++ b/apps/web/src/plugins/selection-explain-plugin.ts
@@ -340,21 +340,50 @@ export function createSelectionExplainPlugin(
   const handleChatReady = (event: Event): void => {
     if (controller) return;
     const detail = (event as CustomEvent<AgentWidgetController>).detail;
-    if (detail) controller = detail;
+    if (detail) {
+      controller = detail;
+      clearWarnTimer();
+    }
   };
   if (autoAttach) {
     window.addEventListener("persona:chat-ready", handleChatReady);
   }
 
+  // A companion created after `persona:chat-ready` fired, with no `controller`
+  // and no `windowKey`, has no channel to the widget: the toolbar just stays
+  // hidden. Silent failure is undiagnosable, so tell the developer what to
+  // wire up if nothing attaches within the grace period.
+  let warnTimer: number | null = null;
+  const clearWarnTimer = (): void => {
+    if (warnTimer !== null) {
+      window.clearTimeout(warnTimer);
+      warnTimer = null;
+    }
+  };
+  if (autoAttach && !controller) {
+    warnTimer = window.setTimeout(() => {
+      warnTimer = null;
+      if (destroyed || resolveController()) return;
+      console.warn(
+        "[selection-explain] No widget controller attached after 4s; the toolbar will stay hidden. " +
+          "Pass `controller` (from initAgentWidget), call `attach(handle)`, or set `windowKey` to match " +
+          "your installer config. Script-tag installs must create this companion before the widget " +
+          "mounts so it can catch `persona:chat-ready`."
+      );
+    }, 4000);
+  }
+
   return {
     attach(next: AgentWidgetController) {
       controller = next;
+      clearWarnTimer();
     },
     destroy() {
       if (destroyed) return;
       destroyed = true;
       document.removeEventListener("selectionchange", handleSelectionChange);
       window.removeEventListener("persona:chat-ready", handleChatReady);
+      clearWarnTimer();
       if (evaluateTimer !== null) window.clearTimeout(evaluateTimer);
       popover?.destroy();
       popover = null;

--- a/apps/web/src/plugins/selection-explain-plugin.ts
+++ b/apps/web/src/plugins/selection-explain-plugin.ts
@@ -187,15 +187,21 @@ export function createSelectionExplainPlugin(
   // registry of mounted handles — imported when this file shares the widget's
   // bundle, or via the `AgentWidget` CDN global on script-tag pages where the
   // two are separate module instances.
+  type MountedHandle = AgentWidgetController & { host?: HTMLElement };
   const registryHandles = (): AgentWidgetController[] => {
-    const imported = getAgentWidgetHandles();
-    if (imported.length) return imported;
+    const imported = getAgentWidgetHandles() as MountedHandle[];
     const cdnGlobal = (
       window as unknown as {
-        AgentWidget?: { getAgentWidgetHandles?: () => AgentWidgetController[] };
+        AgentWidget?: { getAgentWidgetHandles?: () => MountedHandle[] };
       }
     ).AgentWidget;
-    return cdnGlobal?.getAgentWidgetHandles?.() ?? [];
+    const handles = imported.length
+      ? imported
+      : (cdnGlobal?.getAgentWidgetHandles?.() ?? []);
+    // A host that drops a widget's DOM without calling destroy() leaves a
+    // zombie handle in the registry. A disconnected host can't be the widget
+    // the visitor sees, so never adopt one.
+    return handles.filter((handle) => !handle.host || handle.host.isConnected);
   };
   const resolveController = (): AgentWidgetController | null => {
     if (controller) return controller;

--- a/apps/web/src/plugins/selection-explain-plugin.ts
+++ b/apps/web/src/plugins/selection-explain-plugin.ts
@@ -30,8 +30,10 @@ import {
  * attaches on `persona:chat-ready`; one created after adopts the mounted
  * widget from `getAgentWidgetHandles()` (most recent mount). Pass
  * `controller` or set `windowKey` to pin a specific instance on multi-widget
- * pages. The toolbar stays hidden until a controller is attached — it never
- * renders actions that would silently do nothing.
+ * pages. If an adopted widget is destroyed and replaced (SPA remount), the
+ * toolbar drops the stale handle and re-adopts the replacement on its own.
+ * The toolbar stays hidden until a controller is attached — it never renders
+ * actions that would silently do nothing.
  *
  * Each action stages the selection with `controller.setQuote()`. A `"send"`
  * action then calls `submitMessage(prompt)`; a `"draft"` action calls
@@ -188,6 +190,16 @@ export function createSelectionExplainPlugin(
   // bundle, or via the `AgentWidget` CDN global on script-tag pages where the
   // two are separate module instances.
   type MountedHandle = AgentWidgetController & { host?: HTMLElement };
+
+  // A handle is live when it has no host to check (raw controllers stay
+  // trusted) or its host is still in the document. Destroyed widgets lose
+  // their host, so this doubles as the staleness test for cached adoptions.
+  const isLive = (candidate: AgentWidgetController | null): boolean => {
+    if (!candidate) return false;
+    const host = (candidate as MountedHandle).host;
+    return !host || host.isConnected;
+  };
+
   const registryHandles = (): AgentWidgetController[] => {
     const imported = getAgentWidgetHandles() as MountedHandle[];
     const cdnGlobal = (
@@ -204,12 +216,15 @@ export function createSelectionExplainPlugin(
     return handles.filter((handle) => !handle.host || handle.host.isConnected);
   };
   const resolveController = (): AgentWidgetController | null => {
+    // An SPA can destroy and replace the widget after adoption. A cached
+    // handle whose host left the document is stale: drop it and re-adopt.
+    if (controller && !isLive(controller)) controller = null;
     if (controller) return controller;
     if (options.windowKey) {
       const handle = (window as unknown as Record<string, unknown>)[
         options.windowKey
-      ];
-      if (handle) controller = handle as AgentWidgetController;
+      ] as MountedHandle | undefined;
+      if (handle && isLive(handle)) controller = handle;
     }
     if (!controller) {
       const mounted = registryHandles();
@@ -366,7 +381,9 @@ export function createSelectionExplainPlugin(
   // Direct `initAgentWidget()` callers pass `controller` (or call `attach`)
   // because direct init does not dispatch the event.
   const handleChatReady = (event: Event): void => {
-    if (controller) return;
+    // A live cached controller wins; a stale one (destroyed widget) yields
+    // to the replacement widget's ready event.
+    if (isLive(controller)) return;
     const detail = (event as CustomEvent<AgentWidgetController>).detail;
     if (detail) {
       controller = detail;

--- a/apps/web/src/plugins/selection-explain-plugin.ts
+++ b/apps/web/src/plugins/selection-explain-plugin.ts
@@ -22,6 +22,12 @@ import {
  * - Script tag: `createSelectionExplainPlugin({ container: "#article" })`.
  *   It attaches itself when the installer fires `persona:chat-ready`.
  *
+ * `persona:chat-ready` fires once, so create the companion before the widget
+ * initializes. If it may run later, pass `controller`, call `attach()`, or set
+ * `windowKey` to adopt an already-mounted widget from `window[windowKey]`. The
+ * toolbar stays hidden until a controller is attached — it never renders
+ * actions that would silently do nothing.
+ *
  * Each action stages the selection with `controller.setQuote()`. A `"send"`
  * action then calls `submitMessage(prompt)`; a `"draft"` action calls
  * `focusInput()` so the visitor types the question. The quote rides the send
@@ -57,6 +63,12 @@ export type SelectionExplainOptions = {
    * or `attach()` call always wins.
    */
   autoAttach?: boolean;
+  /**
+   * Installer `windowKey` holding the widget handle. Checked lazily, so a
+   * companion created after `persona:chat-ready` already fired can still
+   * adopt the mounted widget.
+   */
+  windowKey?: string;
   /** Quote-banner attribution (e.g. the article title). Static or per-selection. */
   sourceLabel?: string | ((selectionText: string) => string);
   /** Minimum selected characters before the toolbar appears. Default 8. */
@@ -164,6 +176,20 @@ export function createSelectionExplainPlugin(
   let evaluateTimer: number | null = null;
   let destroyed = false;
 
+  // `persona:chat-ready` fires once; a companion created after it has missed
+  // the event. `windowKey` closes that race: the installer stores the handle
+  // on `window[windowKey]`, so check there lazily as the fallback.
+  const resolveController = (): AgentWidgetController | null => {
+    if (controller) return controller;
+    if (options.windowKey) {
+      const handle = (window as unknown as Record<string, unknown>)[
+        options.windowKey
+      ];
+      if (handle) controller = handle as AgentWidgetController;
+    }
+    return controller;
+  };
+
   // Resolved on every evaluation, so the toolbar survives SPA re-renders and
   // containers that mount after this call.
   const resolveContainer = (): HTMLElement | null => {
@@ -199,19 +225,20 @@ export function createSelectionExplainPlugin(
   };
 
   const runAction = (action: SelectionExplainAction): void => {
-    if (!controller || !currentText) return;
+    const active = resolveController();
+    if (!active || !currentText) return;
     const text = currentText;
 
-    controller.setQuote(buildQuote());
-    controller.open();
+    active.setQuote(buildQuote());
+    active.open();
 
     if (action.mode === "send" && action.prompt) {
       // `submitMessage` refuses while a reply is streaming (it returns false
       // and the composer keeps the staged quote), so fall back to the draft
       // flow instead of dropping the visitor's selection on the floor.
-      if (!controller.submitMessage(action.prompt)) controller.focusInput();
+      if (!active.submitMessage(action.prompt)) active.focusInput();
     } else {
-      controller.focusInput();
+      active.focusInput();
     }
 
     window.getSelection()?.removeAllRanges();
@@ -243,6 +270,12 @@ export function createSelectionExplainPlugin(
 
   const evaluate = (): void => {
     if (destroyed) return;
+    // No controller yet (widget not mounted, or the ready event was missed):
+    // keep the toolbar hidden rather than show actions that would no-op.
+    if (!resolveController()) {
+      dismiss();
+      return;
+    }
     const container = resolveContainer();
     const selection = window.getSelection();
     if (

--- a/apps/web/src/plugins/selection-explain-plugin.ts
+++ b/apps/web/src/plugins/selection-explain-plugin.ts
@@ -1,4 +1,8 @@
-import type { AgentWidgetController, ComposerQuote } from "@runtypelabs/persona";
+import {
+  getAgentWidgetHandles,
+  type AgentWidgetController,
+  type ComposerQuote,
+} from "@runtypelabs/persona";
 import {
   createPopover,
   injectStyles,
@@ -22,11 +26,12 @@ import {
  * - Script tag: `createSelectionExplainPlugin({ container: "#article" })`.
  *   It attaches itself when the installer fires `persona:chat-ready`.
  *
- * `persona:chat-ready` fires once, so create the companion before the widget
- * initializes. If it may run later, pass `controller`, call `attach()`, or set
- * `windowKey` to adopt an already-mounted widget from `window[windowKey]`. The
- * toolbar stays hidden until a controller is attached — it never renders
- * actions that would silently do nothing.
+ * Creation order does not matter. A companion created before the widget
+ * attaches on `persona:chat-ready`; one created after adopts the mounted
+ * widget from `getAgentWidgetHandles()` (most recent mount). Pass
+ * `controller` or set `windowKey` to pin a specific instance on multi-widget
+ * pages. The toolbar stays hidden until a controller is attached — it never
+ * renders actions that would silently do nothing.
  *
  * Each action stages the selection with `controller.setQuote()`. A `"send"`
  * action then calls `submitMessage(prompt)`; a `"draft"` action calls
@@ -177,8 +182,21 @@ export function createSelectionExplainPlugin(
   let destroyed = false;
 
   // `persona:chat-ready` fires once; a companion created after it has missed
-  // the event. `windowKey` closes that race: the installer stores the handle
-  // on `window[windowKey]`, so check there lazily as the fallback.
+  // the event. Two lazy fallbacks close that race: `window[windowKey]` (the
+  // installer stores the handle there when configured), then the widget's
+  // registry of mounted handles — imported when this file shares the widget's
+  // bundle, or via the `AgentWidget` CDN global on script-tag pages where the
+  // two are separate module instances.
+  const registryHandles = (): AgentWidgetController[] => {
+    const imported = getAgentWidgetHandles();
+    if (imported.length) return imported;
+    const cdnGlobal = (
+      window as unknown as {
+        AgentWidget?: { getAgentWidgetHandles?: () => AgentWidgetController[] };
+      }
+    ).AgentWidget;
+    return cdnGlobal?.getAgentWidgetHandles?.() ?? [];
+  };
   const resolveController = (): AgentWidgetController | null => {
     if (controller) return controller;
     if (options.windowKey) {
@@ -186,6 +204,10 @@ export function createSelectionExplainPlugin(
         options.windowKey
       ];
       if (handle) controller = handle as AgentWidgetController;
+    }
+    if (!controller) {
+      const mounted = registryHandles();
+      if (mounted.length) controller = mounted[mounted.length - 1];
     }
     return controller;
   };
@@ -366,9 +388,9 @@ export function createSelectionExplainPlugin(
       if (destroyed || resolveController()) return;
       console.warn(
         "[selection-explain] No widget controller attached after 4s; the toolbar will stay hidden. " +
-          "Pass `controller` (from initAgentWidget), call `attach(handle)`, or set `windowKey` to match " +
-          "your installer config. Script-tag installs must create this companion before the widget " +
-          "mounts so it can catch `persona:chat-ready`."
+          "No mounted widget was found via `persona:chat-ready` or `getAgentWidgetHandles()`. " +
+          "Mount the widget (initAgentWidget or the script installer), or wire one explicitly with " +
+          "`controller`, `attach(handle)`, or `windowKey`."
       );
     }, 4000);
   }

--- a/apps/web/src/plugins/selection-explain-plugin.ts
+++ b/apps/web/src/plugins/selection-explain-plugin.ts
@@ -1,0 +1,332 @@
+import type { AgentWidgetController, ComposerQuote } from "@runtypelabs/persona";
+import {
+  createPopover,
+  injectStyles,
+  type PopoverHandle,
+} from "@runtypelabs/persona/plugin-kit";
+
+/**
+ * Blueprint: a floating "ask about this" toolbar for text selections on the
+ * host page. Copy this file into your project and point it at a container.
+ *
+ * This is a host-page companion, not an `AgentWidgetPlugin`. Deliberately so:
+ * every plugin hook renders UI inside the widget, and plugins never receive
+ * the controller. A selection toolbar lives outside the widget and needs the
+ * controller, so it follows the companion convention instead (create, then
+ * `attach(controller)`).
+ *
+ * Integration is one call in either setup:
+ *
+ * - Bundler: `createSelectionExplainPlugin({ container: "#article", controller })`
+ *   with the handle returned by `initAgentWidget()`.
+ * - Script tag: `createSelectionExplainPlugin({ container: "#article" })`.
+ *   It attaches itself when the installer fires `persona:chat-ready`.
+ *
+ * Each action stages the selection with `controller.setQuote()`. A `"send"`
+ * action then calls `submitMessage(prompt)`; a `"draft"` action calls
+ * `focusInput()` so the visitor types the question. The quote rides the send
+ * as a ```quoted-text``` block in the same user turn.
+ *
+ * Customization points, in order of usefulness:
+ * - `actions` replaces the toolbar buttons, labels, and prompts.
+ * - `sourceLabel` sets the quote attribution (static or per-selection).
+ * - `shouldShow` filters selections (e.g. skip code blocks).
+ * - `className` adds your own class; style via `.selection-explain*` rules.
+ *   Colors already follow the `--persona-*` theme variables.
+ */
+
+export type SelectionExplainMode = "send" | "draft";
+
+export type SelectionExplainAction = {
+  id: string;
+  label: string;
+  /** Message submitted with the quoted selection. Required for `"send"`. */
+  prompt?: string;
+  /** `"send"` submits `prompt` immediately. `"draft"` focuses the composer. */
+  mode: SelectionExplainMode;
+};
+
+export type SelectionExplainOptions = {
+  /** Element (or selector) whose selections trigger the toolbar. Resolved lazily. */
+  container: string | HTMLElement;
+  /** Widget handle from `initAgentWidget()`. Omit to rely on auto-attach. */
+  controller?: AgentWidgetController;
+  /**
+   * Attach automatically when `persona:chat-ready` fires (script-tag installs
+   * dispatch it with the controller). Default true. An explicit `controller`
+   * or `attach()` call always wins.
+   */
+  autoAttach?: boolean;
+  /** Quote-banner attribution (e.g. the article title). Static or per-selection. */
+  sourceLabel?: string | ((selectionText: string) => string);
+  /** Minimum selected characters before the toolbar appears. Default 8. */
+  minLength?: number;
+  /** Selections are truncated to this many characters. Default 1000. */
+  maxLength?: number;
+  /** Toolbar actions, in display order. Replaces `DEFAULT_SELECTION_ACTIONS`. */
+  actions?: SelectionExplainAction[];
+  /** Veto a selection (return false to keep the toolbar hidden). */
+  shouldShow?: (context: { text: string; range: Range }) => boolean;
+  /** Extra class for the toolbar element, for host CSS overrides. */
+  className?: string;
+  /** Observer hook, fired after an action runs (logging, analytics). */
+  onAction?: (action: SelectionExplainAction, selectionText: string) => void;
+};
+
+export type SelectionExplainHandle = {
+  /** Point the toolbar at a live widget. Safe to call again after a remount. */
+  attach: (controller: AgentWidgetController) => void;
+  /** Remove listeners, the toolbar, and the anchor. The handle is inert afterward. */
+  destroy: () => void;
+};
+
+export const DEFAULT_SELECTION_ACTIONS: SelectionExplainAction[] = [
+  {
+    id: "explain",
+    label: "Explain this",
+    prompt: "Explain the highlighted passage to me in plain language.",
+    mode: "send",
+  },
+  {
+    id: "ask",
+    label: "Ask about it",
+    mode: "draft",
+  },
+];
+
+const STYLE_ID = "persona-selection-explain";
+const STYLES = `
+.selection-explain {
+  display: flex;
+  align-items: center;
+  gap: 0.15rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: var(--persona-surface, #ffffff);
+  border: 1px solid var(--persona-border, rgba(0, 0, 0, 0.12));
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.18);
+}
+.selection-explain__action {
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  padding: 0.35rem 0.7rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  line-height: 1;
+  color: var(--persona-text, #0f172a);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.selection-explain__action:hover,
+.selection-explain__action:focus-visible {
+  background: var(--persona-button-ghost-hover-bg, rgba(0, 0, 0, 0.06));
+}
+.selection-explain__action--primary {
+  background: var(--persona-text, #111827);
+  color: var(--persona-surface, #ffffff);
+}
+.selection-explain__action--primary:hover,
+.selection-explain__action--primary:focus-visible {
+  background: var(--persona-text, #1f2937);
+  opacity: 0.92;
+}
+`;
+
+/** Collapse runs of whitespace so a multi-paragraph drag quotes cleanly. */
+function normalizeSelectionText(raw: string, maxLength: number): string {
+  const text = raw.replace(/\s+/g, " ").trim();
+  if (text.length <= maxLength) return text;
+  return `${text.slice(0, maxLength).trimEnd()}…`;
+}
+
+function rangeWithin(range: Range, container: HTMLElement): boolean {
+  const node = range.commonAncestorContainer;
+  const element = node instanceof Element ? node : node.parentElement;
+  return !!element && container.contains(element);
+}
+
+export function createSelectionExplainPlugin(
+  options: SelectionExplainOptions
+): SelectionExplainHandle {
+  const {
+    minLength = 8,
+    maxLength = 1000,
+    actions = DEFAULT_SELECTION_ACTIONS,
+    autoAttach = true,
+    shouldShow,
+    onAction,
+  } = options;
+
+  let controller: AgentWidgetController | null = options.controller ?? null;
+  let popover: PopoverHandle | null = null;
+  let currentText = "";
+  let evaluateTimer: number | null = null;
+  let destroyed = false;
+
+  // Resolved on every evaluation, so the toolbar survives SPA re-renders and
+  // containers that mount after this call.
+  const resolveContainer = (): HTMLElement | null => {
+    if (typeof options.container === "string") {
+      return document.querySelector<HTMLElement>(options.container);
+    }
+    return options.container;
+  };
+
+  // Zero-size marker tracking the selection rect in page coordinates, so the
+  // plugin-kit popover (which positions off `anchor.getBoundingClientRect()`
+  // and repositions on scroll) can treat the selection like any element.
+  const anchor = document.createElement("span");
+  anchor.setAttribute("aria-hidden", "true");
+  anchor.style.position = "absolute";
+  anchor.style.pointerEvents = "none";
+  document.body.appendChild(anchor);
+  injectStyles(anchor, STYLE_ID, STYLES);
+
+  const resolveSourceLabel = (text: string): string | undefined => {
+    const { sourceLabel } = options;
+    if (typeof sourceLabel === "function") return sourceLabel(text);
+    return sourceLabel;
+  };
+
+  const buildQuote = (): ComposerQuote => ({
+    text: currentText,
+    sourceLabel: resolveSourceLabel(currentText),
+  });
+
+  const dismiss = (): void => {
+    popover?.close();
+  };
+
+  const runAction = (action: SelectionExplainAction): void => {
+    if (!controller || !currentText) return;
+    const text = currentText;
+
+    controller.setQuote(buildQuote());
+    controller.open();
+
+    if (action.mode === "send" && action.prompt) {
+      // `submitMessage` refuses while a reply is streaming (it returns false
+      // and the composer keeps the staged quote), so fall back to the draft
+      // flow instead of dropping the visitor's selection on the floor.
+      if (!controller.submitMessage(action.prompt)) controller.focusInput();
+    } else {
+      controller.focusInput();
+    }
+
+    window.getSelection()?.removeAllRanges();
+    dismiss();
+    onAction?.(action, text);
+  };
+
+  const toolbar = document.createElement("div");
+  toolbar.className = options.className
+    ? `selection-explain ${options.className}`
+    : "selection-explain";
+  toolbar.setAttribute("role", "toolbar");
+  toolbar.setAttribute("aria-label", "Ask the assistant about this selection");
+  // A pointerdown on the toolbar would collapse the document selection before
+  // `click` fires (closing the toolbar out from under its own buttons), so
+  // swallow it: buttons still receive `click` on pointerup.
+  toolbar.addEventListener("pointerdown", (event) => event.preventDefault());
+  for (const action of actions) {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className =
+      action.mode === "send"
+        ? "selection-explain__action selection-explain__action--primary"
+        : "selection-explain__action";
+    button.textContent = action.label;
+    button.addEventListener("click", () => runAction(action));
+    toolbar.appendChild(button);
+  }
+
+  const evaluate = (): void => {
+    if (destroyed) return;
+    const container = resolveContainer();
+    const selection = window.getSelection();
+    if (
+      !container ||
+      !selection ||
+      selection.isCollapsed ||
+      selection.rangeCount === 0
+    ) {
+      dismiss();
+      return;
+    }
+    const range = selection.getRangeAt(0);
+    if (!rangeWithin(range, container)) {
+      dismiss();
+      return;
+    }
+    const text = normalizeSelectionText(selection.toString(), maxLength);
+    if (text.length < minLength) {
+      dismiss();
+      return;
+    }
+    if (shouldShow && !shouldShow({ text, range })) {
+      dismiss();
+      return;
+    }
+
+    currentText = text;
+    const rect = range.getBoundingClientRect();
+    anchor.style.left = `${rect.left + window.scrollX}px`;
+    anchor.style.top = `${rect.top + window.scrollY}px`;
+    anchor.style.width = `${rect.width}px`;
+    anchor.style.height = `${rect.height}px`;
+
+    if (!popover) {
+      popover = createPopover({
+        anchor,
+        content: toolbar,
+        placement: "top-start",
+        offset: 8,
+      });
+    }
+    popover.open();
+    popover.reposition();
+  };
+
+  // `selectionchange` fires continuously mid-drag; debounce so the toolbar
+  // appears once the selection settles. It also fires on collapse (a plain
+  // click), which is what dismisses the toolbar.
+  const handleSelectionChange = (): void => {
+    if (evaluateTimer !== null) window.clearTimeout(evaluateTimer);
+    evaluateTimer = window.setTimeout(() => {
+      evaluateTimer = null;
+      evaluate();
+    }, 180);
+  };
+  document.addEventListener("selectionchange", handleSelectionChange);
+
+  // Script-tag installs dispatch `persona:chat-ready` with the controller as
+  // `event.detail`. Auto-attaching on it makes those installs zero-wiring.
+  // Direct `initAgentWidget()` callers pass `controller` (or call `attach`)
+  // because direct init does not dispatch the event.
+  const handleChatReady = (event: Event): void => {
+    if (controller) return;
+    const detail = (event as CustomEvent<AgentWidgetController>).detail;
+    if (detail) controller = detail;
+  };
+  if (autoAttach) {
+    window.addEventListener("persona:chat-ready", handleChatReady);
+  }
+
+  return {
+    attach(next: AgentWidgetController) {
+      controller = next;
+    },
+    destroy() {
+      if (destroyed) return;
+      destroyed = true;
+      document.removeEventListener("selectionchange", handleSelectionChange);
+      window.removeEventListener("persona:chat-ready", handleChatReady);
+      if (evaluateTimer !== null) window.clearTimeout(evaluateTimer);
+      popover?.destroy();
+      popover = null;
+      anchor.remove();
+      controller = null;
+    },
+  };
+}

--- a/apps/web/src/selection-explain-demo.ts
+++ b/apps/web/src/selection-explain-demo.ts
@@ -1,0 +1,166 @@
+import "@runtypelabs/persona/widget.css";
+import { renderDemoScaffold } from "./demo-scaffold";
+
+import {
+  initAgentWidget,
+  markdownPostprocessor,
+  DEFAULT_WIDGET_CONFIG,
+  type AgentWidgetConfig,
+} from "@runtypelabs/persona";
+import { createDemoEchoFetch } from "./demo-echo-fetch";
+import {
+  createDemoConfigInspector,
+  reportDemoConfig,
+} from "./demo-config-inspector";
+import {
+  createSelectionExplainPlugin,
+  type SelectionExplainAction,
+} from "./plugins/selection-explain-plugin";
+
+renderDemoScaffold({ slug: "selection-explain-demo" });
+
+const configInspector = createDemoConfigInspector({
+  title: "Select-to-Explain",
+  root: "[data-config-inspector]",
+});
+
+const ARTICLE_TITLE = "Field Notes: How Espresso Extraction Works";
+
+// --- Keyless echo backend -------------------------------------------------------
+// The selection arrives ahead of the prompt as the composer quote's delimited
+// block. Parse it back out so the echo can prove the wire format end-to-end:
+//
+//   ```quoted-text source=<label>
+//   <selection>
+//   ```
+//
+//   <prompt or typed question>
+const QUOTE_BLOCK = /^```quoted-text(?: source=([^\n]*))?\n([\s\S]*?)\n```\s*/;
+
+const echoFetch = createDemoEchoFetch({
+  chunkSize: 6,
+  delayMs: 22,
+  reply: (userText) => {
+    const match = QUOTE_BLOCK.exec(userText);
+    if (!match) {
+      return [
+        `You sent “${userText}”.`,
+        "",
+        "Try highlighting a sentence in the article instead. The toolbar quotes your selection with `controller.setQuote()`, and it arrives here as a `quoted-text` block ahead of your message.",
+      ].join("\n");
+    }
+
+    const [, sourceLabel, quoted] = match;
+    const question = userText.slice(match[0].length).trim();
+    const snippet = quoted.length > 140 ? `${quoted.slice(0, 140).trimEnd()}…` : quoted;
+
+    return [
+      `> ${snippet}`,
+      "",
+      `I received your selection${sourceLabel ? ` from **${sourceLabel}**` : ""} as a \`quoted-text\` block, followed by: “${question}”.`,
+      "",
+      "This demo streams a canned echo instead of a live model. The payload is real, though. The selection and your prompt arrive as one user turn, ready for the model to answer.",
+    ].join("\n");
+  },
+});
+
+// --- Widget --------------------------------------------------------------------
+
+const config: AgentWidgetConfig = {
+  ...DEFAULT_WIDGET_CONFIG,
+  apiUrl: "https://noop.test/chat",
+  customFetch: echoFetch,
+  persistState: false,
+  launcher: {
+    ...DEFAULT_WIDGET_CONFIG.launcher,
+    enabled: true,
+    width: "min(420px, 95vw)",
+    title: "Reading Assistant",
+    subtitle: "Highlight anything to ask about it",
+    agentIconText: "📖",
+  },
+  copy: {
+    ...DEFAULT_WIDGET_CONFIG.copy,
+    welcomeTitle: "Select-to-Explain",
+    welcomeSubtitle:
+      "Highlight a passage in the article and choose “Explain this”. This echo backend replies with what it received.",
+    inputPlaceholder: "Or just type a question…",
+  },
+  postprocessMessage: ({ text }) => markdownPostprocessor(text),
+};
+
+const controller = initAgentWidget({
+  target: "#launcher-root",
+  useShadowDom: false,
+  config,
+});
+
+reportDemoConfig(configInspector, { config, mode: "launcher" });
+
+// --- Selection toolbar ----------------------------------------------------------
+
+const logList = document.getElementById("selection-log");
+
+const logAction = (action: SelectionExplainAction, text: string): void => {
+  console.log(`[SelectionExplain] ${action.id}: "${text}"`);
+  if (!logList) return;
+  const item = document.createElement("li");
+  const preview = text.length > 60 ? `${text.slice(0, 60).trimEnd()}…` : text;
+  item.innerHTML = `<strong>${action.label}</strong> · ${preview.replace(/</g, "&lt;")} <span>(${text.length} chars)</span>`;
+  logList.prepend(item);
+  while (logList.children.length > 5) logList.lastElementChild?.remove();
+  logList.closest(".selection-log-wrap")?.removeAttribute("data-empty");
+};
+
+// Direct `initAgentWidget()` returns the controller, so pass it here. A
+// script-tag install omits it: the toolbar attaches itself on
+// `persona:chat-ready`.
+createSelectionExplainPlugin({
+  container: ".article-pane",
+  controller,
+  sourceLabel: ARTICLE_TITLE,
+  onAction: logAction,
+});
+
+// --- Copy buttons on the notes code blocks --------------------------------------
+
+async function copyCode(text: string, button: HTMLButtonElement): Promise<void> {
+  try {
+    await navigator.clipboard.writeText(text);
+  } catch {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    document.body.appendChild(ta);
+    ta.select();
+    document.execCommand("copy");
+    ta.remove();
+  }
+  button.textContent = "Copied";
+  window.setTimeout(() => {
+    button.textContent = "Copy";
+  }, 2000);
+}
+
+for (const block of document.querySelectorAll<HTMLElement>(".notes .code-block")) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "code-copy-btn";
+  button.textContent = "Copy";
+  button.setAttribute("aria-label", "Copy code");
+  block.appendChild(button);
+}
+
+// The examples shell normalizes each `.code-block` by rewriting its innerHTML
+// after this module runs, which strips element listeners (the button survives
+// only as markup). Delegate from the document and read the code at click time
+// so the buttons keep working regardless of that rewrite.
+document.addEventListener("click", (event) => {
+  const target = event.target instanceof Element ? event.target : null;
+  const button = target?.closest(".code-copy-btn");
+  if (!(button instanceof HTMLButtonElement)) return;
+  const block = button.closest(".code-block");
+  if (!block) return;
+  const clone = block.cloneNode(true) as HTMLElement;
+  clone.querySelectorAll(".code-copy-btn").forEach((el) => el.remove());
+  void copyCode((clone.textContent ?? "").trim(), button);
+});

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -660,6 +660,8 @@ export default defineConfig({
         'approval-demo': path.resolve(__dirname, 'approval-demo.html'),
         // Focus input demo
         'focus-input-demo': path.resolve(__dirname, 'focus-input-demo.html'),
+        // Select-to-explain selection toolbar (setQuote + submitMessage)
+        'selection-explain-demo': path.resolve(__dirname, 'selection-explain-demo.html'),
         // Optional smart-dom-reader page-context provider (shadow DOM / iframes)
         'smart-dom-reader-demo': path.resolve(__dirname, 'smart-dom-reader-demo.html'),
         'event-stream-testing': path.resolve(__dirname, 'event-stream-testing.html'),

--- a/examples/runtype-hono-proxy/.env.example
+++ b/examples/runtype-hono-proxy/.env.example
@@ -17,7 +17,7 @@ RUNTYPE_API_KEY=rt_your_api_key_here
 # PROXY_BEARER_TOKEN=replace_with_a_long_random_token
 
 # Optional: upstream dispatch endpoint (defaults to https://api.runtype.com/v1/dispatch).
-# UPSTREAM_URL=https://api.runtype-staging.com/v1/dispatch
+# UPSTREAM_URL=https://api.your-domain.com/dispatch
 
 # Optional: pin single-agent demo routes to existing hosted Runtype agent ids
 # instead of their bundled server-pinned AgentConfig definitions.

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "185.5 kB",
+    "limit": "185.75 kB",
     "gzip": true
   },
   {
@@ -20,7 +20,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "197.75 kB",
+    "limit": "198 kB",
     "gzip": true
   },
   {

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "184.5 kB",
+    "limit": "185.5 kB",
     "gzip": true
   },
   {
@@ -20,13 +20,13 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "196.75 kB",
+    "limit": "197.75 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "197.75 kB",
+    "limit": "198.75 kB",
     "gzip": true
   },
   {
@@ -44,7 +44,7 @@
   {
     "name": "Opt-in \u00b7 theme-editor preview subpath (theme-editor-preview.js)",
     "path": "dist/theme-editor-preview.js",
-    "limit": "163.75 kB",
+    "limit": "164.75 kB",
     "gzip": true
   },
   {

--- a/packages/widget/THEME-CONFIG.md
+++ b/packages/widget/THEME-CONFIG.md
@@ -2054,6 +2054,7 @@ Templates support **inline formatting markers**: `~dim text~`, `*italic text*`, 
 | `grouped` | `false` | Visually group consecutive tool call rows |
 | `expandable` | `true` | Allow expand/collapse toggle; `false` shows summary only |
 | `loadingAnimation` | `"none"` | Animation mode: `"none"` \| `"pulse"` \| `"shimmer"` \| `"shimmer-color"` \| `"rainbow"` |
+| `completedVisibility` | `"kept"` | `"removed"` renders no row once the tool call completes, so the transcript gap closes with it. The tool call stays on the message and in `getMessages()` |
 
 | Property (`config.toolCall.*`) | Default | Description |
 |----------|---------|-------------|
@@ -2079,7 +2080,8 @@ Templates support **inline formatting markers**: `~dim text~`, `*italic text*`, 
 | `expandable` | `true` | Allow expand/collapse toggle; `false` shows summary only |
 | `loadingAnimation` | `"none"` | Animation mode: `"none"` \| `"pulse"` \| `"shimmer"` \| `"shimmer-color"` \| `"rainbow"` |
 | `iconName` |: | Lucide icon at the leading edge of the collapsed header row (e.g. `"sparkles"`). Class hook: `.persona-reasoning-header-icon` |
-| `completedVisibility` | `"kept"` | `"removed"` renders no row once the trace completes, so the transcript gap closes with it. The reasoning text stays on the message and in `getMessages()` |
+| `completedVisibility` | `"kept"` | `"removed"` renders no row once the trace completes, so the transcript gap closes with it; `"removed-when-short"` does the same only for a short completed trace (see `shortThinkThreshold`). The reasoning text stays on the message and in `getMessages()` |
+| `shortThinkThreshold` | `{ durationMs: 15000, chars: 1200 }` | Thresholds used by `completedVisibility: "removed-when-short"`. Duration is checked first when reported; character count of the joined chunks is the fallback |
 
 ### Text Templates
 | Property | Default | Description |

--- a/packages/widget/src/components/artifact-preview.ts
+++ b/packages/widget/src/components/artifact-preview.ts
@@ -447,6 +447,11 @@ function setupPreviewLoading(
   const addTimer = (fn: () => void, ms: number): void => {
     const id = setTimeout(() => {
       timers.delete(id);
+      // Unit tests drop rendered blocks without running destroy(), so a
+      // pending timer can outlive the test file's DOM environment. Every
+      // callback here does DOM work; with no document left there is nothing
+      // to do (and `document.createElement` would throw).
+      if (typeof document === "undefined") return;
       fn();
     }, ms) as unknown as number;
     timers.add(id);

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -58,8 +58,10 @@ export type RuntypeExecutionStreamEvent = ({
   message: string;
 };
   executionId: string;
+  finalOutput?: string;
   kind: "agent" | "flow";
   seq: number;
+  stopReason?: string;
   type: "execution_error";
   upgradeUrl?: string;
 }) | ({
@@ -430,12 +432,14 @@ export type RuntypeStopReasonKind = NonNullable<
 >;
 
 export type RuntypeClientInitRequest = {
+  durableRecovery?: boolean;
   flowId?: string;
   identityProof?: string;
   token: string;
   visitorHistory?: boolean;
   visitorToken?: string;
 } | {
+  durableRecovery?: boolean;
   flowId?: string;
   identityProof?: string;
   sessionId: string;
@@ -444,6 +448,7 @@ export type RuntypeClientInitRequest = {
   visitorToken?: string;
 } | {
   conversationId: string;
+  durableRecovery?: boolean;
   flowId?: string;
   identityProof?: string;
   token: string;
@@ -451,6 +456,7 @@ export type RuntypeClientInitRequest = {
   visitorToken: string;
 } | {
   conversationId: string;
+  durableRecovery?: boolean;
   flowId?: string;
   identityProof: string;
   token: string;
@@ -469,6 +475,9 @@ export type RuntypeClientInitResponse = {
 };
   conversationId: string;
   conversationRevision: string;
+  durableRecovery?: {
+  enabled: boolean;
+};
   expiresAt: string;
   flow?: {
   description?: string | null;
@@ -536,6 +545,7 @@ export type RuntypeClientChatRequest = {
 export type RuntypeClientChatStreamEvent = RuntypeExecutionStreamEvent;
 
 export type RuntypeClientResumeRequest = {
+  after?: string;
   assistantMessageId?: string;
   clientTools?: Array<{
   description: string;

--- a/packages/widget/src/index-core.ts
+++ b/packages/widget/src/index-core.ts
@@ -1,5 +1,6 @@
 import {
   initAgentWidget as initAgentWidgetFn,
+  getAgentWidgetHandles as getAgentWidgetHandlesFn,
   type AgentWidgetInitHandle
 } from "./runtime/init";
 
@@ -326,6 +327,7 @@ export {
 } from "./suggest-replies-tool";
 
 export { initAgentWidgetFn as initAgentWidget };
+export { getAgentWidgetHandlesFn as getAgentWidgetHandles };
 export {
   createWidgetHostLayout,
   type WidgetHostLayout,

--- a/packages/widget/src/runtime/init.registry.test.ts
+++ b/packages/widget/src/runtime/init.registry.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+
+/**
+ * `getAgentWidgetHandles()` registry: every `initAgentWidget()` mount is
+ * listed (oldest first) until its `destroy()`, so companions created after
+ * `persona:chat-ready` fired can still adopt a mounted widget.
+ */
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { getAgentWidgetHandles, initAgentWidget } from "./init";
+
+const mountHost = (id: string): HTMLElement => {
+  const host = document.createElement("div");
+  host.id = id;
+  document.body.appendChild(host);
+  return host;
+};
+
+const CONFIG = {
+  apiUrl: "https://api.example.com/chat",
+  launcher: { enabled: false },
+  persistState: false,
+};
+
+describe("getAgentWidgetHandles", () => {
+  afterEach(() => {
+    // Sweep any instances a failing assertion left behind.
+    for (const handle of getAgentWidgetHandles()) handle.destroy();
+    document.body.innerHTML = "";
+  });
+
+  it("lists mounted handles oldest-first and drops them on destroy", () => {
+    expect(getAgentWidgetHandles()).toEqual([]);
+
+    const first = initAgentWidget({ target: mountHost("reg-a"), config: CONFIG });
+    const second = initAgentWidget({ target: mountHost("reg-b"), config: CONFIG });
+
+    expect(getAgentWidgetHandles()).toEqual([first, second]);
+    expect(getAgentWidgetHandles().at(-1)).toBe(second);
+
+    second.destroy();
+    expect(getAgentWidgetHandles()).toEqual([first]);
+
+    first.destroy();
+    expect(getAgentWidgetHandles()).toEqual([]);
+  });
+
+  it("returns a copy, not the live registry", () => {
+    const handle = initAgentWidget({ target: mountHost("reg-c"), config: CONFIG });
+    const snapshot = getAgentWidgetHandles();
+    snapshot.length = 0;
+    expect(getAgentWidgetHandles()).toEqual([handle]);
+    handle.destroy();
+  });
+});

--- a/packages/widget/src/runtime/init.ts
+++ b/packages/widget/src/runtime/init.ts
@@ -46,6 +46,19 @@ const mountStyles = (root: ShadowRoot | HTMLElement, ownerDocument: Document) =>
 
 export type AgentWidgetInitHandle = AgentWidgetController & { host: HTMLElement };
 
+// Live handles for every mounted initAgentWidget() instance, oldest first.
+// `persona:chat-ready` is a one-shot broadcast and `windowKey` is opt-in, so
+// code that runs after a widget mounted previously had no way to reach it.
+// This registry closes that gap: late companions (selection toolbars, host
+// integrations) can adopt the most recent mount via
+// `getAgentWidgetHandles().at(-1)`. Handles deregister on destroy().
+const activeHandles: AgentWidgetInitHandle[] = [];
+
+/** Handles of all currently mounted widgets, oldest first. */
+export const getAgentWidgetHandles = (): AgentWidgetInitHandle[] => [
+  ...activeHandles,
+];
+
 export const initAgentWidget = (
   options: AgentWidgetInitOptions
 ): AgentWidgetInitHandle => {
@@ -154,6 +167,8 @@ export const initAgentWidget = (
     destroy() {
       destroyCurrentController();
       hostLayout.destroy();
+      const index = activeHandles.indexOf(handle);
+      if (index !== -1) activeHandles.splice(index, 1);
       if (options.windowKey && typeof window !== "undefined") {
         delete (window as any)[options.windowKey];
       }
@@ -174,6 +189,8 @@ export const initAgentWidget = (
       return typeof value === "function" ? (value as Function).bind(controller) : value;
     }
   }) as AgentWidgetInitHandle;
+
+  activeHandles.push(handle);
 
   if (options.windowKey && typeof window !== 'undefined') {
     (window as any)[options.windowKey] = handle;

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -2238,6 +2238,16 @@ export type AgentWidgetToolCallDisplayFeature = {
    */
   groupedMode?: "stack" | "summary";
   /**
+   * What happens to a tool call row once it completes.
+   *
+   * - `"kept"` (default): the finished row stays in the transcript.
+   * - `"removed"`: no row is rendered at all, so the transcript gap closes with
+   *   it. The tool call stays on the message and in `getMessages()`.
+   *
+   * @default "kept"
+   */
+  completedVisibility?: AgentWidgetToolCallCompletedVisibility;
+  /**
    * When false, tool call bubbles show only the collapsed summary with no
    * expand/collapse toggle. Users see tool awareness without full details.
    * @default true
@@ -2254,6 +2264,9 @@ export type AgentWidgetToolCallDisplayFeature = {
    */
   loadingAnimation?: AgentWidgetToolCallLoadingAnimation;
 };
+
+/** See `features.toolCallDisplay.completedVisibility`. */
+export type AgentWidgetToolCallCompletedVisibility = "kept" | "removed";
 
 export type AgentWidgetReasoningDisplayFeature = {
   /**
@@ -2300,14 +2313,30 @@ export type AgentWidgetReasoningDisplayFeature = {
    * - `"kept"` (default): the finished row stays in the transcript.
    * - `"removed"`: no row is rendered at all, so the transcript gap closes with
    *   it. The reasoning text stays on the message and in `getMessages()`.
+   * - `"removed-when-short"`: behaves as `"removed"` when the completed trace
+   *   is short (see `shortThinkThreshold`), and as `"kept"` otherwise.
    *
    * @default "kept"
    */
   completedVisibility?: AgentWidgetReasoningCompletedVisibility;
+  /**
+   * Thresholds used by `completedVisibility: "removed-when-short"` to decide
+   * whether a completed trace counts as short. Duration is checked first when
+   * the reasoning reports one; the character count is a fallback for traces
+   * with no reported duration.
+   * @default { durationMs: 15000, chars: 1200 }
+   */
+  shortThinkThreshold?: {
+    durationMs?: number;
+    chars?: number;
+  };
 };
 
 /** See `features.reasoningDisplay.completedVisibility`. */
-export type AgentWidgetReasoningCompletedVisibility = "kept" | "removed";
+export type AgentWidgetReasoningCompletedVisibility =
+  | "kept"
+  | "removed"
+  | "removed-when-short";
 
 /**
  * Reveal animation applied to assistant message text while it is streaming.

--- a/packages/widget/src/ui.reasoning-display.test.ts
+++ b/packages/widget/src/ui.reasoning-display.test.ts
@@ -25,7 +25,8 @@ const injectReasoning = (
   controller: ReturnType<typeof createAgentExperience>,
   id: string,
   status: "streaming" | "complete",
-  chunks: string[] = ["Weighing the options"]
+  chunks: string[] = ["Weighing the options"],
+  durationMs?: number
 ) => {
   controller.injectTestMessage({
     type: "message",
@@ -36,7 +37,26 @@ const injectReasoning = (
       createdAt: new Date().toISOString(),
       streaming: status !== "complete",
       variant: "reasoning",
-      reasoning: { id, status, chunks },
+      reasoning: { id, status, chunks, durationMs },
+    },
+  });
+};
+
+const injectToolCall = (
+  controller: ReturnType<typeof createAgentExperience>,
+  id: string,
+  status: "pending" | "running" | "complete"
+) => {
+  controller.injectTestMessage({
+    type: "message",
+    message: {
+      id,
+      role: "assistant",
+      content: "",
+      createdAt: new Date().toISOString(),
+      streaming: status !== "complete",
+      variant: "tool",
+      toolCall: { id, name: "search", status, chunks: [] },
     },
   });
 };
@@ -160,5 +180,119 @@ describe("features.reasoningDisplay.completedVisibility", () => {
       controller.getMessages().find((message) => message.id === "r1")?.reasoning
         ?.chunks
     ).toEqual(["Weighing the options"]);
+  });
+
+  it('"removed-when-short" drops a completed trace with a short reported duration', () => {
+    const { mount, controller } = makeController({
+      features: { reasoningDisplay: { completedVisibility: "removed-when-short" } },
+    });
+    injectReasoning(controller, "r1", "complete", ["Weighing the options"], 5_000);
+    expect(rowOf(mount, "r1")).toBeNull();
+  });
+
+  it('"removed-when-short" keeps a completed trace with a long reported duration', () => {
+    const { mount, controller } = makeController({
+      features: { reasoningDisplay: { completedVisibility: "removed-when-short" } },
+    });
+    injectReasoning(controller, "r1", "complete", ["Weighing the options"], 20_000);
+    expect(rowOf(mount, "r1")).not.toBeNull();
+  });
+
+  it('"removed-when-short" drops a completed trace with no duration and few chars', () => {
+    const { mount, controller } = makeController({
+      features: { reasoningDisplay: { completedVisibility: "removed-when-short" } },
+    });
+    injectReasoning(controller, "r1", "complete", ["Short thought"]);
+    expect(rowOf(mount, "r1")).toBeNull();
+  });
+
+  it('"removed-when-short" keeps a completed trace with no duration and many chars', () => {
+    const { mount, controller } = makeController({
+      features: { reasoningDisplay: { completedVisibility: "removed-when-short" } },
+    });
+    injectReasoning(controller, "r1", "complete", ["x".repeat(1_500)]);
+    expect(rowOf(mount, "r1")).not.toBeNull();
+  });
+
+  it('"removed-when-short" honors custom duration and char thresholds', () => {
+    const { mount, controller } = makeController({
+      features: {
+        reasoningDisplay: {
+          completedVisibility: "removed-when-short",
+          shortThinkThreshold: { durationMs: 1_000, chars: 50 },
+        },
+      },
+    });
+    // 5s exceeds the custom 1s threshold, so this long-by-default trace is kept.
+    injectReasoning(controller, "r1", "complete", ["Weighing the options"], 5_000);
+    expect(rowOf(mount, "r1")).not.toBeNull();
+
+    // 60 chars exceeds the custom 50-char threshold, so this trace is kept too.
+    injectReasoning(controller, "r2", "complete", ["y".repeat(60)]);
+    expect(rowOf(mount, "r2")).not.toBeNull();
+
+    // Under both custom thresholds, so this trace is dropped.
+    injectReasoning(controller, "r3", "complete", ["z".repeat(10)], 500);
+    expect(rowOf(mount, "r3")).toBeNull();
+  });
+});
+
+describe("features.toolCallDisplay.completedVisibility", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    vi.stubGlobal("requestAnimationFrame", (cb: (time: number) => void) => {
+      cb(0);
+      return 1;
+    });
+    vi.stubGlobal("cancelAnimationFrame", () => {});
+    window.scrollTo = vi.fn();
+  });
+
+  afterEach(() => {
+    controllers.splice(0).forEach((controller) => controller.destroy());
+    mounts.splice(0).forEach((mount) => mount.remove());
+    document.body.innerHTML = "";
+    vi.restoreAllMocks();
+  });
+
+  it("keeps a finished tool call row by default", () => {
+    const { mount, controller } = makeController();
+    injectToolCall(controller, "t1", "complete");
+    expect(rowOf(mount, "t1")).not.toBeNull();
+  });
+
+  it('removes the whole row under "removed", leaving no transcript gap', () => {
+    const { mount, controller } = makeController({
+      features: { toolCallDisplay: { completedVisibility: "removed" } },
+    });
+    injectToolCall(controller, "t1", "complete");
+    injectText(controller, "a1", "Here is the answer");
+
+    expect(rowOf(mount, "t1")).toBeNull();
+    const rows = mount.querySelectorAll("[data-wrapper-id]");
+    expect(Array.from(rows).map((row) => row.getAttribute("data-wrapper-id")))
+      .toEqual(["a1"]);
+  });
+
+  it('shows a running tool call under "removed" and drops it once it completes', () => {
+    const { mount, controller } = makeController({
+      features: { toolCallDisplay: { completedVisibility: "removed" } },
+    });
+    injectToolCall(controller, "t1", "running");
+    expect(rowOf(mount, "t1")).not.toBeNull();
+
+    injectToolCall(controller, "t1", "complete");
+    expect(rowOf(mount, "t1")).toBeNull();
+  });
+
+  it('keeps the tool call message in the session under "removed"', () => {
+    const { controller } = makeController({
+      features: { toolCallDisplay: { completedVisibility: "removed" } },
+    });
+    injectToolCall(controller, "t1", "complete");
+    expect(
+      controller.getMessages().find((message) => message.id === "t1")?.toolCall
+        ?.status
+    ).toEqual("complete");
   });
 });

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -61,7 +61,8 @@ import {
   ComposerQuote,
   ComposerState,
   ComposerStreamingSubmitBehavior,
-  ComposerSubmissionSnapshot
+  ComposerSubmissionSnapshot,
+  AgentWidgetReasoning
 } from "./types";
 import { AttachmentManager, type PendingAttachment } from "./utils/attachment-manager";
 import { createComposerStore } from "./utils/composer-store";
@@ -282,7 +283,7 @@ import {
   latestAgentSuggestions,
   resolveFollowUpsFeature,
 } from "./suggest-replies-tool";
-import { formatElapsedMs } from "./utils/formatting";
+import { formatElapsedMs, isShortReasoning } from "./utils/formatting";
 import { loadApprovalUi, getApprovalUiSync, type ApprovalUiModule } from "./approval-ui-loader";
 import { getWebMcpToolDisplayTitle } from "./webmcp-bridge";
 import type { AgentWidgetPlugin } from "./plugins/types";
@@ -6284,17 +6285,40 @@ export const createAgentExperience = (
     /** The live editor, re-grafted into its morphed wrapper after the pass. */
     let editHydrate: { messageId: string; element: HTMLElement } | null = null;
 
-    // `reasoningDisplay.completedVisibility: "removed"`: no row for a finished
-    // trace, so the transcript gap closes with it. Checked before the row is
-    // registered, so the cached wrapper is pruned too.
-    const dropCompletedReasoning =
-      config.features?.reasoningDisplay?.completedVisibility === "removed";
+    // `reasoningDisplay.completedVisibility: "removed"` (or "removed-when-short"
+    // for a short completed trace): no row for the finished trace, so the
+    // transcript gap closes with it. Checked before the row is registered, so
+    // the cached wrapper is pruned too.
+    const reasoningCompletedVisibility =
+      config.features?.reasoningDisplay?.completedVisibility;
+    const dropReasoningRow = (reasoning: AgentWidgetReasoning): boolean => {
+      if (reasoningCompletedVisibility === "removed") return true;
+      if (reasoningCompletedVisibility === "removed-when-short") {
+        return isShortReasoning(
+          reasoning,
+          config.features?.reasoningDisplay?.shortThinkThreshold
+        );
+      }
+      return false;
+    };
+
+    // `toolCallDisplay.completedVisibility: "removed"`: same mechanism as
+    // reasoning removal, no threshold variant.
+    const dropCompletedToolCalls =
+      config.features?.toolCallDisplay?.completedVisibility === "removed";
 
     messages.forEach((message) => {
       if (
-        dropCompletedReasoning &&
         message.variant === "reasoning" &&
-        message.reasoning?.status === "complete"
+        message.reasoning?.status === "complete" &&
+        dropReasoningRow(message.reasoning)
+      ) {
+        return;
+      }
+      if (
+        dropCompletedToolCalls &&
+        message.variant === "tool" &&
+        message.toolCall?.status === "complete"
       ) {
         return;
       }
@@ -6849,6 +6873,12 @@ export const createAgentExperience = (
 
       messages.forEach((message) => {
         if (message.variant === "tool" && message.toolCall && showToolCalls) {
+          // A tool call hidden by `completedVisibility: "removed"` does not
+          // create a visible break in the transcript, so it should not split
+          // an otherwise contiguous group.
+          if (dropCompletedToolCalls && message.toolCall.status === "complete") {
+            return;
+          }
           currentGroup.push(message);
           return;
         }
@@ -6858,7 +6888,8 @@ export const createAgentExperience = (
         if (
           message.variant === "reasoning" &&
           (!showReasoning ||
-            (dropCompletedReasoning && message.reasoning?.status === "complete"))
+            (message.reasoning?.status === "complete" &&
+              dropReasoningRow(message.reasoning)))
         ) {
           return;
         }

--- a/packages/widget/src/utils/formatting.ts
+++ b/packages/widget/src/utils/formatting.ts
@@ -52,6 +52,28 @@ export const describeReasonStatus = (reasoning: AgentWidgetReasoning) => {
   return "";
 };
 
+/** Defaults for `features.reasoningDisplay.shortThinkThreshold`. */
+export const DEFAULT_SHORT_THINK_DURATION_MS = 15_000;
+export const DEFAULT_SHORT_THINK_CHARS = 1_200;
+
+/**
+ * A completed reasoning trace is short when its duration is under the
+ * threshold, or (with no reported duration) its streamed text is under the
+ * character threshold. Duration is preferred when available.
+ */
+export const isShortReasoning = (
+  reasoning: AgentWidgetReasoning,
+  threshold?: { durationMs?: number; chars?: number }
+): boolean => {
+  const durationThreshold = threshold?.durationMs ?? DEFAULT_SHORT_THINK_DURATION_MS;
+  const charsThreshold = threshold?.chars ?? DEFAULT_SHORT_THINK_CHARS;
+  if (typeof reasoning.durationMs === "number") {
+    return reasoning.durationMs < durationThreshold;
+  }
+  const chars = (reasoning.chunks ?? []).join("").length;
+  return chars < charsThreshold;
+};
+
 export const formatToolDuration = (tool: AgentWidgetToolCall) => {
   const durationMs =
     typeof tool.duration === "number"


### PR DESCRIPTION
## What does this PR do?

- Ships the toolbar as a copyable companion blueprint with auto-attach on persona:chat-ready, custom actions, shouldShow filtering, and theme-variable styling.
- Adds a Select-to-Explain demo page: highlight article text and a floating toolbar quotes the selection into the widget via controller.setQuote(), then sends a prompt or focuses the composer.

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Documentation
- [ ] Tooling / CI

## Checklist

- [x] `pnpm lint` passes
- [x] `pnpm typecheck` passes
- [x] Tests pass (`pnpm --filter @runtypelabs/persona test:run`) and I added tests for new behavior
- [x] **Changeset added if I touched `packages/widget` or `packages/proxy`** (`pnpm changeset`). _Not required for changes only under `examples/`, `docs/`, CI, or tooling_
- [x] Docs updated if I changed public API or behavior

















<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a copyable Select-to-Explain companion and demo, exposes a mounted-widget handle registry for late attachment and remount recovery, and expands completed reasoning and tool-call visibility controls.

- Adds selection-driven quote, send, and draft actions with configurable filtering and styling.
- Registers mounted widget handles and removes them during teardown so late companions can discover active widgets.
- Adds reasoning and tool-call completed-visibility options, supporting tests, documentation, generated contracts, and demo navigation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/plugins/selection-explain-plugin.ts | Adds the host-page selection toolbar, controller discovery, stale init-handle recovery, configurable actions, and lifecycle cleanup; the previously reported late-attachment and registry-handle replacement paths are addressed. |
| packages/widget/src/runtime/init.ts | Adds an oldest-first mounted-handle registry, live host proxying, and deterministic deregistration during widget destruction. |
| packages/widget/src/index-core.ts | Exposes mounted-handle discovery through the shared public package surface. |
| packages/widget/src/ui.ts | Implements the new completed reasoning and tool-call visibility behavior while preserving underlying message data. |
| packages/widget/src/types.ts | Extends public configuration types for completed visibility and short-reasoning thresholds. |
| apps/web/src/selection-explain-demo.ts | Demonstrates selection quoting and immediate-send or draft behavior against a streaming echo backend. |
| packages/widget/src/runtime/init.registry.test.ts | Verifies registry order, snapshot isolation, and deregistration on widget destruction. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Create selection companion] --> B{Controller supplied?}
  B -- Yes --> C[Cache controller]
  B -- No --> D{Chat-ready event received?}
  D -- Yes --> C
  D -- No --> E[Read mounted-handle registry]
  E --> C
  C --> F[User selects host-page text]
  F --> G[Show selection toolbar]
  G --> H[Stage quote in widget]
  H --> I{Action mode}
  I -- Send --> J[Submit configured prompt]
  I -- Draft --> K[Focus composer]
  C --> L{Handle host disconnected?}
  L -- Yes --> E
```
</details>

<sub>Reviews (9): Last reviewed commit: ["fix(selection-explain): re-adopt after t..."](https://github.com/runtypelabs/persona/commit/58e917e91a6a88ee3134e6eb0dd8cd55a0e31229) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58856352)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Widget runtime and integration surface](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-runtime.md)
- Knowledge Base — [Demo frontend extensions](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/demo-frontend-extensions.md)
- Knowledge Base — [Widget UI composition and layout](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-ui-composition.md)
</details>


<!-- /greptile_comment -->