### PR TITLE
feat(widget): forward WebMCP tool annotations on clientTools[]

### DIFF
--- a/.changeset/webmcp-forward-annotations.md
+++ b/.changeset/webmcp-forward-annotations.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": minor
+---
+
+Forward WebMCP `Tool.annotations` on `dispatch.clientTools[]` and hoist `annotations.untrustedContentHint` to the top-level field the server acts on, so pages that flag a tool's output as untrusted (reviews, comments, third-party content) get server-side spotlighting before the model reads it. Annotations are returned by `@mcp-b/webmcp-polyfill` v5 and Chrome's native implementation; only the spec's two boolean hints (`readOnlyHint`, `untrustedContentHint`) are forwarded.

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -26,7 +26,7 @@
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "199.25 kB",
+    "limit": "199.5 kB",
     "gzip": true
   },
   {

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -826,6 +826,14 @@ export type ClientToolDefinition = {
     readOnlyHint?: boolean;
     untrustedContentHint?: boolean;
   };
+  /**
+   * Hoisted copy of `annotations.untrustedContentHint`. This is the field the
+   * server actually acts on (`InlineClientToolSchema`): it spotlights the
+   * tool's output before the model reads it, so instructions embedded in
+   * page-provided content (reviews, comments, emails) are not treated as
+   * instructions. `annotations` itself is trace/dashboard metadata only.
+   */
+  untrustedContentHint?: boolean;
 };
 
 /**

--- a/packages/widget/src/webmcp-bridge.test.ts
+++ b/packages/widget/src/webmcp-bridge.test.ts
@@ -12,7 +12,7 @@ import type {
 // We stub the install as a no-op and provide `document.modelContext` ourselves,
 // modeling the strict producer-preview surface the bridge consumes:
 //   - getTools(): async; inputSchema in either generation (see
-//     `registry.schemaShape`); NO annotations
+//     `registry.schemaShape`); annotations only when the tool declared them
 //   - executeTool(info, argsJson, { signal }): async; validates+runs execute(),
 //     returns JSON.stringify(rawResult) or null; honors the abort signal.
 // ---------------------------------------------------------------------------
@@ -46,6 +46,7 @@ type MockTool = {
   description?: string;
   inputSchema?: object;
   title?: string;
+  annotations?: Record<string, unknown>;
   execute: (args: Record<string, unknown>, client: MockClient) => unknown;
 };
 
@@ -84,6 +85,7 @@ const makeModelContext = () => ({
                 : JSON.stringify(t.inputSchema),
           }),
       title: t.title ?? "",
+      ...(t.annotations === undefined ? {} : { annotations: t.annotations }),
     }));
   },
   async executeTool(
@@ -231,6 +233,49 @@ describe("WebMcpBridge.snapshotForDispatch", () => {
     registry.tools = [fakeTool({ name: "ping" })];
     const snap = await new WebMcpBridge({ enabled: true }).snapshotForDispatch();
     expect(snap[0]!.parametersSchema).toEqual({ type: "object", properties: {} });
+  });
+
+  it("forwards annotations and hoists untrustedContentHint to the top level", async () => {
+    registry.tools = [
+      fakeTool({
+        name: "get_reviews",
+        annotations: { readOnlyHint: true, untrustedContentHint: true },
+      }),
+    ];
+    const snap = await new WebMcpBridge({ enabled: true }).snapshotForDispatch();
+    expect(snap[0]!.annotations).toEqual({
+      readOnlyHint: true,
+      untrustedContentHint: true,
+    });
+    // The server acts on the top-level field, not the nested metadata copy.
+    expect(snap[0]!.untrustedContentHint).toBe(true);
+  });
+
+  it("omits annotations and the top-level hint when the tool declared none", async () => {
+    registry.tools = [fakeTool({ name: "search" })];
+    const snap = await new WebMcpBridge({ enabled: true }).snapshotForDispatch();
+    expect(snap[0]!).not.toHaveProperty("annotations");
+    expect(snap[0]!).not.toHaveProperty("untrustedContentHint");
+  });
+
+  it("does not hoist untrustedContentHint: false, and drops unknown annotation keys", async () => {
+    registry.tools = [
+      fakeTool({
+        name: "add_to_cart",
+        annotations: {
+          readOnlyHint: false,
+          untrustedContentHint: false,
+          destructiveHint: true, // MCP-only today; not in the WebMCP dict
+          evil: () => "not JSON",
+        },
+      }),
+    ];
+    const snap = await new WebMcpBridge({ enabled: true }).snapshotForDispatch();
+    expect(snap[0]!.annotations).toEqual({
+      readOnlyHint: false,
+      untrustedContentHint: false,
+    });
+    expect(snap[0]!).not.toHaveProperty("untrustedContentHint");
   });
 
   it.each([

--- a/packages/widget/src/webmcp-bridge.ts
+++ b/packages/widget/src/webmcp-bridge.ts
@@ -73,6 +73,16 @@ export interface ModelContextToolInfo {
    * channel available to us.
    */
   title?: string;
