### PR TITLE
fix(voice): wire custom providers into call controls and settle cancelled turns

### DIFF
--- a/.changeset/custom-voice-provider-controls.md
+++ b/.changeset/custom-voice-provider-controls.md
@@ -3,3 +3,5 @@
 ---
 
 Route custom voice providers through the widget microphone controls, status display, and call lifecycle. Custom realtime providers can now honor None, Cancel, and Barge-in modes without falling back to browser dictation.
+
+Refresh generated event types for additive fields and context notices already present in the public Runtype API.

--- a/.changeset/custom-voice-provider-controls.md
+++ b/.changeset/custom-voice-provider-controls.md
@@ -1,0 +1,5 @@
+---
+"@runtypelabs/persona": patch
+---
+
+Route custom voice providers through the widget microphone controls, status display, and call lifecycle. Custom realtime providers can now honor None, Cancel, and Barge-in modes without falling back to browser dictation.

--- a/.changeset/custom-voice-provider-controls.md
+++ b/.changeset/custom-voice-provider-controls.md
@@ -4,4 +4,6 @@
 
 Route custom voice providers through the widget microphone controls, status display, and call lifecycle. Custom realtime providers can now honor None, Cancel, and Barge-in modes without falling back to browser dictation.
 
+Disconnect replaced or disabled providers, ignore callbacks from retired providers, and discard cancelled replies. Custom providers with overlapping turns can supply optional transcript turn IDs to prevent a late cancelled reply from replacing the next answer.
+
 Refresh generated event types for additive fields and context notices already present in the public Runtype API.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ Text, images (PNG, JPEG, GIF, WebP, SVG), and documents (PDF, DOCX, TXT, CSV, JS
 ### Voice Input & Output
 Optional speech-to-text via the Web Speech API or Runtype's WebSocket voice service with barge-in interruption and voice activity detection. Text-to-speech playback for assistant responses: auto-speak via `textToSpeech`, or a per-message "Read aloud" button with play/pause/resume via `messageActions.showReadAloud`. TTS is backed by a pluggable `SpeechEngine` (browser Web Speech API by default, or a hosted engine via `textToSpeech.createEngine`). Enable via `voiceRecognition` and `textToSpeech`.
 
+Custom voice providers use the same microphone controls. Updating or disabling `voiceRecognition.provider` disconnects the old provider before installing its replacement. A provider's `disconnect()` must release its resources and callbacks. For concurrent turns, pass `{ turnId }` as the fourth `onTranscript` callback argument, using the same ID on each turn's user and assistant transcripts. Persona rejects replies belonging to cancelled or superseded identified turns. Providers that omit IDs must discard cancelled output before emitting the next user final; untagged overlapping replies cannot be correlated by the widget.
+
 ### Reasoning & Extended Thinking
 Collapsible reasoning bubbles that display model chain-of-thought with duration tracking and streaming. Controlled by `features.showReasoning`: on by default, or override the renderer with a plugin hook.
 

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -2,7 +2,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 CDN browser payload (index.global.js)",
     "path": "dist/index.global.js",
-    "limit": "186.25 kB",
+    "limit": "186.75 kB",
     "gzip": true
   },
   {
@@ -20,13 +20,13 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "198.75 kB",
+    "limit": "199.25 kB",
     "gzip": true
   },
   {
     "name": "CJS bundle (index.cjs)",
     "path": "dist/index.cjs",
-    "limit": "199.5 kB",
+    "limit": "200 kB",
     "gzip": true
   },
   {
@@ -44,7 +44,7 @@
   {
     "name": "Opt-in \u00b7 theme-editor preview subpath (theme-editor-preview.js)",
     "path": "dist/theme-editor-preview.js",
-    "limit": "165.25 kB",
+    "limit": "165.75 kB",
     "gzip": true
   },
   {

--- a/packages/widget/.size-limit.json
+++ b/packages/widget/.size-limit.json
@@ -20,7 +20,7 @@
   {
     "name": "\u26d4 CRITICAL \u00b7 ESM bundle shipped by consumers (index.js)",
     "path": "dist/index.js",
-    "limit": "198.5 kB",
+    "limit": "198.75 kB",
     "gzip": true
   },
   {

--- a/packages/widget/src/generated/runtype-openapi-contract.ts
+++ b/packages/widget/src/generated/runtype-openapi-contract.ts
@@ -70,6 +70,11 @@ export type RuntypeExecutionStreamEvent = ({
   iteration?: number;
   role: "user" | "assistant" | "system";
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   turnIndex?: number;
   type: "turn_start";
 }) | ({
@@ -104,6 +109,11 @@ export type RuntypeExecutionStreamEvent = ({
   role: "user" | "assistant" | "system";
   seq: number;
   stopReason?: "end_turn" | "max_tool_calls" | "length" | "content_filter" | "error" | "unknown";
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   tokens?: {
   input: number;
   output: number;
@@ -118,6 +128,11 @@ export type RuntypeExecutionStreamEvent = ({
   seq: number;
   startedAt?: string;
   stepType?: string;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   totalSteps?: number;
   type: "step_start";
 } | ({
@@ -145,6 +160,11 @@ export type RuntypeExecutionStreamEvent = ({
   seq: number;
   stepType?: string;
   stopReason?: "end_turn" | "max_tool_calls" | "length" | "content_filter" | "error" | "unknown";
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   success?: boolean;
   tokensUsed?: number;
   type: "step_complete";
@@ -167,6 +187,11 @@ export type RuntypeExecutionStreamEvent = ({
   role?: "user" | "assistant" | "system";
   seq: number;
   stepId?: string;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   turnId?: string;
   type: "text_start";
 }) | {
@@ -174,11 +199,21 @@ export type RuntypeExecutionStreamEvent = ({
   executionId: string;
   id: string;
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   type: "text_delta";
 } | {
   executionId: string;
   id: string;
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   text?: string;
   type: "text_complete";
 } | ({
@@ -187,18 +222,33 @@ export type RuntypeExecutionStreamEvent = ({
   parentToolCallId?: string;
   scope?: "turn" | "loop";
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   type: "reasoning_start";
 }) | {
   delta: string;
   executionId: string;
   id: string;
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   type: "reasoning_delta";
 } | ({
   executionId: string;
   id: string;
   scope?: "turn" | "loop";
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   text?: string;
   type: "reasoning_complete";
 }) | ({
@@ -291,6 +341,11 @@ export type RuntypeExecutionStreamEvent = ({
   seq: number;
   startedAt?: string;
   stepId?: string;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   toolCallId: string;
   toolName: string;
   toolType: string;
@@ -299,6 +354,11 @@ export type RuntypeExecutionStreamEvent = ({
   delta: string;
   executionId: string;
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   toolCallId: string;
   type: "tool_input_delta";
 } | {
@@ -306,6 +366,11 @@ export type RuntypeExecutionStreamEvent = ({
   hiddenParameterNames?: Array<string>;
   parameters: Record<string, unknown>;
   seq: number;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   toolCallId: string;
   toolName?: string;
   type: "tool_input_complete";
@@ -323,6 +388,11 @@ export type RuntypeExecutionStreamEvent = ({
   result?: unknown;
   seq: number;
   stepId?: string;
+  subagent?: {
+  agentName?: string;
+  parentToolCallId?: string;
+  toolName: string;
+};
   success: boolean;
   toolCallId: string;
   toolCost?: number;
@@ -402,6 +472,19 @@ export type RuntypeExecutionStreamEvent = ({
   recoverable?: boolean;
   seq: number;
   type: "error";
+}) | ({
+  epoch: number;
+  executionId: string;
+  kind: "compaction";
+  outcome?: "ok" | "failed" | "gap" | "skipped";
+  phase: "start" | "complete";
+  reason: "threshold" | "overflow" | "manual" | "surface_policy" | "provider_mismatch";
+  seq: number;
+  strategy: "provider_native" | "summary";
+  tier: number;
+  tokensAfter?: number;
+  tokensBefore?: number;
+  type: "context_notice";
 }) | {
   executionId: string;
   seq: number;

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -1088,6 +1088,7 @@ export class AgentWidgetSession {
 
   /** Widget teardown: release the visitor-store subscription. */
   public destroy(): void {
+    this.cleanupVoice();
     this.visitorStoreUnsubscribe?.();
     this.visitorStoreUnsubscribe = null;
     this.subscribedVisitorStore = null;

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -78,7 +78,8 @@ import {
   ReadAloudController,
   type ReadAloudListener,
 } from "./voice/read-aloud-controller";
-import { isVoiceSupportedProbe } from "./utils/voice-support";
+import { isVoiceSupportedProbe, usesSessionVoice, voiceConnectionChanged } from "./utils/voice-support";
+import { VoiceTurnTracker } from "./voice/voice-turn-tracker";
 import { loadVoiceRuntime } from "./voice-runtime-loader";
 import { resolveSpeakableText } from "./utils/speech-text";
 import { loadRuntypeTts } from "./voice/runtype-tts-loader";
@@ -576,6 +577,7 @@ export class AgentWidgetSession {
    */
   public stopVoicePlayback(): void {
     if (this.voiceProvider?.stopPlayback) {
+      this.voiceTurns.cancel();
       this.voiceProvider.stopPlayback();
     }
   }
@@ -595,6 +597,8 @@ export class AgentWidgetSession {
   // Pending placeholder IDs for Runtype two-phase voice flow
   private pendingVoiceUserMessageId: string | null = null;
   private pendingVoiceAssistantMessageId: string | null = null;
+  private voiceTurns = new VoiceTurnTracker();
+  private voiceDisconnectPromise: Promise<void> = Promise.resolve();
 
   // Track message IDs where the Runtype provider already played TTS audio
   // so browser TTS doesn't double-speak them
@@ -688,6 +692,9 @@ export class AgentWidgetSession {
         throw new Error('Voice configuration not provided');
       }
 
+      this.cleanupVoice();
+      const disconnected = this.voiceDisconnectPromise;
+
       // The provider runtime ships in the lazy voice-runtime chunk. The sync
       // signature is preserved: construction + wiring + connect() happen when
       // the chunk resolves (prefetched at session construction when a
@@ -696,7 +703,8 @@ export class AgentWidgetSession {
       // discarded via the generation token.
       const generation = ++this.voiceSetupGeneration;
       this.voiceSetupPromise = loadVoiceRuntime()
-        .then((mod) => {
+        .then(async (mod) => {
+          await disconnected;
           if (generation !== this.voiceSetupGeneration) return;
           this.wireVoiceProvider(mod.createVoiceProvider(voiceConfig));
         })
@@ -717,6 +725,8 @@ export class AgentWidgetSession {
   private wireVoiceProvider(provider: VoiceProvider): void {
     try {
       this.voiceProvider = provider;
+      const generation = this.voiceSetupGeneration;
+      const isCurrent = () => this.voiceProvider === provider && generation === this.voiceSetupGeneration;
 
       // Read configurable text from widget config
       const voiceRecognitionConfig = this.config.voiceRecognition ?? {};
@@ -727,6 +737,7 @@ export class AgentWidgetSession {
       // via the standard SSE chat path. Only the realtime `runtype` provider is
       // excluded here: it owns the whole turn and drives onTranscript below.
       this.voiceProvider.onResult((result) => {
+        if (!isCurrent()) return;
         if (result.provider !== 'runtype') {
           if (result.text && result.text.trim()) {
             this.sendMessage(result.text, { viaVoice: true });
@@ -741,7 +752,8 @@ export class AgentWidgetSession {
       // In-flight bubbles carry voiceProcessing=true so consumers can style
       // them via messageTransform; it clears once the text is final.
       if (this.voiceProvider.onTranscript) {
-        this.voiceProvider.onTranscript((role, text, isFinal) => {
+        this.voiceProvider.onTranscript((role, text, isFinal, metadata) => {
+          if (!isCurrent()) return;
           if (role === 'user') {
             if (!this.pendingVoiceUserMessageId) {
               const msg = this.injectMessage({
@@ -763,6 +775,7 @@ export class AgentWidgetSession {
             }
 
             if (isFinal) {
+              this.voiceTurns.start(metadata?.turnId);
               // User finished: the agent is now thinking. Release the user
               // bubble (a new interim starts a fresh turn) and show a typing
               // indicator in a fresh assistant placeholder.
@@ -777,6 +790,7 @@ export class AgentWidgetSession {
               this.setStreaming(true);
             }
           } else {
+            if (!this.voiceTurns.accepts(metadata?.turnId)) return;
             // assistant: runtype sends a single final; the isFinal=false path
             // is reserved for delta-streaming providers (future BYO).
             if (this.pendingVoiceAssistantMessageId) {
@@ -816,6 +830,7 @@ export class AgentWidgetSession {
       // not forwarded per callback: the UI samples it on its own frame loop.
       if (this.voiceProvider.onLevel) {
         this.voiceProvider.onLevel((level) => {
+          if (!isCurrent()) return;
           this.voiceLevel = Number.isFinite(level)
             ? Math.max(0, Math.min(1, level))
             : 0;
@@ -825,11 +840,13 @@ export class AgentWidgetSession {
       // Surface per-turn latency metrics to the optional config hook.
       if (this.voiceProvider.onMetrics) {
         this.voiceProvider.onMetrics((metrics) => {
+          if (!isCurrent()) return;
           this.config.voiceRecognition?.onMetrics?.(metrics);
         });
       }
 
       this.voiceProvider.onError((error) => {
+        if (!isCurrent()) return;
         console.error('Voice error:', error);
 
         // If error occurs while placeholders are pending, update assistant with error text
@@ -849,6 +866,7 @@ export class AgentWidgetSession {
       });
 
       this.voiceProvider.onStatusChange((status) => {
+        if (!isCurrent()) return;
         this.voiceStatus = status;
         this.voiceActive = status === 'listening';
         if (status === 'listening' || status === 'idle' || status === 'disconnected') {
@@ -895,21 +913,34 @@ export class AgentWidgetSession {
    * Cleanup voice resources
    */
   public cleanupVoice() {
+    const notifyDisconnected = this.voiceProvider !== null;
     this.voiceSetupGeneration++;
     this.voiceSetupPromise = null;
     if (this.voiceProvider) {
-      this.voiceProvider.disconnect();
+      const provider = this.voiceProvider;
       this.voiceProvider = null;
+      this.voiceDisconnectPromise = this.disconnectVoice(provider);
     }
     this.voiceActive = false;
     this.voiceStatus = 'disconnected';
     this.settlePendingVoiceTurn(true);
+    this.voiceTurns = new VoiceTurnTracker();
+    if (notifyDisconnected) this.callbacks.onVoiceStatusChanged?.('disconnected');
+  }
+
+  private async disconnectVoice(provider: VoiceProvider): Promise<void> {
+    try {
+      await provider.disconnect();
+    } catch (error) {
+      console.error('Failed to disconnect voice:', error);
+    }
   }
 
   private settlePendingVoiceTurn(includeUser: boolean): void {
     const userId = includeUser ? this.pendingVoiceUserMessageId : null;
     const assistantId = this.pendingVoiceAssistantMessageId;
     if (!userId && !assistantId) return;
+    if (assistantId) this.voiceTurns.cancel();
     if (includeUser) this.pendingVoiceUserMessageId = null;
     this.pendingVoiceAssistantMessageId = null;
     if (assistantId) this.ttsSpokenMessageIds.add(assistantId);
@@ -2124,6 +2155,15 @@ export class AgentWidgetSession {
   public updateConfig(next: AgentWidgetConfig) {
     const previousArtifactDisplay = this.config.features?.artifacts?.display;
     const merged = { ...this.config, ...next };
+    const replaceVoice = voiceConnectionChanged(this.config, merged);
+    const replaceClient = connectionConfigChanged(this.config, merged);
+    this.config = merged;
+    if (replaceVoice) {
+      this.cleanupVoice();
+      if (merged.voiceRecognition?.enabled === true && usesSessionVoice(merged.voiceRecognition.provider)) {
+        this.setupVoice();
+      }
+    }
     const artifactDisplayChanged =
       JSON.stringify(previousArtifactDisplay) !==
       JSON.stringify(merged.features?.artifacts?.display);
@@ -2135,8 +2175,7 @@ export class AgentWidgetSession {
     // self-styling widget work: a `webmcp:*` theme tool mutates config and
     // re-renders mid-turn; recreating the client there would abort the very
     // turn that's restyling the widget and strand the paused execution.
-    if (!connectionConfigChanged(this.config, merged)) {
-      this.config = merged;
+    if (!replaceClient) {
       this.client.updateConfig(merged);
       if (artifactDisplayChanged) this.refreshArtifactReferenceBlocks();
       return;
@@ -2153,7 +2192,6 @@ export class AgentWidgetSession {
     this.webMcpInflightKeys.clear();
     this.webMcpResolvedKeys.clear();
     const prevSSECallback = this.client.getSSEEventCallback();
-    this.config = merged;
     this.client = new AgentWidgetClient(this.config, this.historyInternals);
     if (artifactDisplayChanged) this.refreshArtifactReferenceBlocks();
     this.wireDefaultWebMcpConfirm();

--- a/packages/widget/src/session.ts
+++ b/packages/widget/src/session.ts
@@ -851,6 +851,9 @@ export class AgentWidgetSession {
       this.voiceProvider.onStatusChange((status) => {
         this.voiceStatus = status;
         this.voiceActive = status === 'listening';
+        if (status === 'listening' || status === 'idle' || status === 'disconnected') {
+          this.settlePendingVoiceTurn(status !== 'listening');
+        }
         this.callbacks.onVoiceStatusChanged?.(status);
       });
 
@@ -900,6 +903,23 @@ export class AgentWidgetSession {
     }
     this.voiceActive = false;
     this.voiceStatus = 'disconnected';
+    this.settlePendingVoiceTurn(true);
+  }
+
+  private settlePendingVoiceTurn(includeUser: boolean): void {
+    const userId = includeUser ? this.pendingVoiceUserMessageId : null;
+    const assistantId = this.pendingVoiceAssistantMessageId;
+    if (!userId && !assistantId) return;
+    if (includeUser) this.pendingVoiceUserMessageId = null;
+    this.pendingVoiceAssistantMessageId = null;
+    if (assistantId) this.ttsSpokenMessageIds.add(assistantId);
+    this.messages = this.messages.flatMap((message) => {
+      if (message.id !== userId && message.id !== assistantId) return [message];
+      if (message.id === assistantId && !message.content.trim()) return [];
+      return [{ ...message, streaming: false, voiceProcessing: false }];
+    });
+    this.callbacks.onMessagesChanged([...this.messages]);
+    if (assistantId) this.setStreaming(false);
   }
 
   /**

--- a/packages/widget/src/types.ts
+++ b/packages/widget/src/types.ts
@@ -4983,10 +4983,12 @@ export interface VoiceProvider {
    * `isFinal=false` is a live interim update (user partials, or assistant deltas
    * on providers that stream them); `isFinal=true` finalizes that role's text.
    * On the realtime `runtype` path, interim updates fire for the `user` only and
-   * the `assistant` arrives as a single final.
+   * the `assistant` arrives as a single final. Providers with overlapping turns
+   * must include the same turnId on user and assistant finals; without IDs,
+   * providers must discard cancelled output before emitting the next user final.
    */
   onTranscript?(
-    callback: (role: 'user' | 'assistant', text: string, isFinal: boolean) => void,
+    callback: (role: 'user' | 'assistant', text: string, isFinal: boolean, metadata?: { turnId?: string }) => void,
   ): void;
 
   /** Register a callback for per-turn latency metrics (realtime path). */

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -1,3 +1,4 @@
+import { usesSessionVoice } from "./utils/voice-support";
 import { escapeHtml, createMarkdownProcessorFromConfig } from "./postprocessors";
 import { resolveSanitizer } from "./utils/sanitize";
 import { stabilizeStreamingTables } from "./utils/streaming-table";
@@ -5245,7 +5246,7 @@ export const createAgentExperience = (
       setTimeout(() => {
         if (!voiceState.active) {
           voiceState.manuallyDeactivated = false;
-          if (config.voiceRecognition?.provider?.type === 'runtype') {
+          if (usesSessionVoice(config.voiceRecognition?.provider)) {
             session.toggleVoice().then(() => {
               voiceState.active = session.isVoiceActive();
               emitVoiceState("restore");
@@ -8860,7 +8861,7 @@ export const createAgentExperience = (
       // per-state UI (e.g. a listening/speaking status dock). Fires for every
       // provider; the mic-button styling below is runtype-specific.
       eventBus.emit("voice:status", { status, timestamp: Date.now() });
-      if (config.voiceRecognition?.provider?.type !== 'runtype') return;
+      if (!usesSessionVoice(config.voiceRecognition?.provider)) return;
 
       switch (status) {
         case 'listening':
@@ -8983,7 +8984,7 @@ export const createAgentExperience = (
   scrollSendSeeded = true;
 
   // Setup Runtype voice provider when configured (connects WebSocket for server-side STT)
-  if (config.voiceRecognition?.provider?.type === 'runtype') {
+  if (usesSessionVoice(config.voiceRecognition?.provider)) {
     try {
       session.setupVoice();
     } catch (err) {
@@ -12622,7 +12623,7 @@ export const createAgentExperience = (
     // Dictation is composition: a locked input takes none of it.
     if (isComposerInputDisabled()) return;
     // Runtype provider: use session.toggleVoice() (WebSocket-based STT)
-    if (config.voiceRecognition?.provider?.type === 'runtype') {
+    if (usesSessionVoice(config.voiceRecognition?.provider)) {
       const voiceStatus = session.getVoiceStatus();
       const interruptionMode = session.getVoiceInterruptionMode();
 
@@ -12693,7 +12694,7 @@ export const createAgentExperience = (
     // The click listener itself is registered by `wireComposerSurface`, so a
     // composer rebuild unwires it with the rest of the surface.
     destroyCallbacks.push(() => {
-      if (config.voiceRecognition?.provider?.type === 'runtype') {
+      if (usesSessionVoice(config.voiceRecognition?.provider)) {
         if (session.isVoiceActive()) session.toggleVoice();
         removeRuntypeMicStateStyles();
       } else {
@@ -12722,7 +12723,7 @@ export const createAgentExperience = (
     }
     setTimeout(() => {
       if (!voiceState.active && !voiceState.manuallyDeactivated) {
-        if (config.voiceRecognition?.provider?.type === 'runtype') {
+        if (usesSessionVoice(config.voiceRecognition?.provider)) {
           session.toggleVoice().then(() => {
             voiceState.active = session.isVoiceActive();
             emitVoiceState("auto");
@@ -14308,9 +14309,9 @@ export const createAgentExperience = (
         typeof window !== 'undefined' &&
         (typeof (window as any).webkitSpeechRecognition !== 'undefined' ||
          typeof (window as any).SpeechRecognition !== 'undefined');
-      const hasRuntypeProvider =
-        config.voiceRecognition?.provider?.type === 'runtype';
-      const hasVoiceInput = hasSpeechRecognition || hasRuntypeProvider;
+      const hasSessionProvider =
+        usesSessionVoice(config.voiceRecognition?.provider);
+      const hasVoiceInput = hasSpeechRecognition || hasSessionProvider;
 
       if (voiceRecognitionEnabled && hasVoiceInput) {
         // Create or update mic button
@@ -14446,7 +14447,7 @@ export const createAgentExperience = (
         if (micButton && micButtonWrapper) {
           micButtonWrapper.style.display = "none";
           // Stop any active recording if disabling
-          if (config.voiceRecognition?.provider?.type === 'runtype') {
+          if (usesSessionVoice(config.voiceRecognition?.provider)) {
             if (session.isVoiceActive()) session.toggleVoice();
           } else if (isRecording) {
             stopVoiceRecognition();
@@ -15015,8 +15016,8 @@ export const createAgentExperience = (
     },
     startVoiceRecognition(): boolean {
       if (session.isStreaming()) return false;
-      if (config.voiceRecognition?.provider?.type === 'runtype') {
-        if (session.isVoiceActive()) return true;
+      if (usesSessionVoice(config.voiceRecognition?.provider)) {
+        if (session.isVoiceActive() || session.isBargeInActive()) return true;
         if (!open && isPanelToggleable()) setOpenState(true, "system");
         voiceState.manuallyDeactivated = false;
         persistVoiceMetadata();
@@ -15037,9 +15038,12 @@ export const createAgentExperience = (
       return true;
     },
     stopVoiceRecognition(): boolean {
-      if (config.voiceRecognition?.provider?.type === 'runtype') {
-        if (!session.isVoiceActive()) return false;
-        session.toggleVoice().then(() => {
+      if (usesSessionVoice(config.voiceRecognition?.provider)) {
+        if (!session.isVoiceActive() && !session.isBargeInActive()) return false;
+        const stop = session.isBargeInActive()
+          ? session.deactivateBargeIn()
+          : session.toggleVoice();
+        stop.then(() => {
           voiceState.active = false;
           voiceState.manuallyDeactivated = true;
           persistVoiceMetadata();

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -7926,6 +7926,10 @@ export const createAgentExperience = (
   };
 
   const isComposerInputDisabled = (): boolean => composerLock.inputDisabled;
+  const isActiveSessionVoice = (): boolean =>
+    usesSessionVoice(config.voiceRecognition?.provider) &&
+    !!session && (session.isBargeInActive() ||
+      ["listening", "processing", "speaking"].includes(session.getVoiceStatus()));
   /** Any submission path is blocked; stop is not a submission. */
   const isComposerSendBlocked = (): boolean =>
     composerLock.inputDisabled || composerLock.sendDisabled;
@@ -8034,7 +8038,7 @@ export const createAgentExperience = (
         button.disabled = locked;
       });
     }
-    if (micButton) micButton.disabled = blocked;
+    if (micButton) micButton.disabled = locked || (streaming && !isActiveSessionVoice());
 
     suggestionManagers.forEach((manager) => {
       manager.elements.forEach((element) => {
@@ -14344,7 +14348,7 @@ export const createAgentExperience = (
             );
 
             // Set disabled state
-            micButton.disabled = session.isStreaming();
+            micButton.disabled = isComposerInputDisabled() || (session.isStreaming() && !isActiveSessionVoice());
           }
         } else {
           // Update existing mic button with new config
@@ -14440,7 +14444,7 @@ export const createAgentExperience = (
 
           // Show and update disabled state
           micButtonWrapper.style.display = "";
-          micButton.disabled = session.isStreaming();
+          micButton.disabled = isComposerInputDisabled() || (session.isStreaming() && !isActiveSessionVoice());
         }
       } else {
         // Hide mic button

--- a/packages/widget/src/ui.ts
+++ b/packages/widget/src/ui.ts
@@ -8865,7 +8865,7 @@ export const createAgentExperience = (
       // per-state UI (e.g. a listening/speaking status dock). Fires for every
       // provider; the mic-button styling below is runtype-specific.
       eventBus.emit("voice:status", { status, timestamp: Date.now() });
-      if (!usesSessionVoice(config.voiceRecognition?.provider)) return;
+      if (status !== 'disconnected' && !usesSessionVoice(config.voiceRecognition?.provider)) return;
 
       switch (status) {
         case 'listening':
@@ -8988,7 +8988,7 @@ export const createAgentExperience = (
   scrollSendSeeded = true;
 
   // Setup Runtype voice provider when configured (connects WebSocket for server-side STT)
-  if (usesSessionVoice(config.voiceRecognition?.provider)) {
+  if (config.voiceRecognition?.enabled === true && usesSessionVoice(config.voiceRecognition.provider)) {
     try {
       session.setupVoice();
     } catch (err) {

--- a/packages/widget/src/ui.voice-custom-provider.test.ts
+++ b/packages/widget/src/ui.voice-custom-provider.test.ts
@@ -44,7 +44,7 @@ function fixture(mode: "none" | "cancel" | "barge-in" = "cancel") {
   controllers.push(controller);
   const mic = () => mount.querySelector<HTMLButtonElement>("[data-persona-composer-mic]")!;
   return { provider, recognition, mic, controller, emit: (status: VoiceStatus) => statusCallback(status),
-    transcript: (role: "user" | "assistant", text: string, final = true) => transcriptCallback(role, text, final) };
+    transcript: (role: "user" | "assistant", text: string, final = true, turnId?: string) => transcriptCallback(role, text, final, { turnId }) };
 }
 
 it("starts the custom provider from the microphone and cancels playback without hanging up", async () => {
@@ -133,4 +133,79 @@ it("keeps the current user partial in one bubble when playback returns to listen
   transcript("user", "Next question");
   transcript("assistant", "Next answer");
   expect(controller.getMessages().filter(message => message.role === "user").map(message => message.content)).toEqual(["Hello", "Next question"]);
+});
+
+it("drops a cancelled reply arriving after a newer identified turn", async () => {
+  const { provider, mic, emit, transcript, controller } = fixture();
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  transcript("user", "Old question", true, "old");
+  emit("processing");
+  mic().click();
+  transcript("assistant", "Old partial", false, "old");
+  transcript("user", "New question", true, "new");
+  transcript("assistant", "Cancelled old answer", true, "old");
+  transcript("assistant", "New answer", true, "new");
+  expect(controller.getMessages().map(message => message.content)).toEqual(["Old question", "New question", "New answer"]);
+});
+
+it("ignores untagged cancelled output until the next user final without losing that next answer", async () => {
+  const { provider, mic, emit, transcript, controller } = fixture();
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  transcript("user", "Old question");
+  emit("processing");
+  mic().click();
+  transcript("assistant", "Cancelled answer");
+  transcript("user", "New question");
+  transcript("assistant", "New answer");
+  expect(controller.getMessages().map(message => message.content)).toEqual(["Old question", "New question", "New answer"]);
+});
+
+it("disconnects the old provider before constructing its replacement and ignores its stale callbacks", async () => {
+  const { provider, mic, controller, transcript, emit } = fixture();
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  let finishDisconnect!: () => void;
+  vi.mocked(provider.disconnect).mockImplementation(() => new Promise<void>(resolve => { finishDisconnect = resolve; }));
+  const replacement = { ...provider, connect: vi.fn(async () => {}), startListening: vi.fn(async () => {}), disconnect: vi.fn(async () => {}) };
+  const factory = vi.fn(() => replacement);
+  controller.update({ voiceRecognition: { enabled: true, provider: { type: "custom", custom: factory } } });
+  expect(provider.disconnect).toHaveBeenCalledOnce();
+  expect(controller.isVoiceActive()).toBe(false);
+  expect(factory).not.toHaveBeenCalled();
+  transcript("assistant", "Stale reply");
+  emit("speaking");
+  expect(controller.getMessages()).toEqual([]);
+  finishDisconnect();
+  await controller.startVoiceRecognition();
+  await vi.waitFor(() => expect(replacement.startListening).toHaveBeenCalledOnce());
+  expect(factory).toHaveBeenCalledOnce();
+});
+
+it("disconnects a live call when disabled and reinstalls the provider on reenable", async () => {
+  const { provider, mic, controller } = fixture();
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  controller.update({ voiceRecognition: { enabled: false } });
+  expect(provider.disconnect).toHaveBeenCalledOnce();
+  expect(controller.isVoiceActive()).toBe(false);
+  controller.update({ voiceRecognition: { enabled: true } });
+  await controller.startVoiceRecognition();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledTimes(2));
+});
+
+it("sets up custom voice after starting with browser dictation and preserves it for cosmetic updates", async () => {
+  const { provider, controller } = fixture();
+  await controller.startVoiceRecognition();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  controller.update({ voiceRecognition: { provider: { type: "browser" } } });
+  expect(provider.disconnect).toHaveBeenCalledOnce();
+  expect(controller.isVoiceActive()).toBe(false);
+  vi.mocked(provider.startListening).mockClear();
+  controller.update({ voiceRecognition: { provider: { type: "custom", custom: () => provider } } });
+  await controller.startVoiceRecognition();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  controller.update({ voiceRecognition: { iconName: "mic" }, colorScheme: "dark" });
+  expect(provider.disconnect).toHaveBeenCalledOnce();
 });

--- a/packages/widget/src/ui.voice-custom-provider.test.ts
+++ b/packages/widget/src/ui.voice-custom-provider.test.ts
@@ -15,6 +15,7 @@ afterEach(() => {
 
 function fixture(mode: "none" | "cancel" | "barge-in" = "cancel") {
   let statusCallback: (status: VoiceStatus) => void = () => {};
+  let transcriptCallback: NonNullable<Parameters<NonNullable<VoiceProvider["onTranscript"]>>[0]> = () => {};
   let active = false;
   const provider: VoiceProvider = {
     type: "runtype",
@@ -25,6 +26,7 @@ function fixture(mode: "none" | "cancel" | "barge-in" = "cancel") {
     onResult: vi.fn(),
     onError: vi.fn(),
     onStatusChange: callback => { statusCallback = callback; },
+    onTranscript: callback => { transcriptCallback = callback; },
     getInterruptionMode: () => mode,
     isBargeInActive: () => active,
     stopPlayback: vi.fn(() => { statusCallback("listening"); }),
@@ -41,7 +43,8 @@ function fixture(mode: "none" | "cancel" | "barge-in" = "cancel") {
   });
   controllers.push(controller);
   const mic = () => mount.querySelector<HTMLButtonElement>("[data-persona-composer-mic]")!;
-  return { provider, recognition, mic, controller, emit: (status: VoiceStatus) => statusCallback(status) };
+  return { provider, recognition, mic, controller, emit: (status: VoiceStatus) => statusCallback(status),
+    transcript: (role: "user" | "assistant", text: string, final = true) => transcriptCallback(role, text, final) };
 }
 
 it("starts the custom provider from the microphone and cancels playback without hanging up", async () => {
@@ -90,4 +93,44 @@ it("routes controller start and stop to the custom provider after a composer upd
   await controller.stopVoiceRecognition();
   expect(provider.deactivateBargeIn).toHaveBeenCalledOnce();
   expect(recognition).not.toHaveBeenCalled();
+});
+
+it.each(["cancel", "barge-in"] as const)("settles a pending assistant placeholder after %s during thinking", async (mode) => {
+  const { provider, mic, emit, transcript, controller } = fixture(mode);
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  emit("processing");
+  transcript("user", "Tell me a story");
+  expect(controller.getMessages().some(message => message.streaming)).toBe(true);
+  if (mode === "cancel") mic().click();
+  else emit("listening");
+  expect(controller.getMessages().map(message => message.content)).toEqual(["Tell me a story"]);
+  expect(controller.getMessages().some(message => message.streaming || message.voiceProcessing)).toBe(false);
+  transcript("user", "Next question");
+  transcript("assistant", "Next answer");
+  expect(controller.getMessages().map(message => message.content)).toEqual(["Tell me a story", "Next question", "Next answer"]);
+});
+
+it("preserves partial voice content while clearing its streaming flags on hangup", async () => {
+  const { provider, mic, emit, transcript, controller } = fixture("barge-in");
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  transcript("user", "Explain");
+  transcript("assistant", "A partial answer", false);
+  emit("speaking");
+  mic().click();
+  expect(controller.getMessages().at(-1)).toMatchObject({ content: "A partial answer", streaming: false, voiceProcessing: false });
+});
+
+it("keeps the current user partial in one bubble when playback returns to listening", async () => {
+  const { provider, mic, emit, transcript, controller } = fixture();
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  transcript("user", "Hello");
+  transcript("assistant", "Hi");
+  transcript("user", "Next", false);
+  emit("listening");
+  transcript("user", "Next question");
+  transcript("assistant", "Next answer");
+  expect(controller.getMessages().filter(message => message.role === "user").map(message => message.content)).toEqual(["Hello", "Next question"]);
 });

--- a/packages/widget/src/ui.voice-custom-provider.test.ts
+++ b/packages/widget/src/ui.voice-custom-provider.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createAgentExperience } from "./ui";
+import type { VoiceProvider, VoiceStatus } from "./types";
+
+const controllers: ReturnType<typeof createAgentExperience>[] = [];
+beforeEach(() => { window.scrollTo = vi.fn(); });
+afterEach(() => {
+  for (const controller of controllers.splice(0)) controller.destroy();
+  document.body.innerHTML = "";
+  window.localStorage.clear();
+  vi.unstubAllGlobals();
+});
+
+function fixture(mode: "none" | "cancel" | "barge-in" = "cancel") {
+  let statusCallback: (status: VoiceStatus) => void = () => {};
+  let active = false;
+  const provider: VoiceProvider = {
+    type: "runtype",
+    connect: vi.fn(async () => {}),
+    disconnect: vi.fn(async () => { active = false; }),
+    startListening: vi.fn(async () => { active = true; statusCallback("listening"); }),
+    stopListening: vi.fn(async () => { active = false; statusCallback("idle"); }),
+    onResult: vi.fn(),
+    onError: vi.fn(),
+    onStatusChange: callback => { statusCallback = callback; },
+    getInterruptionMode: () => mode,
+    isBargeInActive: () => active,
+    stopPlayback: vi.fn(() => { statusCallback("listening"); }),
+    deactivateBargeIn: vi.fn(async () => { active = false; statusCallback("idle"); }),
+  };
+  const recognition = vi.fn();
+  vi.stubGlobal("SpeechRecognition", recognition);
+  const mount = document.createElement("div");
+  document.body.appendChild(mount);
+  const controller = createAgentExperience(mount, {
+    apiUrl: "https://api.example.test/chat",
+    launcher: { enabled: false }, persistState: false, suggestionChips: [],
+    voiceRecognition: { enabled: true, provider: { type: "custom", custom: () => provider } },
+  });
+  controllers.push(controller);
+  const mic = () => mount.querySelector<HTMLButtonElement>("[data-persona-composer-mic]")!;
+  return { provider, recognition, mic, controller, emit: (status: VoiceStatus) => statusCallback(status) };
+}
+
+it("starts the custom provider from the microphone and cancels playback without hanging up", async () => {
+  const { provider, recognition, mic, emit } = fixture();
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  expect(recognition).not.toHaveBeenCalled();
+  emit("speaking");
+  expect(mic().getAttribute("aria-label")).toBe("Stop playback and re-record");
+  mic().click();
+  expect(provider.stopPlayback).toHaveBeenCalledOnce();
+  expect(provider.stopListening).not.toHaveBeenCalled();
+  expect(provider.deactivateBargeIn).not.toHaveBeenCalled();
+});
+
+it("respects none mode and cleans up the custom provider on destroy", async () => {
+  const { provider, mic, emit, controller } = fixture("none");
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  emit("speaking");
+  mic().click();
+  expect(provider.stopPlayback).not.toHaveBeenCalled();
+  expect(provider.stopListening).not.toHaveBeenCalled();
+  controller.destroy();
+  controllers.splice(controllers.indexOf(controller), 1);
+  expect(provider.disconnect).toHaveBeenCalled();
+});
+
+it("hangs up a barge-in custom call through the microphone control", async () => {
+  const { provider, mic, emit } = fixture("barge-in");
+  mic().click();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  emit("speaking");
+  mic().click();
+  await vi.waitFor(() => expect(provider.deactivateBargeIn).toHaveBeenCalledOnce());
+});
+
+it("routes controller start and stop to the custom provider after a composer update", async () => {
+  const { provider, recognition, controller, mic, emit } = fixture();
+  controller.update({ voiceRecognition: { enabled: false } });
+  controller.update({ voiceRecognition: { enabled: true } });
+  expect(mic()).not.toBeNull();
+  await controller.startVoiceRecognition();
+  await vi.waitFor(() => expect(provider.startListening).toHaveBeenCalledOnce());
+  emit("speaking");
+  await controller.stopVoiceRecognition();
+  expect(provider.deactivateBargeIn).toHaveBeenCalledOnce();
+  expect(recognition).not.toHaveBeenCalled();
+});

--- a/packages/widget/src/utils/voice-support.ts
+++ b/packages/widget/src/utils/voice-support.ts
@@ -1,5 +1,10 @@
 import type { VoiceConfig } from "../types";
 
+/** Providers whose microphone lifecycle is owned by ChatSession instead of browser dictation. */
+export function usesSessionVoice(config?: Partial<VoiceConfig>): boolean {
+  return config?.type === "runtype" || config?.type === "custom";
+}
+
 /**
  * Eager, construction-free replica of the voice factory's `isVoiceSupported`
  * (`voice/voice-factory.ts`, which ships in the lazy voice-runtime chunk).

--- a/packages/widget/src/utils/voice-support.ts
+++ b/packages/widget/src/utils/voice-support.ts
@@ -1,4 +1,16 @@
-import type { VoiceConfig } from "../types";
+import type { AgentWidgetConfig, VoiceConfig } from "../types";
+
+/** Changes that require replacing a session's capture and playback provider. */
+export function voiceConnectionChanged(previous: AgentWidgetConfig, next: AgentWidgetConfig): boolean {
+  const before = previous.voiceRecognition;
+  const after = next.voiceRecognition;
+  return (before?.enabled === true) !== (after?.enabled === true) ||
+    before?.provider?.type !== after?.provider?.type ||
+    before?.provider?.custom !== after?.provider?.custom ||
+    before?.provider?.runtype?.createPlaybackEngine !== after?.provider?.runtype?.createPlaybackEngine ||
+    JSON.stringify(before?.provider?.runtype) !== JSON.stringify(after?.provider?.runtype) ||
+    previous.agentId !== next.agentId || previous.clientToken !== next.clientToken || previous.apiUrl !== next.apiUrl;
+}
 
 /** Providers whose microphone lifecycle is owned by ChatSession instead of browser dictation. */
 export function usesSessionVoice(config?: Partial<VoiceConfig>): boolean {

--- a/packages/widget/src/voice/voice-turn-tracker.ts
+++ b/packages/widget/src/voice/voice-turn-tracker.ts
@@ -1,0 +1,18 @@
+/** Correlate provider transcripts across cancellation and overlapping turns. */
+export class VoiceTurnTracker {
+  private turnId?: string;
+  private cancelled = false;
+
+  start(turnId?: string): void {
+    this.turnId = turnId;
+    this.cancelled = false;
+  }
+
+  cancel(): void {
+    this.cancelled = true;
+  }
+
+  accepts(turnId?: string): boolean {
+    return !this.cancelled && (!turnId || !this.turnId || turnId === this.turnId);
+  }
+}


### PR DESCRIPTION
Custom voice providers were accepted by the factory but their microphone buttons still fell through to browser dictation. Route them through the session lifecycle, keep active voice controls usable while a response streams, and release voice resources on widget teardown.

Cancelling while the agent is thinking now removes the empty assistant placeholder and clears streaming state. Partial replies are preserved, and user interim text stays in the same bubble when playback drains.

Provider changes now await teardown before replacement, discard retired callbacks, and reset the public active-call state. Cancelled replies are rejected until the next user turn; providers with overlapping turns can send optional transcript turn IDs so an old answer cannot replace the next reply. Untagged providers must discard cancelled output before emitting their next user final.

This enables the shared Runtype voice client adapter without adding a package dependency to Persona. Existing browser dictation and explicit input locks retain their behavior.

## Validation

- Full widget suite: 3,875 tests passed across 241 files, including 13 custom voice control and interruption regressions.
- Lint and full `pnpm typecheck` passed for widget, proxy, and showcase.
- Final package build and bundle-size checks passed. Follow-up lifecycle/cancellation safeguards add about 0.37 kB gzip to the main bundles. Measured sizes: CDN 186.61 kB, ESM 199.01 kB, CJS 199.82 kB, theme-editor preview 165.60 kB. Increase only these four budgets by 0.5 kB from the previous PR head; other limits remain unchanged.
- Refreshed the generated public event contract to clear a pre-existing CI drift failure: 83 additive type lines for subagent metadata and context notices already in the live API; no runtime code changes.

## Visual evidence

No intended visual change. Interaction coverage exercises microphone start, Cancel while thinking, None mode, barge-in hangup, composer updates, provider replacement/disable, late transcripts, and teardown using the actual widget UI with deterministic voice providers.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR integrates custom voice providers with the widget’s session-owned microphone controls and strengthens voice turn and provider lifecycle handling.
- Routes custom providers through shared start, stop, cancellation, barge-in, status, and teardown paths.
- Settles cancelled voice placeholders and filters stale assistant transcripts using optional turn identifiers.
- Serializes provider replacement after teardown and ignores callbacks from retired providers.
- Keeps active voice controls available while a voice response is processing or speaking.
- Updates the public voice-provider contract, generated event types, documentation, regression coverage, and bundle budgets.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the current changes address both previously reported voice lifecycle and cancelled-reply defects without introducing a confirmed new issue.

Cancelled replies are now gated by turn state, pending placeholders are settled when playback or calls end, and provider replacements wait for teardown while stale callbacks are ignored. Both previous findings are fully addressed in the current code.

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| packages/widget/src/session.ts | Adds cancelled-turn tracking, deterministic provider replacement, stale-callback guards, pending-turn settlement, and teardown cleanup. |
| packages/widget/src/ui.ts | Routes custom providers through session voice controls and keeps active voice controls usable during processing and playback. |
| packages/widget/src/voice/voice-turn-tracker.ts | Introduces a focused tracker that rejects cancelled or mismatched identified assistant transcripts. |
| packages/widget/src/utils/voice-support.ts | Classifies session-owned providers and detects configuration changes that require provider replacement. |
| packages/widget/src/types.ts | Extends the custom transcript callback contract with optional turn identifiers and documents untagged-provider ordering requirements. |
| packages/widget/src/ui.voice-custom-provider.test.ts | Covers custom controls, cancellation, overlapping turns, stale callbacks, replacement sequencing, disabling, and teardown. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant UI as Microphone control
    participant Session as Widget session
    participant Provider as Voice provider
    participant Tracker as Turn tracker

    UI->>Session: Start session voice
    Session->>Provider: connect / startListening
    Provider-->>Session: user final + optional turnId
    Session->>Tracker: start(turnId)
    Session-->>UI: User message + assistant placeholder
    Provider-->>Session: processing / speaking

    alt User cancels
        UI->>Session: stopVoicePlayback
        Session->>Tracker: cancel()
        Session->>Provider: stopPlayback
        Provider-->>Session: listening
        Session-->>UI: Remove empty placeholder and clear streaming
    else Reply completes
        Provider-->>Session: assistant final + turnId
        Session->>Tracker: accepts(turnId)
        Session-->>UI: Finalize assistant message
    end

    opt Provider configuration changes
        Session->>Provider: disconnect
        Provider-->>Session: teardown complete
        Session->>Provider: construct and connect replacement
    end
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(voice): reconcile providers and reje..."](https://github.com/runtypelabs/persona/commit/6c5304324f91f638e0e7adb518080e1f858e9762) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60825320)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Widget voice and read-aloud](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-voice.md)
- Knowledge Base — [Widget conversation and session runtime](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-conversation-runtime.md)
- Knowledge Base — [Widget UI composition and layout](https://app.greptile.com/runtype/-/custom-context/knowledge-base/runtypelabs/persona/-/docs/widget-ui-composition.md)
</details>


<!-- /greptile_comment -->