### PR TITLE
fix(web): stop webmcp-polyfill v5 side effects failing the test run

### DIFF
--- a/apps/web/src/theme-configurator/index.test.ts
+++ b/apps/web/src/theme-configurator/index.test.ts
@@ -322,8 +322,15 @@ describe('theme configurator shell', () => {
     `;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     window.dispatchEvent(new Event('beforeunload'));
+    // Installing the v5 polyfill also starts a document-level MutationObserver
+    // (the declarative form-tool scanner) plus capture-phase listeners that
+    // outlive this suite's jsdom teardown -- left running, the scanner fires
+    // after vitest removes the DOM globals (`ReferenceError: ShadowRoot is not
+    // defined`). Tear the whole install down with the polyfill's own cleanup.
+    const { cleanupWebMCPPolyfill } = await import('@mcp-b/webmcp-polyfill');
+    cleanupWebMCPPolyfill();
   });
 
   test('initializes grouped sections and preview shell', async () => {

--- a/apps/web/src/theme-configurator/webmcp/register.ts
+++ b/apps/web/src/theme-configurator/webmcp/register.ts
@@ -40,7 +40,17 @@ export function mountThemeEditorMcp(
 
     const tools = [...createThemeEditorTools(state), ...(options?.extraTools ?? [])];
     for (const tool of tools) {
-      modelContext.registerTool(tool, { signal: controller.signal });
+      // `registerTool()` is async since `@mcp-b/webmcp-polyfill` v5 and
+      // REJECTS with the abort reason when the registration signal fires
+      // before it settles. Fire-and-forget turned every prompt unmount into
+      // one unhandled AbortError per tool; await each and treat abort as the
+      // expected unmount path.
+      try {
+        await modelContext.registerTool(tool, { signal: controller.signal });
+      } catch (error) {
+        if (controller.signal.aborted) return;
+        throw error;
+      }
     }
     console.info(`[persona] Registered ${tools.length} theme-editor WebMCP tools.`);
   })();


### PR DESCRIPTION
Main CI red since #427: tests pass, but v5 polyfill side effects fail the run with unhandled errors.

- v5 `registerTool()` is async and rejects on abort; the theme-configurator fire-and-forgot 26 tools → 78 unhandled `AbortError`s per run (also hits prod consoles on unmount). Now awaited, abort = expected unmount.
- v5 installs a document-level MutationObserver that outlives jsdom teardown → `ShadowRoot is not defined`. `afterEach` now calls `cleanupWebMCPPolyfill()`.

Verified: web suite 219 passed / 0 errors (was 78+1); typecheck clean. No changeset (demo app only).

https://claude.ai/code/session_01TvKy6cqf2pDUTS1x95JKrY

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adapts the theme configurator to the WebMCP polyfill v5 lifecycle.
- Awaits tool registration and treats signal-triggered rejection as expected during unmount.
- Cleans up the polyfill’s document-level resources after each theme-configurator test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issues identified.

The registration lifecycle now handles expected unmount rejection, and the test suite explicitly releases polyfill resources that otherwise survive jsdom teardown.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| apps/web/src/theme-configurator/webmcp/register.ts | Awaits each asynchronous tool registration and suppresses expected rejection after the shared registration signal is aborted. |
| apps/web/src/theme-configurator/index.test.ts | Adds asynchronous per-test polyfill cleanup after dispatching the existing page-unload event. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(web): stop webmcp-polyfill v5 side e..."](https://github.com/runtypelabs/persona/commit/f37e6f03528011b55f21942d08d488ed68f9c6af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59117957)</sub>

**Context used:**

- Knowledge Base — [Theme configurator](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/theme-configurator.md)

<!-- /greptile_comment -->