### PR TITLE
chore: bump @mcp-b/webmcp-polyfill to 5.1.0

### DIFF
--- a/.changeset/bump-webmcp-polyfill-5.md
+++ b/.changeset/bump-webmcp-polyfill-5.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Bump `@mcp-b/webmcp-polyfill` to 5.1.0.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@mcp-b/global": "^4.0.0",
-    "@mcp-b/webmcp-polyfill": "^4.0.0",
+    "@mcp-b/webmcp-polyfill": "^5.1.0",
     "@runtypelabs/persona": "workspace:^",
     "alasql": "^4.17.3",
     "echarts": "^6.1.0",

--- a/examples/ai-sdk-webmcp/package.json
+++ b/examples/ai-sdk-webmcp/package.json
@@ -10,7 +10,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
-    "@mcp-b/webmcp-polyfill": "^4.0.0",
+    "@mcp-b/webmcp-polyfill": "^5.1.0",
     "@runtypelabs/persona": "workspace:^",
     "@vercel/functions": "^3.7.1",
     "ai": "^6.0.203",

--- a/packages/widget/package.json
+++ b/packages/widget/package.json
@@ -170,7 +170,7 @@
     "build:event-stream-view": "tsup --config tsup.event-stream-view.config.ts"
   },
   "dependencies": {
-    "@mcp-b/webmcp-polyfill": "^4.0.0",
+    "@mcp-b/webmcp-polyfill": "^5.1.0",
     "dompurify": "^3.4.13",
     "idiomorph": "^0.7.4",
     "lucide": "^1.18.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)
       '@mcp-b/webmcp-polyfill':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^5.1.0
+        version: 5.1.0
       '@runtypelabs/persona':
         specifier: workspace:^
         version: link:../../packages/widget
@@ -122,8 +122,8 @@ importers:
   examples/ai-sdk-webmcp:
     dependencies:
       '@mcp-b/webmcp-polyfill':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^5.1.0
+        version: 5.1.0
       '@runtypelabs/persona':
         specifier: workspace:^
         version: link:../../packages/widget
@@ -263,7 +263,7 @@ importers:
         version: link:../../packages/widget
       eve:
         specifier: ^0.11.6
-        version: 0.11.6(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.66.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(@vercel/functions@3.7.1(ws@8.20.1))(ai@7.0.0-beta.178(zod@4.1.11))(chokidar@4.0.3)(dotenv@16.6.1)(lru-cache@11.2.6)(miniflare@4.20260611.0)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.100.0(@cloudflare/workers-types@4.20260612.1))
+        version: 0.11.6(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.66.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(@vercel/functions@3.7.1(ws@8.20.1))(ai@7.0.0-beta.178(zod@4.5.4))(chokidar@4.0.3)(dotenv@16.6.1)(lru-cache@11.2.6)(miniflare@4.20260611.0)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.100.0(@cloudflare/workers-types@4.20260612.1))
       next:
         specifier: ^16.2.9
         version: 16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -294,13 +294,13 @@ importers:
     dependencies:
       '@langchain/core':
         specifier: ^1.1.49
-        version: 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1)
+        version: 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1)
       '@langchain/langgraph':
         specifier: ^1.4.2
-        version: 1.4.4(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(zod-to-json-schema@3.25.2(zod@4.1.11))(zod@4.1.11)
+        version: 1.4.4(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(zod-to-json-schema@3.25.2(zod@4.5.4))(zod@4.5.4)
       '@langchain/openai':
         specifier: ^1.5.0
-        version: 1.5.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))(ws@8.20.1)
+        version: 1.5.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))(ws@8.20.1)
       '@runtypelabs/persona':
         specifier: workspace:^
         version: link:../../packages/widget
@@ -447,13 +447,13 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/widget:
     dependencies:
       '@mcp-b/webmcp-polyfill':
-        specifier: ^4.0.0
-        version: 4.0.0
+        specifier: ^5.1.0
+        version: 5.1.0
       dompurify:
         specifier: ^3.4.13
         version: 3.4.13
@@ -1498,6 +1498,10 @@ packages:
     resolution: {integrity: sha512-7M6WS3IcxaIEhidbS9N7wrrGjtJf474Vi4Fn1hGkFkmYFT5EoFw/kS/4CSdUR/KmlInO1kyluHRY6t3avMQfFw==}
     engines: {node: '>=18'}
 
