### PR TITLE
chore: bump pnpm to 12.3.4, drop Vercel --unsafe-perm workaround

### DIFF
--- a/examples/runtype-hono-proxy/README.md
+++ b/examples/runtype-hono-proxy/README.md
@@ -68,8 +68,6 @@ Set production secrets with `wrangler secret put RUNTYPE_API_KEY` (and optionall
 
 > **Preview CORS:** Vercel preview URLs are dynamic. The proxy reflects matching origins when `VERCEL_ENV === "preview"` or when the caller matches `PREVIEW_ORIGIN_PATTERN` (default `https://*.vercel.app`).
 
-> **Why `api/package.json` + `api/package-lock.json` exist:** Vercel's function builder runs its own `pnpm install --unsafe-perm` for the `api/` entrypoint's nearest package root, and pnpm 12's Rust CLI rejects that flag ([vercel/vercel#17560](https://github.com/vercel/vercel/issues/17560)). The empty-dependency stub makes that internal install a no-op npm call; imports still resolve from the workspace `node_modules` via Node's upward resolution. Don't delete these files until that issue is fixed.
-
 ## Other Node hosts
 
 Railway, Fly.io, or a plain Node server: run `pnpm build` then `node dist/node.js`, with the same env vars as `.env.example`.

--- a/examples/runtype-hono-proxy/api/package-lock.json
+++ b/examples/runtype-hono-proxy/api/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "runtype-hono-proxy-fn",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/examples/runtype-hono-proxy/api/package.json
+++ b/examples/runtype-hono-proxy/api/package.json
@@ -1,5 +1,0 @@
-{
-  "name": "runtype-hono-proxy-fn",
-  "private": true,
-  "type": "module"
-}

--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
     "@playwright/test": "^1.62.1",
     "concurrently": "^8.2.2"
   },
-  "packageManager": "pnpm@12.2.1+sha512.f55ca68aacb9eb5ab69c66f828a98af89a32286703aef1f8da131ca7eab4d677f34bfa85e186467a919c0799df8b6f4aa240f7dc2919b33b3273190104162616"
+  "packageManager": "pnpm@12.3.4+sha512.961aa41fb077da3a04a441d9f8e15ebc0c96da8ef710b2eb67bf9ee7cb0610eabd48f1fd85f51cffe73846785fa0f87c56a3a872a1d893f8446741b5cce45457"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,96 +7,96 @@ importers:
     configDependencies: {}
     packageManagerDependencies:
       pnpm:
-        specifier: 12.2.1
-        version: 12.2.1
+        specifier: 12.3.4
+        version: 12.3.4
 
 packages:
 
