### PR TITLE
chore: bump to pnpm 12.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ examples/standalone-widget/
 # Local generated API contract cache
 packages/widget/openapi/runtype-public-openapi.local.json
 .claude/
+
+.vercel

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "installCommand": "pnpm install",
   "headers": [
     {
       "source": "/litert-slides(.html)?",

--- a/examples/runtype-hono-proxy/README.md
+++ b/examples/runtype-hono-proxy/README.md
@@ -68,6 +68,8 @@ Set production secrets with `wrangler secret put RUNTYPE_API_KEY` (and optionall
 
 > **Preview CORS:** Vercel preview URLs are dynamic. The proxy reflects matching origins when `VERCEL_ENV === "preview"` or when the caller matches `PREVIEW_ORIGIN_PATTERN` (default `https://*.vercel.app`).
 
+> **Why `api/package.json` + `api/package-lock.json` exist:** Vercel's function builder runs its own `pnpm install --unsafe-perm` for the `api/` entrypoint's nearest package root, and pnpm 12's Rust CLI rejects that flag ([vercel/vercel#17560](https://github.com/vercel/vercel/issues/17560)). The empty-dependency stub makes that internal install a no-op npm call; imports still resolve from the workspace `node_modules` via Node's upward resolution. Don't delete these files until that issue is fixed.
+
 ## Other Node hosts
 
 Railway, Fly.io, or a plain Node server: run `pnpm build` then `node dist/node.js`, with the same env vars as `.env.example`.

--- a/examples/runtype-hono-proxy/api/package-lock.json
+++ b/examples/runtype-hono-proxy/api/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "runtype-hono-proxy-fn",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/examples/runtype-hono-proxy/api/package.json
+++ b/examples/runtype-hono-proxy/api/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "runtype-hono-proxy-fn",
+  "private": true,
+  "type": "module"
+}

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "@playwright/test": "^1.62.1",
     "concurrently": "^8.2.2"
   },
-  "packageManager": "pnpm@11.9.0+sha512.bd682d5d03fe525ef7c9fd6780c6884d1e756ac4c9c9fe00c538782824310dcf90e3ddc4f53835f06dfaebd5085e41855e0bcbb3b60de2ac5bbab89e5036f03b"
+  "packageManager": "pnpm@12.2.1+sha512.f55ca68aacb9eb5ab69c66f828a98af89a32286703aef1f8da131ca7eab4d677f34bfa85e186467a919c0799df8b6f4aa240f7dc2919b33b3273190104162616"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,104 @@
+---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 12.2.1
+        version: 12.2.1
+
+packages:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    resolution: {integrity: sha512-efC1yfz2xbyHiMLrQAYtnoo5XP20LeAiYYcyL1962qQagZrMXIB0BoQYeZoPTLggLh0Q4MD7jpZUInU5fWxCgQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    resolution: {integrity: sha512-0bloFmxrvYY5LYex5V6SZySwg+egBk0pOW+YUeOm9fiG2U1wv+qRVLBOUvIzLAeJE7vBlAzxUwXkQAYtr12n+Q==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    resolution: {integrity: sha512-AZl7apVZC4TV1/vTp/bS16XUsHeqx9AHsU4V55joiGR+iR6vl+WF0WlGvGCTjqjICS4q/kThpgNrtG8aqQ9seQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    resolution: {integrity: sha512-S36+tMEGrPz3nwtfFU9kYxbHoi8sV7WJfMO9njEL4jRaShTNaLRERMAqyI2DUCiA5QCr6/a50lt4+pKCV2mCvw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    resolution: {integrity: sha512-4MQClkAk1em55LFZJpeIqb7j+gEqCgX8yC42j9DFWL42q1uMX1e1tvTy2Dtd4NoWQqgdkLxOStZ+D9CYC+28ow==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    resolution: {integrity: sha512-A/AlR71Leph7qgB3ThSU9yU/vLfre4HmP6nbt3/qt51fzAjQ0xuq7j+cw0f1yDskzOsGzmo5uD6ruefCwLK5uQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    resolution: {integrity: sha512-TEGUmroT6NGfo2O2+tHK9Zr1lhP1zLzpwx+QAQV19l8V4ljUoMfz8Os5V9zzNCtIpzyKcK7SuG7fkVbxFgRMzg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    resolution: {integrity: sha512-V2Q+AF8fCsw8/CC3bWF8kopOmH0aAjgk9m7H7uAQNulOYIJs9YJBiAlgByswmt+igV9axc4dBI//ZlK2NKpDcw==}
+    cpu: [x64]
+    os: [win32]
+
+  pnpm@12.2.1:
+    resolution: {integrity: sha512-9Vymiqy561q2nGb4KKmK+JoyKGcDrvH42hMcp+q01nfzS/qF4YZGepGcB5nfi29KokD33CkZszsycxkBBBYmFg==}
+    engines: {node: '>=18.*'}
+    hasBin: true
+
+snapshots:
+
+  '@pnpm/exe.darwin-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.darwin-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64-musl@12.2.1':
+    optional: true
+
+  '@pnpm/exe.linux-x64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-arm64@12.2.1':
+    optional: true
+
+  '@pnpm/exe.win32-x64@12.2.1':
+    optional: true
+
+  pnpm@12.2.1:
+    optionalDependencies:
+      '@pnpm/exe.darwin-arm64': 12.2.1
+      '@pnpm/exe.darwin-x64': 12.2.1
+      '@pnpm/exe.linux-arm64': 12.2.1
+      '@pnpm/exe.linux-arm64-musl': 12.2.1
+      '@pnpm/exe.linux-x64': 12.2.1
+      '@pnpm/exe.linux-x64-musl': 12.2.1
+      '@pnpm/exe.win32-arm64': 12.2.1
+      '@pnpm/exe.win32-x64': 12.2.1
+
+---
 lockfileVersion: '9.0'
 
 settings:


### PR DESCRIPTION
Bumps `packageManager` to pnpm 12.2.1 (Rust rewrite; lockfile format unchanged).

Vercel can't install pnpm 12 natively yet, so:
- `ENABLE_EXPERIMENTAL_COREPACK=1` is now set on all three Vercel projects (persona, persona-proxy, ai-sdk-webmcp) — corepack handles the binary correctly
- `apps/web/vercel.json` gets an explicit `installCommand` so Vercel doesn't pass `--unsafe-perm` (rejected by the Rust CLI); the other two projects already had one
- `examples/runtype-hono-proxy/api/` gets an empty npm package stub: @vercel/node's function-level install also passes `--unsafe-perm` and can't be overridden ([vercel/vercel#17560](https://github.com/vercel/vercel/issues/17560)); the stub makes it a no-op (see README note)

Verified green on preview deploys: `persona-ges2wud7w` (widget showcase) and `persona-proxy-7c17gosq2` (proxy). After merge, sanity-check the deployed proxy: `curl -X OPTIONS https://proxy.persona-chat.dev/api/chat/dispatch`.

https://claude.ai/code/session_013MxpmtPaEyq69PScvH8s1p

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the repository to pnpm 12.2.1 and adjusts Vercel installation behavior for the new Rust-based CLI.
- Pins pnpm 12.2.1 and records its platform executables in the lockfile.
- Adds an explicit web-app installation command.
- Adds a nested npm package stub to bypass Vercel’s incompatible function-level pnpm invocation.
- Documents the deployment workaround and ignores local Vercel metadata.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Pins the repository package manager to pnpm 12.2.1 with an integrity hash. |
| pnpm-lock.yaml | Records pnpm 12.2.1 as a package-manager dependency with platform-specific executable packages. |
| apps/web/vercel.json | Explicitly runs pnpm install so Vercel does not inject the unsupported unsafe-perm option. |
| examples/runtype-hono-proxy/api/package.json | Introduces an empty nested package root to make Vercel’s function-level installation a no-op. |
| examples/runtype-hono-proxy/api/package-lock.json | Selects npm for the empty nested function package installation. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix: stub api/ package root so Vercel&#39;s ..."](https://github.com/runtypelabs/persona/commit/3c02723fac13f885cd6fdd06ce637e640f5978f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59142734)</sub>

<!-- /greptile_comment -->