+  '@mcp-b/webmcp-polyfill@5.1.0':
+    resolution: {integrity: sha512-KL09hniFssPY8HBO3qzurWPqm+1JYRwV3wx6x2XSySgo+6BL1XHGsHGIoAO7U9zzigv7TA5keNBoZ+3P1jq18g==}
+    engines: {node: '>=20'}
+
   '@mcp-b/webmcp-ts-sdk@4.0.0':
     resolution: {integrity: sha512-zXdbBdefgcBz077NkvZ3WZhkHOvBU2rpsVK8ytQt/SbiS2tCIFshuB027QceuTyuprOjW0b7XKDnSzDB2DQVMA==}
     engines: {node: '>=18'}
@@ -1513,6 +1517,14 @@ packages:
   '@mcp-b/webmcp-types@4.0.0':
     resolution: {integrity: sha512-CUBBmiut1UBsiD3FAF6xrLKeKAuJkzd6/BlL1C/uo8sVpwY42NW4mls9rLcTxmLF/8Cj5/ZOwJiLzXl/T3GIQg==}
 
+  '@mcp-b/webmcp-types@5.1.0':
+    resolution: {integrity: sha512-twOKDUr7al60K890HvRcNvoHSfQ2rnGeKJiQs6eUr+Leg+LQ6K+yz3F4K70jykMK1a09ZIgYb3Oc7mAypuKPig==}
+    engines: {node: '>=20'}
+
+  '@modelcontextprotocol/core@2.0.0':
+    resolution: {integrity: sha512-pJCEwGG7Lfr/+PQp9ZTwKXNeO5wzbfKL7H3MYpCorM4oFBoQrdjnBgEoqG+RjhsvS1FKrDbKux+M1HhlnGWqcA==}
+    engines: {node: '>=20'}
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -1522,6 +1534,10 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    resolution: {integrity: sha512-YhHWdHfpFMQfd0prsEnxKeS3Qz3ytIGmsS0sth4KDjnacIT7hxk6hXHkJ9KysxlkvTM+WZAtQbbcUhdoP4Hvtw==}
+    engines: {node: '>=20'}
 
   '@napi-rs/wasm-runtime@1.1.5':
     resolution: {integrity: sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==}
@@ -4821,6 +4837,9 @@ packages:
   zod@4.1.11:
     resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
+  zod@4.5.4:
+    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
+
   zrender@6.1.0:
     resolution: {integrity: sha512-oEGMDB6pOP2S6OwRR4PdVv610zrjnA3Bh+JnSG12fYJlBKjtNAoEb5fSUoCOOINlH96I2fU38/A2UpRKs67xYQ==}
 
@@ -4842,12 +4861,12 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.1.11
 
-  '@ai-sdk/gateway@4.0.0-beta.109(zod@4.1.11)':
+  '@ai-sdk/gateway@4.0.0-beta.109(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.0-beta.19
-      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.1.11)
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.5.4)
       '@vercel/oidc': 3.2.0
-      zod: 4.1.11
+      zod: 4.5.4
 
   '@ai-sdk/openai@3.0.71(zod@4.1.11)':
     dependencies:
@@ -4869,13 +4888,13 @@ snapshots:
       eventsource-parser: 3.1.0
       zod: 4.1.11
 
-  '@ai-sdk/provider-utils@5.0.0-beta.49(zod@4.1.11)':
+  '@ai-sdk/provider-utils@5.0.0-beta.49(zod@4.5.4)':
     dependencies:
       '@ai-sdk/provider': 4.0.0-beta.19
       '@standard-schema/spec': 1.1.0
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.1.0
-      zod: 4.1.11
+      zod: 4.5.4
 
   '@ai-sdk/provider@3.0.10':
     dependencies:
@@ -5550,12 +5569,12 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1)':
+  '@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@standard-schema/spec': 1.1.0
       js-tiktoken: 1.0.21
-      langsmith: 0.7.10(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1)
+      langsmith: 0.7.10(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1)
       mustache: 4.2.0
       p-queue: 6.6.2
       zod: 3.25.76
@@ -5566,13 +5585,13 @@ snapshots:
       - openai
       - ws
 
-  '@langchain/langgraph-checkpoint@1.1.2(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))':
+  '@langchain/langgraph-checkpoint@1.1.2(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))':
     dependencies:
-      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1)
+      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1)
 
-  '@langchain/langgraph-sdk@1.9.23(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)':
+  '@langchain/langgraph-sdk@1.9.23(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)':
     dependencies:
-      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1)
+      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1)
       '@langchain/protocol': 0.0.16
       '@types/json-schema': 7.0.15
       p-queue: 9.3.0
@@ -5582,25 +5601,25 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
       svelte: 5.56.3
 
-  '@langchain/langgraph@1.4.4(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(zod-to-json-schema@3.25.2(zod@4.1.11))(zod@4.1.11)':
+  '@langchain/langgraph@1.4.4(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(zod-to-json-schema@3.25.2(zod@4.5.4))(zod@4.5.4)':
     dependencies:
-      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1)
-      '@langchain/langgraph-checkpoint': 1.1.2(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))
-      '@langchain/langgraph-sdk': 1.9.23(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)
+      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1)
+      '@langchain/langgraph-checkpoint': 1.1.2(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))
+      '@langchain/langgraph-sdk': 1.9.23(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(svelte@5.56.3)
       '@langchain/protocol': 0.0.16
       '@standard-schema/spec': 1.1.0
-      zod: 4.1.11
+      zod: 4.5.4
     optionalDependencies:
-      zod-to-json-schema: 3.25.2(zod@4.1.11)
+      zod-to-json-schema: 3.25.2(zod@4.5.4)
     transitivePeerDependencies:
       - react
       - react-dom
       - svelte
       - vue
 
-  '@langchain/openai@1.5.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1))(ws@8.20.1)':
+  '@langchain/openai@1.5.1(@langchain/core@1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1))(ws@8.20.1)':
     dependencies:
-      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1)
+      '@langchain/core': 1.2.0(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1)
       js-tiktoken: 1.0.21
       openai: 6.42.0(ws@8.20.1)(zod@3.25.76)
       zod: 3.25.76
@@ -5653,6 +5672,11 @@ snapshots:
       '@mcp-b/webmcp-types': 4.0.0
       '@standard-schema/spec': 1.1.0
 
+  '@mcp-b/webmcp-polyfill@5.1.0':
+    dependencies:
+      '@mcp-b/webmcp-types': 5.1.0
+      '@standard-schema/spec': 1.1.0
+
   '@mcp-b/webmcp-ts-sdk@4.0.0(@cfworker/json-schema@4.1.1)(zod-to-json-schema@3.25.2(zod@3.25.76))(zod@3.25.76)':
     dependencies:
       '@mcp-b/webmcp-polyfill': 4.0.0
@@ -5666,6 +5690,14 @@ snapshots:
       - supports-color
 
   '@mcp-b/webmcp-types@4.0.0': {}
+
+  '@mcp-b/webmcp-types@5.1.0':
+    dependencies:
+      '@modelcontextprotocol/server': 2.0.0
+
+  '@modelcontextprotocol/core@2.0.0':
+    dependencies:
+      zod: 4.5.4
 
   '@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
@@ -5715,6 +5747,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  '@modelcontextprotocol/server@2.0.0':
+    dependencies:
+      '@modelcontextprotocol/core': 2.0.0
+      zod: 4.5.4
 
   '@napi-rs/wasm-runtime@1.1.5(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
     dependencies:
@@ -6318,13 +6355,13 @@ snapshots:
     optionalDependencies:
       vite: 7.3.1(@types/node@25.9.3)(jiti@1.21.7)(lightningcss@1.32.0)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.8
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
@@ -6446,12 +6483,12 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       zod: 4.1.11
 
-  ai@7.0.0-beta.178(zod@4.1.11):
+  ai@7.0.0-beta.178(zod@4.5.4):
     dependencies:
-      '@ai-sdk/gateway': 4.0.0-beta.109(zod@4.1.11)
+      '@ai-sdk/gateway': 4.0.0-beta.109(zod@4.5.4)
       '@ai-sdk/provider': 4.0.0-beta.19
-      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.1.11)
-      zod: 4.1.11
+      '@ai-sdk/provider-utils': 5.0.0-beta.49(zod@4.5.4)
+      zod: 4.5.4
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -6969,9 +7006,9 @@ snapshots:
 
   etag@1.8.1: {}
 
-  eve@0.11.6(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.66.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(@vercel/functions@3.7.1(ws@8.20.1))(ai@7.0.0-beta.178(zod@4.1.11))(chokidar@4.0.3)(dotenv@16.6.1)(lru-cache@11.2.6)(miniflare@4.20260611.0)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.100.0(@cloudflare/workers-types@4.20260612.1)):
+  eve@0.11.6(@opentelemetry/api@1.9.1)(@sveltejs/kit@2.66.0(@opentelemetry/api@1.9.1)(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(svelte@5.56.3)(typescript@6.0.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)))(@vercel/functions@3.7.1(ws@8.20.1))(ai@7.0.0-beta.178(zod@4.5.4))(chokidar@4.0.3)(dotenv@16.6.1)(lru-cache@11.2.6)(miniflare@4.20260611.0)(next@16.2.9(@opentelemetry/api@1.9.1)(@playwright/test@1.62.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)(svelte@5.56.3)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.100.0(@cloudflare/workers-types@4.20260612.1)):
     dependencies:
-      ai: 7.0.0-beta.178(zod@4.1.11)
+      ai: 7.0.0-beta.178(zod@4.5.4)
       nitro: 3.0.260610-beta(@vercel/functions@3.7.1(ws@8.20.1))(chokidar@4.0.3)(dotenv@16.6.1)(lru-cache@11.2.6)(miniflare@4.20260611.0)(vite@8.0.16(@types/node@25.9.3)(esbuild@0.28.1)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))(wrangler@4.100.0(@cloudflare/workers-types@4.20260612.1))
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -7466,12 +7503,12 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  langsmith@0.7.10(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.1.11))(ws@8.20.1):
+  langsmith@0.7.10(@opentelemetry/api@1.9.1)(openai@6.42.0(ws@8.20.1)(zod@4.5.4))(ws@8.20.1):
     dependencies:
       p-queue: 6.6.2
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-      openai: 6.42.0(ws@8.20.1)(zod@4.1.11)
+      openai: 6.42.0(ws@8.20.1)(zod@4.5.4)
       ws: 8.20.1
 
   levn@0.4.1:
@@ -7772,6 +7809,12 @@ snapshots:
     optionalDependencies:
       ws: 8.20.1
       zod: 4.1.11
+
+  openai@6.42.0(ws@8.20.1)(zod@4.5.4):
+    optionalDependencies:
+      ws: 8.20.1
+      zod: 4.5.4
+    optional: true
 
   optionator@0.9.4:
     dependencies:
@@ -8528,7 +8571,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
+  vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -8537,7 +8580,7 @@ snapshots:
       tinyglobby: 0.2.17
     optionalDependencies:
       '@types/node': 20.19.35
-      esbuild: 0.27.3
+      esbuild: 0.28.1
       fsevents: 2.3.3
       jiti: 1.21.7
       terser: 5.49.0
@@ -8644,10 +8687,10 @@ snapshots:
       - tsx
       - yaml
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@20.19.35)(jsdom@28.1.0)(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.8
       '@vitest/runner': 4.1.8
       '@vitest/snapshot': 4.1.8
@@ -8664,7 +8707,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.27.3)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
+      vite: 8.0.16(@types/node@20.19.35)(esbuild@0.28.1)(jiti@1.21.7)(terser@5.49.0)(tsx@4.22.4)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
@@ -8849,9 +8892,16 @@ snapshots:
       zod: 4.1.11
     optional: true
 
+  zod-to-json-schema@3.25.2(zod@4.5.4):
+    dependencies:
+      zod: 4.5.4
+    optional: true
+
   zod@3.25.76: {}
 
   zod@4.1.11: {}
+
+  zod@4.5.4: {}
 
   zrender@6.1.0:
     dependencies:


### PR DESCRIPTION
Bumps `@mcp-b/webmcp-polyfill` from `^4.0.0` to `^5.1.0` in `packages/widget`, `apps/web`, and `examples/ai-sdk-webmcp`.

No source changes needed — v5's removals (`autoInitialize`, `unregisterTool`, `initializeWebModelContextPolyfill`, schema helpers on the root entry) are all unused here; the bridge and demos already call `initializeWebMCPPolyfill()` explicitly.

Build, lint, typecheck, and the 3852 widget tests pass.

https://claude.ai/code/session_01EavygSiVdxh66XEN3hCv9L

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades `@mcp-b/webmcp-polyfill` from v4 to v5.1.0 across the widget, web application, and WebMCP example.

- Updates all three direct dependency declarations and their lockfile resolutions.
- Adds the corresponding patch changeset for `@runtypelabs/persona`.
- Pulls in the v5 WebMCP type and Model Context Protocol dependency chain.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable issues identified.

Existing callers use the retained initialization API, the new dependency’s Node requirement matches the repository’s supported environments, and no observable regression was established from the lockfile changes.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/widget/package.json | Upgrades the published widget’s WebMCP polyfill dependency to v5.1.0; existing package and CI Node requirements are compatible. |
| apps/web/package.json | Aligns the WebMCP demo host with polyfill v5.1.0 without changing its runtime integration. |
| examples/ai-sdk-webmcp/package.json | Aligns the AI SDK WebMCP example with the same polyfill version. |
| pnpm-lock.yaml | Resolves the upgraded dependency and its new transitive packages, with additional peer-context churn but no established incompatibility. |
| .changeset/bump-webmcp-polyfill-5.md | Records a patch release of Persona for the dependency upgrade. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore: bump @mcp-b/webmcp-polyfill to 5...."](https://github.com/runtypelabs/persona/commit/50708e53c8cef30497518cdc332c64c59a832bbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59073559)</sub>

<!-- /greptile_comment -->