+  /**
+   * WebMCP `Tool.annotations`. Returned by `getTools()` since
+   * `@mcp-b/webmcp-polyfill` v5 (and by Chrome's native implementation);
+   * absent on v4 and whenever the tool declared none -- the spec omits the
+   * member rather than emitting an empty object.
+   */
+  annotations?: {
+    readOnlyHint?: boolean;
+    untrustedContentHint?: boolean;
+  };
 }
 
 export interface ModelContextCoreLike {

--- a/packages/widget/src/webmcp-runtime-entry.ts
+++ b/packages/widget/src/webmcp-runtime-entry.ts
@@ -131,12 +131,20 @@ export class WebMcpBridge {
     return infos
       .filter((info) => this.passesClientAllowlist(info.name))
       .map<ClientToolDefinition>((info) => {
+        const annotations = pickAnnotations(info.annotations);
         const def: ClientToolDefinition = {
           name: info.name,
           description: info.description,
           parametersSchema: normalizeInputSchema(info.inputSchema),
           origin: "webmcp",
           ...(pageOrigin ? { pageOrigin } : {}),
+          ...(annotations ? { annotations } : {}),
+          // Hoisted because the server acts on the TOP-LEVEL field
+          // (`InlineClientToolSchema.untrustedContentHint` gates output
+          // spotlighting); the nested `annotations` object is metadata only.
+          ...(annotations?.untrustedContentHint === true
+            ? { untrustedContentHint: true }
+            : {}),
         };
         return def;
       });
@@ -427,6 +435,31 @@ const EMPTY_INPUT_SCHEMA = { type: "object", properties: {} } as const;
  * with no schema, or an unparseable one, degrades to "takes no arguments"
  * instead of taking the conversation down with it.
  */
+/**
+ * Copy the WebMCP annotation hints onto the wire, dropping anything else.
+ *
+ * `getTools()` returns `annotations` since `@mcp-b/webmcp-polyfill` v5 (absent
+ * on v4 and when the tool declared none). Only the spec's two boolean hints are
+ * forwarded -- annotations are page-authored, so an explicit copy keeps
+ * functions/junk off the dispatch payload. Returns `undefined` when nothing
+ * usable remains so the member is omitted, matching the spec's own
+ * omit-when-empty behavior.
+ */
+const pickAnnotations = (
+  raw: ModelContextToolInfo["annotations"],
+): ClientToolDefinition["annotations"] | undefined => {
+  if (!raw || typeof raw !== "object") return undefined;
+  const picked = {
+    ...(typeof raw.readOnlyHint === "boolean"
+      ? { readOnlyHint: raw.readOnlyHint }
+      : {}),
+    ...(typeof raw.untrustedContentHint === "boolean"
+      ? { untrustedContentHint: raw.untrustedContentHint }
+      : {}),
+  };
+  return Object.keys(picked).length > 0 ? picked : undefined;
+};
+
 const normalizeInputSchema = (raw: object | string | undefined): object => {
   if (raw === undefined || raw === "") return { ...EMPTY_INPUT_SCHEMA };
 


### PR DESCRIPTION
Supersedes #430 (auto-closed when its stacked base branch was deleted on #429's merge; unchanged, rebased onto main — Greptile scored it 5/5 with zero threads).

Follow-up flagged on #428. v5's `getTools()` returns `Tool.annotations`; the wire type had the field but nothing populated it.

- Forward the spec's two boolean hints (`readOnlyHint`, `untrustedContentHint`) per `clientTools[]` entry; unknown/non-boolean keys dropped.
- Hoist `untrustedContentHint` to the top-level field the server acts on (output spotlighting); the nested object is trace metadata only.
- Omitted entirely when a tool declares none, matching spec behavior.

Verified: 53 widget tests pass (3 new); typecheck + lint clean; 2167 B gzip vs 3 kB budget; prod dispatch accepts both fields (200, live-tested).

https://claude.ai/code/session_01TvKy6cqf2pDUTS1x95JKrY



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR forwards supported WebMCP tool annotations into dispatch snapshots and hoists the untrusted-content hint used for server-side output spotlighting.
- Filters page-authored annotations to the two supported boolean hints.
- Omits empty annotations and only hoists `untrustedContentHint` when true.
- Adds annotation-forwarding tests, public wire typing, a changeset, and a small bundle-size allowance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/widget/src/webmcp-runtime-entry.ts | Safely filters and forwards supported annotations while deriving the server-consumed top-level trust hint. |
| packages/widget/src/webmcp-bridge.ts | Extends the browser tool-info contract with optional WebMCP annotations. |
| packages/widget/src/types.ts | Adds the optional top-level untrusted-content wire field consumed by the server. |
| packages/widget/src/webmcp-bridge.test.ts | Covers forwarding, omission, boolean false handling, hoisting, and unknown-key filtering. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Page as Host page
    participant Bridge as WebMCP bridge
    participant Client as Widget client
    participant Server as Agent service
    Page->>Bridge: getTools() with annotations
    Bridge->>Bridge: Keep supported boolean hints
    Bridge->>Bridge: Hoist untrustedContentHint when true
    Bridge->>Client: clientTools snapshot
    Client->>Server: Dispatch snapshot or matching fingerprint
    Server->>Server: Spotlight untrusted tool output
```
</details>

<sub>Reviews (2): Last reviewed commit: ["chore(widget): bump index.cjs size budge..."](https://github.com/runtypelabs/persona/commit/2b8602c8ebcfbe64d98f647cdfbaeecc8684df6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59120969)</sub>

**Context used:**

- Knowledge Base — [Widget WebMCP bridge](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-webmcp.md)

<!-- /greptile_comment -->