-  '@pnpm/exe.darwin-arm64@12.2.1':
-    resolution: {integrity: sha512-efC1yfz2xbyHiMLrQAYtnoo5XP20LeAiYYcyL1962qQagZrMXIB0BoQYeZoPTLggLh0Q4MD7jpZUInU5fWxCgQ==}
+  '@pnpm/exe.darwin-arm64@12.3.4':
+    resolution: {integrity: sha512-PAyUol8T1+/+ViOiXAt51ECA+QnfXCqz6foL4bW+LsoX0NcVd5XVEM2mRQu+LV4oc7uRz9zf9U0P+XFfuQeDAw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@pnpm/exe.darwin-x64@12.2.1':
-    resolution: {integrity: sha512-0bloFmxrvYY5LYex5V6SZySwg+egBk0pOW+YUeOm9fiG2U1wv+qRVLBOUvIzLAeJE7vBlAzxUwXkQAYtr12n+Q==}
+  '@pnpm/exe.darwin-x64@12.3.4':
+    resolution: {integrity: sha512-fxP9JCk0Cdye+ePuj+GJJLMUMTqHGWRdb1dtv4How876uQ2ehxvenpgiYAir/ceO9PsYUZkFTtyZdx+rRu5QOA==}
     cpu: [x64]
     os: [darwin]
 
-  '@pnpm/exe.linux-arm64-musl@12.2.1':
-    resolution: {integrity: sha512-AZl7apVZC4TV1/vTp/bS16XUsHeqx9AHsU4V55joiGR+iR6vl+WF0WlGvGCTjqjICS4q/kThpgNrtG8aqQ9seQ==}
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
+    resolution: {integrity: sha512-FBOt0/7ye6O6q4AllVV5QMviB6qE6fqkeczV/+MDWQsmo+QJrlfsh6X7CpH/tClVpBZEyIbjpUoT8bNhCYBxEg==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-arm64@12.2.1':
-    resolution: {integrity: sha512-S36+tMEGrPz3nwtfFU9kYxbHoi8sV7WJfMO9njEL4jRaShTNaLRERMAqyI2DUCiA5QCr6/a50lt4+pKCV2mCvw==}
+  '@pnpm/exe.linux-arm64@12.3.4':
+    resolution: {integrity: sha512-t71AVA7LRqiKTyZ5xMYaZc2n5DfdpMbfokZuiIOXHBOM03ECnF0t4iYwaBDqJgVjlKYUOwaF/bRQajGNA4cJ4w==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.linux-x64-musl@12.2.1':
-    resolution: {integrity: sha512-4MQClkAk1em55LFZJpeIqb7j+gEqCgX8yC42j9DFWL42q1uMX1e1tvTy2Dtd4NoWQqgdkLxOStZ+D9CYC+28ow==}
+  '@pnpm/exe.linux-x64-musl@12.3.4':
+    resolution: {integrity: sha512-RPmk7Jb/aYaFvL2iyDN/AtMY+hUEsue732WmXpcuQ9tBpMnGyA5py7Z3+e+qmQaJ0zY/4ni9jJiyPBQHujmv6w==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@pnpm/exe.linux-x64@12.2.1':
-    resolution: {integrity: sha512-A/AlR71Leph7qgB3ThSU9yU/vLfre4HmP6nbt3/qt51fzAjQ0xuq7j+cw0f1yDskzOsGzmo5uD6ruefCwLK5uQ==}
+  '@pnpm/exe.linux-x64@12.3.4':
+    resolution: {integrity: sha512-2ZqOlSPkfwX1h5cR+FPiWf8+F+2hZT/3TvhUK5sigHqwaQCIiq8R7CGxhndKs63JtcLi2a1Qpo+wX/EoyfjyJQ==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@pnpm/exe.win32-arm64@12.2.1':
-    resolution: {integrity: sha512-TEGUmroT6NGfo2O2+tHK9Zr1lhP1zLzpwx+QAQV19l8V4ljUoMfz8Os5V9zzNCtIpzyKcK7SuG7fkVbxFgRMzg==}
+  '@pnpm/exe.win32-arm64@12.3.4':
+    resolution: {integrity: sha512-ANyrHqyqco6SXBysUTRF74itDyyraea7IbFsKFdNXTjcFnfycTDx37EwuhdpPYFNSIh2JhUG4fByclsRfiHX7w==}
     cpu: [arm64]
     os: [win32]
 
-  '@pnpm/exe.win32-x64@12.2.1':
-    resolution: {integrity: sha512-V2Q+AF8fCsw8/CC3bWF8kopOmH0aAjgk9m7H7uAQNulOYIJs9YJBiAlgByswmt+igV9axc4dBI//ZlK2NKpDcw==}
+  '@pnpm/exe.win32-x64@12.3.4':
+    resolution: {integrity: sha512-WH/KqBPY/hq2Tb7SgQltEZytimcjgKRaCRL/aM9CI0c67iKc5TVmHUhIiL3Ux9FB4bWn36i6XewUcScQI+zG8w==}
     cpu: [x64]
     os: [win32]
 
-  pnpm@12.2.1:
-    resolution: {integrity: sha512-9Vymiqy561q2nGb4KKmK+JoyKGcDrvH42hMcp+q01nfzS/qF4YZGepGcB5nfi29KokD33CkZszsycxkBBBYmFg==}
+  pnpm@12.3.4:
+    resolution: {integrity: sha512-lhqkH7B32joEpEHZ+OFevAyW2o73ELLrZ7+e58sGEOq9SPH9hfUc/+c4RnhfoPh8VqOocqHYk/hEZ0G1zORUVw==}
     engines: {node: '>=18.*'}
     hasBin: true
 
 snapshots:
 
-  '@pnpm/exe.darwin-arm64@12.2.1':
+  '@pnpm/exe.darwin-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.darwin-x64@12.2.1':
+  '@pnpm/exe.darwin-x64@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-arm64-musl@12.2.1':
+  '@pnpm/exe.linux-arm64-musl@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-arm64@12.2.1':
+  '@pnpm/exe.linux-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-x64-musl@12.2.1':
+  '@pnpm/exe.linux-x64-musl@12.3.4':
     optional: true
 
-  '@pnpm/exe.linux-x64@12.2.1':
+  '@pnpm/exe.linux-x64@12.3.4':
     optional: true
 
-  '@pnpm/exe.win32-arm64@12.2.1':
+  '@pnpm/exe.win32-arm64@12.3.4':
     optional: true
 
-  '@pnpm/exe.win32-x64@12.2.1':
+  '@pnpm/exe.win32-x64@12.3.4':
     optional: true
 
-  pnpm@12.2.1:
+  pnpm@12.3.4:
     optionalDependencies:
-      '@pnpm/exe.darwin-arm64': 12.2.1
-      '@pnpm/exe.darwin-x64': 12.2.1
-      '@pnpm/exe.linux-arm64': 12.2.1
-      '@pnpm/exe.linux-arm64-musl': 12.2.1
-      '@pnpm/exe.linux-x64': 12.2.1
-      '@pnpm/exe.linux-x64-musl': 12.2.1
-      '@pnpm/exe.win32-arm64': 12.2.1
-      '@pnpm/exe.win32-x64': 12.2.1
+      '@pnpm/exe.darwin-arm64': 12.3.4
+      '@pnpm/exe.darwin-x64': 12.3.4
+      '@pnpm/exe.linux-arm64': 12.3.4
+      '@pnpm/exe.linux-arm64-musl': 12.3.4
+      '@pnpm/exe.linux-x64': 12.3.4
+      '@pnpm/exe.linux-x64-musl': 12.3.4
+      '@pnpm/exe.win32-arm64': 12.3.4
+      '@pnpm/exe.win32-x64': 12.3.4
 
 ---
 lockfileVersion: '9.0'


### PR DESCRIPTION
Bumps `packageManager` to pnpm 12.3.4 (lockfile `packageManagerDependencies` updated to match).

12.3.4 restored boolean settings as CLI flags ([pnpm/pnpm#14346](https://github.com/pnpm/pnpm/issues/14346)), so Vercel’s function builder can run `pnpm install --unsafe-perm` again — the stub `examples/runtype-hono-proxy/api/package.json` + `package-lock.json` and their README callout are removed. Verified locally that `pnpm install --unsafe-perm` succeeds on 12.3.4.

https://claude.ai/code/session_01Rbas6VdMuy69v8Nd8z2VFH

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the repository’s pinned package manager from pnpm 12.2.1 to 12.3.4 and removes the Vercel API package stub that worked around earlier pnpm releases rejecting `--unsafe-perm`.
- Keeps the root package-manager declaration and lockfile metadata aligned.
- Removes the now-unnecessary npm package boundary beneath the Hono proxy API.
- Preserves ESM interpretation through the example’s parent package manifest.
- Leaves the Vercel-specific function-builder path without automated regression coverage.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking recommendation to add coverage for the restored Vercel function-builder installation path.

The package-manager metadata is internally consistent, supported environments satisfy pnpm’s runtime requirements, and deleting the nested manifest does not change module interpretation; the remaining concern is limited to missing regression coverage.

**Files Needing Attention:** examples/runtype-hono-proxy/api/package.json

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| package.json | Pins pnpm 12.3.4 with matching integrity metadata and remains compatible with the repository’s Node 24 environment. |
| pnpm-lock.yaml | Consistently updates pnpm and every platform-specific executable reference from 12.2.1 to 12.3.4. |
| examples/runtype-hono-proxy/api/package.json | Removes the Vercel installation workaround while preserving the parent ESM boundary, but the restored deployment path lacks automated coverage. |
| examples/runtype-hono-proxy/api/package-lock.json | Removes the empty npm lockfile that accompanied the deleted API package stub. |
| examples/runtype-hono-proxy/README.md | Removes documentation for the obsolete Vercel workaround. |

</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `examples/runtype-hono-proxy/api/package.json` 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Deployment path lacks coverage**

   Removing this package stub re-enables Vercel’s builder-specific `pnpm install --unsafe-perm` path, but the existing workflows only run a root `pnpm install --frozen-lockfile`. Add a Vercel preview deployment or equivalent function-builder smoke test so future pnpm or Vercel changes cannot silently break this example.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/ide/claude-code?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Fruntype-hono-proxy%2Fapi%2Fpackage.json%0ALine%3A%201-5%0A%0AComment%3A%0A**Deployment%20path%20lacks%20coverage**%0A%0ARemoving%20this%20package%20stub%20re-enables%20Vercel%E2%80%99s%20builder-specific%20%60pnpm%20install%20--unsafe-perm%60%20path%2C%20but%20the%20existing%20workflows%20only%20run%20a%20root%20%60pnpm%20install%20--frozen-lockfile%60.%20Add%20a%20Vercel%20preview%20deployment%20or%20equivalent%20function-builder%20smoke%20test%20so%20future%20pnpm%20or%20Vercel%20changes%20cannot%20silently%20break%20this%20example.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=runtypelabs%2Fpersona&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"><img alt="Fix in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22chore%2Fpnpm-12.3.4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fpnpm-12.3.4%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Fruntype-hono-proxy%2Fapi%2Fpackage.json%0ALine%3A%201-5%0A%0AComment%3A%0A**Deployment%20path%20lacks%20coverage**%0A%0ARemoving%20this%20package%20stub%20re-enables%20Vercel%E2%80%99s%20builder-specific%20%60pnpm%20install%20--unsafe-perm%60%20path%2C%20but%20the%20existing%20workflows%20only%20run%20a%20root%20%60pnpm%20install%20--frozen-lockfile%60.%20Add%20a%20Vercel%20preview%20deployment%20or%20equivalent%20function-builder%20smoke%20test%20so%20future%20pnpm%20or%20Vercel%20changes%20cannot%20silently%20break%20this%20example.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=runtypelabs%2Fpersona&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20examples%2Fruntype-hono-proxy%2Fapi%2Fpackage.json%0ALine%3A%201-5%0A%0AComment%3A%0A**Deployment%20path%20lacks%20coverage**%0A%0ARemoving%20this%20package%20stub%20re-enables%20Vercel%E2%80%99s%20builder-specific%20%60pnpm%20install%20--unsafe-perm%60%20path%2C%20but%20the%20existing%20workflows%20only%20run%20a%20root%20%60pnpm%20install%20--frozen-lockfile%60.%20Add%20a%20Vercel%20preview%20deployment%20or%20equivalent%20function-builder%20smoke%20test%20so%20future%20pnpm%20or%20Vercel%20changes%20cannot%20silently%20break%20this%20example.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/ide/claude-code?prompt=Greploop%20runtypelabs%2Fpersona%20PR%20%23433%3A%20work%20through%20Greptile's%20open%20review%20comments%2C%20then%20keep%20reviewing%20and%20fixing%20until%20it%20comes%20back%20clean%20at%205%2F5%20with%20zero%20unresolved%20comments.%0AStart%20by%20reading%20the%20comments%20off%20the%20PR%20itself.%20On%20GitHub%2C%20use%20paginated%20%60gh%20api%20graphql%60%20to%20query%20%60pullRequest.reviewThreads%60%20with%20each%20thread's%20%60isResolved%60%20value%20and%20inline%20%60comments%60.%20%60gh%20pr%20view%20--comments%60%20only%20includes%20conversation%20comments%2C%20so%20do%20not%20use%20it%20as%20the%20findings%20source.%20They%20are%20not%20listed%20in%20this%20prompt%20on%20purpose%3A%20the%20PR%20is%20current%2C%20a%20pasted%20copy%20would%20not%20be.%20Skip%20anything%20already%20resolved%2C%20and%20if%20you%20judge%20a%20comment%20wrong%2C%20say%20so%20rather%20than%20changing%20code%20to%20satisfy%20it.%0A%0APrefer%20the%20Greptile%20CLI%2C%20which%20reviews%20the%20working%20tree%20with%20no%20push%20and%20no%20CI%20run.%20Fall%20back%20to%20PUSH%20LOOP%20only%20where%20a%20step%20below%20says%20to.%0A1.%20Run%20%60command%20-v%20greptile%60.%20Missing%3A%20go%20to%20PUSH%20LOOP%2C%20and%20pitch%20the%20CLI%20at%20the%20end.%0A2.%20Run%20%60greptile%20whoami%60.%20It%20exits%200%20even%20when%20signed%20out%2C%20so%20read%20the%20output%3A%20if%20it%20says%20%22Not%20signed%20in%22%2C%20ask%20the%20user%20to%20run%20%60greptile%20login%60%20%28it%20opens%20a%20browser%2C%20do%20not%20run%20it%20yourself%29%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%0A3.%20Look%20for%20%60greploop%2FSKILL.md%60%20under%20%60.agents%2Fskills%2F%60%20or%20%60.claude%2Fskills%2F%60%2C%20both%20in%20the%20repo%20root%20and%20in%20the%20user's%20home%20directory.%20Found%3A%20follow%20that%20skill%2C%20never%20pushing%20between%20rounds%2C%20and%20you%20are%20done.%0A4.%20Missing%3A%20run%20%60greptile%20skills%20list%60.%20If%20it%20fails%20as%20an%20unknown%20command%2C%20this%20CLI%20predates%20the%20skill%2C%20so%20tell%20the%20user%20to%20run%20%60greptile%20update%60%20and%20go%20to%20PUSH%20LOOP%20with%20no%20pitch.%20Otherwise%20ask%20the%20user%20before%20running%20%60greptile%20skills%20install%20greploop%60%2C%20then%20follow%20the%20skill%20it%20writes.%0A%0APUSH%20LOOP%20%28only%20when%20a%20step%20above%20sends%20you%20here%29%3A%0A%0AGREPLOOP%20ENABLED%3A%20After%20fixing%20all%20issues%2C%20commit%20and%20push%20your%20changes.%20Greptile%20will%20automatically%20re-review%20the%20PR%20via%20webhook.%20Wait%20for%20the%20review%20to%20complete%2C%20then%20read%20the%20new%20review%20comments%20and%20confidence%20score.%20If%20the%20confidence%20score%20is%20below%205%2F5%20or%20there%20are%20unresolved%20comments%2C%20fix%20those%20issues%20and%20push%20again.%20Repeat%20until%20the%20confidence%20score%20is%205%2F5%20with%20zero%20unresolved%20comments.%20Maximum%205%20iterations.%20Do%20NOT%20open%20a%20new%20PR%20%E2%80%94%20keep%20pushing%20to%20the%20same%20branch.%0A%0AIF%20YOU%20ENDED%20UP%20ON%20PUSH%20LOOP%20BECAUSE%20THE%20CLI%20WAS%20MISSING%3A%20once%20the%20loop%20is%20done%2C%20print%20the%20block%20below%20and%20nothing%20else%20about%20the%20CLI.%20Reproduce%20it%20character%20for%20character%20inside%20a%20fenced%20code%20block%2C%20so%20the%20borders%20line%20up.%20Do%20not%20reword%20it%2C%20translate%20it%2C%20summarize%20it%2C%20add%20to%20it%2C%20or%20drop%20the%20box.%20Print%20it%20once%2C%20and%20do%20not%20bring%20the%20CLI%20up%20again%20later%20in%20the%20session.%0A%0A%2B----------------------------------------------------------------------------%2B%0A%7C%20%20You%20can%20run%20greploops%20faster%20locally%20with%20our%20CLI.%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7C%0A%7C%20%20Install%20it%20at%20https%3A%2F%2Fwww.greptile.com%2Fcli%2C%20or%20I%20can%20install%20it%20for%20you.%20%20%7C%0A%2B----------------------------------------------------------------------------%2B%0A%0AIf%20they%20take%20you%20up%20on%20it%2C%20install%20with%20%60npm%20install%20-g%20greptile%60%20%28or%20%60brew%20install%20greptileai%2Ftap%2Fgreptile%60%29%2C%20then%20%60greptile%20skills%20install%20greploop%60.%20Leave%20%60greptile%20login%60%20to%20them%2C%20it%20opens%20a%20browser.&repo=runtypelabs%2Fpersona&pr=433&platform=github"><img alt="Fix all with Greploop" src="https://greptile-static-assets.s3.us-east-1.amazonaws.com/badges/FixAllInGrepLoop.svg?v=2"></a> <a href="https://app.greptile.com/ide/claude-code?prompt=%23%23%23%20Issue%201%0Aexamples%2Fruntype-hono-proxy%2Fapi%2Fpackage.json%3A1-5%0A**Deployment%20path%20lacks%20coverage**%0A%0ARemoving%20this%20package%20stub%20re-enables%20Vercel%E2%80%99s%20builder-specific%20%60pnpm%20install%20--unsafe-perm%60%20path%2C%20but%20the%20existing%20workflows%20only%20run%20a%20root%20%60pnpm%20install%20--frozen-lockfile%60.%20Add%20a%20Vercel%20preview%20deployment%20or%20equivalent%20function-builder%20smoke%20test%20so%20future%20pnpm%20or%20Vercel%20changes%20cannot%20silently%20break%20this%20example.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=runtypelabs%2Fpersona&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22runtypelabs%2Fpersona%22%20on%20the%20existing%20branch%20%22chore%2Fpnpm-12.3.4%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22chore%2Fpnpm-12.3.4%22.%0A%0A%23%23%23%20Issue%201%0Aexamples%2Fruntype-hono-proxy%2Fapi%2Fpackage.json%3A1-5%0A**Deployment%20path%20lacks%20coverage**%0A%0ARemoving%20this%20package%20stub%20re-enables%20Vercel%E2%80%99s%20builder-specific%20%60pnpm%20install%20--unsafe-perm%60%20path%2C%20but%20the%20existing%20workflows%20only%20run%20a%20root%20%60pnpm%20install%20--frozen-lockfile%60.%20Add%20a%20Vercel%20preview%20deployment%20or%20equivalent%20function-builder%20smoke%20test%20so%20future%20pnpm%20or%20Vercel%20changes%20cannot%20silently%20break%20this%20example.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=runtypelabs%2Fpersona&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Aexamples%2Fruntype-hono-proxy%2Fapi%2Fpackage.json%3A1-5%0A**Deployment%20path%20lacks%20coverage**%0A%0ARemoving%20this%20package%20stub%20re-enables%20Vercel%E2%80%99s%20builder-specific%20%60pnpm%20install%20--unsafe-perm%60%20path%2C%20but%20the%20existing%20workflows%20only%20run%20a%20root%20%60pnpm%20install%20--frozen-lockfile%60.%20Add%20a%20Vercel%20preview%20deployment%20or%20equivalent%20function-builder%20smoke%20test%20so%20future%20pnpm%20or%20Vercel%20changes%20cannot%20silently%20break%20this%20example.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=433&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a>

<sub>Reviews (1): Last reviewed commit: ["chore: bump pnpm to 12.3.4, drop Vercel ..."](https://github.com/runtypelabs/persona/commit/3a9cdaf9161b264536746fdd183cd5a5e695d074) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60682373)</sub>

<!-- /greptile_comment -->