### PR TITLE
fix(widget): accept both WebMCP inputSchema generations

### DIFF
--- a/.changeset/webmcp-input-schema-both-generations.md
+++ b/.changeset/webmcp-input-schema-both-generations.md
@@ -1,0 +1,9 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Fix WebMCP page tools being dropped from `dispatch.clientTools[]`, which 400'd every turn on a page with registered tools.
+
+`getTools()` returns each tool's `inputSchema` as a JSON Schema **object** since `webmcp#241` — the shape `@mcp-b/webmcp-polyfill` v5 and Chrome 154+ emit. The widget still assumed the serialized JSON string of the previous generation and `JSON.parse`d it, so every schema was silently discarded, `parametersSchema` was omitted from every tool, and the server rejected the whole dispatch with `INVALID_UNION`.
+
+The snapshot now accepts **both** generations — Chrome 149-153 and 154's same-document tools still emit the string — and always sends a `parametersSchema`, degrading a missing or malformed schema to an empty `{ type: "object" }` rather than omitting the key and failing the entire request.

--- a/packages/widget/src/webmcp-bridge.test.ts
+++ b/packages/widget/src/webmcp-bridge.test.ts
@@ -11,7 +11,8 @@ import type {
 // calls `initializeWebMCPPolyfill()` (idempotent install of document.modelContext).
 // We stub the install as a no-op and provide `document.modelContext` ourselves,
 // modeling the strict producer-preview surface the bridge consumes:
-//   - getTools(): async; inputSchema is a JSON string; NO annotations
+//   - getTools(): async; inputSchema in either generation (see
+//     `registry.schemaShape`); NO annotations
 //   - executeTool(info, argsJson, { signal }): async; validates+runs execute(),
 //     returns JSON.stringify(rawResult) or null; honors the abort signal.
 // ---------------------------------------------------------------------------
@@ -48,17 +49,40 @@ type MockTool = {
   execute: (args: Record<string, unknown>, client: MockClient) => unknown;
 };
 
-const registry: { tools: MockTool[] } = { tools: [] };
+/**
+ * Which generation of the WebMCP `inputSchema` contract the fake emits.
+ *
+ * `"object"` is what `@mcp-b/webmcp-polyfill` v5 and Chrome 154+ return after
+ * `webmcp#241`; `"string"` is the serialized form Chrome 149-153 and 154's
+ * same-document tools still emit. Both are live in the field, so the snapshot
+ * tests run against both -- pinning this fake to one generation is exactly how
+ * the v5 bump landed green while every real dispatch 400'd.
+ */
+type SchemaShape = "object" | "string";
+
+const registry: { tools: MockTool[]; schemaShape: SchemaShape } = {
+  tools: [],
+  schemaShape: "object",
+};
 
 /** A fake `document.modelContext` exposing the strict consumer surface. */
 const makeModelContext = () => ({
   async getTools() {
-    // Mirrors the real polyfill's getRegisteredToolInfos(): `title` is always
-    // present, "" when the tool didn't declare one; annotations are absent.
+    // Mirrors the real polyfill's getTools(): `title` is always present, ""
+    // when the tool didn't declare one; annotations are absent. v5 OMITS
+    // `inputSchema` for a tool that registered none, where v4 always emitted a
+    // `{"type":"object"}` string.
     return registry.tools.map((t) => ({
       name: t.name,
       description: t.description ?? `mock ${t.name}`,
-      inputSchema: JSON.stringify(t.inputSchema ?? { type: "object" }),
+      ...(t.inputSchema === undefined
+        ? {}
+        : {
+            inputSchema:
+              registry.schemaShape === "object"
+                ? t.inputSchema
+                : JSON.stringify(t.inputSchema),
+          }),
       title: t.title ?? "",
     }));
   },
@@ -110,6 +134,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   polyfillMock.initThrows = false;
   registry.tools = [];
+  registry.schemaShape = "object";
   // location is read by snapshotForDispatch; document.modelContext is the
   // consumer surface. Both are absent in the Node test environment.
   vi.stubGlobal("location", { origin: "https://example.test" });
@@ -166,29 +191,68 @@ describe("WebMcpBridge.snapshotForDispatch", () => {
     expect(bridge.isOperational()).toBe(false);
   });
 
-  it("ships only the JSON-serializable surface (name, description, schema, origin)", async () => {
-    registry.tools = [
-      fakeTool({
-        name: "search",
-        description: "search the shop",
-        inputSchema: { type: "object", properties: { q: { type: "string" } } },
-      }),
-    ];
-    const bridge = new WebMcpBridge({ enabled: true });
-    const snap = await bridge.snapshotForDispatch();
-    expect(snap).toHaveLength(1);
-    const tool = snap[0]!;
-    expect(tool.name).toBe("search");
-    expect(tool.description).toBe("search the shop");
-    expect(tool.parametersSchema).toEqual({
-      type: "object",
-      properties: { q: { type: "string" } },
+  // Both `inputSchema` generations must produce the same wire tool: the object
+  // form (webmcp#241 / polyfill v5 / Chrome 154+) and the serialized string
+  // Chrome 149-153 still emits.
+  it.each(["object", "string"] as const)(
+    "ships only the JSON-serializable surface (name, description, schema, origin) [%s inputSchema]",
+    async (schemaShape) => {
+      registry.schemaShape = schemaShape;
+      registry.tools = [
+        fakeTool({
+          name: "search",
+          description: "search the shop",
+          inputSchema: { type: "object", properties: { q: { type: "string" } } },
+        }),
+      ];
+      const bridge = new WebMcpBridge({ enabled: true });
+      const snap = await bridge.snapshotForDispatch();
+      expect(snap).toHaveLength(1);
+      const tool = snap[0]!;
+      expect(tool.name).toBe("search");
+      expect(tool.description).toBe("search the shop");
+      expect(tool.parametersSchema).toEqual({
+        type: "object",
+        properties: { q: { type: "string" } },
+      });
+      expect(tool.origin).toBe("webmcp");
+      expect(tool.pageOrigin).toBe("https://example.test");
+      expect((tool as unknown as { execute?: unknown }).execute).toBeUndefined();
+      // Now that the registry was read, the bridge reports operational.
+      expect(bridge.isOperational()).toBe(true);
+    },
+  );
+
+  // `parametersSchema` is required by the server's InlineClientToolSchema, and
+  // one entry missing it fails the whole DispatchRequestSchema union: a tool
+  // with no usable schema must degrade to "takes no arguments", never to an
+  // omitted key that 400s the turn.
+  it("always sends a parametersSchema, even when the tool declared none", async () => {
+    registry.tools = [fakeTool({ name: "ping" })];
+    const snap = await new WebMcpBridge({ enabled: true }).snapshotForDispatch();
+    expect(snap[0]!.parametersSchema).toEqual({ type: "object", properties: {} });
+  });
+
+  it.each([
+    ["unparseable string", "{not json"],
+    ["non-object JSON string", '"just a string"'],
+    ["JSON array string", "[1,2,3]"],
+    ["array object", [1, 2, 3]],
+    ["null", null],
+  ])("falls back to an empty schema for %s", async (_label, inputSchema) => {
+    registry.tools = [fakeTool({ name: "odd" })];
+    // Bypass the fake's shape switch: these are malformed values a page or a
+    // future runtime could hand us, not either sanctioned generation.
+    vi.stubGlobal("document", {
+      modelContext: {
+        ...makeModelContext(),
+        async getTools() {
+          return [{ name: "odd", description: "odd", inputSchema, title: "" }];
+        },
+      },
     });
-    expect(tool.origin).toBe("webmcp");
-    expect(tool.pageOrigin).toBe("https://example.test");
-    expect((tool as unknown as { execute?: unknown }).execute).toBeUndefined();
-    // Now that the registry was read, the bridge reports operational.
-    expect(bridge.isOperational()).toBe(true);
+    const snap = await new WebMcpBridge({ enabled: true }).snapshotForDispatch();
+    expect(snap[0]!.parametersSchema).toEqual({ type: "object", properties: {} });
   });
 
   it("applies client-side allowlist glob (`search_*`)", async () => {

--- a/packages/widget/src/webmcp-bridge.ts
+++ b/packages/widget/src/webmcp-bridge.ts
@@ -49,8 +49,22 @@ export const WEBMCP_TOOL_PREFIX = "webmcp:";
 export interface ModelContextToolInfo {
   name: string;
   description: string;
-  /** JSON-encoded JSON Schema for the tool's input. */
-  inputSchema?: string;
+  /**
+   * JSON Schema for the tool's input, in EITHER generation of the WebMCP
+   * contract. Never read it raw: `normalizeInputSchema` in
+   * `webmcp-runtime-entry.ts` collapses both shapes to the object the wire
+   * needs.
+   *
+   * `webmcp#241` changed this from a JSON-encoded string to a JSON Schema
+   * object. `@mcp-b/webmcp-polyfill` made the switch in v5, and Chrome ships it
+   * from 154.0.8013 (cross-document tools first) -- but Chrome 149-153, most of
+   * the Origin Trial population, and 154's same-document tools still emit the
+   * string. Both are live in the field, so we accept both.
+   *
+   * Absent when the tool registered no schema: v5 omits the member, where v4
+   * always emitted a `{"type":"object"}` string.
+   */
+  inputSchema?: object | string;
   /**
    * Display title declared on the tool (`ToolDescriptor.title` in the WebMCP
    * spec). The polyfill returns `""` when the tool didn't declare one. Note:

--- a/packages/widget/src/webmcp-runtime-entry.ts
+++ b/packages/widget/src/webmcp-runtime-entry.ts
@@ -134,11 +134,10 @@ export class WebMcpBridge {
         const def: ClientToolDefinition = {
           name: info.name,
           description: info.description,
+          parametersSchema: normalizeInputSchema(info.inputSchema),
           origin: "webmcp",
           ...(pageOrigin ? { pageOrigin } : {}),
         };
-        const schema = parseSchema(info.inputSchema);
-        if (schema) def.parametersSchema = schema;
         return def;
       });
   }
@@ -404,19 +403,47 @@ const matchesGlob = (name: string, pattern: string): boolean => {
 };
 
 /**
- * Parse the JSON-string `inputSchema` from `getTools()` back into an object for
- * `parametersSchema`. Returns `undefined` for a missing or unparseable schema
- * (the server can still accept a tool with no declared parameters).
+ * A tool that declared no usable schema. Sent rather than omitted: see below.
  */
-const parseSchema = (raw: string | undefined): object | undefined => {
-  if (raw === undefined || raw === "") return undefined;
+const EMPTY_INPUT_SCHEMA = { type: "object", properties: {} } as const;
+
+/**
+ * `getTools()`'s `inputSchema`, in either generation, as the JSON Schema object
+ * `dispatch.clientTools[].parametersSchema` carries.
+ *
+ * TWO shapes are live in the field. `webmcp#241` replaced the serialized JSON
+ * string with a JSON Schema object; `@mcp-b/webmcp-polyfill` adopted that in v5
+ * and Chrome ships it from 154.0.8013 (cross-document tools first), while
+ * Chrome 149-153 -- most of the Origin Trial population -- and 154's
+ * same-document tools still emit the string. So: branch on `typeof`, and guard
+ * the parse of the string arm. Assuming one shape is a silent failure here and
+ * a loud one at dispatch, which is how the object generation shipped past us
+ * (`JSON.parse(object)` throws, every schema was dropped, every turn 400'd).
+ *
+ * ALWAYS returns an object. `parametersSchema` is required by the server's
+ * `InlineClientToolSchema`, and one entry missing it fails the whole top-level
+ * `DispatchRequestSchema` union -- 400-ing the entire turn rather than dropping
+ * the one tool, with an `INVALID_UNION` at path `""` that names nothing. A tool
+ * with no schema, or an unparseable one, degrades to "takes no arguments"
+ * instead of taking the conversation down with it.
+ */
+const normalizeInputSchema = (raw: object | string | undefined): object => {
+  if (raw === undefined || raw === "") return { ...EMPTY_INPUT_SCHEMA };
+
+  // Object generation (webmcp#241): pass through as-is. Arrays are `typeof
+  // "object"` but are not JSON Schema objects, so they fall through.
+  if (typeof raw === "object") {
+    return raw !== null && !Array.isArray(raw) ? raw : { ...EMPTY_INPUT_SCHEMA };
+  }
+
+  // String generation: guarded parse.
   try {
-    const parsed = JSON.parse(raw);
-    return parsed !== null && typeof parsed === "object"
+    const parsed: unknown = JSON.parse(raw);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
       ? (parsed as object)
-      : undefined;
+      : { ...EMPTY_INPUT_SCHEMA };
   } catch {
-    return undefined;
+    return { ...EMPTY_INPUT_SCHEMA };
   }
 };
 


### PR DESCRIPTION
Every turn on a page with WebMCP tools 400s (`INVALID_UNION` at path `""`), because every `clientTools[]` entry ships without `parametersSchema` — which the server's `InlineClientToolSchema` requires.

**Cause:** `getTools()` returns `inputSchema` as a JSON Schema object since webmcp#241; `parseSchema` assumed the serialized string, so `JSON.parse(object)` threw and the schema was silently dropped for every tool. #427 (polyfill 4 → 5.1.0) put that shape in front of the code this morning.

**Fix:** accept both generations rather than swapping assumptions — per `@mcp-b/webmcp-types@5.1.0`, Chrome 149-153 and 154's same-document tools still emit the string, so `inputSchema` is typed `object | string` and normalized by branching on `typeof`.

Also: `parametersSchema` is now always sent. v5 omits `inputSchema` when a tool registers none (v4 emitted `{"type":"object"}`), and one such tool would 400 the whole turn the same way. Missing/malformed now degrades to `{ type: "object" }`.

**Why CI stayed green through #427:** the test fake hardcoded the v4 string contract, so it couldn't see the dependency move. It now emits either generation and the snapshot tests run against both — verified non-vacuous (against the old code the `[object]` case fails, `[string]` passes).

**Verified:** 50 tests pass (7 fail without the fix); typecheck + eslint clean; `webmcp-runtime.js` 2028 → 2050 B gzip vs 3 kB budget; on the live demo, forcing the string shape in-page turned the same request 200.

**Follow-ups (not here):** v5's `annotations` are available but unused — forwarding `untrustedContentHint` is a behavior change; and the server's `INVALID_UNION` at path `""` names nothing, which is what made this a bisect.

https://claude.ai/code/session_01TvKy6cqf2pDUTS1x95JKrY

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores WebMCP dispatch compatibility across both live `inputSchema` representations and ensures every page tool carries a server-valid fallback schema.

- Accepts JSON Schema objects from newer WebMCP implementations while retaining guarded parsing for serialized schemas from older implementations.
- Supplies an empty object schema when input metadata is absent or malformed.
- Expands bridge tests to exercise both schema generations and malformed-schema fallbacks.
- Adds a patch changeset documenting the compatibility fix.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking defects identified.

The normalized schema is included consistently in both dispatch payloads and client-tool fingerprints, while the expanded tests cover the supported schema generations and fallback behavior.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/widget/src/webmcp-runtime-entry.ts | Normalizes both live input-schema representations and always includes a fallback object schema in dispatch snapshots. |
| packages/widget/src/webmcp-bridge.ts | Broadens the local WebMCP registry type to accurately represent object, serialized-string, and omitted schemas. |
| packages/widget/src/webmcp-bridge.test.ts | Exercises object and string schema generations, omitted schemas, and malformed values without revealing a changed-code defect. |
| .changeset/webmcp-input-schema-both-generations.md | Accurately documents the WebMCP compatibility fix and its dispatch impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(widget): accept both WebMCP inputSch..."](https://github.com/runtypelabs/persona/commit/788acd728c556228bb1e5f5a123ae452987af188) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59106250)</sub>

**Context used:**

- Knowledge Base — [Widget WebMCP bridge](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-webmcp.md)

<!-- /greptile_comment -->